### PR TITLE
bindgen: Commit expanded bindgen output for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -455,7 +455,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -963,7 +963,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2093,10 +2093,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.63"
+name = "prettyplease"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -2144,9 +2154,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2448,7 +2458,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2634,9 +2644,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2762,7 +2772,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2835,7 +2845,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2918,7 +2928,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3195,7 +3205,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -3217,7 +3227,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3610,11 +3620,13 @@ version = "22.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.32",
+ "similar",
+ "syn 2.0.60",
  "tracing",
  "wasmtime",
  "wasmtime-component-util",
@@ -3813,7 +3825,7 @@ version = "22.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4022,7 +4034,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.32",
+ "syn 2.0.60",
  "witx",
 ]
 
@@ -4032,7 +4044,7 @@ version = "22.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
  "wiggle",
  "wiggle-generate",
 ]
@@ -4316,7 +4328,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4435,7 +4447,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -34,6 +34,8 @@ tracing = { workspace = true }
 # For use with the custom attributes test
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+prettyplease = "0.2.19"
+similar = { workspace = true }
 
 [features]
 async = []

--- a/crates/component-macro/tests/expanded.rs
+++ b/crates/component-macro/tests/expanded.rs
@@ -1,0 +1,65 @@
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+
+macro_rules! genexpand {
+    ($id:ident $name:tt $path:tt) => {
+        process_expanded($path, "", wasmtime::component::bindgen!({
+            path: $path,
+            stringify: true,
+        }))?;
+
+        process_expanded($path, "_async", wasmtime::component::bindgen!({
+            path: $path,
+            async: true,
+            stringify: true,
+        }))?;
+    };
+}
+
+fn process_expanded(path: &str, suffix: &str, src: &str) -> Result<()> {
+    let formatted_src = {
+        let syn_file = syn::parse_file(src).unwrap();
+        prettyplease::unparse(&syn_file)
+    };
+    let expanded_path = {
+        let mut stem = Path::new(path).file_stem().unwrap().to_os_string();
+        stem.push(suffix);
+        Path::new("tests/expanded").join(stem).with_extension("rs")
+    };
+    if std::env::var("BINDGEN_TEST_BLESS").is_ok_and(|val| !val.is_empty()) {
+        std::fs::write(expanded_path, formatted_src)?;
+    } else {
+        match std::fs::read_to_string(&expanded_path) {
+            Ok(expected) if formatted_src == expected => (),
+            Ok(expected) => {
+                bail!(
+                    "checked-in expanded bindings from {expanded_path:?} \
+                    do not match those generated from {path:?}
+                    \n\
+                    {diff}\n\
+                    \n\
+                    This test assertion can be automatically updated by setting the\n\
+                    BINDGEN_TEST_BLESS=1 environment variable when running this test.",
+                    diff = similar::TextDiff::from_lines(&expected, &formatted_src)
+                        .unified_diff()
+                        .header("expected", "actual")
+                )
+            }
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                    "failed to read {expanded_path:?}; re-run with BINDGEN_TEST_BLESS=1 to create"
+                )
+                })
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn expand_wits() -> Result<()> {
+    component_macro_test_helpers::foreach!(genexpand);
+    Ok(())
+}

--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -1,0 +1,170 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::chars::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::chars::Host,
+        {
+            foo::foo::chars::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::chars::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/chars")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/chars` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_chars(&self) -> &exports::foo::foo::chars::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod chars {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                /// A function that accepts a character
+                fn take_char(&mut self, x: char) -> ();
+                /// A function that returns a character
+                fn return_char(&mut self) -> char;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/chars")?;
+                inst.func_wrap(
+                    "take-char",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (char,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::take_char(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-char",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_char(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod chars {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    take_char: wasmtime::component::Func,
+                    return_char: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let take_char = *__exports
+                            .typed_func::<(char,), ()>("take-char")?
+                            .func();
+                        let return_char = *__exports
+                            .typed_func::<(), (char,)>("return-char")?
+                            .func();
+                        Ok(Guest { take_char, return_char })
+                    }
+                    /// A function that accepts a character
+                    pub fn call_take_char<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: char,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (char,),
+                                (),
+                            >::new_unchecked(self.take_char)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    /// A function that returns a character
+                    pub fn call_return_char<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<char> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (char,),
+                            >::new_unchecked(self.return_char)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -1,0 +1,183 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::chars::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::chars::Host + Send,
+            T: Send,
+        {
+            foo::foo::chars::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::chars::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/chars")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/chars` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_chars(&self) -> &exports::foo::foo::chars::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod chars {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                /// A function that accepts a character
+                async fn take_char(&mut self, x: char) -> ();
+                /// A function that returns a character
+                async fn return_char(&mut self) -> char;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/chars")?;
+                inst.func_wrap_async(
+                    "take-char",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (char,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::take_char(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-char",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_char(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod chars {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    take_char: wasmtime::component::Func,
+                    return_char: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let take_char = *__exports
+                            .typed_func::<(char,), ()>("take-char")?
+                            .func();
+                        let return_char = *__exports
+                            .typed_func::<(), (char,)>("return-char")?
+                            .func();
+                        Ok(Guest { take_char, return_char })
+                    }
+                    /// A function that accepts a character
+                    pub async fn call_take_char<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: char,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (char,),
+                                (),
+                            >::new_unchecked(self.take_char)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    /// A function that returns a character
+                    pub async fn call_return_char<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<char>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (char,),
+                            >::new_unchecked(self.return_char)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -1,0 +1,524 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::conventions::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::conventions::Host,
+        {
+            foo::foo::conventions::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::conventions::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/conventions")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/conventions` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_conventions(&self) -> &exports::foo::foo::conventions::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod conventions {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct LudicrousSpeed {
+                #[component(name = "how-fast-are-you-going")]
+                pub how_fast_are_you_going: u32,
+                #[component(name = "i-am-going-extremely-slow")]
+                pub i_am_going_extremely_slow: u64,
+            }
+            impl core::fmt::Debug for LudicrousSpeed {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("LudicrousSpeed")
+                        .field("how-fast-are-you-going", &self.how_fast_are_you_going)
+                        .field(
+                            "i-am-going-extremely-slow",
+                            &self.i_am_going_extremely_slow,
+                        )
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    16 == < LudicrousSpeed as wasmtime::component::ComponentType
+                    >::SIZE32
+                );
+                assert!(
+                    8 == < LudicrousSpeed as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            pub trait Host {
+                fn kebab_case(&mut self) -> ();
+                fn foo(&mut self, x: LudicrousSpeed) -> ();
+                fn function_with_dashes(&mut self) -> ();
+                fn function_with_no_weird_characters(&mut self) -> ();
+                fn apple(&mut self) -> ();
+                fn apple_pear(&mut self) -> ();
+                fn apple_pear_grape(&mut self) -> ();
+                fn a0(&mut self) -> ();
+                /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                /// https://github.com/WebAssembly/component-model/issues/118
+                /// APPLE: func()
+                /// APPLE-pear-GRAPE: func()
+                /// apple-PEAR-grape: func()
+                fn is_xml(&mut self) -> ();
+                fn explicit(&mut self) -> ();
+                fn explicit_kebab(&mut self) -> ();
+                /// Identifiers with the same name as keywords are quoted.
+                fn bool(&mut self) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/conventions")?;
+                inst.func_wrap(
+                    "kebab-case",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::kebab_case(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "foo",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (LudicrousSpeed,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::foo(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "function-with-dashes",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::function_with_dashes(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "function-with-no-weird-characters",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::function_with_no_weird_characters(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "apple",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::apple(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "apple-pear",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::apple_pear(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "apple-pear-grape",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::apple_pear_grape(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a0",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a0(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "is-XML",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::is_xml(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "explicit",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::explicit(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "explicit-kebab",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::explicit_kebab(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "bool",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::bool(host);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod conventions {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct LudicrousSpeed {
+                    #[component(name = "how-fast-are-you-going")]
+                    pub how_fast_are_you_going: u32,
+                    #[component(name = "i-am-going-extremely-slow")]
+                    pub i_am_going_extremely_slow: u64,
+                }
+                impl core::fmt::Debug for LudicrousSpeed {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("LudicrousSpeed")
+                            .field(
+                                "how-fast-are-you-going",
+                                &self.how_fast_are_you_going,
+                            )
+                            .field(
+                                "i-am-going-extremely-slow",
+                                &self.i_am_going_extremely_slow,
+                            )
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < LudicrousSpeed as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < LudicrousSpeed as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    kebab_case: wasmtime::component::Func,
+                    foo: wasmtime::component::Func,
+                    function_with_dashes: wasmtime::component::Func,
+                    function_with_no_weird_characters: wasmtime::component::Func,
+                    apple: wasmtime::component::Func,
+                    apple_pear: wasmtime::component::Func,
+                    apple_pear_grape: wasmtime::component::Func,
+                    a0: wasmtime::component::Func,
+                    is_xml: wasmtime::component::Func,
+                    explicit: wasmtime::component::Func,
+                    explicit_kebab: wasmtime::component::Func,
+                    bool: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let kebab_case = *__exports
+                            .typed_func::<(), ()>("kebab-case")?
+                            .func();
+                        let foo = *__exports
+                            .typed_func::<(LudicrousSpeed,), ()>("foo")?
+                            .func();
+                        let function_with_dashes = *__exports
+                            .typed_func::<(), ()>("function-with-dashes")?
+                            .func();
+                        let function_with_no_weird_characters = *__exports
+                            .typed_func::<(), ()>("function-with-no-weird-characters")?
+                            .func();
+                        let apple = *__exports.typed_func::<(), ()>("apple")?.func();
+                        let apple_pear = *__exports
+                            .typed_func::<(), ()>("apple-pear")?
+                            .func();
+                        let apple_pear_grape = *__exports
+                            .typed_func::<(), ()>("apple-pear-grape")?
+                            .func();
+                        let a0 = *__exports.typed_func::<(), ()>("a0")?.func();
+                        let is_xml = *__exports.typed_func::<(), ()>("is-XML")?.func();
+                        let explicit = *__exports
+                            .typed_func::<(), ()>("explicit")?
+                            .func();
+                        let explicit_kebab = *__exports
+                            .typed_func::<(), ()>("explicit-kebab")?
+                            .func();
+                        let bool = *__exports.typed_func::<(), ()>("bool")?.func();
+                        Ok(Guest {
+                            kebab_case,
+                            foo,
+                            function_with_dashes,
+                            function_with_no_weird_characters,
+                            apple,
+                            apple_pear,
+                            apple_pear_grape,
+                            a0,
+                            is_xml,
+                            explicit,
+                            explicit_kebab,
+                            bool,
+                        })
+                    }
+                    pub fn call_kebab_case<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.kebab_case)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_foo<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: LudicrousSpeed,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LudicrousSpeed,),
+                                (),
+                            >::new_unchecked(self.foo)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_function_with_dashes<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_dashes)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_function_with_no_weird_characters<
+                        S: wasmtime::AsContextMut,
+                    >(&self, mut store: S) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_no_weird_characters)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_apple<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_apple_pear<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear_grape)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a0<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.a0)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                    /// https://github.com/WebAssembly/component-model/issues/118
+                    /// APPLE: func()
+                    /// APPLE-pear-GRAPE: func()
+                    /// apple-PEAR-grape: func()
+                    pub fn call_is_xml<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.is_xml)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_explicit<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_explicit_kebab<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit_kebab)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    /// Identifiers with the same name as keywords are quoted.
+                    pub fn call_bool<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.bool)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -1,0 +1,565 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::conventions::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::conventions::Host + Send,
+            T: Send,
+        {
+            foo::foo::conventions::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::conventions::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/conventions")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/conventions` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_conventions(&self) -> &exports::foo::foo::conventions::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod conventions {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct LudicrousSpeed {
+                #[component(name = "how-fast-are-you-going")]
+                pub how_fast_are_you_going: u32,
+                #[component(name = "i-am-going-extremely-slow")]
+                pub i_am_going_extremely_slow: u64,
+            }
+            impl core::fmt::Debug for LudicrousSpeed {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("LudicrousSpeed")
+                        .field("how-fast-are-you-going", &self.how_fast_are_you_going)
+                        .field(
+                            "i-am-going-extremely-slow",
+                            &self.i_am_going_extremely_slow,
+                        )
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    16 == < LudicrousSpeed as wasmtime::component::ComponentType
+                    >::SIZE32
+                );
+                assert!(
+                    8 == < LudicrousSpeed as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn kebab_case(&mut self) -> ();
+                async fn foo(&mut self, x: LudicrousSpeed) -> ();
+                async fn function_with_dashes(&mut self) -> ();
+                async fn function_with_no_weird_characters(&mut self) -> ();
+                async fn apple(&mut self) -> ();
+                async fn apple_pear(&mut self) -> ();
+                async fn apple_pear_grape(&mut self) -> ();
+                async fn a0(&mut self) -> ();
+                /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                /// https://github.com/WebAssembly/component-model/issues/118
+                /// APPLE: func()
+                /// APPLE-pear-GRAPE: func()
+                /// apple-PEAR-grape: func()
+                async fn is_xml(&mut self) -> ();
+                async fn explicit(&mut self) -> ();
+                async fn explicit_kebab(&mut self) -> ();
+                /// Identifiers with the same name as keywords are quoted.
+                async fn bool(&mut self) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/conventions")?;
+                inst.func_wrap_async(
+                    "kebab-case",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::kebab_case(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "foo",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (LudicrousSpeed,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::foo(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "function-with-dashes",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::function_with_dashes(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "function-with-no-weird-characters",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::function_with_no_weird_characters(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "apple",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::apple(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "apple-pear",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::apple_pear(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "apple-pear-grape",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::apple_pear_grape(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a0",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a0(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "is-XML",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::is_xml(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "explicit",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::explicit(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "explicit-kebab",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::explicit_kebab(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "bool",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::bool(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod conventions {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct LudicrousSpeed {
+                    #[component(name = "how-fast-are-you-going")]
+                    pub how_fast_are_you_going: u32,
+                    #[component(name = "i-am-going-extremely-slow")]
+                    pub i_am_going_extremely_slow: u64,
+                }
+                impl core::fmt::Debug for LudicrousSpeed {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("LudicrousSpeed")
+                            .field(
+                                "how-fast-are-you-going",
+                                &self.how_fast_are_you_going,
+                            )
+                            .field(
+                                "i-am-going-extremely-slow",
+                                &self.i_am_going_extremely_slow,
+                            )
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < LudicrousSpeed as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < LudicrousSpeed as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    kebab_case: wasmtime::component::Func,
+                    foo: wasmtime::component::Func,
+                    function_with_dashes: wasmtime::component::Func,
+                    function_with_no_weird_characters: wasmtime::component::Func,
+                    apple: wasmtime::component::Func,
+                    apple_pear: wasmtime::component::Func,
+                    apple_pear_grape: wasmtime::component::Func,
+                    a0: wasmtime::component::Func,
+                    is_xml: wasmtime::component::Func,
+                    explicit: wasmtime::component::Func,
+                    explicit_kebab: wasmtime::component::Func,
+                    bool: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let kebab_case = *__exports
+                            .typed_func::<(), ()>("kebab-case")?
+                            .func();
+                        let foo = *__exports
+                            .typed_func::<(LudicrousSpeed,), ()>("foo")?
+                            .func();
+                        let function_with_dashes = *__exports
+                            .typed_func::<(), ()>("function-with-dashes")?
+                            .func();
+                        let function_with_no_weird_characters = *__exports
+                            .typed_func::<(), ()>("function-with-no-weird-characters")?
+                            .func();
+                        let apple = *__exports.typed_func::<(), ()>("apple")?.func();
+                        let apple_pear = *__exports
+                            .typed_func::<(), ()>("apple-pear")?
+                            .func();
+                        let apple_pear_grape = *__exports
+                            .typed_func::<(), ()>("apple-pear-grape")?
+                            .func();
+                        let a0 = *__exports.typed_func::<(), ()>("a0")?.func();
+                        let is_xml = *__exports.typed_func::<(), ()>("is-XML")?.func();
+                        let explicit = *__exports
+                            .typed_func::<(), ()>("explicit")?
+                            .func();
+                        let explicit_kebab = *__exports
+                            .typed_func::<(), ()>("explicit-kebab")?
+                            .func();
+                        let bool = *__exports.typed_func::<(), ()>("bool")?.func();
+                        Ok(Guest {
+                            kebab_case,
+                            foo,
+                            function_with_dashes,
+                            function_with_no_weird_characters,
+                            apple,
+                            apple_pear,
+                            apple_pear_grape,
+                            a0,
+                            is_xml,
+                            explicit,
+                            explicit_kebab,
+                            bool,
+                        })
+                    }
+                    pub async fn call_kebab_case<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.kebab_case)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_foo<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: LudicrousSpeed,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LudicrousSpeed,),
+                                (),
+                            >::new_unchecked(self.foo)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_function_with_dashes<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_dashes)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_function_with_no_weird_characters<
+                        S: wasmtime::AsContextMut,
+                    >(&self, mut store: S) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_no_weird_characters)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_apple<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_apple_pear<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear_grape)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a0<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.a0)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                    /// https://github.com/WebAssembly/component-model/issues/118
+                    /// APPLE: func()
+                    /// APPLE-pear-GRAPE: func()
+                    /// apple-PEAR-grape: func()
+                    pub async fn call_is_xml<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.is_xml)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_explicit<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_explicit_kebab<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit_kebab)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    /// Identifiers with the same name as keywords are quoted.
+                    pub async fn call_bool<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.bool)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -1,0 +1,123 @@
+pub struct Imports {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Imports {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: a::b::interface_with_live_type::Host
+                + a::b::interface_with_dead_type::Host,
+        {
+            a::b::interface_with_live_type::add_to_linker(linker, get)?;
+            a::b::interface_with_dead_type::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Imports {})
+        }
+    }
+};
+pub mod a {
+    pub mod b {
+        #[allow(clippy::all)]
+        pub mod interface_with_live_type {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct LiveType {
+                #[component(name = "a")]
+                pub a: u32,
+            }
+            impl core::fmt::Debug for LiveType {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("LiveType").field("a", &self.a).finish()
+                }
+            }
+            const _: () = {
+                assert!(4 == < LiveType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {
+                fn f(&mut self) -> LiveType;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("a:b/interface-with-live-type")?;
+                inst.func_wrap(
+                    "f",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::f(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod interface_with_dead_type {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("a:b/interface-with-dead-type")?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -1,0 +1,128 @@
+pub struct Imports {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Imports {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: a::b::interface_with_live_type::Host
+                + a::b::interface_with_dead_type::Host + Send,
+            T: Send,
+        {
+            a::b::interface_with_live_type::add_to_linker(linker, get)?;
+            a::b::interface_with_dead_type::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Imports {})
+        }
+    }
+};
+pub mod a {
+    pub mod b {
+        #[allow(clippy::all)]
+        pub mod interface_with_live_type {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct LiveType {
+                #[component(name = "a")]
+                pub a: u32,
+            }
+            impl core::fmt::Debug for LiveType {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("LiveType").field("a", &self.a).finish()
+                }
+            }
+            const _: () = {
+                assert!(4 == < LiveType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn f(&mut self) -> LiveType;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("a:b/interface-with-live-type")?;
+                inst.func_wrap_async(
+                    "f",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::f(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod interface_with_dead_type {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("a:b/interface-with-dead-type")?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -1,0 +1,77 @@
+pub struct Foo {}
+pub trait FooImports {
+    fn foo(&mut self) -> ();
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: FooImports,
+        {
+            Self::add_root_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn add_root_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: FooImports,
+        {
+            let mut linker = linker.root();
+            linker
+                .func_wrap(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = FooImports::foo(host);
+                        Ok(r)
+                    },
+                )?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Foo {})
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -1,0 +1,80 @@
+pub struct Foo {}
+#[wasmtime::component::__internal::async_trait]
+pub trait FooImports {
+    async fn foo(&mut self) -> ();
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: FooImports + Send,
+            T: Send,
+        {
+            Self::add_root_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn add_root_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: FooImports + Send,
+            T: Send,
+        {
+            let mut linker = linker.root();
+            linker
+                .func_wrap_async(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = FooImports::foo(host).await;
+                        Ok(r)
+                    }),
+                )?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Foo {})
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/empty.rs
+++ b/crates/component-macro/tests/expanded/empty.rs
@@ -1,0 +1,45 @@
+pub struct Empty {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Empty {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Empty {})
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/empty_async.rs
+++ b/crates/component-macro/tests/expanded/empty_async.rs
@@ -1,0 +1,45 @@
+pub struct Empty {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Empty {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Empty {})
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -1,0 +1,596 @@
+pub struct TheFlags {
+    interface0: exports::foo::foo::flegs::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheFlags {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::flegs::Host,
+        {
+            foo::foo::flegs::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::flegs::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/flegs")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/flegs` not present")
+                    })?,
+            )?;
+            Ok(TheFlags { interface0 })
+        }
+        pub fn foo_foo_flegs(&self) -> &exports::foo::foo::flegs::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod flegs {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            wasmtime::component::flags!(Flag1 { #[component(name = "b0")] const B0; });
+            const _: () = {
+                assert!(1 == < Flag1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag2 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; }
+            );
+            const _: () = {
+                assert!(1 == < Flag2 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag2 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag4 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; }
+            );
+            const _: () = {
+                assert!(1 == < Flag4 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag4 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag8 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; }
+            );
+            const _: () = {
+                assert!(1 == < Flag8 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag8 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag16 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; }
+            );
+            const _: () = {
+                assert!(2 == < Flag16 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(2 == < Flag16 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag32 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; #[component(name = "b16")] const
+                B16; #[component(name = "b17")] const B17; #[component(name = "b18")]
+                const B18; #[component(name = "b19")] const B19; #[component(name =
+                "b20")] const B20; #[component(name = "b21")] const B21; #[component(name
+                = "b22")] const B22; #[component(name = "b23")] const B23;
+                #[component(name = "b24")] const B24; #[component(name = "b25")] const
+                B25; #[component(name = "b26")] const B26; #[component(name = "b27")]
+                const B27; #[component(name = "b28")] const B28; #[component(name =
+                "b29")] const B29; #[component(name = "b30")] const B30; #[component(name
+                = "b31")] const B31; }
+            );
+            const _: () = {
+                assert!(4 == < Flag32 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Flag32 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag64 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; #[component(name = "b16")] const
+                B16; #[component(name = "b17")] const B17; #[component(name = "b18")]
+                const B18; #[component(name = "b19")] const B19; #[component(name =
+                "b20")] const B20; #[component(name = "b21")] const B21; #[component(name
+                = "b22")] const B22; #[component(name = "b23")] const B23;
+                #[component(name = "b24")] const B24; #[component(name = "b25")] const
+                B25; #[component(name = "b26")] const B26; #[component(name = "b27")]
+                const B27; #[component(name = "b28")] const B28; #[component(name =
+                "b29")] const B29; #[component(name = "b30")] const B30; #[component(name
+                = "b31")] const B31; #[component(name = "b32")] const B32;
+                #[component(name = "b33")] const B33; #[component(name = "b34")] const
+                B34; #[component(name = "b35")] const B35; #[component(name = "b36")]
+                const B36; #[component(name = "b37")] const B37; #[component(name =
+                "b38")] const B38; #[component(name = "b39")] const B39; #[component(name
+                = "b40")] const B40; #[component(name = "b41")] const B41;
+                #[component(name = "b42")] const B42; #[component(name = "b43")] const
+                B43; #[component(name = "b44")] const B44; #[component(name = "b45")]
+                const B45; #[component(name = "b46")] const B46; #[component(name =
+                "b47")] const B47; #[component(name = "b48")] const B48; #[component(name
+                = "b49")] const B49; #[component(name = "b50")] const B50;
+                #[component(name = "b51")] const B51; #[component(name = "b52")] const
+                B52; #[component(name = "b53")] const B53; #[component(name = "b54")]
+                const B54; #[component(name = "b55")] const B55; #[component(name =
+                "b56")] const B56; #[component(name = "b57")] const B57; #[component(name
+                = "b58")] const B58; #[component(name = "b59")] const B59;
+                #[component(name = "b60")] const B60; #[component(name = "b61")] const
+                B61; #[component(name = "b62")] const B62; #[component(name = "b63")]
+                const B63; }
+            );
+            const _: () = {
+                assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1;
+                fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2;
+                fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4;
+                fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8;
+                fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16;
+                fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32;
+                fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/flegs")?;
+                inst.func_wrap(
+                    "roundtrip-flag1",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag1,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag1(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "roundtrip-flag2",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag2,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag2(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "roundtrip-flag4",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag4,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag4(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "roundtrip-flag8",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag8,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag8(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "roundtrip-flag16",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag16,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag16(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "roundtrip-flag32",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag32,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag32(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "roundtrip-flag64",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag64,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag64(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod flegs {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                wasmtime::component::flags!(
+                    Flag1 { #[component(name = "b0")] const B0; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag1 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag1 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag2 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag2 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag2 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag4 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; #[component(name = "b2")] const B2; #[component(name =
+                    "b3")] const B3; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag4 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag4 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag8 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; #[component(name = "b2")] const B2; #[component(name =
+                    "b3")] const B3; #[component(name = "b4")] const B4; #[component(name
+                    = "b5")] const B5; #[component(name = "b6")] const B6;
+                    #[component(name = "b7")] const B7; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag8 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag8 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag16 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; }
+                );
+                const _: () = {
+                    assert!(
+                        2 == < Flag16 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        2 == < Flag16 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag32 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; #[component(name = "b16")] const B16;
+                    #[component(name = "b17")] const B17; #[component(name = "b18")]
+                    const B18; #[component(name = "b19")] const B19; #[component(name =
+                    "b20")] const B20; #[component(name = "b21")] const B21;
+                    #[component(name = "b22")] const B22; #[component(name = "b23")]
+                    const B23; #[component(name = "b24")] const B24; #[component(name =
+                    "b25")] const B25; #[component(name = "b26")] const B26;
+                    #[component(name = "b27")] const B27; #[component(name = "b28")]
+                    const B28; #[component(name = "b29")] const B29; #[component(name =
+                    "b30")] const B30; #[component(name = "b31")] const B31; }
+                );
+                const _: () = {
+                    assert!(
+                        4 == < Flag32 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Flag32 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag64 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; #[component(name = "b16")] const B16;
+                    #[component(name = "b17")] const B17; #[component(name = "b18")]
+                    const B18; #[component(name = "b19")] const B19; #[component(name =
+                    "b20")] const B20; #[component(name = "b21")] const B21;
+                    #[component(name = "b22")] const B22; #[component(name = "b23")]
+                    const B23; #[component(name = "b24")] const B24; #[component(name =
+                    "b25")] const B25; #[component(name = "b26")] const B26;
+                    #[component(name = "b27")] const B27; #[component(name = "b28")]
+                    const B28; #[component(name = "b29")] const B29; #[component(name =
+                    "b30")] const B30; #[component(name = "b31")] const B31;
+                    #[component(name = "b32")] const B32; #[component(name = "b33")]
+                    const B33; #[component(name = "b34")] const B34; #[component(name =
+                    "b35")] const B35; #[component(name = "b36")] const B36;
+                    #[component(name = "b37")] const B37; #[component(name = "b38")]
+                    const B38; #[component(name = "b39")] const B39; #[component(name =
+                    "b40")] const B40; #[component(name = "b41")] const B41;
+                    #[component(name = "b42")] const B42; #[component(name = "b43")]
+                    const B43; #[component(name = "b44")] const B44; #[component(name =
+                    "b45")] const B45; #[component(name = "b46")] const B46;
+                    #[component(name = "b47")] const B47; #[component(name = "b48")]
+                    const B48; #[component(name = "b49")] const B49; #[component(name =
+                    "b50")] const B50; #[component(name = "b51")] const B51;
+                    #[component(name = "b52")] const B52; #[component(name = "b53")]
+                    const B53; #[component(name = "b54")] const B54; #[component(name =
+                    "b55")] const B55; #[component(name = "b56")] const B56;
+                    #[component(name = "b57")] const B57; #[component(name = "b58")]
+                    const B58; #[component(name = "b59")] const B59; #[component(name =
+                    "b60")] const B60; #[component(name = "b61")] const B61;
+                    #[component(name = "b62")] const B62; #[component(name = "b63")]
+                    const B63; }
+                );
+                const _: () = {
+                    assert!(
+                        8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    roundtrip_flag1: wasmtime::component::Func,
+                    roundtrip_flag2: wasmtime::component::Func,
+                    roundtrip_flag4: wasmtime::component::Func,
+                    roundtrip_flag8: wasmtime::component::Func,
+                    roundtrip_flag16: wasmtime::component::Func,
+                    roundtrip_flag32: wasmtime::component::Func,
+                    roundtrip_flag64: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let roundtrip_flag1 = *__exports
+                            .typed_func::<(Flag1,), (Flag1,)>("roundtrip-flag1")?
+                            .func();
+                        let roundtrip_flag2 = *__exports
+                            .typed_func::<(Flag2,), (Flag2,)>("roundtrip-flag2")?
+                            .func();
+                        let roundtrip_flag4 = *__exports
+                            .typed_func::<(Flag4,), (Flag4,)>("roundtrip-flag4")?
+                            .func();
+                        let roundtrip_flag8 = *__exports
+                            .typed_func::<(Flag8,), (Flag8,)>("roundtrip-flag8")?
+                            .func();
+                        let roundtrip_flag16 = *__exports
+                            .typed_func::<(Flag16,), (Flag16,)>("roundtrip-flag16")?
+                            .func();
+                        let roundtrip_flag32 = *__exports
+                            .typed_func::<(Flag32,), (Flag32,)>("roundtrip-flag32")?
+                            .func();
+                        let roundtrip_flag64 = *__exports
+                            .typed_func::<(Flag64,), (Flag64,)>("roundtrip-flag64")?
+                            .func();
+                        Ok(Guest {
+                            roundtrip_flag1,
+                            roundtrip_flag2,
+                            roundtrip_flag4,
+                            roundtrip_flag8,
+                            roundtrip_flag16,
+                            roundtrip_flag32,
+                            roundtrip_flag64,
+                        })
+                    }
+                    pub fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag1,
+                    ) -> wasmtime::Result<Flag1> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag1,),
+                                (Flag1,),
+                            >::new_unchecked(self.roundtrip_flag1)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag2,
+                    ) -> wasmtime::Result<Flag2> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag2,),
+                                (Flag2,),
+                            >::new_unchecked(self.roundtrip_flag2)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag4,
+                    ) -> wasmtime::Result<Flag4> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag4,),
+                                (Flag4,),
+                            >::new_unchecked(self.roundtrip_flag4)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag8,
+                    ) -> wasmtime::Result<Flag8> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag8,),
+                                (Flag8,),
+                            >::new_unchecked(self.roundtrip_flag8)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag16,
+                    ) -> wasmtime::Result<Flag16> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag16,),
+                                (Flag16,),
+                            >::new_unchecked(self.roundtrip_flag16)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag32,
+                    ) -> wasmtime::Result<Flag32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag32,),
+                                (Flag32,),
+                            >::new_unchecked(self.roundtrip_flag32)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag64,
+                    ) -> wasmtime::Result<Flag64> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag64,),
+                                (Flag64,),
+                            >::new_unchecked(self.roundtrip_flag64)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -1,0 +1,634 @@
+pub struct TheFlags {
+    interface0: exports::foo::foo::flegs::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheFlags {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::flegs::Host + Send,
+            T: Send,
+        {
+            foo::foo::flegs::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::flegs::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/flegs")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/flegs` not present")
+                    })?,
+            )?;
+            Ok(TheFlags { interface0 })
+        }
+        pub fn foo_foo_flegs(&self) -> &exports::foo::foo::flegs::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod flegs {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            wasmtime::component::flags!(Flag1 { #[component(name = "b0")] const B0; });
+            const _: () = {
+                assert!(1 == < Flag1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag2 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; }
+            );
+            const _: () = {
+                assert!(1 == < Flag2 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag2 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag4 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; }
+            );
+            const _: () = {
+                assert!(1 == < Flag4 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag4 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag8 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; }
+            );
+            const _: () = {
+                assert!(1 == < Flag8 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag8 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag16 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; }
+            );
+            const _: () = {
+                assert!(2 == < Flag16 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(2 == < Flag16 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag32 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; #[component(name = "b16")] const
+                B16; #[component(name = "b17")] const B17; #[component(name = "b18")]
+                const B18; #[component(name = "b19")] const B19; #[component(name =
+                "b20")] const B20; #[component(name = "b21")] const B21; #[component(name
+                = "b22")] const B22; #[component(name = "b23")] const B23;
+                #[component(name = "b24")] const B24; #[component(name = "b25")] const
+                B25; #[component(name = "b26")] const B26; #[component(name = "b27")]
+                const B27; #[component(name = "b28")] const B28; #[component(name =
+                "b29")] const B29; #[component(name = "b30")] const B30; #[component(name
+                = "b31")] const B31; }
+            );
+            const _: () = {
+                assert!(4 == < Flag32 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Flag32 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag64 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; #[component(name = "b16")] const
+                B16; #[component(name = "b17")] const B17; #[component(name = "b18")]
+                const B18; #[component(name = "b19")] const B19; #[component(name =
+                "b20")] const B20; #[component(name = "b21")] const B21; #[component(name
+                = "b22")] const B22; #[component(name = "b23")] const B23;
+                #[component(name = "b24")] const B24; #[component(name = "b25")] const
+                B25; #[component(name = "b26")] const B26; #[component(name = "b27")]
+                const B27; #[component(name = "b28")] const B28; #[component(name =
+                "b29")] const B29; #[component(name = "b30")] const B30; #[component(name
+                = "b31")] const B31; #[component(name = "b32")] const B32;
+                #[component(name = "b33")] const B33; #[component(name = "b34")] const
+                B34; #[component(name = "b35")] const B35; #[component(name = "b36")]
+                const B36; #[component(name = "b37")] const B37; #[component(name =
+                "b38")] const B38; #[component(name = "b39")] const B39; #[component(name
+                = "b40")] const B40; #[component(name = "b41")] const B41;
+                #[component(name = "b42")] const B42; #[component(name = "b43")] const
+                B43; #[component(name = "b44")] const B44; #[component(name = "b45")]
+                const B45; #[component(name = "b46")] const B46; #[component(name =
+                "b47")] const B47; #[component(name = "b48")] const B48; #[component(name
+                = "b49")] const B49; #[component(name = "b50")] const B50;
+                #[component(name = "b51")] const B51; #[component(name = "b52")] const
+                B52; #[component(name = "b53")] const B53; #[component(name = "b54")]
+                const B54; #[component(name = "b55")] const B55; #[component(name =
+                "b56")] const B56; #[component(name = "b57")] const B57; #[component(name
+                = "b58")] const B58; #[component(name = "b59")] const B59;
+                #[component(name = "b60")] const B60; #[component(name = "b61")] const
+                B61; #[component(name = "b62")] const B62; #[component(name = "b63")]
+                const B63; }
+            );
+            const _: () = {
+                assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1;
+                async fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2;
+                async fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4;
+                async fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8;
+                async fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16;
+                async fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32;
+                async fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/flegs")?;
+                inst.func_wrap_async(
+                    "roundtrip-flag1",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag1,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag1(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "roundtrip-flag2",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag2,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag2(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "roundtrip-flag4",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag4,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag4(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "roundtrip-flag8",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag8,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag8(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "roundtrip-flag16",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag16,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag16(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "roundtrip-flag32",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag32,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag32(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "roundtrip-flag64",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag64,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::roundtrip_flag64(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod flegs {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                wasmtime::component::flags!(
+                    Flag1 { #[component(name = "b0")] const B0; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag1 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag1 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag2 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag2 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag2 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag4 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; #[component(name = "b2")] const B2; #[component(name =
+                    "b3")] const B3; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag4 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag4 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag8 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; #[component(name = "b2")] const B2; #[component(name =
+                    "b3")] const B3; #[component(name = "b4")] const B4; #[component(name
+                    = "b5")] const B5; #[component(name = "b6")] const B6;
+                    #[component(name = "b7")] const B7; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag8 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag8 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag16 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; }
+                );
+                const _: () = {
+                    assert!(
+                        2 == < Flag16 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        2 == < Flag16 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag32 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; #[component(name = "b16")] const B16;
+                    #[component(name = "b17")] const B17; #[component(name = "b18")]
+                    const B18; #[component(name = "b19")] const B19; #[component(name =
+                    "b20")] const B20; #[component(name = "b21")] const B21;
+                    #[component(name = "b22")] const B22; #[component(name = "b23")]
+                    const B23; #[component(name = "b24")] const B24; #[component(name =
+                    "b25")] const B25; #[component(name = "b26")] const B26;
+                    #[component(name = "b27")] const B27; #[component(name = "b28")]
+                    const B28; #[component(name = "b29")] const B29; #[component(name =
+                    "b30")] const B30; #[component(name = "b31")] const B31; }
+                );
+                const _: () = {
+                    assert!(
+                        4 == < Flag32 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Flag32 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag64 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; #[component(name = "b16")] const B16;
+                    #[component(name = "b17")] const B17; #[component(name = "b18")]
+                    const B18; #[component(name = "b19")] const B19; #[component(name =
+                    "b20")] const B20; #[component(name = "b21")] const B21;
+                    #[component(name = "b22")] const B22; #[component(name = "b23")]
+                    const B23; #[component(name = "b24")] const B24; #[component(name =
+                    "b25")] const B25; #[component(name = "b26")] const B26;
+                    #[component(name = "b27")] const B27; #[component(name = "b28")]
+                    const B28; #[component(name = "b29")] const B29; #[component(name =
+                    "b30")] const B30; #[component(name = "b31")] const B31;
+                    #[component(name = "b32")] const B32; #[component(name = "b33")]
+                    const B33; #[component(name = "b34")] const B34; #[component(name =
+                    "b35")] const B35; #[component(name = "b36")] const B36;
+                    #[component(name = "b37")] const B37; #[component(name = "b38")]
+                    const B38; #[component(name = "b39")] const B39; #[component(name =
+                    "b40")] const B40; #[component(name = "b41")] const B41;
+                    #[component(name = "b42")] const B42; #[component(name = "b43")]
+                    const B43; #[component(name = "b44")] const B44; #[component(name =
+                    "b45")] const B45; #[component(name = "b46")] const B46;
+                    #[component(name = "b47")] const B47; #[component(name = "b48")]
+                    const B48; #[component(name = "b49")] const B49; #[component(name =
+                    "b50")] const B50; #[component(name = "b51")] const B51;
+                    #[component(name = "b52")] const B52; #[component(name = "b53")]
+                    const B53; #[component(name = "b54")] const B54; #[component(name =
+                    "b55")] const B55; #[component(name = "b56")] const B56;
+                    #[component(name = "b57")] const B57; #[component(name = "b58")]
+                    const B58; #[component(name = "b59")] const B59; #[component(name =
+                    "b60")] const B60; #[component(name = "b61")] const B61;
+                    #[component(name = "b62")] const B62; #[component(name = "b63")]
+                    const B63; }
+                );
+                const _: () = {
+                    assert!(
+                        8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    roundtrip_flag1: wasmtime::component::Func,
+                    roundtrip_flag2: wasmtime::component::Func,
+                    roundtrip_flag4: wasmtime::component::Func,
+                    roundtrip_flag8: wasmtime::component::Func,
+                    roundtrip_flag16: wasmtime::component::Func,
+                    roundtrip_flag32: wasmtime::component::Func,
+                    roundtrip_flag64: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let roundtrip_flag1 = *__exports
+                            .typed_func::<(Flag1,), (Flag1,)>("roundtrip-flag1")?
+                            .func();
+                        let roundtrip_flag2 = *__exports
+                            .typed_func::<(Flag2,), (Flag2,)>("roundtrip-flag2")?
+                            .func();
+                        let roundtrip_flag4 = *__exports
+                            .typed_func::<(Flag4,), (Flag4,)>("roundtrip-flag4")?
+                            .func();
+                        let roundtrip_flag8 = *__exports
+                            .typed_func::<(Flag8,), (Flag8,)>("roundtrip-flag8")?
+                            .func();
+                        let roundtrip_flag16 = *__exports
+                            .typed_func::<(Flag16,), (Flag16,)>("roundtrip-flag16")?
+                            .func();
+                        let roundtrip_flag32 = *__exports
+                            .typed_func::<(Flag32,), (Flag32,)>("roundtrip-flag32")?
+                            .func();
+                        let roundtrip_flag64 = *__exports
+                            .typed_func::<(Flag64,), (Flag64,)>("roundtrip-flag64")?
+                            .func();
+                        Ok(Guest {
+                            roundtrip_flag1,
+                            roundtrip_flag2,
+                            roundtrip_flag4,
+                            roundtrip_flag8,
+                            roundtrip_flag16,
+                            roundtrip_flag32,
+                            roundtrip_flag64,
+                        })
+                    }
+                    pub async fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag1,
+                    ) -> wasmtime::Result<Flag1>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag1,),
+                                (Flag1,),
+                            >::new_unchecked(self.roundtrip_flag1)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag2,
+                    ) -> wasmtime::Result<Flag2>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag2,),
+                                (Flag2,),
+                            >::new_unchecked(self.roundtrip_flag2)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag4,
+                    ) -> wasmtime::Result<Flag4>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag4,),
+                                (Flag4,),
+                            >::new_unchecked(self.roundtrip_flag4)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag8,
+                    ) -> wasmtime::Result<Flag8>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag8,),
+                                (Flag8,),
+                            >::new_unchecked(self.roundtrip_flag8)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag16,
+                    ) -> wasmtime::Result<Flag16>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag16,),
+                                (Flag16,),
+                            >::new_unchecked(self.roundtrip_flag16)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag32,
+                    ) -> wasmtime::Result<Flag32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag32,),
+                                (Flag32,),
+                            >::new_unchecked(self.roundtrip_flag32)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag64,
+                    ) -> wasmtime::Result<Flag64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag64,),
+                                (Flag64,),
+                            >::new_unchecked(self.roundtrip_flag64)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -1,0 +1,223 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::floats::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::floats::Host,
+        {
+            foo::foo::floats::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::floats::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/floats")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/floats` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_floats(&self) -> &exports::foo::foo::floats::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod floats {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn float32_param(&mut self, x: f32) -> ();
+                fn float64_param(&mut self, x: f64) -> ();
+                fn float32_result(&mut self) -> f32;
+                fn float64_result(&mut self) -> f64;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/floats")?;
+                inst.func_wrap(
+                    "float32-param",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f32,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::float32_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "float64-param",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f64,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::float64_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "float32-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::float32_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "float64-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::float64_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod floats {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    float32_param: wasmtime::component::Func,
+                    float64_param: wasmtime::component::Func,
+                    float32_result: wasmtime::component::Func,
+                    float64_result: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let float32_param = *__exports
+                            .typed_func::<(f32,), ()>("float32-param")?
+                            .func();
+                        let float64_param = *__exports
+                            .typed_func::<(f64,), ()>("float64-param")?
+                            .func();
+                        let float32_result = *__exports
+                            .typed_func::<(), (f32,)>("float32-result")?
+                            .func();
+                        let float64_result = *__exports
+                            .typed_func::<(), (f64,)>("float64-result")?
+                            .func();
+                        Ok(Guest {
+                            float32_param,
+                            float64_param,
+                            float32_result,
+                            float64_result,
+                        })
+                    }
+                    pub fn call_float32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: f32,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f32,),
+                                (),
+                            >::new_unchecked(self.float32_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_float64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: f64,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f64,),
+                                (),
+                            >::new_unchecked(self.float64_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_float32_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<f32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f32,),
+                            >::new_unchecked(self.float32_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_float64_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<f64> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f64,),
+                            >::new_unchecked(self.float64_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -1,0 +1,246 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::floats::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::floats::Host + Send,
+            T: Send,
+        {
+            foo::foo::floats::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::floats::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/floats")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/floats` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_floats(&self) -> &exports::foo::foo::floats::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod floats {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn float32_param(&mut self, x: f32) -> ();
+                async fn float64_param(&mut self, x: f64) -> ();
+                async fn float32_result(&mut self) -> f32;
+                async fn float64_result(&mut self) -> f64;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/floats")?;
+                inst.func_wrap_async(
+                    "float32-param",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f32,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::float32_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "float64-param",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f64,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::float64_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "float32-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::float32_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "float64-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::float64_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod floats {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    float32_param: wasmtime::component::Func,
+                    float64_param: wasmtime::component::Func,
+                    float32_result: wasmtime::component::Func,
+                    float64_result: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let float32_param = *__exports
+                            .typed_func::<(f32,), ()>("float32-param")?
+                            .func();
+                        let float64_param = *__exports
+                            .typed_func::<(f64,), ()>("float64-param")?
+                            .func();
+                        let float32_result = *__exports
+                            .typed_func::<(), (f32,)>("float32-result")?
+                            .func();
+                        let float64_result = *__exports
+                            .typed_func::<(), (f64,)>("float64-result")?
+                            .func();
+                        Ok(Guest {
+                            float32_param,
+                            float64_param,
+                            float32_result,
+                            float64_result,
+                        })
+                    }
+                    pub async fn call_float32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: f32,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f32,),
+                                (),
+                            >::new_unchecked(self.float32_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_float64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: f64,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f64,),
+                                (),
+                            >::new_unchecked(self.float64_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_float32_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<f32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f32,),
+                            >::new_unchecked(self.float32_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_float64_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<f64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f64,),
+                            >::new_unchecked(self.float64_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -1,0 +1,59 @@
+pub struct Foo {
+    new: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let new = *__exports.typed_func::<(), ()>("new")?.func();
+            Ok(Foo { new })
+        }
+        pub fn call_new<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<()> {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
+            };
+            let () = callee.call(store.as_context_mut(), ())?;
+            callee.post_return(store.as_context_mut())?;
+            Ok(())
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/function-new_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_async.rs
@@ -1,0 +1,62 @@
+pub struct Foo {
+    new: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let new = *__exports.typed_func::<(), ()>("new")?.func();
+            Ok(Foo { new })
+        }
+        pub async fn call_new<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<()>
+        where
+            <S as wasmtime::AsContext>::Data: Send,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
+            };
+            let () = callee.call_async(store.as_context_mut(), ()).await?;
+            callee.post_return_async(store.as_context_mut()).await?;
+            Ok(())
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -1,0 +1,638 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::integers::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::integers::Host,
+        {
+            foo::foo::integers::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::integers::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/integers")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/integers` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_integers(&self) -> &exports::foo::foo::integers::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod integers {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn a1(&mut self, x: u8) -> ();
+                fn a2(&mut self, x: i8) -> ();
+                fn a3(&mut self, x: u16) -> ();
+                fn a4(&mut self, x: i16) -> ();
+                fn a5(&mut self, x: u32) -> ();
+                fn a6(&mut self, x: i32) -> ();
+                fn a7(&mut self, x: u64) -> ();
+                fn a8(&mut self, x: i64) -> ();
+                fn a9(
+                    &mut self,
+                    p1: u8,
+                    p2: i8,
+                    p3: u16,
+                    p4: i16,
+                    p5: u32,
+                    p6: i32,
+                    p7: u64,
+                    p8: i64,
+                ) -> ();
+                fn r1(&mut self) -> u8;
+                fn r2(&mut self) -> i8;
+                fn r3(&mut self) -> u16;
+                fn r4(&mut self) -> i16;
+                fn r5(&mut self) -> u32;
+                fn r6(&mut self) -> i32;
+                fn r7(&mut self) -> u64;
+                fn r8(&mut self) -> i64;
+                fn pair_ret(&mut self) -> (i64, u8);
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/integers")?;
+                inst.func_wrap(
+                    "a1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u8,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a1(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i8,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a2(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u16,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a3(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i16,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a4(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u32,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a5(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a6",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i32,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a6(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a7",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u64,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a7(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a8",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i64,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a8(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "a9",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                        ): (u8, i8, u16, i16, u32, i32, u64, i64)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::a9(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                        );
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "r1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r1(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "r2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r2(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "r3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r3(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "r4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r4(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "r5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r5(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "r6",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r6(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "r7",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r7(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "r8",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::r8(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "pair-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::pair_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod integers {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    a1: wasmtime::component::Func,
+                    a2: wasmtime::component::Func,
+                    a3: wasmtime::component::Func,
+                    a4: wasmtime::component::Func,
+                    a5: wasmtime::component::Func,
+                    a6: wasmtime::component::Func,
+                    a7: wasmtime::component::Func,
+                    a8: wasmtime::component::Func,
+                    a9: wasmtime::component::Func,
+                    r1: wasmtime::component::Func,
+                    r2: wasmtime::component::Func,
+                    r3: wasmtime::component::Func,
+                    r4: wasmtime::component::Func,
+                    r5: wasmtime::component::Func,
+                    r6: wasmtime::component::Func,
+                    r7: wasmtime::component::Func,
+                    r8: wasmtime::component::Func,
+                    pair_ret: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let a1 = *__exports.typed_func::<(u8,), ()>("a1")?.func();
+                        let a2 = *__exports.typed_func::<(i8,), ()>("a2")?.func();
+                        let a3 = *__exports.typed_func::<(u16,), ()>("a3")?.func();
+                        let a4 = *__exports.typed_func::<(i16,), ()>("a4")?.func();
+                        let a5 = *__exports.typed_func::<(u32,), ()>("a5")?.func();
+                        let a6 = *__exports.typed_func::<(i32,), ()>("a6")?.func();
+                        let a7 = *__exports.typed_func::<(u64,), ()>("a7")?.func();
+                        let a8 = *__exports.typed_func::<(i64,), ()>("a8")?.func();
+                        let a9 = *__exports
+                            .typed_func::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >("a9")?
+                            .func();
+                        let r1 = *__exports.typed_func::<(), (u8,)>("r1")?.func();
+                        let r2 = *__exports.typed_func::<(), (i8,)>("r2")?.func();
+                        let r3 = *__exports.typed_func::<(), (u16,)>("r3")?.func();
+                        let r4 = *__exports.typed_func::<(), (i16,)>("r4")?.func();
+                        let r5 = *__exports.typed_func::<(), (u32,)>("r5")?.func();
+                        let r6 = *__exports.typed_func::<(), (i32,)>("r6")?.func();
+                        let r7 = *__exports.typed_func::<(), (u64,)>("r7")?.func();
+                        let r8 = *__exports.typed_func::<(), (i64,)>("r8")?.func();
+                        let pair_ret = *__exports
+                            .typed_func::<(), ((i64, u8),)>("pair-ret")?
+                            .func();
+                        Ok(Guest {
+                            a1,
+                            a2,
+                            a3,
+                            a4,
+                            a5,
+                            a6,
+                            a7,
+                            a8,
+                            a9,
+                            r1,
+                            r2,
+                            r3,
+                            r4,
+                            r5,
+                            r6,
+                            r7,
+                            r8,
+                            pair_ret,
+                        })
+                    }
+                    pub fn call_a1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u8,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8,),
+                                (),
+                            >::new_unchecked(self.a1)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i8,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i8,),
+                                (),
+                            >::new_unchecked(self.a2)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u16,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u16,),
+                                (),
+                            >::new_unchecked(self.a3)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i16,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i16,),
+                                (),
+                            >::new_unchecked(self.a4)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.a5)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i32,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i32,),
+                                (),
+                            >::new_unchecked(self.a6)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a7<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u64,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u64,),
+                                (),
+                            >::new_unchecked(self.a7)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i64,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i64,),
+                                (),
+                            >::new_unchecked(self.a8)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_a9<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u8,
+                        arg1: i8,
+                        arg2: u16,
+                        arg3: i16,
+                        arg4: u32,
+                        arg5: i32,
+                        arg6: u64,
+                        arg7: i64,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >::new_unchecked(self.a9)
+                        };
+                        let () = callee
+                            .call(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+                            )?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_r1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u8> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u8,),
+                            >::new_unchecked(self.r1)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_r2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i8> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i8,),
+                            >::new_unchecked(self.r2)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_r3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u16> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u16,),
+                            >::new_unchecked(self.r3)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_r4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i16> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i16,),
+                            >::new_unchecked(self.r4)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_r5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.r5)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_r6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i32,),
+                            >::new_unchecked(self.r6)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_r7<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u64> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u64,),
+                            >::new_unchecked(self.r7)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_r8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i64> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i64,),
+                            >::new_unchecked(self.r8)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_pair_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(i64, u8)> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((i64, u8),),
+                            >::new_unchecked(self.pair_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -1,0 +1,731 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::integers::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::integers::Host + Send,
+            T: Send,
+        {
+            foo::foo::integers::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::integers::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/integers")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/integers` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_integers(&self) -> &exports::foo::foo::integers::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod integers {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn a1(&mut self, x: u8) -> ();
+                async fn a2(&mut self, x: i8) -> ();
+                async fn a3(&mut self, x: u16) -> ();
+                async fn a4(&mut self, x: i16) -> ();
+                async fn a5(&mut self, x: u32) -> ();
+                async fn a6(&mut self, x: i32) -> ();
+                async fn a7(&mut self, x: u64) -> ();
+                async fn a8(&mut self, x: i64) -> ();
+                async fn a9(
+                    &mut self,
+                    p1: u8,
+                    p2: i8,
+                    p3: u16,
+                    p4: i16,
+                    p5: u32,
+                    p6: i32,
+                    p7: u64,
+                    p8: i64,
+                ) -> ();
+                async fn r1(&mut self) -> u8;
+                async fn r2(&mut self) -> i8;
+                async fn r3(&mut self) -> u16;
+                async fn r4(&mut self) -> i16;
+                async fn r5(&mut self) -> u32;
+                async fn r6(&mut self) -> i32;
+                async fn r7(&mut self) -> u64;
+                async fn r8(&mut self) -> i64;
+                async fn pair_ret(&mut self) -> (i64, u8);
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/integers")?;
+                inst.func_wrap_async(
+                    "a1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u8,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a1(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i8,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a2(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u16,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a3(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i16,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a4(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u32,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a5(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a6",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i32,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a6(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a7",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u64,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a7(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a8",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i64,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a8(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "a9",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                        ): (u8, i8, u16, i16, u32, i32, u64, i64)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a9(
+                                host,
+                                arg0,
+                                arg1,
+                                arg2,
+                                arg3,
+                                arg4,
+                                arg5,
+                                arg6,
+                                arg7,
+                            )
+                            .await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r1(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r2(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r3(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r4(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r5(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r6",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r6(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r7",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r7(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "r8",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::r8(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "pair-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::pair_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod integers {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    a1: wasmtime::component::Func,
+                    a2: wasmtime::component::Func,
+                    a3: wasmtime::component::Func,
+                    a4: wasmtime::component::Func,
+                    a5: wasmtime::component::Func,
+                    a6: wasmtime::component::Func,
+                    a7: wasmtime::component::Func,
+                    a8: wasmtime::component::Func,
+                    a9: wasmtime::component::Func,
+                    r1: wasmtime::component::Func,
+                    r2: wasmtime::component::Func,
+                    r3: wasmtime::component::Func,
+                    r4: wasmtime::component::Func,
+                    r5: wasmtime::component::Func,
+                    r6: wasmtime::component::Func,
+                    r7: wasmtime::component::Func,
+                    r8: wasmtime::component::Func,
+                    pair_ret: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let a1 = *__exports.typed_func::<(u8,), ()>("a1")?.func();
+                        let a2 = *__exports.typed_func::<(i8,), ()>("a2")?.func();
+                        let a3 = *__exports.typed_func::<(u16,), ()>("a3")?.func();
+                        let a4 = *__exports.typed_func::<(i16,), ()>("a4")?.func();
+                        let a5 = *__exports.typed_func::<(u32,), ()>("a5")?.func();
+                        let a6 = *__exports.typed_func::<(i32,), ()>("a6")?.func();
+                        let a7 = *__exports.typed_func::<(u64,), ()>("a7")?.func();
+                        let a8 = *__exports.typed_func::<(i64,), ()>("a8")?.func();
+                        let a9 = *__exports
+                            .typed_func::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >("a9")?
+                            .func();
+                        let r1 = *__exports.typed_func::<(), (u8,)>("r1")?.func();
+                        let r2 = *__exports.typed_func::<(), (i8,)>("r2")?.func();
+                        let r3 = *__exports.typed_func::<(), (u16,)>("r3")?.func();
+                        let r4 = *__exports.typed_func::<(), (i16,)>("r4")?.func();
+                        let r5 = *__exports.typed_func::<(), (u32,)>("r5")?.func();
+                        let r6 = *__exports.typed_func::<(), (i32,)>("r6")?.func();
+                        let r7 = *__exports.typed_func::<(), (u64,)>("r7")?.func();
+                        let r8 = *__exports.typed_func::<(), (i64,)>("r8")?.func();
+                        let pair_ret = *__exports
+                            .typed_func::<(), ((i64, u8),)>("pair-ret")?
+                            .func();
+                        Ok(Guest {
+                            a1,
+                            a2,
+                            a3,
+                            a4,
+                            a5,
+                            a6,
+                            a7,
+                            a8,
+                            a9,
+                            r1,
+                            r2,
+                            r3,
+                            r4,
+                            r5,
+                            r6,
+                            r7,
+                            r8,
+                            pair_ret,
+                        })
+                    }
+                    pub async fn call_a1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u8,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8,),
+                                (),
+                            >::new_unchecked(self.a1)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i8,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i8,),
+                                (),
+                            >::new_unchecked(self.a2)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u16,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u16,),
+                                (),
+                            >::new_unchecked(self.a3)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i16,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i16,),
+                                (),
+                            >::new_unchecked(self.a4)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.a5)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i32,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i32,),
+                                (),
+                            >::new_unchecked(self.a6)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a7<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u64,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u64,),
+                                (),
+                            >::new_unchecked(self.a7)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i64,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i64,),
+                                (),
+                            >::new_unchecked(self.a8)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_a9<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u8,
+                        arg1: i8,
+                        arg2: u16,
+                        arg3: i16,
+                        arg4: u32,
+                        arg5: i32,
+                        arg6: u64,
+                        arg7: i64,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >::new_unchecked(self.a9)
+                        };
+                        let () = callee
+                            .call_async(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+                            )
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_r1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u8>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u8,),
+                            >::new_unchecked(self.r1)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_r2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i8>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i8,),
+                            >::new_unchecked(self.r2)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_r3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u16>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u16,),
+                            >::new_unchecked(self.r3)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_r4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i16>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i16,),
+                            >::new_unchecked(self.r4)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_r5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.r5)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_r6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i32,),
+                            >::new_unchecked(self.r6)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_r7<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u64,),
+                            >::new_unchecked(self.r7)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_r8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<i64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i64,),
+                            >::new_unchecked(self.r8)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_pair_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(i64, u8)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((i64, u8),),
+                            >::new_unchecked(self.pair_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -1,0 +1,1564 @@
+pub struct TheLists {
+    interface0: exports::foo::foo::lists::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheLists {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::lists::Host,
+        {
+            foo::foo::lists::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::lists::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/lists")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/lists` not present")
+                    })?,
+            )?;
+            Ok(TheLists { interface0 })
+        }
+        pub fn foo_foo_lists(&self) -> &exports::foo::foo::lists::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod lists {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct OtherRecord {
+                #[component(name = "a1")]
+                pub a1: u32,
+                #[component(name = "a2")]
+                pub a2: u64,
+                #[component(name = "a3")]
+                pub a3: i32,
+                #[component(name = "a4")]
+                pub a4: i64,
+                #[component(name = "b")]
+                pub b: wasmtime::component::__internal::String,
+                #[component(name = "c")]
+                pub c: wasmtime::component::__internal::Vec<u8>,
+            }
+            impl core::fmt::Debug for OtherRecord {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("OtherRecord")
+                        .field("a1", &self.a1)
+                        .field("a2", &self.a2)
+                        .field("a3", &self.a3)
+                        .field("a4", &self.a4)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    48 == < OtherRecord as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    8 == < OtherRecord as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct SomeRecord {
+                #[component(name = "x")]
+                pub x: wasmtime::component::__internal::String,
+                #[component(name = "y")]
+                pub y: OtherRecord,
+                #[component(name = "z")]
+                pub z: wasmtime::component::__internal::Vec<OtherRecord>,
+                #[component(name = "c1")]
+                pub c1: u32,
+                #[component(name = "c2")]
+                pub c2: u64,
+                #[component(name = "c3")]
+                pub c3: i32,
+                #[component(name = "c4")]
+                pub c4: i64,
+            }
+            impl core::fmt::Debug for SomeRecord {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("SomeRecord")
+                        .field("x", &self.x)
+                        .field("y", &self.y)
+                        .field("z", &self.z)
+                        .field("c1", &self.c1)
+                        .field("c2", &self.c2)
+                        .field("c3", &self.c3)
+                        .field("c4", &self.c4)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    96 == < SomeRecord as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    8 == < SomeRecord as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum OtherVariant {
+                #[component(name = "a")]
+                A,
+                #[component(name = "b")]
+                B(u32),
+                #[component(name = "c")]
+                C(wasmtime::component::__internal::String),
+            }
+            impl core::fmt::Debug for OtherVariant {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        OtherVariant::A => f.debug_tuple("OtherVariant::A").finish(),
+                        OtherVariant::B(e) => {
+                            f.debug_tuple("OtherVariant::B").field(e).finish()
+                        }
+                        OtherVariant::C(e) => {
+                            f.debug_tuple("OtherVariant::C").field(e).finish()
+                        }
+                    }
+                }
+            }
+            const _: () = {
+                assert!(
+                    12 == < OtherVariant as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < OtherVariant as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum SomeVariant {
+                #[component(name = "a")]
+                A(wasmtime::component::__internal::String),
+                #[component(name = "b")]
+                B,
+                #[component(name = "c")]
+                C(u32),
+                #[component(name = "d")]
+                D(wasmtime::component::__internal::Vec<OtherVariant>),
+            }
+            impl core::fmt::Debug for SomeVariant {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        SomeVariant::A(e) => {
+                            f.debug_tuple("SomeVariant::A").field(e).finish()
+                        }
+                        SomeVariant::B => f.debug_tuple("SomeVariant::B").finish(),
+                        SomeVariant::C(e) => {
+                            f.debug_tuple("SomeVariant::C").field(e).finish()
+                        }
+                        SomeVariant::D(e) => {
+                            f.debug_tuple("SomeVariant::D").field(e).finish()
+                        }
+                    }
+                }
+            }
+            const _: () = {
+                assert!(
+                    12 == < SomeVariant as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < SomeVariant as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type LoadStoreAllSizes = wasmtime::component::__internal::Vec<
+                (
+                    wasmtime::component::__internal::String,
+                    u8,
+                    i8,
+                    u16,
+                    i16,
+                    u32,
+                    i32,
+                    u64,
+                    i64,
+                    f32,
+                    f64,
+                    char,
+                ),
+            >;
+            const _: () = {
+                assert!(
+                    8 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                    >::SIZE32
+                );
+                assert!(
+                    4 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            pub trait Host {
+                fn list_u8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u8>,
+                ) -> ();
+                fn list_u16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u16>,
+                ) -> ();
+                fn list_u32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u32>,
+                ) -> ();
+                fn list_u64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u64>,
+                ) -> ();
+                fn list_s8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i8>,
+                ) -> ();
+                fn list_s16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i16>,
+                ) -> ();
+                fn list_s32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i32>,
+                ) -> ();
+                fn list_s64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i64>,
+                ) -> ();
+                fn list_float32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f32>,
+                ) -> ();
+                fn list_float64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f64>,
+                ) -> ();
+                fn list_u8_ret(&mut self) -> wasmtime::component::__internal::Vec<u8>;
+                fn list_u16_ret(&mut self) -> wasmtime::component::__internal::Vec<u16>;
+                fn list_u32_ret(&mut self) -> wasmtime::component::__internal::Vec<u32>;
+                fn list_u64_ret(&mut self) -> wasmtime::component::__internal::Vec<u64>;
+                fn list_s8_ret(&mut self) -> wasmtime::component::__internal::Vec<i8>;
+                fn list_s16_ret(&mut self) -> wasmtime::component::__internal::Vec<i16>;
+                fn list_s32_ret(&mut self) -> wasmtime::component::__internal::Vec<i32>;
+                fn list_s64_ret(&mut self) -> wasmtime::component::__internal::Vec<i64>;
+                fn list_float32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f32>;
+                fn list_float64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f64>;
+                fn tuple_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
+                ) -> wasmtime::component::__internal::Vec<(i64, u32)>;
+                fn string_list_arg(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> ();
+                fn string_list_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                >;
+                fn tuple_string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        (u8, wasmtime::component::__internal::String),
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    (wasmtime::component::__internal::String, u8),
+                >;
+                fn string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                >;
+                fn record_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeRecord>,
+                ) -> wasmtime::component::__internal::Vec<OtherRecord>;
+                fn record_list_reverse(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<OtherRecord>,
+                ) -> wasmtime::component::__internal::Vec<SomeRecord>;
+                fn variant_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeVariant>,
+                ) -> wasmtime::component::__internal::Vec<OtherVariant>;
+                fn load_store_everything(
+                    &mut self,
+                    a: LoadStoreAllSizes,
+                ) -> LoadStoreAllSizes;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/lists")?;
+                inst.func_wrap(
+                    "list-u8-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u8>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u8_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-u16-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u16>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u16_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-u32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u32_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-u64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u64>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u64_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s8-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i8>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s8_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s16-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i16>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s16_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i32>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s32_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i64>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s64_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-float32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<f32>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float32_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-float64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<f64>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float64_param(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-u8-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u8_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-u16-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u16_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-u32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u32_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-u64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u64_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s8-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s8_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s16-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s16_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s32_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-s64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s64_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-float32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float32_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-float64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float64_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "tuple-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<(u8, i8)>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_list(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "string-list-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::string_list_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "string-list-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::string_list_ret(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "tuple-string-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                (u8, wasmtime::component::__internal::String),
+                            >,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_string_list(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "string-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::string_list(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "record-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<SomeRecord>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_list(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "record-list-reverse",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<OtherRecord>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_list_reverse(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "variant-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<SomeVariant>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::variant_list(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "load-store-everything",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (LoadStoreAllSizes,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::load_store_everything(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod lists {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct OtherRecord {
+                    #[component(name = "a1")]
+                    pub a1: u32,
+                    #[component(name = "a2")]
+                    pub a2: u64,
+                    #[component(name = "a3")]
+                    pub a3: i32,
+                    #[component(name = "a4")]
+                    pub a4: i64,
+                    #[component(name = "b")]
+                    pub b: wasmtime::component::__internal::String,
+                    #[component(name = "c")]
+                    pub c: wasmtime::component::__internal::Vec<u8>,
+                }
+                impl core::fmt::Debug for OtherRecord {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("OtherRecord")
+                            .field("a1", &self.a1)
+                            .field("a2", &self.a2)
+                            .field("a3", &self.a3)
+                            .field("a4", &self.a4)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        48 == < OtherRecord as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < OtherRecord as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct SomeRecord {
+                    #[component(name = "x")]
+                    pub x: wasmtime::component::__internal::String,
+                    #[component(name = "y")]
+                    pub y: OtherRecord,
+                    #[component(name = "z")]
+                    pub z: wasmtime::component::__internal::Vec<OtherRecord>,
+                    #[component(name = "c1")]
+                    pub c1: u32,
+                    #[component(name = "c2")]
+                    pub c2: u64,
+                    #[component(name = "c3")]
+                    pub c3: i32,
+                    #[component(name = "c4")]
+                    pub c4: i64,
+                }
+                impl core::fmt::Debug for SomeRecord {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("SomeRecord")
+                            .field("x", &self.x)
+                            .field("y", &self.y)
+                            .field("z", &self.z)
+                            .field("c1", &self.c1)
+                            .field("c2", &self.c2)
+                            .field("c3", &self.c3)
+                            .field("c4", &self.c4)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        96 == < SomeRecord as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < SomeRecord as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum OtherVariant {
+                    #[component(name = "a")]
+                    A,
+                    #[component(name = "b")]
+                    B(u32),
+                    #[component(name = "c")]
+                    C(wasmtime::component::__internal::String),
+                }
+                impl core::fmt::Debug for OtherVariant {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            OtherVariant::A => f.debug_tuple("OtherVariant::A").finish(),
+                            OtherVariant::B(e) => {
+                                f.debug_tuple("OtherVariant::B").field(e).finish()
+                            }
+                            OtherVariant::C(e) => {
+                                f.debug_tuple("OtherVariant::C").field(e).finish()
+                            }
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < OtherVariant as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < OtherVariant as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum SomeVariant {
+                    #[component(name = "a")]
+                    A(wasmtime::component::__internal::String),
+                    #[component(name = "b")]
+                    B,
+                    #[component(name = "c")]
+                    C(u32),
+                    #[component(name = "d")]
+                    D(wasmtime::component::__internal::Vec<OtherVariant>),
+                }
+                impl core::fmt::Debug for SomeVariant {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            SomeVariant::A(e) => {
+                                f.debug_tuple("SomeVariant::A").field(e).finish()
+                            }
+                            SomeVariant::B => f.debug_tuple("SomeVariant::B").finish(),
+                            SomeVariant::C(e) => {
+                                f.debug_tuple("SomeVariant::C").field(e).finish()
+                            }
+                            SomeVariant::D(e) => {
+                                f.debug_tuple("SomeVariant::D").field(e).finish()
+                            }
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < SomeVariant as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < SomeVariant as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type LoadStoreAllSizes = wasmtime::component::__internal::Vec<
+                    (
+                        wasmtime::component::__internal::String,
+                        u8,
+                        i8,
+                        u16,
+                        i16,
+                        u32,
+                        i32,
+                        u64,
+                        i64,
+                        f32,
+                        f64,
+                        char,
+                    ),
+                >;
+                const _: () = {
+                    assert!(
+                        8 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    list_u8_param: wasmtime::component::Func,
+                    list_u16_param: wasmtime::component::Func,
+                    list_u32_param: wasmtime::component::Func,
+                    list_u64_param: wasmtime::component::Func,
+                    list_s8_param: wasmtime::component::Func,
+                    list_s16_param: wasmtime::component::Func,
+                    list_s32_param: wasmtime::component::Func,
+                    list_s64_param: wasmtime::component::Func,
+                    list_float32_param: wasmtime::component::Func,
+                    list_float64_param: wasmtime::component::Func,
+                    list_u8_ret: wasmtime::component::Func,
+                    list_u16_ret: wasmtime::component::Func,
+                    list_u32_ret: wasmtime::component::Func,
+                    list_u64_ret: wasmtime::component::Func,
+                    list_s8_ret: wasmtime::component::Func,
+                    list_s16_ret: wasmtime::component::Func,
+                    list_s32_ret: wasmtime::component::Func,
+                    list_s64_ret: wasmtime::component::Func,
+                    list_float32_ret: wasmtime::component::Func,
+                    list_float64_ret: wasmtime::component::Func,
+                    tuple_list: wasmtime::component::Func,
+                    string_list_arg: wasmtime::component::Func,
+                    string_list_ret: wasmtime::component::Func,
+                    tuple_string_list: wasmtime::component::Func,
+                    string_list: wasmtime::component::Func,
+                    record_list: wasmtime::component::Func,
+                    record_list_reverse: wasmtime::component::Func,
+                    variant_list: wasmtime::component::Func,
+                    load_store_everything: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let list_u8_param = *__exports
+                            .typed_func::<(&[u8],), ()>("list-u8-param")?
+                            .func();
+                        let list_u16_param = *__exports
+                            .typed_func::<(&[u16],), ()>("list-u16-param")?
+                            .func();
+                        let list_u32_param = *__exports
+                            .typed_func::<(&[u32],), ()>("list-u32-param")?
+                            .func();
+                        let list_u64_param = *__exports
+                            .typed_func::<(&[u64],), ()>("list-u64-param")?
+                            .func();
+                        let list_s8_param = *__exports
+                            .typed_func::<(&[i8],), ()>("list-s8-param")?
+                            .func();
+                        let list_s16_param = *__exports
+                            .typed_func::<(&[i16],), ()>("list-s16-param")?
+                            .func();
+                        let list_s32_param = *__exports
+                            .typed_func::<(&[i32],), ()>("list-s32-param")?
+                            .func();
+                        let list_s64_param = *__exports
+                            .typed_func::<(&[i64],), ()>("list-s64-param")?
+                            .func();
+                        let list_float32_param = *__exports
+                            .typed_func::<(&[f32],), ()>("list-float32-param")?
+                            .func();
+                        let list_float64_param = *__exports
+                            .typed_func::<(&[f64],), ()>("list-float64-param")?
+                            .func();
+                        let list_u8_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >("list-u8-ret")?
+                            .func();
+                        let list_u16_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >("list-u16-ret")?
+                            .func();
+                        let list_u32_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >("list-u32-ret")?
+                            .func();
+                        let list_u64_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >("list-u64-ret")?
+                            .func();
+                        let list_s8_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >("list-s8-ret")?
+                            .func();
+                        let list_s16_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >("list-s16-ret")?
+                            .func();
+                        let list_s32_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >("list-s32-ret")?
+                            .func();
+                        let list_s64_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >("list-s64-ret")?
+                            .func();
+                        let list_float32_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >("list-float32-ret")?
+                            .func();
+                        let list_float64_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >("list-float64-ret")?
+                            .func();
+                        let tuple_list = *__exports
+                            .typed_func::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >("tuple-list")?
+                            .func();
+                        let string_list_arg = *__exports
+                            .typed_func::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >("string-list-arg")?
+                            .func();
+                        let string_list_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >("string-list-ret")?
+                            .func();
+                        let tuple_string_list = *__exports
+                            .typed_func::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >("tuple-string-list")?
+                            .func();
+                        let string_list = *__exports
+                            .typed_func::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >("string-list")?
+                            .func();
+                        let record_list = *__exports
+                            .typed_func::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >("record-list")?
+                            .func();
+                        let record_list_reverse = *__exports
+                            .typed_func::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >("record-list-reverse")?
+                            .func();
+                        let variant_list = *__exports
+                            .typed_func::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >("variant-list")?
+                            .func();
+                        let load_store_everything = *__exports
+                            .typed_func::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >("load-store-everything")?
+                            .func();
+                        Ok(Guest {
+                            list_u8_param,
+                            list_u16_param,
+                            list_u32_param,
+                            list_u64_param,
+                            list_s8_param,
+                            list_s16_param,
+                            list_s32_param,
+                            list_s64_param,
+                            list_float32_param,
+                            list_float64_param,
+                            list_u8_ret,
+                            list_u16_ret,
+                            list_u32_ret,
+                            list_u64_ret,
+                            list_s8_ret,
+                            list_s16_ret,
+                            list_s32_ret,
+                            list_s64_ret,
+                            list_float32_ret,
+                            list_float64_ret,
+                            tuple_list,
+                            string_list_arg,
+                            string_list_ret,
+                            tuple_string_list,
+                            string_list,
+                            record_list,
+                            record_list_reverse,
+                            variant_list,
+                            load_store_everything,
+                        })
+                    }
+                    pub fn call_list_u8_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u8],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u8],),
+                                (),
+                            >::new_unchecked(self.list_u8_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_u16_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u16],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u16],),
+                                (),
+                            >::new_unchecked(self.list_u16_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_u32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u32],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.list_u32_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_u64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u64],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u64],),
+                                (),
+                            >::new_unchecked(self.list_u64_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_s8_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i8],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i8],),
+                                (),
+                            >::new_unchecked(self.list_s8_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_s16_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i16],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i16],),
+                                (),
+                            >::new_unchecked(self.list_s16_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_s32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i32],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i32],),
+                                (),
+                            >::new_unchecked(self.list_s32_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_s64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i64],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i64],),
+                                (),
+                            >::new_unchecked(self.list_s64_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_float32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[f32],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f32],),
+                                (),
+                            >::new_unchecked(self.list_float32_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_float64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[f64],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f64],),
+                                (),
+                            >::new_unchecked(self.list_float64_param)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_list_u8_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >::new_unchecked(self.list_u8_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_u16_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >::new_unchecked(self.list_u16_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_u32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.list_u32_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_u64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >::new_unchecked(self.list_u64_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_s8_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >::new_unchecked(self.list_s8_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_s16_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >::new_unchecked(self.list_s16_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_s32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >::new_unchecked(self.list_s32_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_s64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >::new_unchecked(self.list_s64_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_float32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >::new_unchecked(self.list_float32_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_list_float64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >::new_unchecked(self.list_float64_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_tuple_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[(u8, i8)],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<(i64, u32)>,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >::new_unchecked(self.tuple_list)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_string_list_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[wasmtime::component::__internal::String],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >::new_unchecked(self.string_list_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_string_list_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        >,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list_ret)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_tuple_string_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[(u8, wasmtime::component::__internal::String)],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            (wasmtime::component::__internal::String, u8),
+                        >,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >::new_unchecked(self.tuple_string_list)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_string_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[wasmtime::component::__internal::String],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        >,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_record_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[SomeRecord],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<OtherRecord>,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >::new_unchecked(self.record_list)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_record_list_reverse<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[OtherRecord],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<SomeRecord>,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >::new_unchecked(self.record_list_reverse)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_variant_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[SomeVariant],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<OtherVariant>,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >::new_unchecked(self.variant_list)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_load_store_everything<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &LoadStoreAllSizes,
+                    ) -> wasmtime::Result<LoadStoreAllSizes> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >::new_unchecked(self.load_store_everything)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -1,0 +1,1728 @@
+pub struct TheLists {
+    interface0: exports::foo::foo::lists::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheLists {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::lists::Host + Send,
+            T: Send,
+        {
+            foo::foo::lists::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::lists::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/lists")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/lists` not present")
+                    })?,
+            )?;
+            Ok(TheLists { interface0 })
+        }
+        pub fn foo_foo_lists(&self) -> &exports::foo::foo::lists::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod lists {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct OtherRecord {
+                #[component(name = "a1")]
+                pub a1: u32,
+                #[component(name = "a2")]
+                pub a2: u64,
+                #[component(name = "a3")]
+                pub a3: i32,
+                #[component(name = "a4")]
+                pub a4: i64,
+                #[component(name = "b")]
+                pub b: wasmtime::component::__internal::String,
+                #[component(name = "c")]
+                pub c: wasmtime::component::__internal::Vec<u8>,
+            }
+            impl core::fmt::Debug for OtherRecord {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("OtherRecord")
+                        .field("a1", &self.a1)
+                        .field("a2", &self.a2)
+                        .field("a3", &self.a3)
+                        .field("a4", &self.a4)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    48 == < OtherRecord as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    8 == < OtherRecord as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct SomeRecord {
+                #[component(name = "x")]
+                pub x: wasmtime::component::__internal::String,
+                #[component(name = "y")]
+                pub y: OtherRecord,
+                #[component(name = "z")]
+                pub z: wasmtime::component::__internal::Vec<OtherRecord>,
+                #[component(name = "c1")]
+                pub c1: u32,
+                #[component(name = "c2")]
+                pub c2: u64,
+                #[component(name = "c3")]
+                pub c3: i32,
+                #[component(name = "c4")]
+                pub c4: i64,
+            }
+            impl core::fmt::Debug for SomeRecord {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("SomeRecord")
+                        .field("x", &self.x)
+                        .field("y", &self.y)
+                        .field("z", &self.z)
+                        .field("c1", &self.c1)
+                        .field("c2", &self.c2)
+                        .field("c3", &self.c3)
+                        .field("c4", &self.c4)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    96 == < SomeRecord as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    8 == < SomeRecord as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum OtherVariant {
+                #[component(name = "a")]
+                A,
+                #[component(name = "b")]
+                B(u32),
+                #[component(name = "c")]
+                C(wasmtime::component::__internal::String),
+            }
+            impl core::fmt::Debug for OtherVariant {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        OtherVariant::A => f.debug_tuple("OtherVariant::A").finish(),
+                        OtherVariant::B(e) => {
+                            f.debug_tuple("OtherVariant::B").field(e).finish()
+                        }
+                        OtherVariant::C(e) => {
+                            f.debug_tuple("OtherVariant::C").field(e).finish()
+                        }
+                    }
+                }
+            }
+            const _: () = {
+                assert!(
+                    12 == < OtherVariant as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < OtherVariant as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum SomeVariant {
+                #[component(name = "a")]
+                A(wasmtime::component::__internal::String),
+                #[component(name = "b")]
+                B,
+                #[component(name = "c")]
+                C(u32),
+                #[component(name = "d")]
+                D(wasmtime::component::__internal::Vec<OtherVariant>),
+            }
+            impl core::fmt::Debug for SomeVariant {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        SomeVariant::A(e) => {
+                            f.debug_tuple("SomeVariant::A").field(e).finish()
+                        }
+                        SomeVariant::B => f.debug_tuple("SomeVariant::B").finish(),
+                        SomeVariant::C(e) => {
+                            f.debug_tuple("SomeVariant::C").field(e).finish()
+                        }
+                        SomeVariant::D(e) => {
+                            f.debug_tuple("SomeVariant::D").field(e).finish()
+                        }
+                    }
+                }
+            }
+            const _: () = {
+                assert!(
+                    12 == < SomeVariant as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < SomeVariant as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type LoadStoreAllSizes = wasmtime::component::__internal::Vec<
+                (
+                    wasmtime::component::__internal::String,
+                    u8,
+                    i8,
+                    u16,
+                    i16,
+                    u32,
+                    i32,
+                    u64,
+                    i64,
+                    f32,
+                    f64,
+                    char,
+                ),
+            >;
+            const _: () = {
+                assert!(
+                    8 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                    >::SIZE32
+                );
+                assert!(
+                    4 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn list_u8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u8>,
+                ) -> ();
+                async fn list_u16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u16>,
+                ) -> ();
+                async fn list_u32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u32>,
+                ) -> ();
+                async fn list_u64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u64>,
+                ) -> ();
+                async fn list_s8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i8>,
+                ) -> ();
+                async fn list_s16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i16>,
+                ) -> ();
+                async fn list_s32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i32>,
+                ) -> ();
+                async fn list_s64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i64>,
+                ) -> ();
+                async fn list_float32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f32>,
+                ) -> ();
+                async fn list_float64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f64>,
+                ) -> ();
+                async fn list_u8_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u8>;
+                async fn list_u16_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u16>;
+                async fn list_u32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u32>;
+                async fn list_u64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u64>;
+                async fn list_s8_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i8>;
+                async fn list_s16_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i16>;
+                async fn list_s32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i32>;
+                async fn list_s64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i64>;
+                async fn list_float32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f32>;
+                async fn list_float64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f64>;
+                async fn tuple_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
+                ) -> wasmtime::component::__internal::Vec<(i64, u32)>;
+                async fn string_list_arg(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> ();
+                async fn string_list_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                >;
+                async fn tuple_string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        (u8, wasmtime::component::__internal::String),
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    (wasmtime::component::__internal::String, u8),
+                >;
+                async fn string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                >;
+                async fn record_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeRecord>,
+                ) -> wasmtime::component::__internal::Vec<OtherRecord>;
+                async fn record_list_reverse(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<OtherRecord>,
+                ) -> wasmtime::component::__internal::Vec<SomeRecord>;
+                async fn variant_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeVariant>,
+                ) -> wasmtime::component::__internal::Vec<OtherVariant>;
+                async fn load_store_everything(
+                    &mut self,
+                    a: LoadStoreAllSizes,
+                ) -> LoadStoreAllSizes;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/lists")?;
+                inst.func_wrap_async(
+                    "list-u8-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u8>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u8_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-u16-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u16>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u16_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-u32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u32_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-u64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u64>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u64_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s8-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i8>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s8_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s16-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i16>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s16_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i32>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s32_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i64>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s64_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-float32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<f32>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float32_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-float64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<f64>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float64_param(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-u8-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u8_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-u16-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u16_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-u32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u32_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-u64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_u64_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s8-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s8_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s16-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s16_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s32_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-s64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_s64_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-float32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float32_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-float64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_float64_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "tuple-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<(u8, i8)>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_list(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "string-list-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::string_list_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "string-list-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::string_list_ret(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "tuple-string-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                (u8, wasmtime::component::__internal::String),
+                            >,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_string_list(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "string-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::string_list(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "record-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<SomeRecord>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_list(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "record-list-reverse",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<OtherRecord>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_list_reverse(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "variant-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<SomeVariant>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::variant_list(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "load-store-everything",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (LoadStoreAllSizes,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::load_store_everything(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod lists {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct OtherRecord {
+                    #[component(name = "a1")]
+                    pub a1: u32,
+                    #[component(name = "a2")]
+                    pub a2: u64,
+                    #[component(name = "a3")]
+                    pub a3: i32,
+                    #[component(name = "a4")]
+                    pub a4: i64,
+                    #[component(name = "b")]
+                    pub b: wasmtime::component::__internal::String,
+                    #[component(name = "c")]
+                    pub c: wasmtime::component::__internal::Vec<u8>,
+                }
+                impl core::fmt::Debug for OtherRecord {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("OtherRecord")
+                            .field("a1", &self.a1)
+                            .field("a2", &self.a2)
+                            .field("a3", &self.a3)
+                            .field("a4", &self.a4)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        48 == < OtherRecord as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < OtherRecord as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct SomeRecord {
+                    #[component(name = "x")]
+                    pub x: wasmtime::component::__internal::String,
+                    #[component(name = "y")]
+                    pub y: OtherRecord,
+                    #[component(name = "z")]
+                    pub z: wasmtime::component::__internal::Vec<OtherRecord>,
+                    #[component(name = "c1")]
+                    pub c1: u32,
+                    #[component(name = "c2")]
+                    pub c2: u64,
+                    #[component(name = "c3")]
+                    pub c3: i32,
+                    #[component(name = "c4")]
+                    pub c4: i64,
+                }
+                impl core::fmt::Debug for SomeRecord {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("SomeRecord")
+                            .field("x", &self.x)
+                            .field("y", &self.y)
+                            .field("z", &self.z)
+                            .field("c1", &self.c1)
+                            .field("c2", &self.c2)
+                            .field("c3", &self.c3)
+                            .field("c4", &self.c4)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        96 == < SomeRecord as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < SomeRecord as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum OtherVariant {
+                    #[component(name = "a")]
+                    A,
+                    #[component(name = "b")]
+                    B(u32),
+                    #[component(name = "c")]
+                    C(wasmtime::component::__internal::String),
+                }
+                impl core::fmt::Debug for OtherVariant {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            OtherVariant::A => f.debug_tuple("OtherVariant::A").finish(),
+                            OtherVariant::B(e) => {
+                                f.debug_tuple("OtherVariant::B").field(e).finish()
+                            }
+                            OtherVariant::C(e) => {
+                                f.debug_tuple("OtherVariant::C").field(e).finish()
+                            }
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < OtherVariant as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < OtherVariant as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum SomeVariant {
+                    #[component(name = "a")]
+                    A(wasmtime::component::__internal::String),
+                    #[component(name = "b")]
+                    B,
+                    #[component(name = "c")]
+                    C(u32),
+                    #[component(name = "d")]
+                    D(wasmtime::component::__internal::Vec<OtherVariant>),
+                }
+                impl core::fmt::Debug for SomeVariant {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            SomeVariant::A(e) => {
+                                f.debug_tuple("SomeVariant::A").field(e).finish()
+                            }
+                            SomeVariant::B => f.debug_tuple("SomeVariant::B").finish(),
+                            SomeVariant::C(e) => {
+                                f.debug_tuple("SomeVariant::C").field(e).finish()
+                            }
+                            SomeVariant::D(e) => {
+                                f.debug_tuple("SomeVariant::D").field(e).finish()
+                            }
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < SomeVariant as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < SomeVariant as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type LoadStoreAllSizes = wasmtime::component::__internal::Vec<
+                    (
+                        wasmtime::component::__internal::String,
+                        u8,
+                        i8,
+                        u16,
+                        i16,
+                        u32,
+                        i32,
+                        u64,
+                        i64,
+                        f32,
+                        f64,
+                        char,
+                    ),
+                >;
+                const _: () = {
+                    assert!(
+                        8 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    list_u8_param: wasmtime::component::Func,
+                    list_u16_param: wasmtime::component::Func,
+                    list_u32_param: wasmtime::component::Func,
+                    list_u64_param: wasmtime::component::Func,
+                    list_s8_param: wasmtime::component::Func,
+                    list_s16_param: wasmtime::component::Func,
+                    list_s32_param: wasmtime::component::Func,
+                    list_s64_param: wasmtime::component::Func,
+                    list_float32_param: wasmtime::component::Func,
+                    list_float64_param: wasmtime::component::Func,
+                    list_u8_ret: wasmtime::component::Func,
+                    list_u16_ret: wasmtime::component::Func,
+                    list_u32_ret: wasmtime::component::Func,
+                    list_u64_ret: wasmtime::component::Func,
+                    list_s8_ret: wasmtime::component::Func,
+                    list_s16_ret: wasmtime::component::Func,
+                    list_s32_ret: wasmtime::component::Func,
+                    list_s64_ret: wasmtime::component::Func,
+                    list_float32_ret: wasmtime::component::Func,
+                    list_float64_ret: wasmtime::component::Func,
+                    tuple_list: wasmtime::component::Func,
+                    string_list_arg: wasmtime::component::Func,
+                    string_list_ret: wasmtime::component::Func,
+                    tuple_string_list: wasmtime::component::Func,
+                    string_list: wasmtime::component::Func,
+                    record_list: wasmtime::component::Func,
+                    record_list_reverse: wasmtime::component::Func,
+                    variant_list: wasmtime::component::Func,
+                    load_store_everything: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let list_u8_param = *__exports
+                            .typed_func::<(&[u8],), ()>("list-u8-param")?
+                            .func();
+                        let list_u16_param = *__exports
+                            .typed_func::<(&[u16],), ()>("list-u16-param")?
+                            .func();
+                        let list_u32_param = *__exports
+                            .typed_func::<(&[u32],), ()>("list-u32-param")?
+                            .func();
+                        let list_u64_param = *__exports
+                            .typed_func::<(&[u64],), ()>("list-u64-param")?
+                            .func();
+                        let list_s8_param = *__exports
+                            .typed_func::<(&[i8],), ()>("list-s8-param")?
+                            .func();
+                        let list_s16_param = *__exports
+                            .typed_func::<(&[i16],), ()>("list-s16-param")?
+                            .func();
+                        let list_s32_param = *__exports
+                            .typed_func::<(&[i32],), ()>("list-s32-param")?
+                            .func();
+                        let list_s64_param = *__exports
+                            .typed_func::<(&[i64],), ()>("list-s64-param")?
+                            .func();
+                        let list_float32_param = *__exports
+                            .typed_func::<(&[f32],), ()>("list-float32-param")?
+                            .func();
+                        let list_float64_param = *__exports
+                            .typed_func::<(&[f64],), ()>("list-float64-param")?
+                            .func();
+                        let list_u8_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >("list-u8-ret")?
+                            .func();
+                        let list_u16_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >("list-u16-ret")?
+                            .func();
+                        let list_u32_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >("list-u32-ret")?
+                            .func();
+                        let list_u64_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >("list-u64-ret")?
+                            .func();
+                        let list_s8_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >("list-s8-ret")?
+                            .func();
+                        let list_s16_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >("list-s16-ret")?
+                            .func();
+                        let list_s32_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >("list-s32-ret")?
+                            .func();
+                        let list_s64_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >("list-s64-ret")?
+                            .func();
+                        let list_float32_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >("list-float32-ret")?
+                            .func();
+                        let list_float64_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >("list-float64-ret")?
+                            .func();
+                        let tuple_list = *__exports
+                            .typed_func::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >("tuple-list")?
+                            .func();
+                        let string_list_arg = *__exports
+                            .typed_func::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >("string-list-arg")?
+                            .func();
+                        let string_list_ret = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >("string-list-ret")?
+                            .func();
+                        let tuple_string_list = *__exports
+                            .typed_func::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >("tuple-string-list")?
+                            .func();
+                        let string_list = *__exports
+                            .typed_func::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >("string-list")?
+                            .func();
+                        let record_list = *__exports
+                            .typed_func::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >("record-list")?
+                            .func();
+                        let record_list_reverse = *__exports
+                            .typed_func::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >("record-list-reverse")?
+                            .func();
+                        let variant_list = *__exports
+                            .typed_func::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >("variant-list")?
+                            .func();
+                        let load_store_everything = *__exports
+                            .typed_func::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >("load-store-everything")?
+                            .func();
+                        Ok(Guest {
+                            list_u8_param,
+                            list_u16_param,
+                            list_u32_param,
+                            list_u64_param,
+                            list_s8_param,
+                            list_s16_param,
+                            list_s32_param,
+                            list_s64_param,
+                            list_float32_param,
+                            list_float64_param,
+                            list_u8_ret,
+                            list_u16_ret,
+                            list_u32_ret,
+                            list_u64_ret,
+                            list_s8_ret,
+                            list_s16_ret,
+                            list_s32_ret,
+                            list_s64_ret,
+                            list_float32_ret,
+                            list_float64_ret,
+                            tuple_list,
+                            string_list_arg,
+                            string_list_ret,
+                            tuple_string_list,
+                            string_list,
+                            record_list,
+                            record_list_reverse,
+                            variant_list,
+                            load_store_everything,
+                        })
+                    }
+                    pub async fn call_list_u8_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u8],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u8],),
+                                (),
+                            >::new_unchecked(self.list_u8_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_u16_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u16],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u16],),
+                                (),
+                            >::new_unchecked(self.list_u16_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_u32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u32],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.list_u32_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_u64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u64],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u64],),
+                                (),
+                            >::new_unchecked(self.list_u64_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_s8_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i8],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i8],),
+                                (),
+                            >::new_unchecked(self.list_s8_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_s16_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i16],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i16],),
+                                (),
+                            >::new_unchecked(self.list_s16_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_s32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i32],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i32],),
+                                (),
+                            >::new_unchecked(self.list_s32_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_s64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[i64],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[i64],),
+                                (),
+                            >::new_unchecked(self.list_s64_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_float32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[f32],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f32],),
+                                (),
+                            >::new_unchecked(self.list_float32_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_float64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[f64],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[f64],),
+                                (),
+                            >::new_unchecked(self.list_float64_param)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_list_u8_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >::new_unchecked(self.list_u8_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_u16_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >::new_unchecked(self.list_u16_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_u32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.list_u32_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_u64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >::new_unchecked(self.list_u64_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_s8_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >::new_unchecked(self.list_s8_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_s16_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >::new_unchecked(self.list_s16_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_s32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >::new_unchecked(self.list_s32_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_s64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >::new_unchecked(self.list_s64_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_float32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >::new_unchecked(self.list_float32_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_list_float64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >::new_unchecked(self.list_float64_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_tuple_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[(u8, i8)],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<(i64, u32)>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >::new_unchecked(self.tuple_list)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_string_list_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[wasmtime::component::__internal::String],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >::new_unchecked(self.string_list_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_string_list_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list_ret)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_tuple_string_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[(u8, wasmtime::component::__internal::String)],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            (wasmtime::component::__internal::String, u8),
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >::new_unchecked(self.tuple_string_list)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_string_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[wasmtime::component::__internal::String],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_record_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[SomeRecord],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<OtherRecord>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >::new_unchecked(self.record_list)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_record_list_reverse<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[OtherRecord],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<SomeRecord>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >::new_unchecked(self.record_list_reverse)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_variant_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[SomeVariant],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<OtherVariant>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >::new_unchecked(self.variant_list)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_load_store_everything<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &LoadStoreAllSizes,
+                    ) -> wasmtime::Result<LoadStoreAllSizes>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >::new_unchecked(self.load_store_everything)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -1,0 +1,481 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::manyarg::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::manyarg::Host,
+        {
+            foo::foo::manyarg::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::manyarg::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/manyarg")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/manyarg` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_manyarg(&self) -> &exports::foo::foo::manyarg::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod manyarg {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct BigStruct {
+                #[component(name = "a1")]
+                pub a1: wasmtime::component::__internal::String,
+                #[component(name = "a2")]
+                pub a2: wasmtime::component::__internal::String,
+                #[component(name = "a3")]
+                pub a3: wasmtime::component::__internal::String,
+                #[component(name = "a4")]
+                pub a4: wasmtime::component::__internal::String,
+                #[component(name = "a5")]
+                pub a5: wasmtime::component::__internal::String,
+                #[component(name = "a6")]
+                pub a6: wasmtime::component::__internal::String,
+                #[component(name = "a7")]
+                pub a7: wasmtime::component::__internal::String,
+                #[component(name = "a8")]
+                pub a8: wasmtime::component::__internal::String,
+                #[component(name = "a9")]
+                pub a9: wasmtime::component::__internal::String,
+                #[component(name = "a10")]
+                pub a10: wasmtime::component::__internal::String,
+                #[component(name = "a11")]
+                pub a11: wasmtime::component::__internal::String,
+                #[component(name = "a12")]
+                pub a12: wasmtime::component::__internal::String,
+                #[component(name = "a13")]
+                pub a13: wasmtime::component::__internal::String,
+                #[component(name = "a14")]
+                pub a14: wasmtime::component::__internal::String,
+                #[component(name = "a15")]
+                pub a15: wasmtime::component::__internal::String,
+                #[component(name = "a16")]
+                pub a16: wasmtime::component::__internal::String,
+                #[component(name = "a17")]
+                pub a17: wasmtime::component::__internal::String,
+                #[component(name = "a18")]
+                pub a18: wasmtime::component::__internal::String,
+                #[component(name = "a19")]
+                pub a19: wasmtime::component::__internal::String,
+                #[component(name = "a20")]
+                pub a20: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for BigStruct {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("BigStruct")
+                        .field("a1", &self.a1)
+                        .field("a2", &self.a2)
+                        .field("a3", &self.a3)
+                        .field("a4", &self.a4)
+                        .field("a5", &self.a5)
+                        .field("a6", &self.a6)
+                        .field("a7", &self.a7)
+                        .field("a8", &self.a8)
+                        .field("a9", &self.a9)
+                        .field("a10", &self.a10)
+                        .field("a11", &self.a11)
+                        .field("a12", &self.a12)
+                        .field("a13", &self.a13)
+                        .field("a14", &self.a14)
+                        .field("a15", &self.a15)
+                        .field("a16", &self.a16)
+                        .field("a17", &self.a17)
+                        .field("a18", &self.a18)
+                        .field("a19", &self.a19)
+                        .field("a20", &self.a20)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    160 == < BigStruct as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {
+                fn many_args(
+                    &mut self,
+                    a1: u64,
+                    a2: u64,
+                    a3: u64,
+                    a4: u64,
+                    a5: u64,
+                    a6: u64,
+                    a7: u64,
+                    a8: u64,
+                    a9: u64,
+                    a10: u64,
+                    a11: u64,
+                    a12: u64,
+                    a13: u64,
+                    a14: u64,
+                    a15: u64,
+                    a16: u64,
+                ) -> ();
+                fn big_argument(&mut self, x: BigStruct) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/manyarg")?;
+                inst.func_wrap(
+                    "many-args",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                            arg8,
+                            arg9,
+                            arg10,
+                            arg11,
+                            arg12,
+                            arg13,
+                            arg14,
+                            arg15,
+                        ): (
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::many_args(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                            arg8,
+                            arg9,
+                            arg10,
+                            arg11,
+                            arg12,
+                            arg13,
+                            arg14,
+                            arg15,
+                        );
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "big-argument",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (BigStruct,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::big_argument(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod manyarg {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct BigStruct {
+                    #[component(name = "a1")]
+                    pub a1: wasmtime::component::__internal::String,
+                    #[component(name = "a2")]
+                    pub a2: wasmtime::component::__internal::String,
+                    #[component(name = "a3")]
+                    pub a3: wasmtime::component::__internal::String,
+                    #[component(name = "a4")]
+                    pub a4: wasmtime::component::__internal::String,
+                    #[component(name = "a5")]
+                    pub a5: wasmtime::component::__internal::String,
+                    #[component(name = "a6")]
+                    pub a6: wasmtime::component::__internal::String,
+                    #[component(name = "a7")]
+                    pub a7: wasmtime::component::__internal::String,
+                    #[component(name = "a8")]
+                    pub a8: wasmtime::component::__internal::String,
+                    #[component(name = "a9")]
+                    pub a9: wasmtime::component::__internal::String,
+                    #[component(name = "a10")]
+                    pub a10: wasmtime::component::__internal::String,
+                    #[component(name = "a11")]
+                    pub a11: wasmtime::component::__internal::String,
+                    #[component(name = "a12")]
+                    pub a12: wasmtime::component::__internal::String,
+                    #[component(name = "a13")]
+                    pub a13: wasmtime::component::__internal::String,
+                    #[component(name = "a14")]
+                    pub a14: wasmtime::component::__internal::String,
+                    #[component(name = "a15")]
+                    pub a15: wasmtime::component::__internal::String,
+                    #[component(name = "a16")]
+                    pub a16: wasmtime::component::__internal::String,
+                    #[component(name = "a17")]
+                    pub a17: wasmtime::component::__internal::String,
+                    #[component(name = "a18")]
+                    pub a18: wasmtime::component::__internal::String,
+                    #[component(name = "a19")]
+                    pub a19: wasmtime::component::__internal::String,
+                    #[component(name = "a20")]
+                    pub a20: wasmtime::component::__internal::String,
+                }
+                impl core::fmt::Debug for BigStruct {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("BigStruct")
+                            .field("a1", &self.a1)
+                            .field("a2", &self.a2)
+                            .field("a3", &self.a3)
+                            .field("a4", &self.a4)
+                            .field("a5", &self.a5)
+                            .field("a6", &self.a6)
+                            .field("a7", &self.a7)
+                            .field("a8", &self.a8)
+                            .field("a9", &self.a9)
+                            .field("a10", &self.a10)
+                            .field("a11", &self.a11)
+                            .field("a12", &self.a12)
+                            .field("a13", &self.a13)
+                            .field("a14", &self.a14)
+                            .field("a15", &self.a15)
+                            .field("a16", &self.a16)
+                            .field("a17", &self.a17)
+                            .field("a18", &self.a18)
+                            .field("a19", &self.a19)
+                            .field("a20", &self.a20)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        160 == < BigStruct as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    many_args: wasmtime::component::Func,
+                    big_argument: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let many_args = *__exports
+                            .typed_func::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >("many-args")?
+                            .func();
+                        let big_argument = *__exports
+                            .typed_func::<(&BigStruct,), ()>("big-argument")?
+                            .func();
+                        Ok(Guest { many_args, big_argument })
+                    }
+                    pub fn call_many_args<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u64,
+                        arg1: u64,
+                        arg2: u64,
+                        arg3: u64,
+                        arg4: u64,
+                        arg5: u64,
+                        arg6: u64,
+                        arg7: u64,
+                        arg8: u64,
+                        arg9: u64,
+                        arg10: u64,
+                        arg11: u64,
+                        arg12: u64,
+                        arg13: u64,
+                        arg14: u64,
+                        arg15: u64,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >::new_unchecked(self.many_args)
+                        };
+                        let () = callee
+                            .call(
+                                store.as_context_mut(),
+                                (
+                                    arg0,
+                                    arg1,
+                                    arg2,
+                                    arg3,
+                                    arg4,
+                                    arg5,
+                                    arg6,
+                                    arg7,
+                                    arg8,
+                                    arg9,
+                                    arg10,
+                                    arg11,
+                                    arg12,
+                                    arg13,
+                                    arg14,
+                                    arg15,
+                                ),
+                            )?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_big_argument<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &BigStruct,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&BigStruct,),
+                                (),
+                            >::new_unchecked(self.big_argument)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -1,0 +1,494 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::manyarg::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::manyarg::Host + Send,
+            T: Send,
+        {
+            foo::foo::manyarg::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::manyarg::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/manyarg")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/manyarg` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_manyarg(&self) -> &exports::foo::foo::manyarg::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod manyarg {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct BigStruct {
+                #[component(name = "a1")]
+                pub a1: wasmtime::component::__internal::String,
+                #[component(name = "a2")]
+                pub a2: wasmtime::component::__internal::String,
+                #[component(name = "a3")]
+                pub a3: wasmtime::component::__internal::String,
+                #[component(name = "a4")]
+                pub a4: wasmtime::component::__internal::String,
+                #[component(name = "a5")]
+                pub a5: wasmtime::component::__internal::String,
+                #[component(name = "a6")]
+                pub a6: wasmtime::component::__internal::String,
+                #[component(name = "a7")]
+                pub a7: wasmtime::component::__internal::String,
+                #[component(name = "a8")]
+                pub a8: wasmtime::component::__internal::String,
+                #[component(name = "a9")]
+                pub a9: wasmtime::component::__internal::String,
+                #[component(name = "a10")]
+                pub a10: wasmtime::component::__internal::String,
+                #[component(name = "a11")]
+                pub a11: wasmtime::component::__internal::String,
+                #[component(name = "a12")]
+                pub a12: wasmtime::component::__internal::String,
+                #[component(name = "a13")]
+                pub a13: wasmtime::component::__internal::String,
+                #[component(name = "a14")]
+                pub a14: wasmtime::component::__internal::String,
+                #[component(name = "a15")]
+                pub a15: wasmtime::component::__internal::String,
+                #[component(name = "a16")]
+                pub a16: wasmtime::component::__internal::String,
+                #[component(name = "a17")]
+                pub a17: wasmtime::component::__internal::String,
+                #[component(name = "a18")]
+                pub a18: wasmtime::component::__internal::String,
+                #[component(name = "a19")]
+                pub a19: wasmtime::component::__internal::String,
+                #[component(name = "a20")]
+                pub a20: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for BigStruct {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("BigStruct")
+                        .field("a1", &self.a1)
+                        .field("a2", &self.a2)
+                        .field("a3", &self.a3)
+                        .field("a4", &self.a4)
+                        .field("a5", &self.a5)
+                        .field("a6", &self.a6)
+                        .field("a7", &self.a7)
+                        .field("a8", &self.a8)
+                        .field("a9", &self.a9)
+                        .field("a10", &self.a10)
+                        .field("a11", &self.a11)
+                        .field("a12", &self.a12)
+                        .field("a13", &self.a13)
+                        .field("a14", &self.a14)
+                        .field("a15", &self.a15)
+                        .field("a16", &self.a16)
+                        .field("a17", &self.a17)
+                        .field("a18", &self.a18)
+                        .field("a19", &self.a19)
+                        .field("a20", &self.a20)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    160 == < BigStruct as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn many_args(
+                    &mut self,
+                    a1: u64,
+                    a2: u64,
+                    a3: u64,
+                    a4: u64,
+                    a5: u64,
+                    a6: u64,
+                    a7: u64,
+                    a8: u64,
+                    a9: u64,
+                    a10: u64,
+                    a11: u64,
+                    a12: u64,
+                    a13: u64,
+                    a14: u64,
+                    a15: u64,
+                    a16: u64,
+                ) -> ();
+                async fn big_argument(&mut self, x: BigStruct) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/manyarg")?;
+                inst.func_wrap_async(
+                    "many-args",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                            arg8,
+                            arg9,
+                            arg10,
+                            arg11,
+                            arg12,
+                            arg13,
+                            arg14,
+                            arg15,
+                        ): (
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::many_args(
+                                host,
+                                arg0,
+                                arg1,
+                                arg2,
+                                arg3,
+                                arg4,
+                                arg5,
+                                arg6,
+                                arg7,
+                                arg8,
+                                arg9,
+                                arg10,
+                                arg11,
+                                arg12,
+                                arg13,
+                                arg14,
+                                arg15,
+                            )
+                            .await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "big-argument",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (BigStruct,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::big_argument(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod manyarg {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct BigStruct {
+                    #[component(name = "a1")]
+                    pub a1: wasmtime::component::__internal::String,
+                    #[component(name = "a2")]
+                    pub a2: wasmtime::component::__internal::String,
+                    #[component(name = "a3")]
+                    pub a3: wasmtime::component::__internal::String,
+                    #[component(name = "a4")]
+                    pub a4: wasmtime::component::__internal::String,
+                    #[component(name = "a5")]
+                    pub a5: wasmtime::component::__internal::String,
+                    #[component(name = "a6")]
+                    pub a6: wasmtime::component::__internal::String,
+                    #[component(name = "a7")]
+                    pub a7: wasmtime::component::__internal::String,
+                    #[component(name = "a8")]
+                    pub a8: wasmtime::component::__internal::String,
+                    #[component(name = "a9")]
+                    pub a9: wasmtime::component::__internal::String,
+                    #[component(name = "a10")]
+                    pub a10: wasmtime::component::__internal::String,
+                    #[component(name = "a11")]
+                    pub a11: wasmtime::component::__internal::String,
+                    #[component(name = "a12")]
+                    pub a12: wasmtime::component::__internal::String,
+                    #[component(name = "a13")]
+                    pub a13: wasmtime::component::__internal::String,
+                    #[component(name = "a14")]
+                    pub a14: wasmtime::component::__internal::String,
+                    #[component(name = "a15")]
+                    pub a15: wasmtime::component::__internal::String,
+                    #[component(name = "a16")]
+                    pub a16: wasmtime::component::__internal::String,
+                    #[component(name = "a17")]
+                    pub a17: wasmtime::component::__internal::String,
+                    #[component(name = "a18")]
+                    pub a18: wasmtime::component::__internal::String,
+                    #[component(name = "a19")]
+                    pub a19: wasmtime::component::__internal::String,
+                    #[component(name = "a20")]
+                    pub a20: wasmtime::component::__internal::String,
+                }
+                impl core::fmt::Debug for BigStruct {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("BigStruct")
+                            .field("a1", &self.a1)
+                            .field("a2", &self.a2)
+                            .field("a3", &self.a3)
+                            .field("a4", &self.a4)
+                            .field("a5", &self.a5)
+                            .field("a6", &self.a6)
+                            .field("a7", &self.a7)
+                            .field("a8", &self.a8)
+                            .field("a9", &self.a9)
+                            .field("a10", &self.a10)
+                            .field("a11", &self.a11)
+                            .field("a12", &self.a12)
+                            .field("a13", &self.a13)
+                            .field("a14", &self.a14)
+                            .field("a15", &self.a15)
+                            .field("a16", &self.a16)
+                            .field("a17", &self.a17)
+                            .field("a18", &self.a18)
+                            .field("a19", &self.a19)
+                            .field("a20", &self.a20)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        160 == < BigStruct as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    many_args: wasmtime::component::Func,
+                    big_argument: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let many_args = *__exports
+                            .typed_func::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >("many-args")?
+                            .func();
+                        let big_argument = *__exports
+                            .typed_func::<(&BigStruct,), ()>("big-argument")?
+                            .func();
+                        Ok(Guest { many_args, big_argument })
+                    }
+                    pub async fn call_many_args<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u64,
+                        arg1: u64,
+                        arg2: u64,
+                        arg3: u64,
+                        arg4: u64,
+                        arg5: u64,
+                        arg6: u64,
+                        arg7: u64,
+                        arg8: u64,
+                        arg9: u64,
+                        arg10: u64,
+                        arg11: u64,
+                        arg12: u64,
+                        arg13: u64,
+                        arg14: u64,
+                        arg15: u64,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >::new_unchecked(self.many_args)
+                        };
+                        let () = callee
+                            .call_async(
+                                store.as_context_mut(),
+                                (
+                                    arg0,
+                                    arg1,
+                                    arg2,
+                                    arg3,
+                                    arg4,
+                                    arg5,
+                                    arg6,
+                                    arg7,
+                                    arg8,
+                                    arg9,
+                                    arg10,
+                                    arg11,
+                                    arg12,
+                                    arg13,
+                                    arg14,
+                                    arg15,
+                                ),
+                            )
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_big_argument<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &BigStruct,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&BigStruct,),
+                                (),
+                            >::new_unchecked(self.big_argument)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/multi-return.rs
+++ b/crates/component-macro/tests/expanded/multi-return.rs
@@ -1,0 +1,235 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::multi_return::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::multi_return::Host,
+        {
+            foo::foo::multi_return::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::multi_return::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/multi-return")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/multi-return` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_multi_return(&self) -> &exports::foo::foo::multi_return::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod multi_return {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn mra(&mut self) -> ();
+                fn mrb(&mut self) -> ();
+                fn mrc(&mut self) -> u32;
+                fn mrd(&mut self) -> u32;
+                fn mre(&mut self) -> (u32, f32);
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/multi-return")?;
+                inst.func_wrap(
+                    "mra",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::mra(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "mrb",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::mrb(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "mrc",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::mrc(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "mrd",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::mrd(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "mre",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::mre(host);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod multi_return {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    mra: wasmtime::component::Func,
+                    mrb: wasmtime::component::Func,
+                    mrc: wasmtime::component::Func,
+                    mrd: wasmtime::component::Func,
+                    mre: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let mra = *__exports.typed_func::<(), ()>("mra")?.func();
+                        let mrb = *__exports.typed_func::<(), ()>("mrb")?.func();
+                        let mrc = *__exports.typed_func::<(), (u32,)>("mrc")?.func();
+                        let mrd = *__exports.typed_func::<(), (u32,)>("mrd")?.func();
+                        let mre = *__exports.typed_func::<(), (u32, f32)>("mre")?.func();
+                        Ok(Guest { mra, mrb, mrc, mrd, mre })
+                    }
+                    pub fn call_mra<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.mra)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_mrb<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.mrb)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_mrc<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.mrc)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_mrd<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.mrd)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_mre<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(u32, f32)> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32, f32),
+                            >::new_unchecked(self.mre)
+                        };
+                        let (ret0, ret1) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok((ret0, ret1))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/multi-return_async.rs
+++ b/crates/component-macro/tests/expanded/multi-return_async.rs
@@ -1,0 +1,259 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::multi_return::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::multi_return::Host + Send,
+            T: Send,
+        {
+            foo::foo::multi_return::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::multi_return::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/multi-return")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/multi-return` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_multi_return(&self) -> &exports::foo::foo::multi_return::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod multi_return {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn mra(&mut self) -> ();
+                async fn mrb(&mut self) -> ();
+                async fn mrc(&mut self) -> u32;
+                async fn mrd(&mut self) -> u32;
+                async fn mre(&mut self) -> (u32, f32);
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/multi-return")?;
+                inst.func_wrap_async(
+                    "mra",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::mra(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "mrb",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::mrb(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "mrc",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::mrc(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "mrd",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::mrd(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "mre",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::mre(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod multi_return {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    mra: wasmtime::component::Func,
+                    mrb: wasmtime::component::Func,
+                    mrc: wasmtime::component::Func,
+                    mrd: wasmtime::component::Func,
+                    mre: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let mra = *__exports.typed_func::<(), ()>("mra")?.func();
+                        let mrb = *__exports.typed_func::<(), ()>("mrb")?.func();
+                        let mrc = *__exports.typed_func::<(), (u32,)>("mrc")?.func();
+                        let mrd = *__exports.typed_func::<(), (u32,)>("mrd")?.func();
+                        let mre = *__exports.typed_func::<(), (u32, f32)>("mre")?.func();
+                        Ok(Guest { mra, mrb, mrc, mrd, mre })
+                    }
+                    pub async fn call_mra<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.mra)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_mrb<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.mrb)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_mrc<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.mrc)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_mrd<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.mrd)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_mre<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(u32, f32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32, f32),
+                            >::new_unchecked(self.mre)
+                        };
+                        let (ret0, ret1) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok((ret0, ret1))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -1,0 +1,205 @@
+pub struct Foo {
+    interface0: exports::my::dep0_1_0::a::Guest,
+    interface1: exports::my::dep0_2_0::a::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host,
+        {
+            my::dep0_1_0::a::add_to_linker(linker, get)?;
+            my::dep0_2_0::a::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::my::dep0_1_0::a::Guest::new(
+                &mut __exports
+                    .instance("my:dep/a@0.1.0")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `my:dep/a@0.1.0` not present")
+                    })?,
+            )?;
+            let interface1 = exports::my::dep0_2_0::a::Guest::new(
+                &mut __exports
+                    .instance("my:dep/a@0.2.0")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `my:dep/a@0.2.0` not present")
+                    })?,
+            )?;
+            Ok(Foo { interface0, interface1 })
+        }
+        pub fn my_dep0_1_0_a(&self) -> &exports::my::dep0_1_0::a::Guest {
+            &self.interface0
+        }
+        pub fn my_dep0_2_0_a(&self) -> &exports::my::dep0_2_0::a::Guest {
+            &self.interface1
+        }
+    }
+};
+pub mod my {
+    pub mod dep0_1_0 {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn x(&mut self) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("my:dep/a@0.1.0")?;
+                inst.func_wrap(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::x(host);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+    pub mod dep0_2_0 {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn x(&mut self) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("my:dep/a@0.2.0")?;
+                inst.func_wrap(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::x(host);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod my {
+        pub mod dep0_1_0 {
+            #[allow(clippy::all)]
+            pub mod a {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    x: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let x = *__exports.typed_func::<(), ()>("x")?.func();
+                        Ok(Guest { x })
+                    }
+                    pub fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+        pub mod dep0_2_0 {
+            #[allow(clippy::all)]
+            pub mod a {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    x: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let x = *__exports.typed_func::<(), ()>("x")?.func();
+                        Ok(Guest { x })
+                    }
+                    pub fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -1,0 +1,216 @@
+pub struct Foo {
+    interface0: exports::my::dep0_1_0::a::Guest,
+    interface1: exports::my::dep0_2_0::a::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host + Send,
+            T: Send,
+        {
+            my::dep0_1_0::a::add_to_linker(linker, get)?;
+            my::dep0_2_0::a::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::my::dep0_1_0::a::Guest::new(
+                &mut __exports
+                    .instance("my:dep/a@0.1.0")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `my:dep/a@0.1.0` not present")
+                    })?,
+            )?;
+            let interface1 = exports::my::dep0_2_0::a::Guest::new(
+                &mut __exports
+                    .instance("my:dep/a@0.2.0")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `my:dep/a@0.2.0` not present")
+                    })?,
+            )?;
+            Ok(Foo { interface0, interface1 })
+        }
+        pub fn my_dep0_1_0_a(&self) -> &exports::my::dep0_1_0::a::Guest {
+            &self.interface0
+        }
+        pub fn my_dep0_2_0_a(&self) -> &exports::my::dep0_2_0::a::Guest {
+            &self.interface1
+        }
+    }
+};
+pub mod my {
+    pub mod dep0_1_0 {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn x(&mut self) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.1.0")?;
+                inst.func_wrap_async(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::x(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+    pub mod dep0_2_0 {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn x(&mut self) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.2.0")?;
+                inst.func_wrap_async(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::x(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod my {
+        pub mod dep0_1_0 {
+            #[allow(clippy::all)]
+            pub mod a {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    x: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let x = *__exports.typed_func::<(), ()>("x")?.func();
+                        Ok(Guest { x })
+                    }
+                    pub async fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+        pub mod dep0_2_0 {
+            #[allow(clippy::all)]
+            pub mod a {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    x: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let x = *__exports.typed_func::<(), ()>("x")?.func();
+                        Ok(Guest { x })
+                    }
+                    pub async fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -1,0 +1,762 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::records::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::records::Host,
+        {
+            foo::foo::records::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::records::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/records")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/records` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_records(&self) -> &exports::foo::foo::records::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod records {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Empty {}
+            impl core::fmt::Debug for Empty {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Empty").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Empty as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Empty as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record containing two scalar fields
+            /// that both have the same type
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Scalars {
+                /// The first field, named a
+                #[component(name = "a")]
+                pub a: u32,
+                /// The second field, named b
+                #[component(name = "b")]
+                pub b: u32,
+            }
+            impl core::fmt::Debug for Scalars {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Scalars")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Scalars as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record that is really just flags
+            /// All of the fields are bool
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct ReallyFlags {
+                #[component(name = "a")]
+                pub a: bool,
+                #[component(name = "b")]
+                pub b: bool,
+                #[component(name = "c")]
+                pub c: bool,
+                #[component(name = "d")]
+                pub d: bool,
+                #[component(name = "e")]
+                pub e: bool,
+                #[component(name = "f")]
+                pub f: bool,
+                #[component(name = "g")]
+                pub g: bool,
+                #[component(name = "h")]
+                pub h: bool,
+                #[component(name = "i")]
+                pub i: bool,
+            }
+            impl core::fmt::Debug for ReallyFlags {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("ReallyFlags")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .field("f", &self.f)
+                        .field("g", &self.g)
+                        .field("h", &self.h)
+                        .field("i", &self.i)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    9 == < ReallyFlags as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < ReallyFlags as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Aggregates {
+                #[component(name = "a")]
+                pub a: Scalars,
+                #[component(name = "b")]
+                pub b: u32,
+                #[component(name = "c")]
+                pub c: Empty,
+                #[component(name = "d")]
+                pub d: wasmtime::component::__internal::String,
+                #[component(name = "e")]
+                pub e: ReallyFlags,
+            }
+            impl core::fmt::Debug for Aggregates {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Aggregates")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    32 == < Aggregates as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type IntTypedef = i32;
+            const _: () = {
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type TupleTypedef2 = (IntTypedef,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {
+                fn tuple_arg(&mut self, x: (char, u32)) -> ();
+                fn tuple_result(&mut self) -> (char, u32);
+                fn empty_arg(&mut self, x: Empty) -> ();
+                fn empty_result(&mut self) -> Empty;
+                fn scalar_arg(&mut self, x: Scalars) -> ();
+                fn scalar_result(&mut self) -> Scalars;
+                fn flags_arg(&mut self, x: ReallyFlags) -> ();
+                fn flags_result(&mut self) -> ReallyFlags;
+                fn aggregate_arg(&mut self, x: Aggregates) -> ();
+                fn aggregate_result(&mut self) -> Aggregates;
+                fn typedef_inout(&mut self, e: TupleTypedef2) -> i32;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                inst.func_wrap(
+                    "tuple-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((char, u32),)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "tuple-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "empty-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Empty,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::empty_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "empty-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::empty_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "scalar-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Scalars,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::scalar_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "scalar-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::scalar_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "flags-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (ReallyFlags,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::flags_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "flags-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::flags_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "aggregate-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Aggregates,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::aggregate_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "aggregate-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::aggregate_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "typedef-inout",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (TupleTypedef2,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::typedef_inout(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod records {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Empty {}
+                impl core::fmt::Debug for Empty {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Empty").finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        0 == < Empty as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Empty as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record containing two scalar fields
+                /// that both have the same type
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Scalars {
+                    /// The first field, named a
+                    #[component(name = "a")]
+                    pub a: u32,
+                    /// The second field, named b
+                    #[component(name = "b")]
+                    pub b: u32,
+                }
+                impl core::fmt::Debug for Scalars {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Scalars")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        8 == < Scalars as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record that is really just flags
+                /// All of the fields are bool
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct ReallyFlags {
+                    #[component(name = "a")]
+                    pub a: bool,
+                    #[component(name = "b")]
+                    pub b: bool,
+                    #[component(name = "c")]
+                    pub c: bool,
+                    #[component(name = "d")]
+                    pub d: bool,
+                    #[component(name = "e")]
+                    pub e: bool,
+                    #[component(name = "f")]
+                    pub f: bool,
+                    #[component(name = "g")]
+                    pub g: bool,
+                    #[component(name = "h")]
+                    pub h: bool,
+                    #[component(name = "i")]
+                    pub i: bool,
+                }
+                impl core::fmt::Debug for ReallyFlags {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("ReallyFlags")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .field("f", &self.f)
+                            .field("g", &self.g)
+                            .field("h", &self.h)
+                            .field("i", &self.i)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        9 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        1 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct Aggregates {
+                    #[component(name = "a")]
+                    pub a: Scalars,
+                    #[component(name = "b")]
+                    pub b: u32,
+                    #[component(name = "c")]
+                    pub c: Empty,
+                    #[component(name = "d")]
+                    pub d: wasmtime::component::__internal::String,
+                    #[component(name = "e")]
+                    pub e: ReallyFlags,
+                }
+                impl core::fmt::Debug for Aggregates {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Aggregates")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        32 == < Aggregates as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type IntTypedef = i32;
+                const _: () = {
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef2 = (IntTypedef,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    tuple_arg: wasmtime::component::Func,
+                    tuple_result: wasmtime::component::Func,
+                    empty_arg: wasmtime::component::Func,
+                    empty_result: wasmtime::component::Func,
+                    scalar_arg: wasmtime::component::Func,
+                    scalar_result: wasmtime::component::Func,
+                    flags_arg: wasmtime::component::Func,
+                    flags_result: wasmtime::component::Func,
+                    aggregate_arg: wasmtime::component::Func,
+                    aggregate_result: wasmtime::component::Func,
+                    typedef_inout: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let tuple_arg = *__exports
+                            .typed_func::<((char, u32),), ()>("tuple-arg")?
+                            .func();
+                        let tuple_result = *__exports
+                            .typed_func::<(), ((char, u32),)>("tuple-result")?
+                            .func();
+                        let empty_arg = *__exports
+                            .typed_func::<(Empty,), ()>("empty-arg")?
+                            .func();
+                        let empty_result = *__exports
+                            .typed_func::<(), (Empty,)>("empty-result")?
+                            .func();
+                        let scalar_arg = *__exports
+                            .typed_func::<(Scalars,), ()>("scalar-arg")?
+                            .func();
+                        let scalar_result = *__exports
+                            .typed_func::<(), (Scalars,)>("scalar-result")?
+                            .func();
+                        let flags_arg = *__exports
+                            .typed_func::<(ReallyFlags,), ()>("flags-arg")?
+                            .func();
+                        let flags_result = *__exports
+                            .typed_func::<(), (ReallyFlags,)>("flags-result")?
+                            .func();
+                        let aggregate_arg = *__exports
+                            .typed_func::<(&Aggregates,), ()>("aggregate-arg")?
+                            .func();
+                        let aggregate_result = *__exports
+                            .typed_func::<(), (Aggregates,)>("aggregate-result")?
+                            .func();
+                        let typedef_inout = *__exports
+                            .typed_func::<(TupleTypedef2,), (i32,)>("typedef-inout")?
+                            .func();
+                        Ok(Guest {
+                            tuple_arg,
+                            tuple_result,
+                            empty_arg,
+                            empty_result,
+                            scalar_arg,
+                            scalar_result,
+                            flags_arg,
+                            flags_result,
+                            aggregate_arg,
+                            aggregate_result,
+                            typedef_inout,
+                        })
+                    }
+                    pub fn call_tuple_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: (char, u32),
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_tuple_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(char, u32)> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_empty_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Empty,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_empty_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Empty> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_scalar_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Scalars,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_scalar_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Scalars> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_flags_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: ReallyFlags,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_flags_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<ReallyFlags> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_aggregate_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &Aggregates,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_aggregate_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Aggregates> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_typedef_inout<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: TupleTypedef2,
+                    ) -> wasmtime::Result<i32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -1,0 +1,820 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::records::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::records::Host + Send,
+            T: Send,
+        {
+            foo::foo::records::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::records::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/records")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/records` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_records(&self) -> &exports::foo::foo::records::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod records {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Empty {}
+            impl core::fmt::Debug for Empty {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Empty").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Empty as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Empty as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record containing two scalar fields
+            /// that both have the same type
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Scalars {
+                /// The first field, named a
+                #[component(name = "a")]
+                pub a: u32,
+                /// The second field, named b
+                #[component(name = "b")]
+                pub b: u32,
+            }
+            impl core::fmt::Debug for Scalars {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Scalars")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Scalars as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record that is really just flags
+            /// All of the fields are bool
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct ReallyFlags {
+                #[component(name = "a")]
+                pub a: bool,
+                #[component(name = "b")]
+                pub b: bool,
+                #[component(name = "c")]
+                pub c: bool,
+                #[component(name = "d")]
+                pub d: bool,
+                #[component(name = "e")]
+                pub e: bool,
+                #[component(name = "f")]
+                pub f: bool,
+                #[component(name = "g")]
+                pub g: bool,
+                #[component(name = "h")]
+                pub h: bool,
+                #[component(name = "i")]
+                pub i: bool,
+            }
+            impl core::fmt::Debug for ReallyFlags {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("ReallyFlags")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .field("f", &self.f)
+                        .field("g", &self.g)
+                        .field("h", &self.h)
+                        .field("i", &self.i)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    9 == < ReallyFlags as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < ReallyFlags as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Aggregates {
+                #[component(name = "a")]
+                pub a: Scalars,
+                #[component(name = "b")]
+                pub b: u32,
+                #[component(name = "c")]
+                pub c: Empty,
+                #[component(name = "d")]
+                pub d: wasmtime::component::__internal::String,
+                #[component(name = "e")]
+                pub e: ReallyFlags,
+            }
+            impl core::fmt::Debug for Aggregates {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Aggregates")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    32 == < Aggregates as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type IntTypedef = i32;
+            const _: () = {
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type TupleTypedef2 = (IntTypedef,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn tuple_arg(&mut self, x: (char, u32)) -> ();
+                async fn tuple_result(&mut self) -> (char, u32);
+                async fn empty_arg(&mut self, x: Empty) -> ();
+                async fn empty_result(&mut self) -> Empty;
+                async fn scalar_arg(&mut self, x: Scalars) -> ();
+                async fn scalar_result(&mut self) -> Scalars;
+                async fn flags_arg(&mut self, x: ReallyFlags) -> ();
+                async fn flags_result(&mut self) -> ReallyFlags;
+                async fn aggregate_arg(&mut self, x: Aggregates) -> ();
+                async fn aggregate_result(&mut self) -> Aggregates;
+                async fn typedef_inout(&mut self, e: TupleTypedef2) -> i32;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                inst.func_wrap_async(
+                    "tuple-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((char, u32),)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "tuple-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "empty-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Empty,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::empty_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "empty-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::empty_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "scalar-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Scalars,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::scalar_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "scalar-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::scalar_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "flags-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (ReallyFlags,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::flags_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "flags-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::flags_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "aggregate-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Aggregates,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::aggregate_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "aggregate-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::aggregate_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "typedef-inout",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (TupleTypedef2,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::typedef_inout(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod records {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Empty {}
+                impl core::fmt::Debug for Empty {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Empty").finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        0 == < Empty as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Empty as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record containing two scalar fields
+                /// that both have the same type
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Scalars {
+                    /// The first field, named a
+                    #[component(name = "a")]
+                    pub a: u32,
+                    /// The second field, named b
+                    #[component(name = "b")]
+                    pub b: u32,
+                }
+                impl core::fmt::Debug for Scalars {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Scalars")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        8 == < Scalars as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record that is really just flags
+                /// All of the fields are bool
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct ReallyFlags {
+                    #[component(name = "a")]
+                    pub a: bool,
+                    #[component(name = "b")]
+                    pub b: bool,
+                    #[component(name = "c")]
+                    pub c: bool,
+                    #[component(name = "d")]
+                    pub d: bool,
+                    #[component(name = "e")]
+                    pub e: bool,
+                    #[component(name = "f")]
+                    pub f: bool,
+                    #[component(name = "g")]
+                    pub g: bool,
+                    #[component(name = "h")]
+                    pub h: bool,
+                    #[component(name = "i")]
+                    pub i: bool,
+                }
+                impl core::fmt::Debug for ReallyFlags {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("ReallyFlags")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .field("f", &self.f)
+                            .field("g", &self.g)
+                            .field("h", &self.h)
+                            .field("i", &self.i)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        9 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        1 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct Aggregates {
+                    #[component(name = "a")]
+                    pub a: Scalars,
+                    #[component(name = "b")]
+                    pub b: u32,
+                    #[component(name = "c")]
+                    pub c: Empty,
+                    #[component(name = "d")]
+                    pub d: wasmtime::component::__internal::String,
+                    #[component(name = "e")]
+                    pub e: ReallyFlags,
+                }
+                impl core::fmt::Debug for Aggregates {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Aggregates")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        32 == < Aggregates as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type IntTypedef = i32;
+                const _: () = {
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef2 = (IntTypedef,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    tuple_arg: wasmtime::component::Func,
+                    tuple_result: wasmtime::component::Func,
+                    empty_arg: wasmtime::component::Func,
+                    empty_result: wasmtime::component::Func,
+                    scalar_arg: wasmtime::component::Func,
+                    scalar_result: wasmtime::component::Func,
+                    flags_arg: wasmtime::component::Func,
+                    flags_result: wasmtime::component::Func,
+                    aggregate_arg: wasmtime::component::Func,
+                    aggregate_result: wasmtime::component::Func,
+                    typedef_inout: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let tuple_arg = *__exports
+                            .typed_func::<((char, u32),), ()>("tuple-arg")?
+                            .func();
+                        let tuple_result = *__exports
+                            .typed_func::<(), ((char, u32),)>("tuple-result")?
+                            .func();
+                        let empty_arg = *__exports
+                            .typed_func::<(Empty,), ()>("empty-arg")?
+                            .func();
+                        let empty_result = *__exports
+                            .typed_func::<(), (Empty,)>("empty-result")?
+                            .func();
+                        let scalar_arg = *__exports
+                            .typed_func::<(Scalars,), ()>("scalar-arg")?
+                            .func();
+                        let scalar_result = *__exports
+                            .typed_func::<(), (Scalars,)>("scalar-result")?
+                            .func();
+                        let flags_arg = *__exports
+                            .typed_func::<(ReallyFlags,), ()>("flags-arg")?
+                            .func();
+                        let flags_result = *__exports
+                            .typed_func::<(), (ReallyFlags,)>("flags-result")?
+                            .func();
+                        let aggregate_arg = *__exports
+                            .typed_func::<(&Aggregates,), ()>("aggregate-arg")?
+                            .func();
+                        let aggregate_result = *__exports
+                            .typed_func::<(), (Aggregates,)>("aggregate-result")?
+                            .func();
+                        let typedef_inout = *__exports
+                            .typed_func::<(TupleTypedef2,), (i32,)>("typedef-inout")?
+                            .func();
+                        Ok(Guest {
+                            tuple_arg,
+                            tuple_result,
+                            empty_arg,
+                            empty_result,
+                            scalar_arg,
+                            scalar_result,
+                            flags_arg,
+                            flags_result,
+                            aggregate_arg,
+                            aggregate_result,
+                            typedef_inout,
+                        })
+                    }
+                    pub async fn call_tuple_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: (char, u32),
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_tuple_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(char, u32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_empty_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Empty,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_empty_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Empty>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_scalar_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Scalars,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_scalar_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Scalars>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_flags_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: ReallyFlags,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_flags_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<ReallyFlags>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_aggregate_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &Aggregates,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_aggregate_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Aggregates>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_typedef_inout<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: TupleTypedef2,
+                    ) -> wasmtime::Result<i32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -1,0 +1,112 @@
+pub struct Neptune {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Neptune {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::green::Host + foo::foo::red::Host,
+        {
+            foo::foo::green::add_to_linker(linker, get)?;
+            foo::foo::red::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Neptune {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod green {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Thing = i32;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/green")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod red {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Thing = super::super::super::foo::foo::green::Thing;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn foo(&mut self) -> Thing;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/red")?;
+                inst.func_wrap(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::foo(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -1,0 +1,117 @@
+pub struct Neptune {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Neptune {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::green::Host + foo::foo::red::Host + Send,
+            T: Send,
+        {
+            foo::foo::green::add_to_linker(linker, get)?;
+            foo::foo::red::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Neptune {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod green {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Thing = i32;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/green")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod red {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Thing = super::super::super::foo::foo::green::Thing;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn foo(&mut self) -> Thing;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/red")?;
+                inst.func_wrap_async(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::foo(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -1,0 +1,440 @@
+pub struct W {
+    interface0: exports::foo::foo::simple_export::Guest,
+    interface1: exports::foo::foo::export_using_import::Guest,
+    interface2: exports::foo::foo::export_using_export1::Guest,
+    interface3: exports::foo::foo::export_using_export2::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl W {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::transitive_import::Host,
+        {
+            foo::foo::transitive_import::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::simple_export::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/simple-export")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/simple-export` not present"
+                        )
+                    })?,
+            )?;
+            let interface1 = exports::foo::foo::export_using_import::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/export-using-import")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/export-using-import` not present"
+                        )
+                    })?,
+            )?;
+            let interface2 = exports::foo::foo::export_using_export1::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/export-using-export1")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/export-using-export1` not present"
+                        )
+                    })?,
+            )?;
+            let interface3 = exports::foo::foo::export_using_export2::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/export-using-export2")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/export-using-export2` not present"
+                        )
+                    })?,
+            )?;
+            Ok(W {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+        pub fn foo_foo_simple_export(&self) -> &exports::foo::foo::simple_export::Guest {
+            &self.interface0
+        }
+        pub fn foo_foo_export_using_import(
+            &self,
+        ) -> &exports::foo::foo::export_using_import::Guest {
+            &self.interface1
+        }
+        pub fn foo_foo_export_using_export1(
+            &self,
+        ) -> &exports::foo::foo::export_using_export1::Guest {
+            &self.interface2
+        }
+        pub fn foo_foo_export_using_export2(
+            &self,
+        ) -> &exports::foo::foo::export_using_export2::Guest {
+            &self.interface3
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod transitive_import {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum Y {}
+            pub trait HostY {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Y>,
+                ) -> wasmtime::Result<()>;
+            }
+            pub trait Host: HostY {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                inst.resource(
+                    "y",
+                    wasmtime::component::ResourceType::host::<Y>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostY::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple_export {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_a_constructor = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]a")?
+                            .func();
+                        let static_a_static_a = *__exports
+                            .typed_func::<(), (u32,)>("[static]a.static-a")?
+                            .func();
+                        let method_a_method_a = *__exports
+                            .typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >("[method]a.method-a")?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> wasmtime::Result<u32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_import {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type Y = super::super::super::super::foo::foo::transitive_import::Y;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_a_constructor = *__exports
+                            .typed_func::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]a")?
+                            .func();
+                        let static_a_static_a = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >("[static]a.static-a")?
+                            .func();
+                        let method_a_method_a = *__exports
+                            .typed_func::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >("[method]a.method-a")?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Y>,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                        arg1: wasmtime::component::Resource<Y>,
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0, arg1))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export1 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_a_constructor = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]a")?
+                            .func();
+                        Ok(Guest { constructor_a_constructor })
+                    }
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export2 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type A = super::super::super::super::exports::foo::foo::export_using_export1::A;
+                pub type B = wasmtime::component::ResourceAny;
+                pub struct GuestB<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_b_constructor: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_b_constructor = *__exports
+                            .typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]b")?
+                            .func();
+                        Ok(Guest { constructor_b_constructor })
+                    }
+                    pub fn b(&self) -> GuestB<'_> {
+                        GuestB { funcs: self }
+                    }
+                }
+                impl GuestB<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -1,0 +1,484 @@
+pub struct W {
+    interface0: exports::foo::foo::simple_export::Guest,
+    interface1: exports::foo::foo::export_using_import::Guest,
+    interface2: exports::foo::foo::export_using_export1::Guest,
+    interface3: exports::foo::foo::export_using_export2::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl W {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::transitive_import::Host + Send,
+            T: Send,
+        {
+            foo::foo::transitive_import::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::simple_export::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/simple-export")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/simple-export` not present"
+                        )
+                    })?,
+            )?;
+            let interface1 = exports::foo::foo::export_using_import::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/export-using-import")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/export-using-import` not present"
+                        )
+                    })?,
+            )?;
+            let interface2 = exports::foo::foo::export_using_export1::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/export-using-export1")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/export-using-export1` not present"
+                        )
+                    })?,
+            )?;
+            let interface3 = exports::foo::foo::export_using_export2::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/export-using-export2")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/export-using-export2` not present"
+                        )
+                    })?,
+            )?;
+            Ok(W {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+        pub fn foo_foo_simple_export(&self) -> &exports::foo::foo::simple_export::Guest {
+            &self.interface0
+        }
+        pub fn foo_foo_export_using_import(
+            &self,
+        ) -> &exports::foo::foo::export_using_import::Guest {
+            &self.interface1
+        }
+        pub fn foo_foo_export_using_export1(
+            &self,
+        ) -> &exports::foo::foo::export_using_export1::Guest {
+            &self.interface2
+        }
+        pub fn foo_foo_export_using_export2(
+            &self,
+        ) -> &exports::foo::foo::export_using_export2::Guest {
+            &self.interface3
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod transitive_import {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum Y {}
+            #[wasmtime::component::__internal::async_trait]
+            pub trait HostY {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Y>,
+                ) -> wasmtime::Result<()>;
+            }
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: HostY {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                inst.resource(
+                    "y",
+                    wasmtime::component::ResourceType::host::<Y>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostY::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple_export {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_a_constructor = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]a")?
+                            .func();
+                        let static_a_static_a = *__exports
+                            .typed_func::<(), (u32,)>("[static]a.static-a")?
+                            .func();
+                        let method_a_method_a = *__exports
+                            .typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >("[method]a.method-a")?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_import {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type Y = super::super::super::super::foo::foo::transitive_import::Y;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_a_constructor = *__exports
+                            .typed_func::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]a")?
+                            .func();
+                        let static_a_static_a = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >("[static]a.static-a")?
+                            .func();
+                        let method_a_method_a = *__exports
+                            .typed_func::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >("[method]a.method-a")?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Y>,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                        arg1: wasmtime::component::Resource<Y>,
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export1 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_a_constructor = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]a")?
+                            .func();
+                        Ok(Guest { constructor_a_constructor })
+                    }
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export2 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type A = super::super::super::super::exports::foo::foo::export_using_export1::A;
+                pub type B = wasmtime::component::ResourceAny;
+                pub struct GuestB<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_b_constructor: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let constructor_b_constructor = *__exports
+                            .typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >("[constructor]b")?
+                            .func();
+                        Ok(Guest { constructor_b_constructor })
+                    }
+                    pub fn b(&self) -> GuestB<'_> {
+                        GuestB { funcs: self }
+                    }
+                }
+                impl GuestB<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -1,0 +1,732 @@
+pub enum WorldResource {}
+pub trait HostWorldResource {
+    fn new(&mut self) -> wasmtime::component::Resource<WorldResource>;
+    fn foo(&mut self, self_: wasmtime::component::Resource<WorldResource>) -> ();
+    fn static_foo(&mut self) -> ();
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<WorldResource>,
+    ) -> wasmtime::Result<()>;
+}
+pub struct TheWorld {
+    interface1: exports::foo::foo::uses_resource_transitively::Guest,
+    some_world_func2: wasmtime::component::Func,
+}
+pub trait TheWorldImports: HostWorldResource {
+    fn some_world_func(&mut self) -> wasmtime::component::Resource<WorldResource>;
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::resources::Host + foo::foo::long_use_chain1::Host
+                + foo::foo::long_use_chain2::Host + foo::foo::long_use_chain3::Host
+                + foo::foo::long_use_chain4::Host
+                + foo::foo::transitive_interface_with_resource::Host + TheWorldImports,
+        {
+            foo::foo::resources::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain1::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain2::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain3::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain4::add_to_linker(linker, get)?;
+            foo::foo::transitive_interface_with_resource::add_to_linker(linker, get)?;
+            Self::add_root_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn add_root_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: TheWorldImports,
+        {
+            let mut linker = linker.root();
+            linker
+                .resource(
+                    "world-resource",
+                    wasmtime::component::ResourceType::host::<WorldResource>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostWorldResource::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+            linker
+                .func_wrap(
+                    "[constructor]world-resource",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = HostWorldResource::new(host);
+                        Ok((r,))
+                    },
+                )?;
+            linker
+                .func_wrap(
+                    "[method]world-resource.foo",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<WorldResource>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = HostWorldResource::foo(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+            linker
+                .func_wrap(
+                    "[static]world-resource.static-foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = HostWorldResource::static_foo(host);
+                        Ok(r)
+                    },
+                )?;
+            linker
+                .func_wrap(
+                    "some-world-func",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = TheWorldImports::some_world_func(host);
+                        Ok((r,))
+                    },
+                )?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface1 = exports::foo::foo::uses_resource_transitively::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/uses-resource-transitively")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/uses-resource-transitively` not present"
+                        )
+                    })?,
+            )?;
+            let some_world_func2 = *__exports
+                .typed_func::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >("some-world-func2")?
+                .func();
+            Ok(TheWorld {
+                interface1,
+                some_world_func2,
+            })
+        }
+        pub fn call_some_world_func2<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<wasmtime::component::Resource<WorldResource>> {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >::new_unchecked(self.some_world_func2)
+            };
+            let (ret0,) = callee.call(store.as_context_mut(), ())?;
+            callee.post_return(store.as_context_mut())?;
+            Ok(ret0)
+        }
+        pub fn foo_foo_uses_resource_transitively(
+            &self,
+        ) -> &exports::foo::foo::uses_resource_transitively::Guest {
+            &self.interface1
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod resources {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum Bar {}
+            pub trait HostBar {
+                fn new(&mut self) -> wasmtime::component::Resource<Bar>;
+                fn static_a(&mut self) -> u32;
+                fn method_a(&mut self, self_: wasmtime::component::Resource<Bar>) -> u32;
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()>;
+            }
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedOwn {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedOwn {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedOwn")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedBorrow {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedBorrow {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedBorrow")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type SomeHandle = wasmtime::component::Resource<Bar>;
+            const _: () = {
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host: HostBar {
+                fn bar_own_arg(&mut self, x: wasmtime::component::Resource<Bar>) -> ();
+                fn bar_borrow_arg(
+                    &mut self,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> ();
+                fn bar_result(&mut self) -> wasmtime::component::Resource<Bar>;
+                fn tuple_own_arg(
+                    &mut self,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> ();
+                fn tuple_borrow_arg(
+                    &mut self,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> ();
+                fn tuple_result(&mut self) -> (wasmtime::component::Resource<Bar>, u32);
+                fn option_own_arg(
+                    &mut self,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> ();
+                fn option_borrow_arg(
+                    &mut self,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> ();
+                fn option_result(
+                    &mut self,
+                ) -> Option<wasmtime::component::Resource<Bar>>;
+                fn result_own_arg(
+                    &mut self,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> ();
+                fn result_borrow_arg(
+                    &mut self,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> ();
+                fn result_result(
+                    &mut self,
+                ) -> Result<wasmtime::component::Resource<Bar>, ()>;
+                fn list_own_arg(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> ();
+                fn list_borrow_arg(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> ();
+                fn list_result(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::Resource<Bar>,
+                >;
+                fn record_own_arg(&mut self, x: NestedOwn) -> ();
+                fn record_borrow_arg(&mut self, x: NestedBorrow) -> ();
+                fn record_result(&mut self) -> NestedOwn;
+                fn func_with_handle_typedef(&mut self, x: SomeHandle) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                inst.resource(
+                    "bar",
+                    wasmtime::component::ResourceType::host::<Bar>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostBar::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                inst.func_wrap(
+                    "[constructor]bar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = HostBar::new(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "[static]bar.static-a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = HostBar::static_a(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "[method]bar.method-a",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = HostBar::method_a(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "bar-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::bar_own_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "bar-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::bar_borrow_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "bar-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::bar_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "tuple-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_own_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "tuple-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_borrow_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "tuple-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "option-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_own_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "option-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_borrow_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "option-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "result-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_own_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "result-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_borrow_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "result-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_own_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_borrow_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "list-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "record-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (NestedOwn,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_own_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "record-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (NestedBorrow,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_borrow_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "record-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "func-with-handle-typedef",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (SomeHandle,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::func_with_handle_typedef(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain1 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum A {}
+            pub trait HostA {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<A>,
+                ) -> wasmtime::Result<()>;
+            }
+            pub trait Host: HostA {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                inst.resource(
+                    "a",
+                    wasmtime::component::ResourceType::host::<A>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostA::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain2 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type A = super::super::super::foo::foo::long_use_chain1::A;
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain2")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain3 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type A = super::super::super::foo::foo::long_use_chain2::A;
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain3")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain4 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type A = super::super::super::foo::foo::long_use_chain3::A;
+            pub trait Host {
+                fn foo(&mut self) -> wasmtime::component::Resource<A>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
+                inst.func_wrap(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::foo(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod transitive_interface_with_resource {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum Foo {}
+            pub trait HostFoo {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Foo>,
+                ) -> wasmtime::Result<()>;
+            }
+            pub trait Host: HostFoo {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                inst.resource(
+                    "foo",
+                    wasmtime::component::ResourceType::host::<Foo>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostFoo::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod uses_resource_transitively {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type Foo = super::super::super::super::foo::foo::transitive_interface_with_resource::Foo;
+                pub struct Guest {
+                    handle: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let handle = *__exports
+                            .typed_func::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >("handle")?
+                            .func();
+                        Ok(Guest { handle })
+                    }
+                    pub fn call_handle<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Foo>,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -1,0 +1,768 @@
+pub enum WorldResource {}
+#[wasmtime::component::__internal::async_trait]
+pub trait HostWorldResource {
+    async fn new(&mut self) -> wasmtime::component::Resource<WorldResource>;
+    async fn foo(&mut self, self_: wasmtime::component::Resource<WorldResource>) -> ();
+    async fn static_foo(&mut self) -> ();
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<WorldResource>,
+    ) -> wasmtime::Result<()>;
+}
+pub struct TheWorld {
+    interface1: exports::foo::foo::uses_resource_transitively::Guest,
+    some_world_func2: wasmtime::component::Func,
+}
+#[wasmtime::component::__internal::async_trait]
+pub trait TheWorldImports: HostWorldResource {
+    async fn some_world_func(&mut self) -> wasmtime::component::Resource<WorldResource>;
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::resources::Host + foo::foo::long_use_chain1::Host
+                + foo::foo::long_use_chain2::Host + foo::foo::long_use_chain3::Host
+                + foo::foo::long_use_chain4::Host
+                + foo::foo::transitive_interface_with_resource::Host + TheWorldImports
+                + Send,
+            T: Send,
+        {
+            foo::foo::resources::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain1::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain2::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain3::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain4::add_to_linker(linker, get)?;
+            foo::foo::transitive_interface_with_resource::add_to_linker(linker, get)?;
+            Self::add_root_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn add_root_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: TheWorldImports + Send,
+            T: Send,
+        {
+            let mut linker = linker.root();
+            linker
+                .resource(
+                    "world-resource",
+                    wasmtime::component::ResourceType::host::<WorldResource>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostWorldResource::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+            linker
+                .func_wrap_async(
+                    "[constructor]world-resource",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = HostWorldResource::new(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+            linker
+                .func_wrap_async(
+                    "[method]world-resource.foo",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<WorldResource>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = HostWorldResource::foo(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+            linker
+                .func_wrap_async(
+                    "[static]world-resource.static-foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = HostWorldResource::static_foo(host).await;
+                        Ok(r)
+                    }),
+                )?;
+            linker
+                .func_wrap_async(
+                    "some-world-func",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = TheWorldImports::some_world_func(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface1 = exports::foo::foo::uses_resource_transitively::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/uses-resource-transitively")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/uses-resource-transitively` not present"
+                        )
+                    })?,
+            )?;
+            let some_world_func2 = *__exports
+                .typed_func::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >("some-world-func2")?
+                .func();
+            Ok(TheWorld {
+                interface1,
+                some_world_func2,
+            })
+        }
+        pub async fn call_some_world_func2<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<wasmtime::component::Resource<WorldResource>>
+        where
+            <S as wasmtime::AsContext>::Data: Send,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >::new_unchecked(self.some_world_func2)
+            };
+            let (ret0,) = callee.call_async(store.as_context_mut(), ()).await?;
+            callee.post_return_async(store.as_context_mut()).await?;
+            Ok(ret0)
+        }
+        pub fn foo_foo_uses_resource_transitively(
+            &self,
+        ) -> &exports::foo::foo::uses_resource_transitively::Guest {
+            &self.interface1
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod resources {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum Bar {}
+            #[wasmtime::component::__internal::async_trait]
+            pub trait HostBar {
+                async fn new(&mut self) -> wasmtime::component::Resource<Bar>;
+                async fn static_a(&mut self) -> u32;
+                async fn method_a(
+                    &mut self,
+                    self_: wasmtime::component::Resource<Bar>,
+                ) -> u32;
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()>;
+            }
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedOwn {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedOwn {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedOwn")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedBorrow {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedBorrow {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedBorrow")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type SomeHandle = wasmtime::component::Resource<Bar>;
+            const _: () = {
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: HostBar {
+                async fn bar_own_arg(
+                    &mut self,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> ();
+                async fn bar_borrow_arg(
+                    &mut self,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> ();
+                async fn bar_result(&mut self) -> wasmtime::component::Resource<Bar>;
+                async fn tuple_own_arg(
+                    &mut self,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> ();
+                async fn tuple_borrow_arg(
+                    &mut self,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> ();
+                async fn tuple_result(
+                    &mut self,
+                ) -> (wasmtime::component::Resource<Bar>, u32);
+                async fn option_own_arg(
+                    &mut self,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> ();
+                async fn option_borrow_arg(
+                    &mut self,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> ();
+                async fn option_result(
+                    &mut self,
+                ) -> Option<wasmtime::component::Resource<Bar>>;
+                async fn result_own_arg(
+                    &mut self,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> ();
+                async fn result_borrow_arg(
+                    &mut self,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> ();
+                async fn result_result(
+                    &mut self,
+                ) -> Result<wasmtime::component::Resource<Bar>, ()>;
+                async fn list_own_arg(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> ();
+                async fn list_borrow_arg(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> ();
+                async fn list_result(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::Resource<Bar>,
+                >;
+                async fn record_own_arg(&mut self, x: NestedOwn) -> ();
+                async fn record_borrow_arg(&mut self, x: NestedBorrow) -> ();
+                async fn record_result(&mut self) -> NestedOwn;
+                async fn func_with_handle_typedef(&mut self, x: SomeHandle) -> ();
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                inst.resource(
+                    "bar",
+                    wasmtime::component::ResourceType::host::<Bar>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostBar::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                inst.func_wrap_async(
+                    "[constructor]bar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = HostBar::new(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "[static]bar.static-a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = HostBar::static_a(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "[method]bar.method-a",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = HostBar::method_a(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "bar-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::bar_own_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "bar-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::bar_borrow_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "bar-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::bar_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "tuple-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_own_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "tuple-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_borrow_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "tuple-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::tuple_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "option-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_own_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "option-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_borrow_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "option-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "result-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_own_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "result-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_borrow_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "result-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_own_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_borrow_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "list-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::list_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "record-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (NestedOwn,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_own_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "record-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (NestedBorrow,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_borrow_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "record-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::record_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "func-with-handle-typedef",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (SomeHandle,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::func_with_handle_typedef(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain1 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum A {}
+            #[wasmtime::component::__internal::async_trait]
+            pub trait HostA {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<A>,
+                ) -> wasmtime::Result<()>;
+            }
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: HostA {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                inst.resource(
+                    "a",
+                    wasmtime::component::ResourceType::host::<A>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostA::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain2 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type A = super::super::super::foo::foo::long_use_chain1::A;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain2")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain3 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type A = super::super::super::foo::foo::long_use_chain2::A;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain3")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain4 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type A = super::super::super::foo::foo::long_use_chain3::A;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn foo(&mut self) -> wasmtime::component::Resource<A>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
+                inst.func_wrap_async(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::foo(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod transitive_interface_with_resource {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub enum Foo {}
+            #[wasmtime::component::__internal::async_trait]
+            pub trait HostFoo {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Foo>,
+                ) -> wasmtime::Result<()>;
+            }
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: HostFoo {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                inst.resource(
+                    "foo",
+                    wasmtime::component::ResourceType::host::<Foo>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostFoo::drop(
+                            get(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod uses_resource_transitively {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type Foo = super::super::super::super::foo::foo::transitive_interface_with_resource::Foo;
+                pub struct Guest {
+                    handle: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let handle = *__exports
+                            .typed_func::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >("handle")?
+                            .func();
+                        Ok(Guest { handle })
+                    }
+                    pub async fn call_handle<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Foo>,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -1,0 +1,207 @@
+pub struct HttpInterface {
+    interface0: exports::http_handler::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl HttpInterface {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::http_types::Host + http_fetch::Host,
+        {
+            foo::foo::http_types::add_to_linker(linker, get)?;
+            http_fetch::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::http_handler::Guest::new(
+                &mut __exports
+                    .instance("http-handler")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `http-handler` not present")
+                    })?,
+            )?;
+            Ok(HttpInterface { interface0 })
+        }
+        pub fn http_handler(&self) -> &exports::http_handler::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod http_types {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Request {
+                #[component(name = "method")]
+                pub method: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Request {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Request").field("method", &self.method).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Response {
+                #[component(name = "body")]
+                pub body: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Response {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Response").field("body", &self.body).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < Response as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/http-types")?;
+                Ok(())
+            }
+        }
+    }
+}
+#[allow(clippy::all)]
+pub mod http_fetch {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    pub type Request = super::foo::foo::http_types::Request;
+    const _: () = {
+        assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub type Response = super::foo::foo::http_types::Response;
+    const _: () = {
+        assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub trait Host {
+        fn fetch_request(&mut self, request: Request) -> Response;
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        U: Host,
+    {
+        let mut inst = linker.instance("http-fetch")?;
+        inst.func_wrap(
+            "fetch-request",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (Request,)| {
+                let host = get(caller.data_mut());
+                let r = Host::fetch_request(host, arg0);
+                Ok((r,))
+            },
+        )?;
+        Ok(())
+    }
+}
+pub mod exports {
+    #[allow(clippy::all)]
+    pub mod http_handler {
+        #[allow(unused_imports)]
+        use wasmtime::component::__internal::anyhow;
+        pub type Request = super::super::foo::foo::http_types::Request;
+        const _: () = {
+            assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub type Response = super::super::foo::foo::http_types::Response;
+        const _: () = {
+            assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub struct Guest {
+            handle_request: wasmtime::component::Func,
+        }
+        impl Guest {
+            pub fn new(
+                __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+            ) -> wasmtime::Result<Guest> {
+                let handle_request = *__exports
+                    .typed_func::<(&Request,), (Response,)>("handle-request")?
+                    .func();
+                Ok(Guest { handle_request })
+            }
+            pub fn call_handle_request<S: wasmtime::AsContextMut>(
+                &self,
+                mut store: S,
+                arg0: &Request,
+            ) -> wasmtime::Result<Response> {
+                let callee = unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (&Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                };
+                let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                callee.post_return(store.as_context_mut())?;
+                Ok(ret0)
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -1,0 +1,215 @@
+pub struct HttpInterface {
+    interface0: exports::http_handler::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl HttpInterface {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::http_types::Host + http_fetch::Host + Send,
+            T: Send,
+        {
+            foo::foo::http_types::add_to_linker(linker, get)?;
+            http_fetch::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::http_handler::Guest::new(
+                &mut __exports
+                    .instance("http-handler")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `http-handler` not present")
+                    })?,
+            )?;
+            Ok(HttpInterface { interface0 })
+        }
+        pub fn http_handler(&self) -> &exports::http_handler::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod http_types {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Request {
+                #[component(name = "method")]
+                pub method: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Request {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Request").field("method", &self.method).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Response {
+                #[component(name = "body")]
+                pub body: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Response {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Response").field("body", &self.body).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < Response as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/http-types")?;
+                Ok(())
+            }
+        }
+    }
+}
+#[allow(clippy::all)]
+pub mod http_fetch {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    pub type Request = super::foo::foo::http_types::Request;
+    const _: () = {
+        assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub type Response = super::foo::foo::http_types::Response;
+    const _: () = {
+        assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    #[wasmtime::component::__internal::async_trait]
+    pub trait Host {
+        async fn fetch_request(&mut self, request: Request) -> Response;
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        T: Send,
+        U: Host + Send,
+    {
+        let mut inst = linker.instance("http-fetch")?;
+        inst.func_wrap_async(
+            "fetch-request",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (Request,)| wasmtime::component::__internal::Box::new(async move {
+                let host = get(caller.data_mut());
+                let r = Host::fetch_request(host, arg0).await;
+                Ok((r,))
+            }),
+        )?;
+        Ok(())
+    }
+}
+pub mod exports {
+    #[allow(clippy::all)]
+    pub mod http_handler {
+        #[allow(unused_imports)]
+        use wasmtime::component::__internal::anyhow;
+        pub type Request = super::super::foo::foo::http_types::Request;
+        const _: () = {
+            assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub type Response = super::super::foo::foo::http_types::Response;
+        const _: () = {
+            assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub struct Guest {
+            handle_request: wasmtime::component::Func,
+        }
+        impl Guest {
+            pub fn new(
+                __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+            ) -> wasmtime::Result<Guest> {
+                let handle_request = *__exports
+                    .typed_func::<(&Request,), (Response,)>("handle-request")?
+                    .func();
+                Ok(Guest { handle_request })
+            }
+            pub async fn call_handle_request<S: wasmtime::AsContextMut>(
+                &self,
+                mut store: S,
+                arg0: &Request,
+            ) -> wasmtime::Result<Response>
+            where
+                <S as wasmtime::AsContext>::Data: Send,
+            {
+                let callee = unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (&Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                };
+                let (ret0,) = callee.call_async(store.as_context_mut(), (arg0,)).await?;
+                callee.post_return_async(store.as_context_mut()).await?;
+                Ok(ret0)
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -1,0 +1,275 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::simple::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::simple::Host,
+        {
+            foo::foo::simple::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::simple::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/simple")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/simple` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_simple(&self) -> &exports::foo::foo::simple::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod simple {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn f1(&mut self) -> ();
+                fn f2(&mut self, a: u32) -> ();
+                fn f3(&mut self, a: u32, b: u32) -> ();
+                fn f4(&mut self) -> u32;
+                fn f5(&mut self) -> (u32, u32);
+                fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32);
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/simple")?;
+                inst.func_wrap(
+                    "f1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::f1(host);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "f2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u32,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::f2(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "f3",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0, arg1): (u32, u32)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::f3(host, arg0, arg1);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "f4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::f4(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "f5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::f5(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "f6",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0, arg1, arg2): (u32, u32, u32)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::f6(host, arg0, arg1, arg2);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    f1: wasmtime::component::Func,
+                    f2: wasmtime::component::Func,
+                    f3: wasmtime::component::Func,
+                    f4: wasmtime::component::Func,
+                    f5: wasmtime::component::Func,
+                    f6: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let f1 = *__exports.typed_func::<(), ()>("f1")?.func();
+                        let f2 = *__exports.typed_func::<(u32,), ()>("f2")?.func();
+                        let f3 = *__exports.typed_func::<(u32, u32), ()>("f3")?.func();
+                        let f4 = *__exports.typed_func::<(), (u32,)>("f4")?.func();
+                        let f5 = *__exports
+                            .typed_func::<(), ((u32, u32),)>("f5")?
+                            .func();
+                        let f6 = *__exports
+                            .typed_func::<(u32, u32, u32), ((u32, u32, u32),)>("f6")?
+                            .func();
+                        Ok(Guest { f1, f2, f3, f4, f5, f6 })
+                    }
+                    pub fn call_f1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.f1)
+                        };
+                        let () = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_f2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.f2)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_f3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                        arg1: u32,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32),
+                                (),
+                            >::new_unchecked(self.f3)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0, arg1))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_f4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.f4)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_f5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(u32, u32)> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((u32, u32),),
+                            >::new_unchecked(self.f5)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_f6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                        arg1: u32,
+                        arg2: u32,
+                    ) -> wasmtime::Result<(u32, u32, u32)> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >::new_unchecked(self.f6)
+                        };
+                        let (ret0,) = callee
+                            .call(store.as_context_mut(), (arg0, arg1, arg2))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -1,0 +1,305 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::simple::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::simple::Host + Send,
+            T: Send,
+        {
+            foo::foo::simple::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::simple::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/simple")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/simple` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_simple(&self) -> &exports::foo::foo::simple::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod simple {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn f1(&mut self) -> ();
+                async fn f2(&mut self, a: u32) -> ();
+                async fn f3(&mut self, a: u32, b: u32) -> ();
+                async fn f4(&mut self) -> u32;
+                async fn f5(&mut self) -> (u32, u32);
+                async fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32);
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple")?;
+                inst.func_wrap_async(
+                    "f1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::f1(host).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "f2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u32,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::f2(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "f3",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0, arg1): (u32, u32)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::f3(host, arg0, arg1).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "f4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::f4(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "f5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::f5(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "f6",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0, arg1, arg2): (u32, u32, u32)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::f6(host, arg0, arg1, arg2).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    f1: wasmtime::component::Func,
+                    f2: wasmtime::component::Func,
+                    f3: wasmtime::component::Func,
+                    f4: wasmtime::component::Func,
+                    f5: wasmtime::component::Func,
+                    f6: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let f1 = *__exports.typed_func::<(), ()>("f1")?.func();
+                        let f2 = *__exports.typed_func::<(u32,), ()>("f2")?.func();
+                        let f3 = *__exports.typed_func::<(u32, u32), ()>("f3")?.func();
+                        let f4 = *__exports.typed_func::<(), (u32,)>("f4")?.func();
+                        let f5 = *__exports
+                            .typed_func::<(), ((u32, u32),)>("f5")?
+                            .func();
+                        let f6 = *__exports
+                            .typed_func::<(u32, u32, u32), ((u32, u32, u32),)>("f6")?
+                            .func();
+                        Ok(Guest { f1, f2, f3, f4, f5, f6 })
+                    }
+                    pub async fn call_f1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.f1)
+                        };
+                        let () = callee.call_async(store.as_context_mut(), ()).await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_f2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.f2)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_f3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                        arg1: u32,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32),
+                                (),
+                            >::new_unchecked(self.f3)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_f4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.f4)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_f5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<(u32, u32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((u32, u32),),
+                            >::new_unchecked(self.f5)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_f6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                        arg1: u32,
+                        arg2: u32,
+                    ) -> wasmtime::Result<(u32, u32, u32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >::new_unchecked(self.f6)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0, arg1, arg2))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -1,0 +1,301 @@
+pub struct MyWorld {
+    interface0: exports::foo::foo::simple_lists::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl MyWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::simple_lists::Host,
+        {
+            foo::foo::simple_lists::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::simple_lists::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/simple-lists")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/simple-lists` not present"
+                        )
+                    })?,
+            )?;
+            Ok(MyWorld { interface0 })
+        }
+        pub fn foo_foo_simple_lists(&self) -> &exports::foo::foo::simple_lists::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod simple_lists {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn simple_list1(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<u32>,
+                ) -> ();
+                fn simple_list2(&mut self) -> wasmtime::component::__internal::Vec<u32>;
+                fn simple_list3(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
+                ) -> (
+                    wasmtime::component::__internal::Vec<u32>,
+                    wasmtime::component::__internal::Vec<u32>,
+                );
+                fn simple_list4(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::Vec<u32>,
+                >;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
+                inst.func_wrap(
+                    "simple-list1",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list1(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "simple-list2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list2(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "simple-list3",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list3(host, arg0, arg1);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "simple-list4",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list4(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple_lists {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    simple_list1: wasmtime::component::Func,
+                    simple_list2: wasmtime::component::Func,
+                    simple_list3: wasmtime::component::Func,
+                    simple_list4: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let simple_list1 = *__exports
+                            .typed_func::<(&[u32],), ()>("simple-list1")?
+                            .func();
+                        let simple_list2 = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >("simple-list2")?
+                            .func();
+                        let simple_list3 = *__exports
+                            .typed_func::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >("simple-list3")?
+                            .func();
+                        let simple_list4 = *__exports
+                            .typed_func::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >("simple-list4")?
+                            .func();
+                        Ok(Guest {
+                            simple_list1,
+                            simple_list2,
+                            simple_list3,
+                            simple_list4,
+                        })
+                    }
+                    pub fn call_simple_list1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u32],
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.simple_list1)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_simple_list2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_simple_list3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u32],
+                        arg1: &[u32],
+                    ) -> wasmtime::Result<
+                        (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        ),
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0, arg1))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_simple_list4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[wasmtime::component::__internal::Vec<u32>],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::Vec<u32>,
+                        >,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -1,0 +1,326 @@
+pub struct MyWorld {
+    interface0: exports::foo::foo::simple_lists::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl MyWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::simple_lists::Host + Send,
+            T: Send,
+        {
+            foo::foo::simple_lists::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::simple_lists::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/simple-lists")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/simple-lists` not present"
+                        )
+                    })?,
+            )?;
+            Ok(MyWorld { interface0 })
+        }
+        pub fn foo_foo_simple_lists(&self) -> &exports::foo::foo::simple_lists::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod simple_lists {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn simple_list1(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<u32>,
+                ) -> ();
+                async fn simple_list2(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u32>;
+                async fn simple_list3(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
+                ) -> (
+                    wasmtime::component::__internal::Vec<u32>,
+                    wasmtime::component::__internal::Vec<u32>,
+                );
+                async fn simple_list4(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::Vec<u32>,
+                >;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
+                inst.func_wrap_async(
+                    "simple-list1",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list1(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "simple-list2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list2(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "simple-list3",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list3(host, arg0, arg1).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "simple-list4",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::simple_list4(host, arg0).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple_lists {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    simple_list1: wasmtime::component::Func,
+                    simple_list2: wasmtime::component::Func,
+                    simple_list3: wasmtime::component::Func,
+                    simple_list4: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let simple_list1 = *__exports
+                            .typed_func::<(&[u32],), ()>("simple-list1")?
+                            .func();
+                        let simple_list2 = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >("simple-list2")?
+                            .func();
+                        let simple_list3 = *__exports
+                            .typed_func::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >("simple-list3")?
+                            .func();
+                        let simple_list4 = *__exports
+                            .typed_func::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >("simple-list4")?
+                            .func();
+                        Ok(Guest {
+                            simple_list1,
+                            simple_list2,
+                            simple_list3,
+                            simple_list4,
+                        })
+                    }
+                    pub async fn call_simple_list1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u32],
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32],),
+                                (),
+                            >::new_unchecked(self.simple_list1)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_simple_list2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_simple_list3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[u32],
+                        arg1: &[u32],
+                    ) -> wasmtime::Result<
+                        (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        ),
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_simple_list4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &[wasmtime::component::__internal::Vec<u32>],
+                    ) -> wasmtime::Result<
+                        wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::Vec<u32>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -1,0 +1,171 @@
+pub struct Wasi {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Wasi {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host,
+        {
+            foo::foo::wasi_filesystem::add_to_linker(linker, get)?;
+            foo::foo::wall_clock::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Wasi {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod wasi_filesystem {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct DescriptorStat {}
+            impl core::fmt::Debug for DescriptorStat {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("DescriptorStat").finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    0 == < DescriptorStat as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < DescriptorStat as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum Errno {
+                #[component(name = "e")]
+                E,
+            }
+            impl Errno {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        Errno::E => "e",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        Errno::E => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for Errno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Errno")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for Errno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for Errno {}
+            const _: () = {
+                assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn create_directory_at(&mut self) -> Result<(), Errno>;
+                fn stat(&mut self) -> Result<DescriptorStat, Errno>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
+                inst.func_wrap(
+                    "create-directory-at",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::create_directory_at(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "stat",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::stat(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod wall_clock {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/wall-clock")?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -1,0 +1,176 @@
+pub struct Wasi {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Wasi {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host + Send,
+            T: Send,
+        {
+            foo::foo::wasi_filesystem::add_to_linker(linker, get)?;
+            foo::foo::wall_clock::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Wasi {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod wasi_filesystem {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct DescriptorStat {}
+            impl core::fmt::Debug for DescriptorStat {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("DescriptorStat").finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    0 == < DescriptorStat as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < DescriptorStat as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum Errno {
+                #[component(name = "e")]
+                E,
+            }
+            impl Errno {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        Errno::E => "e",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        Errno::E => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for Errno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Errno")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for Errno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for Errno {}
+            const _: () = {
+                assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn create_directory_at(&mut self) -> Result<(), Errno>;
+                async fn stat(&mut self) -> Result<DescriptorStat, Errno>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
+                inst.func_wrap_async(
+                    "create-directory-at",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::create_directory_at(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "stat",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::stat(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod wall_clock {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/wall-clock")?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -1,0 +1,250 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::anon::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::anon::Host,
+        {
+            foo::foo::anon::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::anon::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/anon")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/anon` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_anon(&self) -> &exports::foo::foo::anon::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod anon {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum Error {
+                #[component(name = "success")]
+                Success,
+                #[component(name = "failure")]
+                Failure,
+            }
+            impl Error {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        Error::Success => "success",
+                        Error::Failure => "failure",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        Error::Success => "",
+                        Error::Failure => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Error")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for Error {}
+            const _: () = {
+                assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn option_test(
+                    &mut self,
+                ) -> Result<Option<wasmtime::component::__internal::String>, Error>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/anon")?;
+                inst.func_wrap(
+                    "option-test",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_test(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod anon {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                pub enum Error {
+                    #[component(name = "success")]
+                    Success,
+                    #[component(name = "failure")]
+                    Failure,
+                }
+                impl Error {
+                    pub fn name(&self) -> &'static str {
+                        match self {
+                            Error::Success => "success",
+                            Error::Failure => "failure",
+                        }
+                    }
+                    pub fn message(&self) -> &'static str {
+                        match self {
+                            Error::Success => "",
+                            Error::Failure => "",
+                        }
+                    }
+                }
+                impl core::fmt::Debug for Error {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Error")
+                            .field("code", &(*self as i32))
+                            .field("name", &self.name())
+                            .field("message", &self.message())
+                            .finish()
+                    }
+                }
+                impl core::fmt::Display for Error {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        write!(f, "{} (error {})", self.name(), * self as i32)
+                    }
+                }
+                impl std::error::Error for Error {}
+                const _: () = {
+                    assert!(
+                        1 == < Error as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Error as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    option_test: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let option_test = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >("option-test")?
+                            .func();
+                        Ok(Guest { option_test })
+                    }
+                    pub fn call_option_test<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        Result<Option<wasmtime::component::__internal::String>, Error>,
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >::new_unchecked(self.option_test)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -1,0 +1,258 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::anon::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::anon::Host + Send,
+            T: Send,
+        {
+            foo::foo::anon::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::anon::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/anon")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `foo:foo/anon` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_anon(&self) -> &exports::foo::foo::anon::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod anon {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum Error {
+                #[component(name = "success")]
+                Success,
+                #[component(name = "failure")]
+                Failure,
+            }
+            impl Error {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        Error::Success => "success",
+                        Error::Failure => "failure",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        Error::Success => "",
+                        Error::Failure => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Error")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for Error {}
+            const _: () = {
+                assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn option_test(
+                    &mut self,
+                ) -> Result<Option<wasmtime::component::__internal::String>, Error>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/anon")?;
+                inst.func_wrap_async(
+                    "option-test",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_test(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod anon {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                pub enum Error {
+                    #[component(name = "success")]
+                    Success,
+                    #[component(name = "failure")]
+                    Failure,
+                }
+                impl Error {
+                    pub fn name(&self) -> &'static str {
+                        match self {
+                            Error::Success => "success",
+                            Error::Failure => "failure",
+                        }
+                    }
+                    pub fn message(&self) -> &'static str {
+                        match self {
+                            Error::Success => "",
+                            Error::Failure => "",
+                        }
+                    }
+                }
+                impl core::fmt::Debug for Error {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Error")
+                            .field("code", &(*self as i32))
+                            .field("name", &self.name())
+                            .field("message", &self.message())
+                            .finish()
+                    }
+                }
+                impl core::fmt::Display for Error {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        write!(f, "{} (error {})", self.name(), * self as i32)
+                    }
+                }
+                impl std::error::Error for Error {}
+                const _: () = {
+                    assert!(
+                        1 == < Error as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Error as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    option_test: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let option_test = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >("option-test")?
+                            .func();
+                        Ok(Guest { option_test })
+                    }
+                    pub async fn call_option_test<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        Result<Option<wasmtime::component::__internal::String>, Error>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >::new_unchecked(self.option_test)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -1,0 +1,59 @@
+pub struct TheWorld {
+    y: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let y = *__exports.typed_func::<(), ()>("y")?.func();
+            Ok(TheWorld { y })
+        }
+        pub fn call_y<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<()> {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+            };
+            let () = callee.call(store.as_context_mut(), ())?;
+            callee.post_return(store.as_context_mut())?;
+            Ok(())
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/smoke-default_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_async.rs
@@ -1,0 +1,62 @@
+pub struct TheWorld {
+    y: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let y = *__exports.typed_func::<(), ()>("y")?.func();
+            Ok(TheWorld { y })
+        }
+        pub async fn call_y<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<()>
+        where
+            <S as wasmtime::AsContext>::Data: Send,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+            };
+            let () = callee.call_async(store.as_context_mut(), ()).await?;
+            callee.post_return_async(store.as_context_mut()).await?;
+            Ok(())
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -1,0 +1,86 @@
+pub struct TheWorld {
+    interface0: exports::the_name::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::the_name::Guest::new(
+                &mut __exports
+                    .instance("the-name")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `the-name` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn the_name(&self) -> &exports::the_name::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod exports {
+    #[allow(clippy::all)]
+    pub mod the_name {
+        #[allow(unused_imports)]
+        use wasmtime::component::__internal::anyhow;
+        pub struct Guest {
+            y: wasmtime::component::Func,
+        }
+        impl Guest {
+            pub fn new(
+                __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+            ) -> wasmtime::Result<Guest> {
+                let y = *__exports.typed_func::<(), ()>("y")?.func();
+                Ok(Guest { y })
+            }
+            pub fn call_y<S: wasmtime::AsContextMut>(
+                &self,
+                mut store: S,
+            ) -> wasmtime::Result<()> {
+                let callee = unsafe {
+                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+                };
+                let () = callee.call(store.as_context_mut(), ())?;
+                callee.post_return(store.as_context_mut())?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -1,0 +1,89 @@
+pub struct TheWorld {
+    interface0: exports::the_name::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::the_name::Guest::new(
+                &mut __exports
+                    .instance("the-name")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("exported instance `the-name` not present")
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn the_name(&self) -> &exports::the_name::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod exports {
+    #[allow(clippy::all)]
+    pub mod the_name {
+        #[allow(unused_imports)]
+        use wasmtime::component::__internal::anyhow;
+        pub struct Guest {
+            y: wasmtime::component::Func,
+        }
+        impl Guest {
+            pub fn new(
+                __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+            ) -> wasmtime::Result<Guest> {
+                let y = *__exports.typed_func::<(), ()>("y")?.func();
+                Ok(Guest { y })
+            }
+            pub async fn call_y<S: wasmtime::AsContextMut>(
+                &self,
+                mut store: S,
+            ) -> wasmtime::Result<()>
+            where
+                <S as wasmtime::AsContext>::Data: Send,
+            {
+                let callee = unsafe {
+                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+                };
+                let () = callee.call_async(store.as_context_mut(), ()).await?;
+                callee.post_return_async(store.as_context_mut()).await?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -1,0 +1,81 @@
+pub struct TheWorld {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: imports::Host,
+        {
+            imports::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(TheWorld {})
+        }
+    }
+};
+#[allow(clippy::all)]
+pub mod imports {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    pub trait Host {
+        fn y(&mut self) -> ();
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        U: Host,
+    {
+        let mut inst = linker.instance("imports")?;
+        inst.func_wrap(
+            "y",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                let host = get(caller.data_mut());
+                let r = Host::y(host);
+                Ok(r)
+            },
+        )?;
+        Ok(())
+    }
+}

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -1,0 +1,84 @@
+pub struct TheWorld {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: imports::Host + Send,
+            T: Send,
+        {
+            imports::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(TheWorld {})
+        }
+    }
+};
+#[allow(clippy::all)]
+pub mod imports {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    #[wasmtime::component::__internal::async_trait]
+    pub trait Host {
+        async fn y(&mut self) -> ();
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        T: Send,
+        U: Host + Send,
+    {
+        let mut inst = linker.instance("imports")?;
+        inst.func_wrap_async(
+            "y",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                let host = get(caller.data_mut());
+                let r = Host::y(host).await;
+                Ok(r)
+            }),
+        )?;
+        Ok(())
+    }
+}

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -1,0 +1,214 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::strings::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::strings::Host,
+        {
+            foo::foo::strings::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::strings::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/strings")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/strings` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_strings(&self) -> &exports::foo::foo::strings::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod strings {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {
+                fn a(&mut self, x: wasmtime::component::__internal::String) -> ();
+                fn b(&mut self) -> wasmtime::component::__internal::String;
+                fn c(
+                    &mut self,
+                    a: wasmtime::component::__internal::String,
+                    b: wasmtime::component::__internal::String,
+                ) -> wasmtime::component::__internal::String;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/strings")?;
+                inst.func_wrap(
+                    "a",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::String,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "b",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::b(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "c",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::c(host, arg0, arg1);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod strings {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    a: wasmtime::component::Func,
+                    b: wasmtime::component::Func,
+                    c: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let a = *__exports.typed_func::<(&str,), ()>("a")?.func();
+                        let b = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >("b")?
+                            .func();
+                        let c = *__exports
+                            .typed_func::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >("c")?
+                            .func();
+                        Ok(Guest { a, b, c })
+                    }
+                    pub fn call_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &str,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str,),
+                                (),
+                            >::new_unchecked(self.a)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_b<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::String> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.b)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_c<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &str,
+                        arg1: &str,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::String> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.c)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), (arg0, arg1))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -1,0 +1,232 @@
+pub struct TheWorld {
+    interface0: exports::foo::foo::strings::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::strings::Host + Send,
+            T: Send,
+        {
+            foo::foo::strings::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::strings::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/strings")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/strings` not present"
+                        )
+                    })?,
+            )?;
+            Ok(TheWorld { interface0 })
+        }
+        pub fn foo_foo_strings(&self) -> &exports::foo::foo::strings::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod strings {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn a(&mut self, x: wasmtime::component::__internal::String) -> ();
+                async fn b(&mut self) -> wasmtime::component::__internal::String;
+                async fn c(
+                    &mut self,
+                    a: wasmtime::component::__internal::String,
+                    b: wasmtime::component::__internal::String,
+                ) -> wasmtime::component::__internal::String;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/strings")?;
+                inst.func_wrap_async(
+                    "a",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::String,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "b",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::b(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "c",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::c(host, arg0, arg1).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod strings {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub struct Guest {
+                    a: wasmtime::component::Func,
+                    b: wasmtime::component::Func,
+                    c: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let a = *__exports.typed_func::<(&str,), ()>("a")?.func();
+                        let b = *__exports
+                            .typed_func::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >("b")?
+                            .func();
+                        let c = *__exports
+                            .typed_func::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >("c")?
+                            .func();
+                        Ok(Guest { a, b, c })
+                    }
+                    pub async fn call_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &str,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str,),
+                                (),
+                            >::new_unchecked(self.a)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_b<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::String>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.b)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_c<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &str,
+                        arg1: &str,
+                    ) -> wasmtime::Result<wasmtime::component::__internal::String>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.c)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -1,0 +1,113 @@
+pub struct Nope {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Nope {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::a::Host,
+        {
+            foo::foo::a::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Nope {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum Error {
+                #[component(name = "other")]
+                Other(wasmtime::component::__internal::String),
+            }
+            impl core::fmt::Debug for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Error::Other(e) => {
+                            f.debug_tuple("Error::Other").field(e).finish()
+                        }
+                    }
+                }
+            }
+            impl core::fmt::Display for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{:?}", self)
+                }
+            }
+            impl std::error::Error for Error {}
+            const _: () = {
+                assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn g(&mut self) -> Result<(), Error>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                inst.func_wrap(
+                    "g",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::g(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -1,0 +1,116 @@
+pub struct Nope {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Nope {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::a::Host + Send,
+            T: Send,
+        {
+            foo::foo::a::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(Nope {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum Error {
+                #[component(name = "other")]
+                Other(wasmtime::component::__internal::String),
+            }
+            impl core::fmt::Debug for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Error::Other(e) => {
+                            f.debug_tuple("Error::Other").field(e).finish()
+                        }
+                    }
+                }
+            }
+            impl core::fmt::Display for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{:?}", self)
+                }
+            }
+            impl std::error::Error for Error {}
+            const _: () = {
+                assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn g(&mut self) -> Result<(), Error>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                inst.func_wrap_async(
+                    "g",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::g(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -1,0 +1,196 @@
+pub struct D {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl D {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host,
+        {
+            foo::foo::a::add_to_linker(linker, get)?;
+            foo::foo::b::add_to_linker(linker, get)?;
+            foo::foo::c::add_to_linker(linker, get)?;
+            d::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(D {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Foo {}
+            impl core::fmt::Debug for Foo {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Foo").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn a(&mut self) -> Foo;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                inst.func_wrap(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod b {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Foo = super::super::super::foo::foo::a::Foo;
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn a(&mut self) -> Foo;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/b")?;
+                inst.func_wrap(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod c {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Foo = super::super::super::foo::foo::b::Foo;
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn a(&mut self) -> Foo;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/c")?;
+                inst.func_wrap(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+#[allow(clippy::all)]
+pub mod d {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    pub type Foo = super::foo::foo::c::Foo;
+    const _: () = {
+        assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+        assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub trait Host {
+        fn b(&mut self) -> Foo;
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        U: Host,
+    {
+        let mut inst = linker.instance("d")?;
+        inst.func_wrap(
+            "b",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                let host = get(caller.data_mut());
+                let r = Host::b(host);
+                Ok((r,))
+            },
+        )?;
+        Ok(())
+    }
+}

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -1,0 +1,206 @@
+pub struct D {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl D {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host
+                + Send,
+            T: Send,
+        {
+            foo::foo::a::add_to_linker(linker, get)?;
+            foo::foo::b::add_to_linker(linker, get)?;
+            foo::foo::c::add_to_linker(linker, get)?;
+            d::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            Ok(D {})
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Foo {}
+            impl core::fmt::Debug for Foo {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Foo").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn a(&mut self) -> Foo;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                inst.func_wrap_async(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod b {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Foo = super::super::super::foo::foo::a::Foo;
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn a(&mut self) -> Foo;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/b")?;
+                inst.func_wrap_async(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod c {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type Foo = super::super::super::foo::foo::b::Foo;
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn a(&mut self) -> Foo;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/c")?;
+                inst.func_wrap_async(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::a(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+#[allow(clippy::all)]
+pub mod d {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    pub type Foo = super::foo::foo::c::Foo;
+    const _: () = {
+        assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+        assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    #[wasmtime::component::__internal::async_trait]
+    pub trait Host {
+        async fn b(&mut self) -> Foo;
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        T: Send,
+        U: Host + Send,
+    {
+        let mut inst = linker.instance("d")?;
+        inst.func_wrap_async(
+            "b",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                let host = get(caller.data_mut());
+                let r = Host::b(host).await;
+                Ok((r,))
+            }),
+        )?;
+        Ok(())
+    }
+}

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -1,0 +1,1616 @@
+pub struct MyWorld {
+    interface0: exports::foo::foo::variants::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl MyWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::variants::Host,
+        {
+            foo::foo::variants::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::variants::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/variants")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/variants` not present"
+                        )
+                    })?,
+            )?;
+            Ok(MyWorld { interface0 })
+        }
+        pub fn foo_foo_variants(&self) -> &exports::foo::foo::variants::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod variants {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum E1 {
+                #[component(name = "a")]
+                A,
+            }
+            impl core::fmt::Debug for E1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        E1::A => f.debug_tuple("E1::A").finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(1 == < E1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < E1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Empty {}
+            impl core::fmt::Debug for Empty {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Empty").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Empty as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Empty as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum V1 {
+                #[component(name = "a")]
+                A,
+                #[component(name = "c")]
+                C(E1),
+                #[component(name = "d")]
+                D(wasmtime::component::__internal::String),
+                #[component(name = "e")]
+                E(Empty),
+                #[component(name = "f")]
+                F,
+                #[component(name = "g")]
+                G(u32),
+            }
+            impl core::fmt::Debug for V1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        V1::A => f.debug_tuple("V1::A").finish(),
+                        V1::C(e) => f.debug_tuple("V1::C").field(e).finish(),
+                        V1::D(e) => f.debug_tuple("V1::D").field(e).finish(),
+                        V1::E(e) => f.debug_tuple("V1::E").field(e).finish(),
+                        V1::F => f.debug_tuple("V1::F").finish(),
+                        V1::G(e) => f.debug_tuple("V1::G").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(12 == < V1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < V1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts1 {
+                #[component(name = "a")]
+                A(i32),
+                #[component(name = "b")]
+                B(f32),
+            }
+            impl core::fmt::Debug for Casts1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts1::A(e) => f.debug_tuple("Casts1::A").field(e).finish(),
+                        Casts1::B(e) => f.debug_tuple("Casts1::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(8 == < Casts1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Casts1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts2 {
+                #[component(name = "a")]
+                A(f64),
+                #[component(name = "b")]
+                B(f32),
+            }
+            impl core::fmt::Debug for Casts2 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts2::A(e) => f.debug_tuple("Casts2::A").field(e).finish(),
+                        Casts2::B(e) => f.debug_tuple("Casts2::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts2 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts2 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts3 {
+                #[component(name = "a")]
+                A(f64),
+                #[component(name = "b")]
+                B(u64),
+            }
+            impl core::fmt::Debug for Casts3 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts3::A(e) => f.debug_tuple("Casts3::A").field(e).finish(),
+                        Casts3::B(e) => f.debug_tuple("Casts3::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts3 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts3 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts4 {
+                #[component(name = "a")]
+                A(u32),
+                #[component(name = "b")]
+                B(i64),
+            }
+            impl core::fmt::Debug for Casts4 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts4::A(e) => f.debug_tuple("Casts4::A").field(e).finish(),
+                        Casts4::B(e) => f.debug_tuple("Casts4::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts4 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts4 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts5 {
+                #[component(name = "a")]
+                A(f32),
+                #[component(name = "b")]
+                B(i64),
+            }
+            impl core::fmt::Debug for Casts5 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts5::A(e) => f.debug_tuple("Casts5::A").field(e).finish(),
+                        Casts5::B(e) => f.debug_tuple("Casts5::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts5 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts5 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts6 {
+                #[component(name = "a")]
+                A((f32, u32)),
+                #[component(name = "b")]
+                B((u32, u32)),
+            }
+            impl core::fmt::Debug for Casts6 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts6::A(e) => f.debug_tuple("Casts6::A").field(e).finish(),
+                        Casts6::B(e) => f.debug_tuple("Casts6::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(12 == < Casts6 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Casts6 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum MyErrno {
+                #[component(name = "bad1")]
+                Bad1,
+                #[component(name = "bad2")]
+                Bad2,
+            }
+            impl MyErrno {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        MyErrno::Bad1 => "bad1",
+                        MyErrno::Bad2 => "bad2",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        MyErrno::Bad1 => "",
+                        MyErrno::Bad2 => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for MyErrno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("MyErrno")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for MyErrno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for MyErrno {}
+            const _: () = {
+                assert!(1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct IsClone {
+                #[component(name = "v1")]
+                pub v1: V1,
+            }
+            impl core::fmt::Debug for IsClone {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("IsClone").field("v1", &self.v1).finish()
+                }
+            }
+            const _: () = {
+                assert!(12 == < IsClone as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                fn e1_arg(&mut self, x: E1) -> ();
+                fn e1_result(&mut self) -> E1;
+                fn v1_arg(&mut self, x: V1) -> ();
+                fn v1_result(&mut self) -> V1;
+                fn bool_arg(&mut self, x: bool) -> ();
+                fn bool_result(&mut self) -> bool;
+                fn option_arg(
+                    &mut self,
+                    a: Option<bool>,
+                    b: Option<()>,
+                    c: Option<u32>,
+                    d: Option<E1>,
+                    e: Option<f32>,
+                    g: Option<Option<bool>>,
+                ) -> ();
+                fn option_result(
+                    &mut self,
+                ) -> (
+                    Option<bool>,
+                    Option<()>,
+                    Option<u32>,
+                    Option<E1>,
+                    Option<f32>,
+                    Option<Option<bool>>,
+                );
+                fn casts(
+                    &mut self,
+                    a: Casts1,
+                    b: Casts2,
+                    c: Casts3,
+                    d: Casts4,
+                    e: Casts5,
+                    f: Casts6,
+                ) -> (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6);
+                fn result_arg(
+                    &mut self,
+                    a: Result<(), ()>,
+                    b: Result<(), E1>,
+                    c: Result<E1, ()>,
+                    d: Result<(), ()>,
+                    e: Result<u32, V1>,
+                    f: Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) -> ();
+                fn result_result(
+                    &mut self,
+                ) -> (
+                    Result<(), ()>,
+                    Result<(), E1>,
+                    Result<E1, ()>,
+                    Result<(), ()>,
+                    Result<u32, V1>,
+                    Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                );
+                fn return_result_sugar(&mut self) -> Result<i32, MyErrno>;
+                fn return_result_sugar2(&mut self) -> Result<(), MyErrno>;
+                fn return_result_sugar3(&mut self) -> Result<MyErrno, MyErrno>;
+                fn return_result_sugar4(&mut self) -> Result<(i32, u32), MyErrno>;
+                fn return_option_sugar(&mut self) -> Option<i32>;
+                fn return_option_sugar2(&mut self) -> Option<MyErrno>;
+                fn result_simple(&mut self) -> Result<u32, i32>;
+                fn is_clone_arg(&mut self, a: IsClone) -> ();
+                fn is_clone_return(&mut self) -> IsClone;
+                fn return_named_option(&mut self) -> Option<u8>;
+                fn return_named_result(&mut self) -> Result<u8, MyErrno>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/variants")?;
+                inst.func_wrap(
+                    "e1-arg",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (E1,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::e1_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "e1-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::e1_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "v1-arg",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (V1,)| {
+                        let host = get(caller.data_mut());
+                        let r = Host::v1_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "v1-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::v1_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "bool-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (bool,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::bool_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "bool-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::bool_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "option-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_arg(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        );
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "option-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "casts",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::casts(host, arg0, arg1, arg2, arg3, arg4, arg5);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "result-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        )|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_arg(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        );
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "result-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-result-sugar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-result-sugar2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar2(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-result-sugar3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar3(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-result-sugar4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar4(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-option-sugar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_option_sugar(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-option-sugar2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_option_sugar2(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "result-simple",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_simple(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "is-clone-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (IsClone,)|
+                    {
+                        let host = get(caller.data_mut());
+                        let r = Host::is_clone_arg(host, arg0);
+                        Ok(r)
+                    },
+                )?;
+                inst.func_wrap(
+                    "is-clone-return",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::is_clone_return(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-named-option",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_named_option(host);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "return-named-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_named_result(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod variants {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                pub enum E1 {
+                    #[component(name = "a")]
+                    A,
+                }
+                impl core::fmt::Debug for E1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            E1::A => f.debug_tuple("E1::A").finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(1 == < E1 as wasmtime::component::ComponentType >::SIZE32);
+                    assert!(1 == < E1 as wasmtime::component::ComponentType >::ALIGN32);
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Empty {}
+                impl core::fmt::Debug for Empty {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Empty").finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        0 == < Empty as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Empty as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum V1 {
+                    #[component(name = "a")]
+                    A,
+                    #[component(name = "c")]
+                    C(E1),
+                    #[component(name = "d")]
+                    D(wasmtime::component::__internal::String),
+                    #[component(name = "e")]
+                    E(Empty),
+                    #[component(name = "f")]
+                    F,
+                    #[component(name = "g")]
+                    G(u32),
+                }
+                impl core::fmt::Debug for V1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            V1::A => f.debug_tuple("V1::A").finish(),
+                            V1::C(e) => f.debug_tuple("V1::C").field(e).finish(),
+                            V1::D(e) => f.debug_tuple("V1::D").field(e).finish(),
+                            V1::E(e) => f.debug_tuple("V1::E").field(e).finish(),
+                            V1::F => f.debug_tuple("V1::F").finish(),
+                            V1::G(e) => f.debug_tuple("V1::G").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(12 == < V1 as wasmtime::component::ComponentType >::SIZE32);
+                    assert!(4 == < V1 as wasmtime::component::ComponentType >::ALIGN32);
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts1 {
+                    #[component(name = "a")]
+                    A(i32),
+                    #[component(name = "b")]
+                    B(f32),
+                }
+                impl core::fmt::Debug for Casts1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts1::A(e) => f.debug_tuple("Casts1::A").field(e).finish(),
+                            Casts1::B(e) => f.debug_tuple("Casts1::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        8 == < Casts1 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Casts1 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts2 {
+                    #[component(name = "a")]
+                    A(f64),
+                    #[component(name = "b")]
+                    B(f32),
+                }
+                impl core::fmt::Debug for Casts2 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts2::A(e) => f.debug_tuple("Casts2::A").field(e).finish(),
+                            Casts2::B(e) => f.debug_tuple("Casts2::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts2 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts2 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts3 {
+                    #[component(name = "a")]
+                    A(f64),
+                    #[component(name = "b")]
+                    B(u64),
+                }
+                impl core::fmt::Debug for Casts3 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts3::A(e) => f.debug_tuple("Casts3::A").field(e).finish(),
+                            Casts3::B(e) => f.debug_tuple("Casts3::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts3 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts3 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts4 {
+                    #[component(name = "a")]
+                    A(u32),
+                    #[component(name = "b")]
+                    B(i64),
+                }
+                impl core::fmt::Debug for Casts4 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts4::A(e) => f.debug_tuple("Casts4::A").field(e).finish(),
+                            Casts4::B(e) => f.debug_tuple("Casts4::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts4 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts4 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts5 {
+                    #[component(name = "a")]
+                    A(f32),
+                    #[component(name = "b")]
+                    B(i64),
+                }
+                impl core::fmt::Debug for Casts5 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts5::A(e) => f.debug_tuple("Casts5::A").field(e).finish(),
+                            Casts5::B(e) => f.debug_tuple("Casts5::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts5 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts5 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts6 {
+                    #[component(name = "a")]
+                    A((f32, u32)),
+                    #[component(name = "b")]
+                    B((u32, u32)),
+                }
+                impl core::fmt::Debug for Casts6 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts6::A(e) => f.debug_tuple("Casts6::A").field(e).finish(),
+                            Casts6::B(e) => f.debug_tuple("Casts6::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < Casts6 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Casts6 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                pub enum MyErrno {
+                    #[component(name = "bad1")]
+                    Bad1,
+                    #[component(name = "bad2")]
+                    Bad2,
+                }
+                impl MyErrno {
+                    pub fn name(&self) -> &'static str {
+                        match self {
+                            MyErrno::Bad1 => "bad1",
+                            MyErrno::Bad2 => "bad2",
+                        }
+                    }
+                    pub fn message(&self) -> &'static str {
+                        match self {
+                            MyErrno::Bad1 => "",
+                            MyErrno::Bad2 => "",
+                        }
+                    }
+                }
+                impl core::fmt::Debug for MyErrno {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("MyErrno")
+                            .field("code", &(*self as i32))
+                            .field("name", &self.name())
+                            .field("message", &self.message())
+                            .finish()
+                    }
+                }
+                impl core::fmt::Display for MyErrno {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        write!(f, "{} (error {})", self.name(), * self as i32)
+                    }
+                }
+                impl std::error::Error for MyErrno {}
+                const _: () = {
+                    assert!(
+                        1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct IsClone {
+                    #[component(name = "v1")]
+                    pub v1: V1,
+                }
+                impl core::fmt::Debug for IsClone {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("IsClone").field("v1", &self.v1).finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < IsClone as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    e1_arg: wasmtime::component::Func,
+                    e1_result: wasmtime::component::Func,
+                    v1_arg: wasmtime::component::Func,
+                    v1_result: wasmtime::component::Func,
+                    bool_arg: wasmtime::component::Func,
+                    bool_result: wasmtime::component::Func,
+                    option_arg: wasmtime::component::Func,
+                    option_result: wasmtime::component::Func,
+                    casts: wasmtime::component::Func,
+                    result_arg: wasmtime::component::Func,
+                    result_result: wasmtime::component::Func,
+                    return_result_sugar: wasmtime::component::Func,
+                    return_result_sugar2: wasmtime::component::Func,
+                    return_result_sugar3: wasmtime::component::Func,
+                    return_result_sugar4: wasmtime::component::Func,
+                    return_option_sugar: wasmtime::component::Func,
+                    return_option_sugar2: wasmtime::component::Func,
+                    result_simple: wasmtime::component::Func,
+                    is_clone_arg: wasmtime::component::Func,
+                    is_clone_return: wasmtime::component::Func,
+                    return_named_option: wasmtime::component::Func,
+                    return_named_result: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let e1_arg = *__exports
+                            .typed_func::<(E1,), ()>("e1-arg")?
+                            .func();
+                        let e1_result = *__exports
+                            .typed_func::<(), (E1,)>("e1-result")?
+                            .func();
+                        let v1_arg = *__exports
+                            .typed_func::<(&V1,), ()>("v1-arg")?
+                            .func();
+                        let v1_result = *__exports
+                            .typed_func::<(), (V1,)>("v1-result")?
+                            .func();
+                        let bool_arg = *__exports
+                            .typed_func::<(bool,), ()>("bool-arg")?
+                            .func();
+                        let bool_result = *__exports
+                            .typed_func::<(), (bool,)>("bool-result")?
+                            .func();
+                        let option_arg = *__exports
+                            .typed_func::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >("option-arg")?
+                            .func();
+                        let option_result = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >("option-result")?
+                            .func();
+                        let casts = *__exports
+                            .typed_func::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >("casts")?
+                            .func();
+                        let result_arg = *__exports
+                            .typed_func::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, &V1>,
+                                    Result<&str, &[u8]>,
+                                ),
+                                (),
+                            >("result-arg")?
+                            .func();
+                        let result_result = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >("result-result")?
+                            .func();
+                        let return_result_sugar = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >("return-result-sugar")?
+                            .func();
+                        let return_result_sugar2 = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >("return-result-sugar2")?
+                            .func();
+                        let return_result_sugar3 = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >("return-result-sugar3")?
+                            .func();
+                        let return_result_sugar4 = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >("return-result-sugar4")?
+                            .func();
+                        let return_option_sugar = *__exports
+                            .typed_func::<(), (Option<i32>,)>("return-option-sugar")?
+                            .func();
+                        let return_option_sugar2 = *__exports
+                            .typed_func::<
+                                (),
+                                (Option<MyErrno>,),
+                            >("return-option-sugar2")?
+                            .func();
+                        let result_simple = *__exports
+                            .typed_func::<(), (Result<u32, i32>,)>("result-simple")?
+                            .func();
+                        let is_clone_arg = *__exports
+                            .typed_func::<(&IsClone,), ()>("is-clone-arg")?
+                            .func();
+                        let is_clone_return = *__exports
+                            .typed_func::<(), (IsClone,)>("is-clone-return")?
+                            .func();
+                        let return_named_option = *__exports
+                            .typed_func::<(), (Option<u8>,)>("return-named-option")?
+                            .func();
+                        let return_named_result = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<u8, MyErrno>,),
+                            >("return-named-result")?
+                            .func();
+                        Ok(Guest {
+                            e1_arg,
+                            e1_result,
+                            v1_arg,
+                            v1_result,
+                            bool_arg,
+                            bool_result,
+                            option_arg,
+                            option_result,
+                            casts,
+                            result_arg,
+                            result_result,
+                            return_result_sugar,
+                            return_result_sugar2,
+                            return_result_sugar3,
+                            return_result_sugar4,
+                            return_option_sugar,
+                            return_option_sugar2,
+                            result_simple,
+                            is_clone_arg,
+                            is_clone_return,
+                            return_named_option,
+                            return_named_result,
+                        })
+                    }
+                    pub fn call_e1_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: E1,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (E1,),
+                                (),
+                            >::new_unchecked(self.e1_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_e1_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<E1> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (E1,),
+                            >::new_unchecked(self.e1_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_v1_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &V1,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&V1,),
+                                (),
+                            >::new_unchecked(self.v1_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_v1_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<V1> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (V1,),
+                            >::new_unchecked(self.v1_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_bool_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: bool,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (bool,),
+                                (),
+                            >::new_unchecked(self.bool_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_bool_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<bool> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (bool,),
+                            >::new_unchecked(self.bool_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_option_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Option<bool>,
+                        arg1: Option<()>,
+                        arg2: Option<u32>,
+                        arg3: Option<E1>,
+                        arg4: Option<f32>,
+                        arg5: Option<Option<bool>>,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >::new_unchecked(self.option_arg)
+                        };
+                        let () = callee
+                            .call(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_option_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ),
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.option_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_casts<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Casts1,
+                        arg1: Casts2,
+                        arg2: Casts3,
+                        arg3: Casts4,
+                        arg4: Casts5,
+                        arg5: Casts6,
+                    ) -> wasmtime::Result<
+                        (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >::new_unchecked(self.casts)
+                        };
+                        let (ret0,) = callee
+                            .call(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_result_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Result<(), ()>,
+                        arg1: Result<(), E1>,
+                        arg2: Result<E1, ()>,
+                        arg3: Result<(), ()>,
+                        arg4: Result<u32, &V1>,
+                        arg5: Result<&str, &[u8]>,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, &V1>,
+                                    Result<&str, &[u8]>,
+                                ),
+                                (),
+                            >::new_unchecked(self.result_arg)
+                        };
+                        let () = callee
+                            .call(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_result_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        ),
+                    > {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >::new_unchecked(self.result_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_result_sugar<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<i32, MyErrno>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<(), MyErrno>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar2)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<MyErrno, MyErrno>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar3)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<(i32, u32), MyErrno>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar4)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_option_sugar<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Option<i32>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<i32>,),
+                            >::new_unchecked(self.return_option_sugar)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Option<MyErrno>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<MyErrno>,),
+                            >::new_unchecked(self.return_option_sugar2)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_result_simple<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<u32, i32>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u32, i32>,),
+                            >::new_unchecked(self.result_simple)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_is_clone_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &IsClone,
+                    ) -> wasmtime::Result<()> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&IsClone,),
+                                (),
+                            >::new_unchecked(self.is_clone_arg)
+                        };
+                        let () = callee.call(store.as_context_mut(), (arg0,))?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(())
+                    }
+                    pub fn call_is_clone_return<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<IsClone> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (IsClone,),
+                            >::new_unchecked(self.is_clone_return)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_named_option<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Option<u8>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<u8>,),
+                            >::new_unchecked(self.return_named_option)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                    pub fn call_return_named_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<u8, MyErrno>> {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u8, MyErrno>,),
+                            >::new_unchecked(self.return_named_result)
+                        };
+                        let (ret0,) = callee.call(store.as_context_mut(), ())?;
+                        callee.post_return(store.as_context_mut())?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -1,0 +1,1729 @@
+pub struct MyWorld {
+    interface0: exports::foo::foo::variants::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl MyWorld {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::variants::Host + Send,
+            T: Send,
+        {
+            foo::foo::variants::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::foo::foo::variants::Guest::new(
+                &mut __exports
+                    .instance("foo:foo/variants")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `foo:foo/variants` not present"
+                        )
+                    })?,
+            )?;
+            Ok(MyWorld { interface0 })
+        }
+        pub fn foo_foo_variants(&self) -> &exports::foo::foo::variants::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod variants {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum E1 {
+                #[component(name = "a")]
+                A,
+            }
+            impl core::fmt::Debug for E1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        E1::A => f.debug_tuple("E1::A").finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(1 == < E1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < E1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Empty {}
+            impl core::fmt::Debug for Empty {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Empty").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Empty as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Empty as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum V1 {
+                #[component(name = "a")]
+                A,
+                #[component(name = "c")]
+                C(E1),
+                #[component(name = "d")]
+                D(wasmtime::component::__internal::String),
+                #[component(name = "e")]
+                E(Empty),
+                #[component(name = "f")]
+                F,
+                #[component(name = "g")]
+                G(u32),
+            }
+            impl core::fmt::Debug for V1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        V1::A => f.debug_tuple("V1::A").finish(),
+                        V1::C(e) => f.debug_tuple("V1::C").field(e).finish(),
+                        V1::D(e) => f.debug_tuple("V1::D").field(e).finish(),
+                        V1::E(e) => f.debug_tuple("V1::E").field(e).finish(),
+                        V1::F => f.debug_tuple("V1::F").finish(),
+                        V1::G(e) => f.debug_tuple("V1::G").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(12 == < V1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < V1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts1 {
+                #[component(name = "a")]
+                A(i32),
+                #[component(name = "b")]
+                B(f32),
+            }
+            impl core::fmt::Debug for Casts1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts1::A(e) => f.debug_tuple("Casts1::A").field(e).finish(),
+                        Casts1::B(e) => f.debug_tuple("Casts1::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(8 == < Casts1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Casts1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts2 {
+                #[component(name = "a")]
+                A(f64),
+                #[component(name = "b")]
+                B(f32),
+            }
+            impl core::fmt::Debug for Casts2 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts2::A(e) => f.debug_tuple("Casts2::A").field(e).finish(),
+                        Casts2::B(e) => f.debug_tuple("Casts2::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts2 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts2 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts3 {
+                #[component(name = "a")]
+                A(f64),
+                #[component(name = "b")]
+                B(u64),
+            }
+            impl core::fmt::Debug for Casts3 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts3::A(e) => f.debug_tuple("Casts3::A").field(e).finish(),
+                        Casts3::B(e) => f.debug_tuple("Casts3::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts3 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts3 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts4 {
+                #[component(name = "a")]
+                A(u32),
+                #[component(name = "b")]
+                B(i64),
+            }
+            impl core::fmt::Debug for Casts4 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts4::A(e) => f.debug_tuple("Casts4::A").field(e).finish(),
+                        Casts4::B(e) => f.debug_tuple("Casts4::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts4 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts4 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts5 {
+                #[component(name = "a")]
+                A(f32),
+                #[component(name = "b")]
+                B(i64),
+            }
+            impl core::fmt::Debug for Casts5 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts5::A(e) => f.debug_tuple("Casts5::A").field(e).finish(),
+                        Casts5::B(e) => f.debug_tuple("Casts5::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts5 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts5 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts6 {
+                #[component(name = "a")]
+                A((f32, u32)),
+                #[component(name = "b")]
+                B((u32, u32)),
+            }
+            impl core::fmt::Debug for Casts6 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts6::A(e) => f.debug_tuple("Casts6::A").field(e).finish(),
+                        Casts6::B(e) => f.debug_tuple("Casts6::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(12 == < Casts6 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Casts6 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            pub enum MyErrno {
+                #[component(name = "bad1")]
+                Bad1,
+                #[component(name = "bad2")]
+                Bad2,
+            }
+            impl MyErrno {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        MyErrno::Bad1 => "bad1",
+                        MyErrno::Bad2 => "bad2",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        MyErrno::Bad1 => "",
+                        MyErrno::Bad2 => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for MyErrno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("MyErrno")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for MyErrno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for MyErrno {}
+            const _: () = {
+                assert!(1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct IsClone {
+                #[component(name = "v1")]
+                pub v1: V1,
+            }
+            impl core::fmt::Debug for IsClone {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("IsClone").field("v1", &self.v1).finish()
+                }
+            }
+            const _: () = {
+                assert!(12 == < IsClone as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {
+                async fn e1_arg(&mut self, x: E1) -> ();
+                async fn e1_result(&mut self) -> E1;
+                async fn v1_arg(&mut self, x: V1) -> ();
+                async fn v1_result(&mut self) -> V1;
+                async fn bool_arg(&mut self, x: bool) -> ();
+                async fn bool_result(&mut self) -> bool;
+                async fn option_arg(
+                    &mut self,
+                    a: Option<bool>,
+                    b: Option<()>,
+                    c: Option<u32>,
+                    d: Option<E1>,
+                    e: Option<f32>,
+                    g: Option<Option<bool>>,
+                ) -> ();
+                async fn option_result(
+                    &mut self,
+                ) -> (
+                    Option<bool>,
+                    Option<()>,
+                    Option<u32>,
+                    Option<E1>,
+                    Option<f32>,
+                    Option<Option<bool>>,
+                );
+                async fn casts(
+                    &mut self,
+                    a: Casts1,
+                    b: Casts2,
+                    c: Casts3,
+                    d: Casts4,
+                    e: Casts5,
+                    f: Casts6,
+                ) -> (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6);
+                async fn result_arg(
+                    &mut self,
+                    a: Result<(), ()>,
+                    b: Result<(), E1>,
+                    c: Result<E1, ()>,
+                    d: Result<(), ()>,
+                    e: Result<u32, V1>,
+                    f: Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) -> ();
+                async fn result_result(
+                    &mut self,
+                ) -> (
+                    Result<(), ()>,
+                    Result<(), E1>,
+                    Result<E1, ()>,
+                    Result<(), ()>,
+                    Result<u32, V1>,
+                    Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                );
+                async fn return_result_sugar(&mut self) -> Result<i32, MyErrno>;
+                async fn return_result_sugar2(&mut self) -> Result<(), MyErrno>;
+                async fn return_result_sugar3(&mut self) -> Result<MyErrno, MyErrno>;
+                async fn return_result_sugar4(&mut self) -> Result<(i32, u32), MyErrno>;
+                async fn return_option_sugar(&mut self) -> Option<i32>;
+                async fn return_option_sugar2(&mut self) -> Option<MyErrno>;
+                async fn result_simple(&mut self) -> Result<u32, i32>;
+                async fn is_clone_arg(&mut self, a: IsClone) -> ();
+                async fn is_clone_return(&mut self) -> IsClone;
+                async fn return_named_option(&mut self) -> Option<u8>;
+                async fn return_named_result(&mut self) -> Result<u8, MyErrno>;
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/variants")?;
+                inst.func_wrap_async(
+                    "e1-arg",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (E1,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::e1_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "e1-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::e1_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "v1-arg",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (V1,)| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::v1_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "v1-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::v1_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "bool-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (bool,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::bool_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "bool-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::bool_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "option-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_arg(
+                                host,
+                                arg0,
+                                arg1,
+                                arg2,
+                                arg3,
+                                arg4,
+                                arg5,
+                            )
+                            .await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "option-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::option_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "casts",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::casts(host, arg0, arg1, arg2, arg3, arg4, arg5)
+                            .await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "result-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        )|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_arg(
+                                host,
+                                arg0,
+                                arg1,
+                                arg2,
+                                arg3,
+                                arg4,
+                                arg5,
+                            )
+                            .await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "result-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-result-sugar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-result-sugar2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar2(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-result-sugar3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar3(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-result-sugar4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_result_sugar4(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-option-sugar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_option_sugar(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-option-sugar2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_option_sugar2(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "result-simple",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::result_simple(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "is-clone-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (IsClone,)|
+                    wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::is_clone_arg(host, arg0).await;
+                        Ok(r)
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "is-clone-return",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::is_clone_return(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-named-option",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_named_option(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                inst.func_wrap_async(
+                    "return-named-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| wasmtime::component::__internal::Box::new(async move {
+                        let host = get(caller.data_mut());
+                        let r = Host::return_named_result(host).await;
+                        Ok((r,))
+                    }),
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod variants {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                pub enum E1 {
+                    #[component(name = "a")]
+                    A,
+                }
+                impl core::fmt::Debug for E1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            E1::A => f.debug_tuple("E1::A").finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(1 == < E1 as wasmtime::component::ComponentType >::SIZE32);
+                    assert!(1 == < E1 as wasmtime::component::ComponentType >::ALIGN32);
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Empty {}
+                impl core::fmt::Debug for Empty {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Empty").finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        0 == < Empty as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Empty as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum V1 {
+                    #[component(name = "a")]
+                    A,
+                    #[component(name = "c")]
+                    C(E1),
+                    #[component(name = "d")]
+                    D(wasmtime::component::__internal::String),
+                    #[component(name = "e")]
+                    E(Empty),
+                    #[component(name = "f")]
+                    F,
+                    #[component(name = "g")]
+                    G(u32),
+                }
+                impl core::fmt::Debug for V1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            V1::A => f.debug_tuple("V1::A").finish(),
+                            V1::C(e) => f.debug_tuple("V1::C").field(e).finish(),
+                            V1::D(e) => f.debug_tuple("V1::D").field(e).finish(),
+                            V1::E(e) => f.debug_tuple("V1::E").field(e).finish(),
+                            V1::F => f.debug_tuple("V1::F").finish(),
+                            V1::G(e) => f.debug_tuple("V1::G").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(12 == < V1 as wasmtime::component::ComponentType >::SIZE32);
+                    assert!(4 == < V1 as wasmtime::component::ComponentType >::ALIGN32);
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts1 {
+                    #[component(name = "a")]
+                    A(i32),
+                    #[component(name = "b")]
+                    B(f32),
+                }
+                impl core::fmt::Debug for Casts1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts1::A(e) => f.debug_tuple("Casts1::A").field(e).finish(),
+                            Casts1::B(e) => f.debug_tuple("Casts1::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        8 == < Casts1 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Casts1 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts2 {
+                    #[component(name = "a")]
+                    A(f64),
+                    #[component(name = "b")]
+                    B(f32),
+                }
+                impl core::fmt::Debug for Casts2 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts2::A(e) => f.debug_tuple("Casts2::A").field(e).finish(),
+                            Casts2::B(e) => f.debug_tuple("Casts2::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts2 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts2 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts3 {
+                    #[component(name = "a")]
+                    A(f64),
+                    #[component(name = "b")]
+                    B(u64),
+                }
+                impl core::fmt::Debug for Casts3 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts3::A(e) => f.debug_tuple("Casts3::A").field(e).finish(),
+                            Casts3::B(e) => f.debug_tuple("Casts3::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts3 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts3 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts4 {
+                    #[component(name = "a")]
+                    A(u32),
+                    #[component(name = "b")]
+                    B(i64),
+                }
+                impl core::fmt::Debug for Casts4 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts4::A(e) => f.debug_tuple("Casts4::A").field(e).finish(),
+                            Casts4::B(e) => f.debug_tuple("Casts4::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts4 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts4 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts5 {
+                    #[component(name = "a")]
+                    A(f32),
+                    #[component(name = "b")]
+                    B(i64),
+                }
+                impl core::fmt::Debug for Casts5 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts5::A(e) => f.debug_tuple("Casts5::A").field(e).finish(),
+                            Casts5::B(e) => f.debug_tuple("Casts5::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts5 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts5 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts6 {
+                    #[component(name = "a")]
+                    A((f32, u32)),
+                    #[component(name = "b")]
+                    B((u32, u32)),
+                }
+                impl core::fmt::Debug for Casts6 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts6::A(e) => f.debug_tuple("Casts6::A").field(e).finish(),
+                            Casts6::B(e) => f.debug_tuple("Casts6::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < Casts6 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Casts6 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                pub enum MyErrno {
+                    #[component(name = "bad1")]
+                    Bad1,
+                    #[component(name = "bad2")]
+                    Bad2,
+                }
+                impl MyErrno {
+                    pub fn name(&self) -> &'static str {
+                        match self {
+                            MyErrno::Bad1 => "bad1",
+                            MyErrno::Bad2 => "bad2",
+                        }
+                    }
+                    pub fn message(&self) -> &'static str {
+                        match self {
+                            MyErrno::Bad1 => "",
+                            MyErrno::Bad2 => "",
+                        }
+                    }
+                }
+                impl core::fmt::Debug for MyErrno {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("MyErrno")
+                            .field("code", &(*self as i32))
+                            .field("name", &self.name())
+                            .field("message", &self.message())
+                            .finish()
+                    }
+                }
+                impl core::fmt::Display for MyErrno {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        write!(f, "{} (error {})", self.name(), * self as i32)
+                    }
+                }
+                impl std::error::Error for MyErrno {}
+                const _: () = {
+                    assert!(
+                        1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct IsClone {
+                    #[component(name = "v1")]
+                    pub v1: V1,
+                }
+                impl core::fmt::Debug for IsClone {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("IsClone").field("v1", &self.v1).finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < IsClone as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    e1_arg: wasmtime::component::Func,
+                    e1_result: wasmtime::component::Func,
+                    v1_arg: wasmtime::component::Func,
+                    v1_result: wasmtime::component::Func,
+                    bool_arg: wasmtime::component::Func,
+                    bool_result: wasmtime::component::Func,
+                    option_arg: wasmtime::component::Func,
+                    option_result: wasmtime::component::Func,
+                    casts: wasmtime::component::Func,
+                    result_arg: wasmtime::component::Func,
+                    result_result: wasmtime::component::Func,
+                    return_result_sugar: wasmtime::component::Func,
+                    return_result_sugar2: wasmtime::component::Func,
+                    return_result_sugar3: wasmtime::component::Func,
+                    return_result_sugar4: wasmtime::component::Func,
+                    return_option_sugar: wasmtime::component::Func,
+                    return_option_sugar2: wasmtime::component::Func,
+                    result_simple: wasmtime::component::Func,
+                    is_clone_arg: wasmtime::component::Func,
+                    is_clone_return: wasmtime::component::Func,
+                    return_named_option: wasmtime::component::Func,
+                    return_named_result: wasmtime::component::Func,
+                }
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        let e1_arg = *__exports
+                            .typed_func::<(E1,), ()>("e1-arg")?
+                            .func();
+                        let e1_result = *__exports
+                            .typed_func::<(), (E1,)>("e1-result")?
+                            .func();
+                        let v1_arg = *__exports
+                            .typed_func::<(&V1,), ()>("v1-arg")?
+                            .func();
+                        let v1_result = *__exports
+                            .typed_func::<(), (V1,)>("v1-result")?
+                            .func();
+                        let bool_arg = *__exports
+                            .typed_func::<(bool,), ()>("bool-arg")?
+                            .func();
+                        let bool_result = *__exports
+                            .typed_func::<(), (bool,)>("bool-result")?
+                            .func();
+                        let option_arg = *__exports
+                            .typed_func::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >("option-arg")?
+                            .func();
+                        let option_result = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >("option-result")?
+                            .func();
+                        let casts = *__exports
+                            .typed_func::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >("casts")?
+                            .func();
+                        let result_arg = *__exports
+                            .typed_func::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, &V1>,
+                                    Result<&str, &[u8]>,
+                                ),
+                                (),
+                            >("result-arg")?
+                            .func();
+                        let result_result = *__exports
+                            .typed_func::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >("result-result")?
+                            .func();
+                        let return_result_sugar = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >("return-result-sugar")?
+                            .func();
+                        let return_result_sugar2 = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >("return-result-sugar2")?
+                            .func();
+                        let return_result_sugar3 = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >("return-result-sugar3")?
+                            .func();
+                        let return_result_sugar4 = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >("return-result-sugar4")?
+                            .func();
+                        let return_option_sugar = *__exports
+                            .typed_func::<(), (Option<i32>,)>("return-option-sugar")?
+                            .func();
+                        let return_option_sugar2 = *__exports
+                            .typed_func::<
+                                (),
+                                (Option<MyErrno>,),
+                            >("return-option-sugar2")?
+                            .func();
+                        let result_simple = *__exports
+                            .typed_func::<(), (Result<u32, i32>,)>("result-simple")?
+                            .func();
+                        let is_clone_arg = *__exports
+                            .typed_func::<(&IsClone,), ()>("is-clone-arg")?
+                            .func();
+                        let is_clone_return = *__exports
+                            .typed_func::<(), (IsClone,)>("is-clone-return")?
+                            .func();
+                        let return_named_option = *__exports
+                            .typed_func::<(), (Option<u8>,)>("return-named-option")?
+                            .func();
+                        let return_named_result = *__exports
+                            .typed_func::<
+                                (),
+                                (Result<u8, MyErrno>,),
+                            >("return-named-result")?
+                            .func();
+                        Ok(Guest {
+                            e1_arg,
+                            e1_result,
+                            v1_arg,
+                            v1_result,
+                            bool_arg,
+                            bool_result,
+                            option_arg,
+                            option_result,
+                            casts,
+                            result_arg,
+                            result_result,
+                            return_result_sugar,
+                            return_result_sugar2,
+                            return_result_sugar3,
+                            return_result_sugar4,
+                            return_option_sugar,
+                            return_option_sugar2,
+                            result_simple,
+                            is_clone_arg,
+                            is_clone_return,
+                            return_named_option,
+                            return_named_result,
+                        })
+                    }
+                    pub async fn call_e1_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: E1,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (E1,),
+                                (),
+                            >::new_unchecked(self.e1_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_e1_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<E1>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (E1,),
+                            >::new_unchecked(self.e1_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_v1_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &V1,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&V1,),
+                                (),
+                            >::new_unchecked(self.v1_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_v1_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<V1>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (V1,),
+                            >::new_unchecked(self.v1_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_bool_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: bool,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (bool,),
+                                (),
+                            >::new_unchecked(self.bool_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_bool_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<bool>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (bool,),
+                            >::new_unchecked(self.bool_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_option_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Option<bool>,
+                        arg1: Option<()>,
+                        arg2: Option<u32>,
+                        arg3: Option<E1>,
+                        arg4: Option<f32>,
+                        arg5: Option<Option<bool>>,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >::new_unchecked(self.option_arg)
+                        };
+                        let () = callee
+                            .call_async(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_option_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ),
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.option_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_casts<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Casts1,
+                        arg1: Casts2,
+                        arg2: Casts3,
+                        arg3: Casts4,
+                        arg4: Casts5,
+                        arg5: Casts6,
+                    ) -> wasmtime::Result<
+                        (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >::new_unchecked(self.casts)
+                        };
+                        let (ret0,) = callee
+                            .call_async(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_result_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Result<(), ()>,
+                        arg1: Result<(), E1>,
+                        arg2: Result<E1, ()>,
+                        arg3: Result<(), ()>,
+                        arg4: Result<u32, &V1>,
+                        arg5: Result<&str, &[u8]>,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, &V1>,
+                                    Result<&str, &[u8]>,
+                                ),
+                                (),
+                            >::new_unchecked(self.result_arg)
+                        };
+                        let () = callee
+                            .call_async(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_result_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        ),
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >::new_unchecked(self.result_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_result_sugar<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<i32, MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<(), MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar2)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<MyErrno, MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar3)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<(i32, u32), MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar4)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_option_sugar<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Option<i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<i32>,),
+                            >::new_unchecked(self.return_option_sugar)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Option<MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<MyErrno>,),
+                            >::new_unchecked(self.return_option_sugar2)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_result_simple<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<u32, i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u32, i32>,),
+                            >::new_unchecked(self.result_simple)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_is_clone_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: &IsClone,
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (&IsClone,),
+                                (),
+                            >::new_unchecked(self.is_clone_arg)
+                        };
+                        let () = callee
+                            .call_async(store.as_context_mut(), (arg0,))
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(())
+                    }
+                    pub async fn call_is_clone_return<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<IsClone>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (IsClone,),
+                            >::new_unchecked(self.is_clone_return)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_named_option<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Option<u8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<u8>,),
+                            >::new_unchecked(self.return_named_option)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                    pub async fn call_return_named_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<Result<u8, MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u8, MyErrno>,),
+                            >::new_unchecked(self.return_named_result)
+                        };
+                        let (ret0,) = callee
+                            .call_async(store.as_context_mut(), ())
+                            .await?;
+                        callee.post_return_async(store.as_context_mut()).await?;
+                        Ok(ret0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/wat.rs
+++ b/crates/component-macro/tests/expanded/wat.rs
@@ -1,0 +1,84 @@
+pub struct Example {
+    interface0: exports::same::name::this_name_is_duplicated::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Example {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::same::name::this_name_is_duplicated::Guest::new(
+                &mut __exports
+                    .instance("same:name/this-name-is-duplicated")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `same:name/this-name-is-duplicated` not present"
+                        )
+                    })?,
+            )?;
+            Ok(Example { interface0 })
+        }
+        pub fn same_name_this_name_is_duplicated(
+            &self,
+        ) -> &exports::same::name::this_name_is_duplicated::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod exports {
+    pub mod same {
+        pub mod name {
+            #[allow(clippy::all)]
+            pub mod this_name_is_duplicated {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type ThisNameIsDuplicated = wasmtime::component::ResourceAny;
+                pub struct GuestThisNameIsDuplicated<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {}
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        Ok(Guest {})
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/wat_async.rs
+++ b/crates/component-macro/tests/expanded/wat_async.rs
@@ -1,0 +1,84 @@
+pub struct Example {
+    interface0: exports::same::name::this_name_is_duplicated::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Example {
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let interface0 = exports::same::name::this_name_is_duplicated::Guest::new(
+                &mut __exports
+                    .instance("same:name/this-name-is-duplicated")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "exported instance `same:name/this-name-is-duplicated` not present"
+                        )
+                    })?,
+            )?;
+            Ok(Example { interface0 })
+        }
+        pub fn same_name_this_name_is_duplicated(
+            &self,
+        ) -> &exports::same::name::this_name_is_duplicated::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod exports {
+    pub mod same {
+        pub mod name {
+            #[allow(clippy::all)]
+            pub mod this_name_is_duplicated {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::anyhow;
+                pub type ThisNameIsDuplicated = wasmtime::component::ResourceAny;
+                pub struct GuestThisNameIsDuplicated<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {}
+                impl Guest {
+                    pub fn new(
+                        __exports: &mut wasmtime::component::ExportInstance<'_, '_>,
+                    ) -> wasmtime::Result<Guest> {
+                        Ok(Guest {})
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -1,0 +1,119 @@
+pub type U = foo::foo::i::T;
+const _: () = {
+    assert!(2 == < U as wasmtime::component::ComponentType >::SIZE32);
+    assert!(2 == < U as wasmtime::component::ComponentType >::ALIGN32);
+};
+pub type T = u32;
+const _: () = {
+    assert!(4 == < T as wasmtime::component::ComponentType >::SIZE32);
+    assert!(4 == < T as wasmtime::component::ComponentType >::ALIGN32);
+};
+#[derive(wasmtime::component::ComponentType)]
+#[derive(wasmtime::component::Lift)]
+#[derive(wasmtime::component::Lower)]
+#[component(record)]
+#[derive(Clone, Copy)]
+pub struct R {}
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("R").finish()
+    }
+}
+const _: () = {
+    assert!(0 == < R as wasmtime::component::ComponentType >::SIZE32);
+    assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
+};
+pub struct Foo {
+    f: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::i::Host,
+        {
+            foo::foo::i::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate(&mut store, component)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub fn instantiate_pre<T>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate(&mut store)?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let f = *__exports.typed_func::<(), ((T, U, R),)>("f")?.func();
+            Ok(Foo { f })
+        }
+        pub fn call_f<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<(T, U, R)> {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
+            };
+            let (ret0,) = callee.call(store.as_context_mut(), ())?;
+            callee.post_return(store.as_context_mut())?;
+            Ok(ret0)
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod i {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type T = u16;
+            const _: () = {
+                assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
+                assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                let mut inst = linker.instance("foo:foo/i")?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -1,0 +1,125 @@
+pub type U = foo::foo::i::T;
+const _: () = {
+    assert!(2 == < U as wasmtime::component::ComponentType >::SIZE32);
+    assert!(2 == < U as wasmtime::component::ComponentType >::ALIGN32);
+};
+pub type T = u32;
+const _: () = {
+    assert!(4 == < T as wasmtime::component::ComponentType >::SIZE32);
+    assert!(4 == < T as wasmtime::component::ComponentType >::ALIGN32);
+};
+#[derive(wasmtime::component::ComponentType)]
+#[derive(wasmtime::component::Lift)]
+#[derive(wasmtime::component::Lower)]
+#[component(record)]
+#[derive(Clone, Copy)]
+pub struct R {}
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("R").finish()
+    }
+}
+const _: () = {
+    assert!(0 == < R as wasmtime::component::ComponentType >::SIZE32);
+    assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
+};
+pub struct Foo {
+    f: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Foo {
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: foo::foo::i::Host + Send,
+            T: Send,
+        {
+            foo::foo::i::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        /// Instantiates the provided `module` using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_async<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = linker.instantiate_async(&mut store, component).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Instantiates a pre-instantiated module using the specified
+        /// parameters, wrapping up the result in a structure that
+        /// translates between wasm and the host.
+        pub async fn instantiate_pre<T: Send>(
+            mut store: impl wasmtime::AsContextMut<Data = T>,
+            instance_pre: &wasmtime::component::InstancePre<T>,
+        ) -> wasmtime::Result<(Self, wasmtime::component::Instance)> {
+            let instance = instance_pre.instantiate_async(&mut store).await?;
+            Ok((Self::new(store, &instance)?, instance))
+        }
+        /// Low-level creation wrapper for wrapping up the exports
+        /// of the `instance` provided in this structure of wasm
+        /// exports.
+        ///
+        /// This function will extract exports from the `instance`
+        /// defined within `store` and wrap them all up in the
+        /// returned structure which can be used to interact with
+        /// the wasm module.
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let mut store = store.as_context_mut();
+            let mut exports = instance.exports(&mut store);
+            let mut __exports = exports.root();
+            let f = *__exports.typed_func::<(), ((T, U, R),)>("f")?.func();
+            Ok(Foo { f })
+        }
+        pub async fn call_f<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<(T, U, R)>
+        where
+            <S as wasmtime::AsContext>::Data: Send,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
+            };
+            let (ret0,) = callee.call_async(store.as_context_mut(), ()).await?;
+            callee.post_return_async(store.as_context_mut()).await?;
+            Ok(ret0)
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod i {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub type T = u16;
+            const _: () = {
+                assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
+                assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host {}
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+                U: Host + Send,
+            {
+                let mut inst = linker.instance("foo:foo/i")?;
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -119,6 +119,10 @@ pub struct Opts {
     ///
     /// These derive attributes will be added to any generated structs or enums
     pub additional_derive_attributes: Vec<String>,
+
+    /// Evaluate to a string literal containing the generated code rather than the generated tokens
+    /// themselves. Mostly useful for Wasmtime internal debugging and development.
+    pub stringify: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3538,6 +3538,18 @@ user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-03-19"
 end = "2024-07-06"
 
+[[trusted.prettyplease]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2022-01-04"
+end = "2025-05-06"
+
+[[trusted.proc-macro2]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-04-23"
+end = "2025-05-06"
+
 [[trusted.quote]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1192,9 +1192,30 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.prettyplease]]
+version = "0.2.19"
+when = "2024-04-15"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.proc-macro2]]
+version = "1.0.81"
+when = "2024-04-17"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.quote]]
 version = "1.0.29"
 when = "2023-06-29"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.quote]]
+version = "1.0.36"
+when = "2024-04-10"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -1313,6 +1334,13 @@ user-name = "David Tolnay"
 [[publisher.syn]]
 version = "2.0.32"
 when = "2023-09-10"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.syn]]
+version = "2.0.60"
+when = "2024-04-17"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"


### PR DESCRIPTION
These outputs are checked in and verified to be fresh by a test so that they can be relied on for code review.

Adds a `stringify` option to `bindgen!` which causes the macro to evaluate to a string literal of the generated code instead of actual tokens.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
