### PR TITLE
Bump Wasmtime's MSRV to 1.76.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -22,6 +22,8 @@ runs:
           echo "version=1.$((msrv+2)).0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
+        elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
+          echo "version=nightly-2024-05-06" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-04-19
+        toolchain: nightly-2024-05-06
 
     # Build C API documentation
     - run: curl -L https://sourceforge.net/projects/doxygen/files/rel-1.9.3/doxygen-1.9.3.linux.bin.tar.gz/download | tar xzf -
@@ -463,7 +463,7 @@ jobs:
     # happen upstream. This is periodically updated through a PR.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-04-19
+        toolchain: nightly-2024-05-06
 
     # Ensure that fuzzers still build.
     #
@@ -826,7 +826,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-03-21
+        toolchain: nightly-2024-05-06
     - run: rustup component add rust-src miri
     - uses: actions/cache@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-05-06
+        toolchain: wasmtime-ci-pinned-nightly
 
     # Build C API documentation
     - run: curl -L https://sourceforge.net/projects/doxygen/files/rel-1.9.3/doxygen-1.9.3.linux.bin.tar.gz/download | tar xzf -
@@ -463,7 +463,7 @@ jobs:
     # happen upstream. This is periodically updated through a PR.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-05-06
+        toolchain: wasmtime-ci-pinned-nightly
 
     # Ensure that fuzzers still build.
     #
@@ -826,7 +826,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-05-06
+        toolchain: wasmtime-ci-pinned-nightly
     - run: rustup component add rust-src miri
     - uses: actions/cache@v4
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.75.0"
+rust-version = "1.76.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -61,7 +61,7 @@ for (let build of array) {
   // Next generate a "min" build and add it to the builds list. Min builds
   // require Nightly rust due to some nightly build options that are configured.
   build.build += '-min';
-  build.rust = 'nightly-2024-04-19';
+  build.rust = 'nightly-2024-05-06';
   builds.push(build);
 }
 

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -61,7 +61,7 @@ for (let build of array) {
   // Next generate a "min" build and add it to the builds list. Min builds
   // require Nightly rust due to some nightly build options that are configured.
   build.build += '-min';
-  build.rust = 'nightly-2024-05-06';
+  build.rust = 'wasmtime-ci-pinned-nightly';
   builds.push(build);
 }
 

--- a/crates/fiber/build.rs
+++ b/crates/fiber/build.rs
@@ -10,7 +10,7 @@ fn main() {
     // `#![feature]` but sort of abuse the fact that cfgs are "leaked" through
     // into Cargo ungated via `--print cfg`. Translate that to `cfg(asan)` for
     // us to write down in the code.
-    println!("cargo::rustc-check-cfg=cfg(asan)");
+    println!("cargo:rustc-check-cfg=cfg(asan)");
     match env::var("CARGO_CFG_SANITIZE") {
         Ok(s) if s == "address" => {
             println!("cargo:rustc-cfg=asan");

--- a/crates/fiber/build.rs
+++ b/crates/fiber/build.rs
@@ -10,6 +10,7 @@ fn main() {
     // `#![feature]` but sort of abuse the fact that cfgs are "leaked" through
     // into Cargo ungated via `--print cfg`. Translate that to `cfg(asan)` for
     // us to write down in the code.
+    println!("cargo::rustc-check-cfg=cfg(asan)");
     match env::var("CARGO_CFG_SANITIZE") {
         Ok(s) if s == "address" => {
             println!("cargo:rustc-cfg=asan");

--- a/crates/fuzzing/wasm-spec-interpreter/build.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/build.rs
@@ -15,6 +15,8 @@ const SPEC_REPOSITORY_BRANCH: &'static str = "wasmtime_fuzzing";
 const SPEC_REPOSITORY_REV: &'static str = "c6bab4461e10229e557aae2e1027cadfce0161ce";
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(feature, values(\"has-libinterpret\"))");
+    println!("cargo:rustc-check-cfg=cfg(fuzzing)");
     if cfg!(feature = "build-libinterpret") {
         build();
     }

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -10,6 +10,7 @@ fn build_c_helpers() {
     use wasmtime_versioned_export_macros::versioned_suffix;
 
     // NB: duplicating a workaround in the wasmtime-fiber build script.
+    println!("cargo:rustc-check-cfg=cfg(asan)");
     match std::env::var("CARGO_CFG_SANITIZE") {
         Ok(s) if s == "address" => {
             println!("cargo:rustc-cfg=asan");

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -101,7 +101,6 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
         config.memory_protection_keys(wasmtime::MpkEnabled::Enable);
     }
 
-    #[cfg(feature = "async")]
     config.total_stacks(1);
 
     config


### PR DESCRIPTION
* Update Rust in CI to 1.78.0, the current stable
* Update nightly tests to the latest nightly



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
