### PR TITLE
Copy through the URI authority unmodified to `Host`

### DIFF
--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -63,8 +63,7 @@ impl WasiHttpView for Ctx {
     ) -> HttpResult<HostFutureIncomingResponse> {
         if let Some(rejected_authority) = &self.rejected_authority {
             let authority = request.uri().authority().map(ToString::to_string).unwrap();
-            let (auth, _port) = authority.split_once(':').unwrap();
-            if auth == rejected_authority {
+            if &authority == rejected_authority {
                 return Err(ErrorCode::HttpRequestDenied.into());
             }
         }


### PR DESCRIPTION
Rather than construct an authority that includes the default port for the scheme given, copy the authority through. This better matches the behavior in the http/1.1 spec, as pointed out in #8430.

Fixes #8430

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
