### PR TITLE
V8 differential fuzzing: add new table out-of-bounds error message to expectations list.

### DIFF
--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -129,6 +129,7 @@ impl DiffEngine for V8Engine {
                 return verify_v8(&[
                     "table initializer is out of bounds",
                     "table index is out of bounds",
+                    "element segment out of bounds",
                 ])
             }
             Trap::BadSignature => return verify_v8(&["function signature mismatch"]),


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68735.

That fuzzbug bisected to the call-indirect caching changes, but this turned out to be a red herring (the options added in that PR mean that the fuzzbug config deserializes differently prior to the commit). In any case, it's an easy fix -- it appears that V8 added a new error message, so we need to add it to the allowlist of messages that we expect for a table out-of-bounds condition.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
