### PR TITLE
wasmtime: Remove ALL constant phis

### DIFF
--- a/cranelift/filetests/filetests/remove-constant-phis/maximal.clif
+++ b/cranelift/filetests/filetests/remove-constant-phis/maximal.clif
@@ -1,0 +1,33 @@
+test optimize precise-output
+target x86_64
+
+function u0:0(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    brif v0, block1(v1), block1(v2)
+
+block1(v3: i32):
+    brif v0, block3(v3), block2(v3)
+
+block2(v4: i32):
+    jump block3(v4)
+
+block3(v5: i32):
+    return v5
+}
+
+; function u0:0(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     brif v0, block1(v1), block1(v2)
+;
+; block1(v3: i32):
+;     v4 -> v3
+;     v5 -> v3
+;     brif.i32 v0, block3, block2
+;
+; block2:
+;     jump block3
+;
+; block3:
+;     return v5
+; }
+


### PR DESCRIPTION
When we're trying to delete block-params that can be replaced by a single dominating value, we weren't handling some cases.

In particular, if we concluded that a block formal parameter (say, `v3`) had more than one value, then we believed that any uses of that parameter (say, defining another formal parameter `v4`) also had more than one value, and therefore could not be deleted.

However, in such cases we can try using `v3` itself as the definition of `v4`. If there are no other definitions of `v4`, then it can be deleted.

With this change, if a block has only one predecessor, it is now true that this pass will delete all of its block params. We couldn't rely on that property before.