### PR TITLE
Release Wasmtime 20.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "20.0.1"
+version = "20.0.2"
 
 [[package]]
 name = "byteorder"
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -589,14 +589,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -624,25 +624,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.107.1"
+version = "0.107.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.107.1"
+version = "0.107.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1047,7 +1047,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embedding"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3088,7 +3088,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "wasmparser 0.202.0",
@@ -3138,7 +3138,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "byte-array-literals",
  "object 0.33.0",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3448,14 +3448,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3471,14 +3471,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3621,11 +3621,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "20.0.1"
+version = "20.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "object 0.33.0",
  "once_cell",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -3822,11 +3822,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "20.0.1"
+version = "20.0.2"
 
 [[package]]
 name = "wasmtime-types"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "20.0.1"
+version = "20.0.2"
 
 [[package]]
 name = "wast"
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "20.0.1"
+version = "20.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4121,7 +4121,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "20.0.1"
+version = "20.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -158,57 +158,57 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=20.0.1" }
-wasmtime = { path = "crates/wasmtime", version = "20.0.1", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=20.0.1" }
-wasmtime-cache = { path = "crates/cache", version = "=20.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=20.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=20.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=20.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=20.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=20.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=20.0.1" }
-wasmtime-types = { path = "crates/types", version = "20.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=20.0.1" }
-wasmtime-runtime = { path = "crates/runtime", version = "=20.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=20.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "20.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=20.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "20.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "20.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=20.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=20.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=20.0.1" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=20.0.1" }
-wasmtime-slab = { path = "crates/slab", version = "=20.0.1" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=20.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "20.0.2", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=20.0.2" }
+wasmtime-cache = { path = "crates/cache", version = "=20.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=20.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=20.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=20.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=20.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=20.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=20.0.2" }
+wasmtime-types = { path = "crates/types", version = "20.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=20.0.2" }
+wasmtime-runtime = { path = "crates/runtime", version = "=20.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=20.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "20.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=20.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "20.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "20.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=20.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=20.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=20.0.2" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=20.0.2" }
+wasmtime-slab = { path = "crates/slab", version = "=20.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=20.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=20.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=20.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=20.0.1", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=20.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=20.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=20.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=20.0.2", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=20.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=20.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=20.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=20.0.2" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.107.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.107.1", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.107.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.107.1" }
-cranelift-native = { path = "cranelift/native", version = "0.107.1" }
-cranelift-module = { path = "cranelift/module", version = "0.107.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.107.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.107.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.107.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.107.2", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.107.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.107.2" }
+cranelift-native = { path = "cranelift/native", version = "0.107.2" }
+cranelift-module = { path = "cranelift/module", version = "0.107.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.107.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.107.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.107.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.107.1" }
+cranelift-object = { path = "cranelift/object", version = "0.107.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.107.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.107.1" }
-cranelift-control = { path = "cranelift/control", version = "0.107.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.107.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.107.2" }
+cranelift-control = { path = "cranelift/control", version = "0.107.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.107.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.18.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.18.2" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,23 @@
 --------------------------------------------------------------------------------
 
+## 20.0.2
+
+Released 2024-05-07.
+
+### Added
+
+* Improve error in CMake for when Cargo is not found.
+  [#8497](https://github.com/bytecodealliance/wasmtime/issues/8497)
+
+* Use `--release` in CMake with MinSizeRel and RelWithDebInfo.
+  [#8549](https://github.com/bytecodealliance/wasmtime/issues/8549)
+
+* Add a `WASMTIME_FASTEST_RUNTIME` configuration option for CMake which enables
+  LTO and other related optimization options.
+  [#8554](https://github.com/bytecodealliance/wasmtime/issues/8554)
+
+--------------------------------------------------------------------------------
+
 ## 20.0.1
 
 Released 2024-05-03.

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.107.1"
+version = "0.107.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.107.1"
+version = "0.107.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.107.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.107.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -44,8 +44,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.107.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.107.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.107.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.107.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.107.1"
+version = "0.107.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.107.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.107.2" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.107.1"
+version = "0.107.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.107.1"
+version = "0.107.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.107.1"
+version = "0.107.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.107.1"
+version = "0.107.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.107.1"
+version = "0.107.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.107.1"
+version = "0.107.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.107.1"
+version = "0.107.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.107.1"
+version = "0.107.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.107.1"
+version = "0.107.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.107.1"
+version = "0.107.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.107.1"
+version = "0.107.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.107.1"
+version = "0.107.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.107.1"
+version = "0.107.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.107.1"
+version = "0.107.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -205,7 +205,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "20.0.1"
+#define WASMTIME_VERSION "20.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -217,7 +217,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -16,6 +20,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-bforest]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.107.0"
@@ -25,6 +33,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-codegen]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -32,6 +44,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.107.0"
@@ -41,6 +57,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-control]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -48,6 +68,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-control]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-control]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.107.0"
@@ -57,6 +81,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-entity]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-frontend]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -64,6 +92,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-frontend]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-frontend]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.107.0"
@@ -73,6 +105,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-isle]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -80,6 +116,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-isle]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-isle]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.107.0"
@@ -89,6 +129,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-jit]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-module]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -96,6 +140,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-module]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-module]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-native]]
 version = "0.107.0"
@@ -105,6 +153,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-native]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-object]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -112,6 +164,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-object]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-object]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.107.0"
@@ -121,6 +177,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.cranelift-serde]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -128,6 +188,10 @@ audited_as = "0.105.2"
 [[unpublished.cranelift-serde]]
 version = "0.107.1"
 audited_as = "0.107.0"
+
+[[unpublished.cranelift-serde]]
+version = "0.107.2"
+audited_as = "0.107.1"
 
 [[unpublished.cranelift-wasm]]
 version = "0.107.0"
@@ -137,6 +201,10 @@ audited_as = "0.105.2"
 version = "0.107.1"
 audited_as = "0.107.0"
 
+[[unpublished.cranelift-wasm]]
+version = "0.107.2"
+audited_as = "0.107.1"
+
 [[unpublished.wasi-common]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -144,6 +212,10 @@ audited_as = "18.0.2"
 [[unpublished.wasi-common]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasi-common]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime]]
 version = "20.0.0"
@@ -153,6 +225,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -160,6 +236,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-asm-macros]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "20.0.0"
@@ -169,6 +249,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -176,6 +260,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-cli]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "20.0.0"
@@ -185,6 +273,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -192,6 +284,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-component-macro]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "20.0.0"
@@ -201,6 +297,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -208,6 +308,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-cranelift]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "20.0.0"
@@ -221,6 +325,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-environ]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-explorer]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -228,6 +336,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-explorer]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-explorer]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-fiber]]
 version = "20.0.0"
@@ -237,6 +349,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-fiber]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -244,6 +360,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-jit-debug]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "20.0.0"
@@ -253,6 +373,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-runtime]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -260,6 +384,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-runtime]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-runtime]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-slab]]
 version = "20.0.0"
@@ -269,6 +397,10 @@ audited_as = "19.0.0"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-slab]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-types]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -276,6 +408,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-types]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-types]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "20.0.0"
@@ -285,6 +421,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -292,6 +432,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-wasi-http]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "20.0.0"
@@ -301,6 +445,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -308,6 +456,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-wasi-threads]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "20.0.0"
@@ -317,6 +469,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -324,6 +480,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-winch]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "20.0.0"
@@ -333,6 +493,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -340,6 +504,10 @@ audited_as = "18.0.2"
 [[unpublished.wasmtime-wmemcheck]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wiggle]]
 version = "20.0.0"
@@ -349,6 +517,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wiggle]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -357,6 +529,10 @@ audited_as = "18.0.2"
 version = "20.0.1"
 audited_as = "20.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "20.0.2"
+audited_as = "20.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -364,6 +540,10 @@ audited_as = "18.0.2"
 [[unpublished.wiggle-macro]]
 version = "20.0.1"
 audited_as = "20.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "20.0.2"
+audited_as = "20.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -376,6 +556,10 @@ audited_as = "0.16.2"
 [[unpublished.winch-codegen]]
 version = "0.18.1"
 audited_as = "0.18.0"
+
+[[unpublished.winch-codegen]]
+version = "0.18.2"
+audited_as = "0.18.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -564,6 +748,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -573,6 +763,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -588,6 +784,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -597,6 +799,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -612,6 +820,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -621,6 +835,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -636,6 +856,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -645,6 +871,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -660,6 +892,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -669,6 +907,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -684,6 +928,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -693,6 +943,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -708,6 +964,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -717,6 +979,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -732,6 +1000,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -744,6 +1018,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.107.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -753,6 +1033,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.107.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.107.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1131,6 +1417,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1250,6 +1542,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1259,6 +1557,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1274,6 +1578,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1283,6 +1593,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1298,6 +1614,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1307,6 +1629,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1322,6 +1650,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1331,6 +1665,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1346,6 +1686,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1355,6 +1701,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1370,6 +1722,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1379,6 +1737,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1394,6 +1758,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1403,6 +1773,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-runtime]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1418,6 +1794,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-slab]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-types]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1427,6 +1809,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-types]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-types]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1442,6 +1830,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1451,6 +1845,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1466,6 +1866,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1475,6 +1881,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1490,6 +1902,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1499,6 +1917,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-winch]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1514,6 +1938,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1523,6 +1953,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1562,6 +1998,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1574,6 +2016,12 @@ when = "2024-04-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "20.0.1"
+when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1583,6 +2031,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "20.0.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "20.0.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1609,6 +2063,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.18.0"
 when = "2024-04-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.18.1"
+when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 20.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
