### PR TITLE
[21.0.0] Copy through the authority unmodified to `Host` 

### DIFF
--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -63,8 +63,7 @@ impl WasiHttpView for Ctx {
     ) -> HttpResult<HostFutureIncomingResponse> {
         if let Some(rejected_authority) = &self.rejected_authority {
             let authority = request.uri().authority().map(ToString::to_string).unwrap();
-            let (auth, _port) = authority.split_once(':').unwrap();
-            if auth == rejected_authority {
+            if &authority == rejected_authority {
                 return Err(ErrorCode::HttpRequestDenied.into());
             }
         }


### PR DESCRIPTION
Backport of #8563, seemed like a good bugfix to get in.