### PR TITLE
wasmtime(gc): Fix wasm-to-native trampoline lookup for subtyping

### DIFF
--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -34,7 +34,7 @@ pub struct WasmFunctionInfo {
 
 /// Description of where a function is located in the text section of a
 /// compiled image.
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct FunctionLoc {
     /// The byte offset from the start of the text section where this
     /// function starts.

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -1,12 +1,10 @@
 use crate::PrimaryMap;
 use core::ops::{Index, Range};
+use cranelift_entity::{packed_option::PackedOption, SecondaryMap};
 use serde_derive::{Deserialize, Serialize};
 use wasmtime_types::{ModuleInternedRecGroupIndex, ModuleInternedTypeIndex, WasmSubType};
 
 /// All types used in a core wasm module.
-///
-/// At this time this only contains function types. Note, though, that function
-/// types are deduplicated within this [`ModuleTypes`].
 ///
 /// Note that accesing this type is primarily done through the `Index`
 /// implementations for this type.
@@ -14,6 +12,7 @@ use wasmtime_types::{ModuleInternedRecGroupIndex, ModuleInternedTypeIndex, WasmS
 pub struct ModuleTypes {
     rec_groups: PrimaryMap<ModuleInternedRecGroupIndex, Range<ModuleInternedTypeIndex>>,
     wasm_types: PrimaryMap<ModuleInternedTypeIndex, WasmSubType>,
+    trampoline_types: SecondaryMap<ModuleInternedTypeIndex, PackedOption<ModuleInternedTypeIndex>>,
 }
 
 impl ModuleTypes {
@@ -56,6 +55,55 @@ impl ModuleTypes {
     /// Adds a new type to this interned list of types.
     pub fn push(&mut self, ty: WasmSubType) -> ModuleInternedTypeIndex {
         self.wasm_types.push(ty)
+    }
+
+    /// Iterate over the trampoline function types that this module requires.
+    ///
+    /// Yields pairs of (1) a function type and (2) its associated trampoline
+    /// type. They might be the same.
+    ///
+    /// See the docs for `WasmFuncType::trampoline_type` for details on
+    /// trampoline types.
+    pub fn trampoline_types(
+        &self,
+    ) -> impl Iterator<Item = (ModuleInternedTypeIndex, ModuleInternedTypeIndex)> + '_ {
+        self.trampoline_types
+            .iter()
+            .filter_map(|(k, v)| v.expand().map(|v| (k, v)))
+    }
+
+    /// Get the trampoline type for the given function type.
+    ///
+    /// See the docs for `WasmFuncType::trampoline_type` for details on
+    /// trampoline types.
+    pub fn trampoline_type(&self, ty: ModuleInternedTypeIndex) -> ModuleInternedTypeIndex {
+        debug_assert!(self[ty].is_func());
+        self.trampoline_types[ty].unwrap()
+    }
+}
+
+/// Methods that only exist for `ModuleTypesBuilder`.
+#[cfg(feature = "compile")]
+impl ModuleTypes {
+    /// Associate `trampoline_ty` as the trampoline type for `for_ty`.
+    ///
+    /// This is really only for use by the `ModuleTypesBuilder`.
+    pub fn set_trampoline_type(
+        &mut self,
+        for_ty: ModuleInternedTypeIndex,
+        trampoline_ty: ModuleInternedTypeIndex,
+    ) {
+        use cranelift_entity::packed_option::ReservedValue;
+
+        debug_assert!(!for_ty.is_reserved_value());
+        debug_assert!(!trampoline_ty.is_reserved_value());
+        debug_assert!(self.wasm_types[for_ty].is_func());
+        debug_assert!(self.trampoline_types[for_ty].is_none());
+        debug_assert!(self.wasm_types[trampoline_ty]
+            .unwrap_func()
+            .is_trampoline_type());
+
+        self.trampoline_types[for_ty] = Some(trampoline_ty).into();
     }
 
     /// Adds a new rec group to this interned list of types.

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1300,8 +1300,8 @@ impl Func {
 
                     let sig = self.type_index(store.store_data());
                     module.runtime_info().wasm_to_native_trampoline(sig).expect(
-                        "must have a wasm-to-native trampoline for this signature if the Wasm \
-                         module is importing a function of this signature",
+                        "if the wasm is importing a function of a given type, it must have the \
+                         type's trampoline",
                     )
                 },
                 native_call: f.as_ref().native_call,

--- a/crates/wasmtime/src/runtime/instantiate.rs
+++ b/crates/wasmtime/src/runtime/instantiate.rs
@@ -192,10 +192,14 @@ impl CompiledModule {
     /// `VMFuncRef::wasm_call` for `Func::wrap`-style host funcrefs
     /// that don't have access to a compiler when created.
     pub fn wasm_to_native_trampoline(&self, signature: ModuleInternedTypeIndex) -> &[u8] {
-        let idx = self
+        let idx = match self
             .wasm_to_native_trampolines
             .binary_search_by_key(&signature, |entry| entry.0)
-            .expect("should have a Wasm-to-native trampline for all signatures");
+        {
+            Ok(idx) => idx,
+            Err(_) => panic!("missing trampoline for {signature:?}"),
+        };
+
         let (_, loc) = self.wasm_to_native_trampolines[idx];
         &self.text()[loc.start as usize..][..loc.length as usize]
     }

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -172,6 +172,14 @@ impl fmt::Debug for Module {
     }
 }
 
+impl std::fmt::Debug for ModuleInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModuleInner")
+            .field("name", &self.module.module().name.as_ref())
+            .finish_non_exhaustive()
+    }
+}
+
 impl Module {
     /// Creates a new WebAssembly `Module` from the given in-memory `bytes`.
     ///
@@ -1104,10 +1112,28 @@ impl crate::runtime::vm::ModuleRuntimeInfo for ModuleInner {
         &self,
         signature: VMSharedTypeIndex,
     ) -> Option<NonNull<VMWasmCallFunction>> {
-        let sig = self.code.signatures().module_local_type(signature)?;
+        log::trace!("Looking up trampoline for {signature:?}");
+        let trampoline_shared_ty = self.engine.signatures().trampoline_type(signature);
+        let trampoline_module_ty = self
+            .code
+            .signatures()
+            .trampoline_type(trampoline_shared_ty)?;
+        debug_assert!(self
+            .engine
+            .signatures()
+            .borrow(
+                self.code
+                    .signatures()
+                    .shared_type(trampoline_module_ty)
+                    .unwrap()
+            )
+            .unwrap()
+            .unwrap_func()
+            .is_trampoline_type());
+
         let ptr = self
             .module
-            .wasm_to_native_trampoline(sig)
+            .wasm_to_native_trampoline(trampoline_module_ty)
             .as_ptr()
             .cast::<VMWasmCallFunction>()
             .cast_mut();

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -172,8 +172,8 @@ impl fmt::Debug for Module {
     }
 }
 
-impl std::fmt::Debug for ModuleInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for ModuleInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ModuleInner")
             .field("name", &self.module.module().name.as_ref())
             .finish_non_exhaustive()

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -2132,3 +2132,123 @@ fn call_func_with_funcref_both_typed_and_untyped() -> Result<()> {
     f1.call(&mut store, &[Val::FuncRef(Some(f2))], &mut [])?;
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn wasm_to_host_trampolines_and_subtyping() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+
+    let engine = Engine::new(&config)?;
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $ty (func (result (ref null extern))))
+
+                (import "" "a" (func $imported_func (type $ty)))
+                (import "" "return_func" (func $return_func (result (ref $ty))))
+                (global $g (export "g") (mut (ref null $ty)) (ref.null $ty))
+                (table $t (export "t") 10 10 (ref null $ty))
+
+                (func (export "f")
+                    (drop (call $imported_func))
+                    (drop (call_ref $ty (call $return_func)))
+                    (drop (call_ref $ty (global.get $g)))
+                    (drop (call_ref $ty (table.get $t (i32.const 0))))
+                )
+            )
+        "#,
+    )?;
+
+    // This defines functions of type `(func (result (ref extern)))` and not of
+    // type `(func (result (ref null extern)))` that the Wasm imports. But it is
+    // still a subtype of the Wasm import's type, so we should be able to use
+    // the Wasm's precompiled trampolines with this host function.
+    //
+    // But this means we also need to look up the trampoline by the caller's
+    // type, rather than the callee's type.
+    //
+    // So take each kind of function we can define, and give it to Wasm in every
+    // way that Wasm can receive a function, and make sure we find the correct
+    // trampolines in all cases and everything works.
+    //
+    // Note that we create multiple versions of the same function by calling
+    // these constructors multiple times in the loop below. This is to avoid the
+    // scenario where we reuse the function, the first time it is exposed to
+    // Wasm its trampoline is filled in, and then all subsequent uses don't
+    // actually exercise their associated code paths for finding and
+    // initializing their trampoline.
+    let func_ty = FuncType::new(&engine, [], [RefType::new(false, HeapType::Extern).into()]);
+    let func_ctors: Vec<Box<dyn Fn(&mut Store<_>) -> Func>> = vec![
+        Box::new(|store| {
+            Func::wrap(store, |mut caller: Caller<'_, ()>| {
+                ExternRef::new(&mut caller, 100)
+            })
+        }),
+        Box::new(|store| {
+            Func::new(
+                store,
+                func_ty.clone(),
+                |mut caller: Caller<'_, ()>, _args, results| {
+                    results[0] = ExternRef::new(&mut caller, 200)?.into();
+                    Ok(())
+                },
+            )
+        }),
+    ];
+
+    let return_func_ty = FuncType::new(
+        &engine,
+        [],
+        [RefType::new(false, HeapType::ConcreteFunc(func_ty.clone())).into()],
+    );
+
+    for make_func in func_ctors {
+        let mut store = Store::new(&engine, ());
+
+        let imported_func = make_func(&mut store);
+        assert!(FuncType::eq(&imported_func.ty(&store), &func_ty));
+
+        let returned_func = make_func(&mut store);
+        assert!(FuncType::eq(&returned_func.ty(&store), &func_ty));
+
+        let return_func = Func::new(
+            &mut store,
+            return_func_ty.clone(),
+            move |_caller, _args, results| {
+                results[0] = returned_func.clone().into();
+                Ok(())
+            },
+        );
+
+        let instance = Instance::new(
+            &mut store,
+            &module,
+            &[imported_func.into(), return_func.into()],
+        )?;
+
+        let g = make_func(&mut store);
+        assert!(FuncType::eq(&g.ty(&store), &func_ty));
+        instance
+            .get_global(&mut store, "g")
+            .unwrap()
+            .set(&mut store, g.into())?;
+
+        let t = make_func(&mut store);
+        assert!(FuncType::eq(&t.ty(&store), &func_ty));
+        instance
+            .get_table(&mut store, "t")
+            .unwrap()
+            .set(&mut store, 0, t.into())?;
+
+        let f = instance.get_typed_func::<(), ()>(&mut store, "f")?;
+        f.call(&mut store, ())?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Previously, we would look up a wasm-to-native trampoline in the Wasm module based on the host function's type. With Wasm GC and subtyping, this becomes problematic because a Wasm module can import a function of type `T` but the host can define a function of type `U` where `U <: T`. And if the Wasm has never defined type `U` then it wouldn't have a trampoline for it. But our trampolines don't actually care, they treat all reference values within the same type hierarchy identically. So the trampoline for `T` would have worked in practice. But once we find a trampoline for a function, we cache it and reuse it every time that function is used in the same store again. Even if the function is imported with its precise type somewhere else. So then we would have a trampoline of the wrong type. But this happened to be okay in practice because the trampolines happen not to inspect their arguments or do anything with them other than forward them between calling convention locations. But relying on that accidental invariant seems fragile and like a gun aimed at the future's feet.

This commit makes that invariant non-accidental, centering it and hopefully making it less fragile by doing so, by making every function type have an associated "trampoline type". A trampoline type is the original function type but where all the reference types in its params and results are replaced with the nullable top versions, e.g. `(ref $my_struct)` is replaced with `(ref null any)`. Often a function type is its own associated trampoline type, as is the case for all functions that don't have take or return any references, for example. Then, all trampoline lookup begins by first getting the trampoline type of the actual function type, or actual import type, and then only afterwards finding for the pre-compiled trampoline in the Wasm module.

Fixes https://github.com/bytecodealliance/wasmtime/issues/8432

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
