### PR TITLE
[21.0.0] Update wasm-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmtime-types",
  "wat",
 ]
@@ -2743,7 +2743,7 @@ dependencies = [
  "cargo_metadata",
  "heck",
  "wasmtime",
- "wit-component 0.206.0",
+ "wit-component 0.207.0",
 ]
 
 [[package]]
@@ -3079,7 +3079,7 @@ name = "verify-component-adapter"
 version = "21.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wat",
 ]
 
@@ -3171,7 +3171,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.33.0",
  "wasi",
- "wasm-encoder 0.206.0",
+ "wasm-encoder 0.207.0",
  "wit-bindgen",
 ]
 
@@ -3240,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d759312e1137f199096d80a70be685899cd7d3d09c572836bb2e9b69b4dc3b1e"
+checksum = "d996306fb3aeaee0d9157adbe2f670df0236caf19f6728b221e92d0f27b3fe17"
 dependencies = [
  "leb128",
 ]
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84435ac34e29de6154fdb180ebbe2bdde96336f7ad0990003c43a21bd441303f"
+checksum = "b2c44e62d325ce9253f88c01f0f67be121356767d12f2f13e701fdcd99e1f5b0"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3275,36 +3275,36 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.206.0",
- "wasmparser 0.206.0",
+ "wasm-encoder 0.207.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd8f7a4dc2b33e16b5fe96e31922ab3d5351abd93e404fcdc5bdd67d91915f0"
+checksum = "17f1f13b2d32934450e1092213385bf98411c9448a4418b79d54640df0280c36"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.206.0",
- "wasmparser 0.206.0",
+ "wasm-encoder 0.207.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797d1293e8c8ce440c22dc283b7db0f68035929928f1736f12f4d9bf8fd2a24d"
+checksum = "604b90d8a005c9dfb783c5cfba074429f9c7f3f7d6aea5ba79a4657413fdb1ad"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder 0.206.0",
+ "wasm-encoder 0.207.0",
 ]
 
 [[package]]
@@ -3360,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39192edb55d55b41963db40fd49b0b542156f04447b5b512744a91d38567bdbc"
+checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -3382,12 +3382,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dec456f9cc479792c9920055cd499ae1d13f85e98f9443dfe4ea5751b21f3b0"
+checksum = "9c2d8a7b4dabb460208e6b4334d9db5766e84505038b2529e69c3d07ac619115"
 dependencies = [
  "anyhow",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
@@ -3430,8 +3430,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder 0.206.0",
- "wasmparser 0.206.0",
+ "wasm-encoder 0.207.0",
+ "wasmparser 0.207.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3573,7 +3573,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3586,10 +3586,10 @@ dependencies = [
  "wasmtime-wasi-nn",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 206.0.0",
+ "wast 207.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component 0.206.0",
+ "wit-component 0.207.0",
 ]
 
 [[package]]
@@ -3620,7 +3620,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.206.0",
+ "wit-parser 0.207.0",
 ]
 
 [[package]]
@@ -3644,7 +3644,7 @@ dependencies = [
  "object 0.33.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3667,8 +3667,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.206.0",
- "wasmparser 0.206.0",
+ "wasm-encoder 0.207.0",
+ "wasmparser 0.207.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3683,7 +3683,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3740,7 +3740,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3761,12 +3761,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.206.0",
+ "wasm-encoder 0.207.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3805,7 +3805,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]
@@ -3912,7 +3912,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 206.0.0",
+ "wast 207.0.0",
 ]
 
 [[package]]
@@ -3924,7 +3924,7 @@ dependencies = [
  "gimli",
  "object 0.33.0",
  "target-lexicon",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3937,7 +3937,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.2.6",
- "wit-parser 0.206.0",
+ "wit-parser 0.207.0",
 ]
 
 [[package]]
@@ -3955,24 +3955,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "206.0.0"
+version = "207.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68586953ee4960b1f5d84ebf26df3b628b17e6173bc088e0acfbce431469795a"
+checksum = "0e40be9fd494bfa501309487d2dc0b3f229be6842464ecbdc54eac2679c84c93"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.206.0",
+ "wasm-encoder 0.207.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.206.0"
+version = "1.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4c6f2606276c6e991aebf441b2fc92c517807393f039992a3e0ad873efe4ad"
+checksum = "8eb2b15e2d5f300f5e1209e7dc237f2549edbd4203655b6c6cab5cf180561ee7"
 dependencies = [
- "wast 206.0.0",
+ "wast 207.0.0",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4343,9 +4343,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e1ae4cace3706e29a8cf1f728b792255ecdc02653b9f4130ab6cc64f435a67"
+checksum = "a411ff9c471737091b2c1a738a25031029fc4d0b8f1a60bef0e68906e9f6534b"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4354,10 +4354,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.206.0",
- "wasm-metadata 0.206.0",
- "wasmparser 0.206.0",
- "wit-parser 0.206.0",
+ "wasm-encoder 0.207.0",
+ "wasm-metadata 0.207.0",
+ "wasmparser 0.207.0",
+ "wit-parser 0.207.0",
 ]
 
 [[package]]
@@ -4380,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d226de4e95e052cb664d2bdad2f31d9cad5117038a3439568f078d1afd8842fe"
+checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4393,7 +4393,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.206.0",
+ "wasmparser 0.207.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,15 +231,15 @@ rustix = "0.38.31"
 wit-bindgen = { version = "0.22.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.206.0", default-features = false }
-wat = "1.206.0"
-wast = "206.0.0"
-wasmprinter = "0.206.0"
-wasm-encoder = "0.206.0"
-wasm-smith = "0.206.0"
-wasm-mutate = "0.206.0"
-wit-parser = "0.206.0"
-wit-component = "0.206.0"
+wasmparser = { version = "0.207.0", default-features = false }
+wat = "1.207.0"
+wast = "207.0.0"
+wasmprinter = "0.207.0"
+wasm-encoder = "0.207.0"
+wasm-smith = "0.207.0"
+wasm-mutate = "0.207.0"
+wit-parser = "0.207.0"
+wit-component = "0.207.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-wasmparser = { workspace = true }
+wasmparser = { workspace = true, features = ['validate'] }
 cranelift-codegen = { workspace = true }
 cranelift-entity = { workspace = true }
 cranelift-frontend = { workspace = true }

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -85,7 +85,7 @@ pub fn parse_import_section<'data>(
                 environ.declare_global_import(ty, import.module, import.name)?;
             }
             TypeRef::Table(ty) => {
-                let ty = environ.convert_table_type(&ty);
+                let ty = environ.convert_table_type(&ty)?;
                 environ.declare_table_import(ty, import.module, import.name)?;
             }
         }
@@ -124,7 +124,7 @@ pub fn parse_table_section(
     environ.reserve_tables(tables.count())?;
 
     for entry in tables {
-        let ty = environ.convert_table_type(&entry?.ty);
+        let ty = environ.convert_table_type(&entry?.ty)?;
         environ.declare_table(ty)?;
     }
 

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -19,7 +19,7 @@ postcard = { workspace = true }
 cpp_demangle = { version = "0.4.3", optional = true }
 cranelift-entity = { workspace = true }
 wasmtime-types = { workspace = true }
-wasmparser = { workspace = true }
+wasmparser = { workspace = true, features = ['validate'] }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -322,7 +322,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                         }
                         TypeRef::Table(ty) => {
                             self.result.module.num_imported_tables += 1;
-                            EntityType::Table(self.convert_table_type(&ty))
+                            EntityType::Table(self.convert_table_type(&ty)?)
                         }
 
                         // doesn't get past validation
@@ -353,7 +353,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
 
                 for entry in tables {
                     let wasmparser::Table { ty, init } = entry?;
-                    let table = self.convert_table_type(&ty);
+                    let table = self.convert_table_type(&ty)?;
                     let plan = TablePlan::for_table(table, &self.tunables);
                     self.result.module.table_plans.push(plan);
                     let init = match init {

--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -379,7 +379,7 @@ impl ComponentTypesBuilder {
                     .intern_type(&module, types, *id)?
                     .into()
             }),
-            types::EntityType::Table(ty) => EntityType::Table(self.convert_table_type(ty)),
+            types::EntityType::Table(ty) => EntityType::Table(self.convert_table_type(ty)?),
             types::EntityType::Memory(ty) => EntityType::Memory(ty.clone().into()),
             types::EntityType::Global(ty) => EntityType::Global(self.convert_global_type(ty)),
             types::EntityType::Tag(_) => bail!("exceptions proposal not implemented"),

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -83,8 +83,9 @@ impl TableOps {
         let mut tables = TableSection::new();
         tables.table(TableType {
             element_type: RefType::EXTERNREF,
-            minimum: self.table_size as u32,
+            minimum: self.table_size as u64,
             maximum: None,
+            table64: false,
         });
 
         // Define our globals.

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1445,12 +1445,15 @@ pub trait TypeConvert {
     }
 
     /// Converts a wasmparser table type into a wasmtime type
-    fn convert_table_type(&self, ty: &wasmparser::TableType) -> Table {
-        Table {
-            wasm_ty: self.convert_ref_type(ty.element_type),
-            minimum: ty.initial,
-            maximum: ty.maximum,
+    fn convert_table_type(&self, ty: &wasmparser::TableType) -> WasmResult<Table> {
+        if ty.table64 {
+            return Err(wasm_unsupported!("wasm memory64: 64-bit table type"));
         }
+        Ok(Table {
+            wasm_ty: self.convert_ref_type(ty.element_type),
+            minimum: ty.initial.try_into().unwrap(),
+            maximum: ty.maximum.map(|i| i.try_into().unwrap()),
+        })
     }
 
     fn convert_sub_type(&self, ty: &wasmparser::SubType) -> WasmResult<WasmSubType> {

--- a/crates/wasi-preview1-component-adapter/verify/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/verify/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 workspace = true
 
 [dependencies]
-wasmparser = { workspace = true, features = ['std'] }
+wasmparser = { workspace = true, features = ['std', 'validate'] }
 wat = { workspace = true }
 anyhow = { workspace = true, features = ['std'] }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -264,6 +264,9 @@ impl Config {
             ret.cranelift_opt_level(OptLevel::Speed);
         }
 
+        // Not yet implemented in Wasmtime
+        ret.features.set(WasmFeatures::EXTENDED_CONST, false);
+
         // Conditionally enabled features depending on compile-time crate
         // features. Note that if these features are disabled then `Config` has
         // no way of re-enabling them.

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1216,6 +1216,12 @@ when = "2024-04-25"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-encoder]]
+version = "0.207.0"
+when = "2024-05-07"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-metadata]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -1252,6 +1258,12 @@ when = "2024-04-25"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-metadata]]
+version = "0.207.0"
+when = "2024-05-07"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-mutate]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -1360,6 +1372,12 @@ when = "2024-04-25"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmparser]]
+version = "0.207.0"
+when = "2024-05-07"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmprinter]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -1393,6 +1411,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmprinter]]
 version = "0.206.0"
 when = "2024-04-25"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmprinter]]
+version = "0.207.0"
+when = "2024-05-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1720,6 +1744,12 @@ when = "2024-04-25"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wast]]
+version = "207.0.0"
+when = "2024-05-07"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wat]]
 version = "1.201.0"
 when = "2024-02-27"
@@ -1753,6 +1783,12 @@ user-login = "wasmtime-publish"
 [[publisher.wat]]
 version = "1.206.0"
 when = "2024-04-25"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wat]]
+version = "1.207.0"
+when = "2024-05-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2062,6 +2098,12 @@ when = "2024-04-25"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-component]]
+version = "0.207.0"
+when = "2024-05-07"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-parser]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -2095,6 +2137,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-parser]]
 version = "0.206.0"
 when = "2024-04-25"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-parser]]
+version = "0.207.0"
+when = "2024-05-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Backport of #8580 to get the no_std fix on this branch as well.