### PR TITLE
Add another feature to CI checks for no_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,7 +364,7 @@ jobs:
     # Checks for no_std support, ensure that crates can build on a no_std
     # target
     - run: rustup target add x86_64-unknown-none
-    - run: cargo check -p wasmtime --no-default-features --features gc,component-model
+    - run: cargo check -p wasmtime --no-default-features --features runtime,gc,component-model
       env:
         CARGO_BUILD_TARGET: x86_64-unknown-none
 


### PR DESCRIPTION
Forgot this which meant it was actually testing very little in the wasmtime crate.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
