### PR TITLE
Handle all `decommit`s/`madvise(DONTNEED)`s homogenously

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -2,7 +2,7 @@ use super::{
     index_allocator::{SimpleIndexAllocator, SlotId},
     round_up_to_pow2, TableAllocationIndex,
 };
-use crate::runtime::vm::sys::vm::{commit_table_pages, decommit_table_pages};
+use crate::runtime::vm::sys::vm::{commit_pages, decommit_pages};
 use crate::runtime::vm::{
     InstanceAllocationRequest, Mmap, PoolingInstanceAllocatorConfig, SendSyncPtr, Table,
 };
@@ -132,7 +132,7 @@ impl TablePool {
             let base = self.get(allocation_index);
 
             unsafe {
-                commit_table_pages(
+                commit_pages(
                     base as *mut u8,
                     self.table_elements * mem::size_of::<*mut u8>(),
                 )?;
@@ -187,7 +187,7 @@ impl TablePool {
         let size_to_memset = size.min(self.keep_resident);
         unsafe {
             std::ptr::write_bytes(base, 0, size_to_memset);
-            decommit_table_pages(base.add(size_to_memset), size - size_to_memset)
+            decommit_pages(base.add(size_to_memset), size - size_to_memset)
                 .context("failed to decommit table page")?;
         }
         Ok(())

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -4,7 +4,7 @@ use super::{
     index_allocator::{SimpleIndexAllocator, SlotId},
     round_up_to_pow2,
 };
-use crate::runtime::vm::sys::vm::{commit_stack_pages, reset_stack_pages_to_zero};
+use crate::runtime::vm::sys::vm::{commit_pages, decommit_pages};
 use crate::runtime::vm::{Mmap, PoolingInstanceAllocatorConfig};
 use anyhow::{anyhow, bail, Context, Result};
 
@@ -110,7 +110,7 @@ impl StackPool {
                 .add((index * self.stack_size) + self.page_size)
                 .cast_mut();
 
-            commit_stack_pages(bottom_of_stack, size_without_guard)?;
+            commit_pages(bottom_of_stack, size_without_guard)?;
 
             let stack =
                 wasmtime_fiber::FiberStack::from_raw_parts(bottom_of_stack, size_without_guard)?;
@@ -170,7 +170,7 @@ impl StackPool {
             );
 
             // Use the system to reset remaining stack pages to zero.
-            reset_stack_pages_to_zero(bottom as _, size - size_to_memset).unwrap();
+            decommit_pages(bottom as _, size - size_to_memset).unwrap();
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
@@ -1,6 +1,7 @@
 use super::cvt;
 use crate::runtime::vm::sys::capi;
 use crate::runtime::vm::SendSyncPtr;
+use crate::vm::sys::DecommitBehavior;
 use anyhow::Result;
 use core::ptr::{self, NonNull};
 #[cfg(feature = "std")]
@@ -29,7 +30,6 @@ pub unsafe fn commit_pages(_addr: *mut u8, _len: usize) -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "pooling-allocator")]
 pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> Result<()> {
     if len == 0 {
         return Ok(());
@@ -46,12 +46,8 @@ pub fn get_page_size() -> usize {
     unsafe { capi::wasmtime_page_size() }
 }
 
-pub fn supports_madvise_dontneed() -> bool {
-    false
-}
-
-pub unsafe fn madvise_dontneed(_ptr: *mut u8, _len: usize) -> Result<()> {
-    unreachable!()
+pub fn decommit_behavior() -> DecommitBehavior {
+    DecommitBehavior::Zero
 }
 
 #[derive(PartialEq, Debug)]

--- a/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
@@ -23,14 +23,14 @@ pub unsafe fn erase_existing_mapping(ptr: *mut u8, len: usize) -> Result<()> {
 }
 
 #[cfg(feature = "pooling-allocator")]
-pub unsafe fn commit_table_pages(_addr: *mut u8, _len: usize) -> Result<()> {
-    // Table pages are always READ | WRITE so there's nothing that needs to be
+pub unsafe fn commit_pages(_addr: *mut u8, _len: usize) -> Result<()> {
+    // Pages are always READ | WRITE so there's nothing that needs to be
     // done here.
     Ok(())
 }
 
 #[cfg(feature = "pooling-allocator")]
-pub unsafe fn decommit_table_pages(addr: *mut u8, len: usize) -> Result<()> {
+pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> Result<()> {
     if len == 0 {
         return Ok(());
     }

--- a/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
@@ -18,13 +18,13 @@ pub unsafe fn erase_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()>
 }
 
 #[cfg(feature = "pooling-allocator")]
-pub unsafe fn commit_table_pages(ptr: *mut u8, len: usize) -> io::Result<()> {
+pub unsafe fn commit_pages(ptr: *mut u8, len: usize) -> io::Result<()> {
     std::ptr::write_bytes(ptr, 0, len);
     Ok(())
 }
 
 #[cfg(feature = "pooling-allocator")]
-pub unsafe fn decommit_table_pages(ptr: *mut u8, len: usize) -> io::Result<()> {
+pub unsafe fn decommit_pages(ptr: *mut u8, len: usize) -> io::Result<()> {
     std::ptr::write_bytes(ptr, 0, len);
     Ok(())
 }

--- a/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
@@ -1,3 +1,4 @@
+use crate::vm::sys::DecommitBehavior;
 use std::fs::File;
 use std::io;
 use std::sync::Arc;
@@ -23,7 +24,6 @@ pub unsafe fn commit_pages(ptr: *mut u8, len: usize) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "pooling-allocator")]
 pub unsafe fn decommit_pages(ptr: *mut u8, len: usize) -> io::Result<()> {
     std::ptr::write_bytes(ptr, 0, len);
     Ok(())
@@ -33,12 +33,8 @@ pub fn get_page_size() -> usize {
     4096
 }
 
-pub fn supports_madvise_dontneed() -> bool {
-    false
-}
-
-pub unsafe fn madvise_dontneed(_ptr: *mut u8, _len: usize) -> io::Result<()> {
-    unreachable!()
+pub fn decommit_behavior() -> DecommitBehavior {
+    DecommitBehavior::Zero
 }
 
 #[derive(PartialEq, Debug)]

--- a/crates/wasmtime/src/runtime/vm/sys/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/mod.rs
@@ -8,6 +8,17 @@
 
 #![allow(clippy::cast_sign_loss)] // platforms too fiddly to worry about this
 
+/// What happens to a mapping after it is decommitted?
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DecommitBehavior {
+    /// The mapping is zeroed.
+    Zero,
+    /// The original mapping is restored. If it was zero, then it is zero again;
+    /// if it was a CoW mapping, then the original CoW mapping is restored;
+    /// etc...
+    RestoreOriginalMapping,
+}
+
 cfg_if::cfg_if! {
     if #[cfg(miri)] {
         mod miri;

--- a/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
@@ -1,3 +1,4 @@
+use crate::runtime::vm::sys::DecommitBehavior;
 use rustix::fd::AsRawFd;
 use rustix::mm::{mmap, mmap_anonymous, mprotect, MapFlags, MprotectFlags, ProtFlags};
 use std::fs::File;
@@ -27,6 +28,12 @@ pub unsafe fn erase_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()>
 }
 
 #[cfg(feature = "pooling-allocator")]
+pub unsafe fn commit_pages(_addr: *mut u8, _len: usize) -> io::Result<()> {
+    // Pages are always READ | WRITE so there's nothing that needs to be done
+    // here.
+    Ok(())
+}
+
 pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     if len == 0 {
         return Ok(());
@@ -58,30 +65,15 @@ pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "pooling-allocator")]
-pub unsafe fn commit_pages(_addr: *mut u8, _len: usize) -> io::Result<()> {
-    // Pages are always READ | WRITE so there's nothing that needs to be done
-    // here.
-    Ok(())
-}
-
 pub fn get_page_size() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE).try_into().unwrap() }
 }
 
-pub fn supports_madvise_dontneed() -> bool {
-    cfg!(target_os = "linux")
-}
-
-pub unsafe fn madvise_dontneed(ptr: *mut u8, len: usize) -> io::Result<()> {
-    cfg_if::cfg_if! {
-        if #[cfg(target_os = "linux")] {
-            rustix::mm::madvise(ptr.cast(), len, rustix::mm::Advice::LinuxDontNeed)?;
-            Ok(())
-        } else {
-            let _ = (ptr, len);
-            unreachable!();
-        }
+pub fn decommit_behavior() -> DecommitBehavior {
+    if cfg!(target_os = "linux") {
+        DecommitBehavior::RestoreOriginalMapping
+    } else {
+        DecommitBehavior::Zero
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
@@ -27,7 +27,7 @@ pub unsafe fn erase_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()>
 }
 
 #[cfg(feature = "pooling-allocator")]
-unsafe fn decommit(addr: *mut u8, len: usize) -> io::Result<()> {
+pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     if len == 0 {
         return Ok(());
     }
@@ -59,27 +59,10 @@ unsafe fn decommit(addr: *mut u8, len: usize) -> io::Result<()> {
 }
 
 #[cfg(feature = "pooling-allocator")]
-pub unsafe fn commit_table_pages(_addr: *mut u8, _len: usize) -> io::Result<()> {
-    // Table pages are always READ | WRITE so there's nothing that needs to be
-    // done here.
+pub unsafe fn commit_pages(_addr: *mut u8, _len: usize) -> io::Result<()> {
+    // Pages are always READ | WRITE so there's nothing that needs to be done
+    // here.
     Ok(())
-}
-
-#[cfg(feature = "pooling-allocator")]
-pub unsafe fn decommit_table_pages(addr: *mut u8, len: usize) -> io::Result<()> {
-    decommit(addr, len)
-}
-
-#[cfg(all(feature = "pooling-allocator", feature = "async"))]
-pub unsafe fn commit_stack_pages(_addr: *mut u8, _len: usize) -> io::Result<()> {
-    // Like table pages stack pages are always READ | WRITE so nothing extra
-    // needs to be done to ensure they can be committed.
-    Ok(())
-}
-
-#[cfg(all(feature = "pooling-allocator", feature = "async"))]
-pub unsafe fn reset_stack_pages_to_zero(addr: *mut u8, len: usize) -> io::Result<()> {
-    decommit(addr, len)
 }
 
 pub fn get_page_size() -> usize {

--- a/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
@@ -1,3 +1,4 @@
+use crate::vm::sys::DecommitBehavior;
 use std::fs::File;
 use std::io;
 use std::mem::MaybeUninit;
@@ -36,7 +37,6 @@ pub unsafe fn commit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     expose_existing_mapping(addr, len)
 }
 
-#[cfg(feature = "pooling-allocator")]
 pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     erase_existing_mapping(addr, len)
 }
@@ -49,12 +49,8 @@ pub fn get_page_size() -> usize {
     }
 }
 
-pub fn supports_madvise_dontneed() -> bool {
-    false
-}
-
-pub unsafe fn madvise_dontneed(_ptr: *mut u8, _len: usize) -> io::Result<()> {
-    unreachable!()
+pub fn decommit_behavior() -> DecommitBehavior {
+    DecommitBehavior::Zero
 }
 
 #[derive(PartialEq, Debug)]

--- a/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
@@ -32,12 +32,12 @@ pub unsafe fn erase_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()>
 }
 
 #[cfg(feature = "pooling-allocator")]
-pub unsafe fn commit_table_pages(addr: *mut u8, len: usize) -> io::Result<()> {
+pub unsafe fn commit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     expose_existing_mapping(addr, len)
 }
 
 #[cfg(feature = "pooling-allocator")]
-pub unsafe fn decommit_table_pages(addr: *mut u8, len: usize) -> io::Result<()> {
+pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     erase_existing_mapping(addr, len)
 }
 


### PR DESCRIPTION
We previously had different functions for tables vs memories vs stacks vs etc...

Now we use the same system virtual memory interface function for all of them. This enables follow up PRs where we will start batching these calls together (and potentially merging regions together in the further future, although that isn't a clear win as we've seen larger `madvise`s take longer than small ones in the past). Those future batching PRs will allow us to in turn start prototyping new syscalls that can take advantage of that batching, like `madvisev`.