### PR TITLE
Disable fuzzing of memory64

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -399,6 +399,11 @@ impl<'a> Arbitrary<'a> for Config {
         // doesn't implement this yet, so forcibly always disable it.
         config.module_config.config.tail_call_enabled = false;
 
+        // Wasm-smith implements the most up-to-date version of memory64 where
+        // it supports 64-bit tables as well, but Wasmtime doesn't support that
+        // yet, so disable the memory64 proposal in fuzzing for now.
+        config.module_config.config.memory64_enabled = false;
+
         // If using the pooling allocator, constrain the memory and module configurations
         // to the module limits.
         if let InstanceAllocationStrategy::Pooling(pooling) = &mut config.wasmtime.strategy {


### PR DESCRIPTION
The proposal has been updated to include 64-bit tables which aren't yet implemented in Wasmtime, so disable the fuzz test case generation for now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
