### PR TITLE
Wasmtime(pooling allocator): Batch decommits

### DIFF
--- a/benches/wasmtime-serve-rps.sh
+++ b/benches/wasmtime-serve-rps.sh
@@ -15,12 +15,16 @@ set -e
 
 repo_dir="$(dirname $0)/.."
 cargo_toml="$repo_dir/Cargo.toml"
+target_dir="$CARGO_TARGET_DIR"
+if [[ "$target_dir" == "" ]]; then
+    target_dir="$repo_dir/target"
+fi
 
 # Build Wasmtime.
 cargo build --manifest-path "$cargo_toml" --release -p wasmtime-cli
 
 # Spawn `wasmtime serve` in the background.
-cargo run --manifest-path "$cargo_toml" --release -- serve "$@" &
+"$target_dir/release/wasmtime" serve "$@" &
 pid=$!
 
 # Give it a second to print its diagnostic information and get the server up and

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -66,6 +66,10 @@ wasmtime_option_group! {
         /// Enable the pooling allocator, in place of the on-demand allocator.
         pub pooling_allocator: Option<bool>,
 
+        /// The number of decommits to do per batch. A batch size of 1
+        /// effectively disables decommit batching. (default: 1)
+        pub pooling_decommit_batch_size: Option<u32>,
+
         /// How many bytes to keep resident between instantiations for the
         /// pooling allocator in linear memories.
         pub pooling_memory_keep_resident: Option<usize>,

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -41,7 +41,7 @@ pub struct FiberStack {
 
     /// Stored here to ensure that when this `FiberStack` the backing storage,
     /// if any, is additionally dropped.
-    _storage: FiberStackStorage,
+    storage: FiberStackStorage,
 }
 
 enum FiberStackStorage {
@@ -66,7 +66,7 @@ impl FiberStack {
         Ok(FiberStack {
             base: stack.mapping_base.wrapping_byte_add(page_size),
             len: stack.mapping_len - page_size,
-            _storage: FiberStackStorage::Mmap(stack),
+            storage: FiberStackStorage::Mmap(stack),
         })
     }
 
@@ -79,8 +79,12 @@ impl FiberStack {
         Ok(FiberStack {
             base,
             len,
-            _storage: FiberStackStorage::Unmanaged,
+            storage: FiberStackStorage::Unmanaged,
         })
+    }
+
+    pub fn is_from_raw_parts(&self) -> bool {
+        matches!(self.storage, FiberStackStorage::Unmanaged)
     }
 
     pub fn from_custom(custom: Box<dyn RuntimeFiberStack>) -> io::Result<Self> {
@@ -99,7 +103,7 @@ impl FiberStack {
         Ok(FiberStack {
             base: start_ptr,
             len: range.len(),
-            _storage: FiberStackStorage::Custom(custom),
+            storage: FiberStackStorage::Custom(custom),
         })
     }
 

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -19,6 +19,10 @@ impl FiberStack {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }
 
+    pub fn is_from_raw_parts(&self) -> bool {
+        false
+    }
+
     pub fn from_custom(_custom: Box<dyn RuntimeFiberStack>) -> io::Result<Self> {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }

--- a/crates/fuzzing/src/generators/pooling_config.rs
+++ b/crates/fuzzing/src/generators/pooling_config.rs
@@ -27,6 +27,7 @@ pub struct PoolingAllocationConfig {
     pub table_keep_resident: usize,
     pub linear_memory_keep_resident: usize,
 
+    pub decommit_batch_size: usize,
     pub max_unused_warm_slots: u32,
 
     pub async_stack_zeroing: bool,
@@ -61,6 +62,7 @@ impl PoolingAllocationConfig {
         cfg.table_keep_resident(self.table_keep_resident);
         cfg.linear_memory_keep_resident(self.linear_memory_keep_resident);
 
+        cfg.decommit_batch_size(self.decommit_batch_size);
         cfg.max_unused_warm_slots(self.max_unused_warm_slots);
 
         cfg.async_stack_zeroing(self.async_stack_zeroing);
@@ -106,6 +108,7 @@ impl<'a> Arbitrary<'a> for PoolingAllocationConfig {
             table_keep_resident: u.int_in_range(0..=1 << 20)?,
             linear_memory_keep_resident: u.int_in_range(0..=1 << 20)?,
 
+            decommit_batch_size: u.int_in_range(1..=1000)?,
             max_unused_warm_slots: u.int_in_range(0..=total_memories + 10)?,
 
             async_stack_zeroing: u.arbitrary()?,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2405,6 +2405,20 @@ impl PoolingAllocationConfig {
         self
     }
 
+    /// The target number of decommits to do per batch.
+    ///
+    /// This is not precise, as we can queue up decommits at times when we
+    /// aren't prepared to immediately flush them, and so we may go over this
+    /// target size occasionally.
+    ///
+    /// A batch size of one effectively disables batching.
+    ///
+    /// Defaults to `1`.
+    pub fn decommit_batch_size(&mut self, batch_size: usize) -> &mut Self {
+        self.config.decommit_batch_size = batch_size;
+        self
+    }
+
     /// Configures whether or not stacks used for async futures are reset to
     /// zero after usage.
     ///

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -61,6 +61,9 @@ pub use values::*;
 
 pub(crate) use uninhabited::*;
 
+#[cfg(feature = "pooling-allocator")]
+pub use vm::PoolConcurrencyLimitError;
+
 #[cfg(feature = "profiling")]
 mod profiling;
 #[cfg(feature = "profiling")]

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -248,7 +248,7 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
     }
 
     #[cfg(feature = "async")]
-    unsafe fn deallocate_fiber_stack(&self, _stack: &wasmtime_fiber::FiberStack) {
+    unsafe fn deallocate_fiber_stack(&self, _stack: wasmtime_fiber::FiberStack) {
         unreachable!()
     }
 

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -55,7 +55,8 @@ pub use crate::runtime::vm::instance::{
 };
 #[cfg(feature = "pooling-allocator")]
 pub use crate::runtime::vm::instance::{
-    InstanceLimits, PoolingInstanceAllocator, PoolingInstanceAllocatorConfig,
+    InstanceLimits, PoolConcurrencyLimitError, PoolingInstanceAllocator,
+    PoolingInstanceAllocatorConfig,
 };
 pub use crate::runtime::vm::memory::{Memory, RuntimeLinearMemory, RuntimeMemoryCreator};
 pub use crate::runtime::vm::mmap::Mmap;

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -30,7 +30,10 @@ pub use self::on_demand::OnDemandInstanceAllocator;
 #[cfg(feature = "pooling-allocator")]
 mod pooling;
 #[cfg(feature = "pooling-allocator")]
-pub use self::pooling::{InstanceLimits, PoolingInstanceAllocator, PoolingInstanceAllocatorConfig};
+pub use self::pooling::{
+    InstanceLimits, PoolConcurrencyLimitError, PoolingInstanceAllocator,
+    PoolingInstanceAllocatorConfig,
+};
 
 /// Represents a request for a new runtime instance.
 pub struct InstanceAllocationRequest<'a> {
@@ -290,7 +293,7 @@ pub unsafe trait InstanceAllocatorImpl {
     /// The provided stack is required to have been allocated with
     /// `allocate_fiber_stack`.
     #[cfg(feature = "async")]
-    unsafe fn deallocate_fiber_stack(&self, stack: &wasmtime_fiber::FiberStack);
+    unsafe fn deallocate_fiber_stack(&self, stack: wasmtime_fiber::FiberStack);
 
     /// Allocate a GC heap for allocating Wasm GC objects within.
     #[cfg(feature = "gc")]

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
@@ -171,8 +171,10 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
     }
 
     #[cfg(feature = "async")]
-    unsafe fn deallocate_fiber_stack(&self, _stack: &wasmtime_fiber::FiberStack) {
+    unsafe fn deallocate_fiber_stack(&self, stack: wasmtime_fiber::FiberStack) {
         // The on-demand allocator has no further bookkeeping for fiber stacks
+        // beyond dropping them.
+        let _ = stack;
     }
 
     fn purge_module(&self, _: CompiledModuleId) {}

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/decommit_queue.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/decommit_queue.rs
@@ -1,0 +1,194 @@
+//! A queue for batching decommits together.
+//!
+//! We don't immediately decommit a Wasm table/memory/stack/etc... eagerly, but
+//! instead batch them up to be decommitted together. This module implements
+//! that queuing and batching.
+//!
+//! Even when batching is "disabled" we still use this queue. Batching is
+//! disabled by specifying a batch size of one, in which case, this queue will
+//! immediately get flushed everytime we push onto it.
+
+use super::PoolingInstanceAllocator;
+use crate::vm::{MemoryAllocationIndex, MemoryImageSlot, Table, TableAllocationIndex};
+use smallvec::SmallVec;
+
+#[cfg(feature = "async")]
+use wasmtime_fiber::FiberStack;
+
+#[cfg(unix)]
+#[allow(non_camel_case_types)]
+type iovec = libc::iovec;
+
+#[cfg(not(unix))]
+#[allow(non_camel_case_types)]
+struct iovec {
+    iov_base: *mut libc::c_void,
+    iov_len: libc::size_t,
+}
+
+#[repr(transparent)]
+struct IoVec(iovec);
+
+unsafe impl Send for IoVec {}
+unsafe impl Sync for IoVec {}
+
+impl std::fmt::Debug for IoVec {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IoVec")
+            .field("base", &self.0.iov_base)
+            .field("len", &self.0.iov_len)
+            .finish()
+    }
+}
+
+#[cfg(feature = "async")]
+struct SendSyncStack(FiberStack);
+#[cfg(feature = "async")]
+unsafe impl Send for SendSyncStack {}
+#[cfg(feature = "async")]
+unsafe impl Sync for SendSyncStack {}
+
+#[derive(Default)]
+pub struct DecommitQueue {
+    raw: SmallVec<[IoVec; 2]>,
+    memories: SmallVec<[(MemoryAllocationIndex, MemoryImageSlot); 1]>,
+    tables: SmallVec<[(TableAllocationIndex, Table); 1]>,
+    #[cfg(feature = "async")]
+    stacks: SmallVec<[SendSyncStack; 1]>,
+    //
+    // TODO: GC heaps are not well-integrated with the pooling allocator
+    // yet. Once we better integrate them, we should start (optionally) zeroing
+    // them, and batching that up here.
+    //
+    // #[cfg(feature = "gc")]
+    // pub gc_heaps: SmallVec<[(GcHeapAllocationIndex, Box<dyn GcHeap>); 1]>,
+}
+
+impl std::fmt::Debug for DecommitQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DecommitQueue")
+            .field("raw", &self.raw)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DecommitQueue {
+    /// Append another queue to this queue.
+    pub fn append(
+        &mut self,
+        Self {
+            raw,
+            memories,
+            tables,
+            #[cfg(feature = "async")]
+            stacks,
+        }: &mut Self,
+    ) {
+        self.raw.append(raw);
+        self.memories.append(memories);
+        self.tables.append(tables);
+        #[cfg(feature = "async")]
+        self.stacks.append(stacks);
+    }
+
+    /// How many raw memory regions are enqueued for decommit?
+    pub fn raw_len(&self) -> usize {
+        self.raw.len()
+    }
+
+    /// Enqueue a region of memory for decommit.
+    ///
+    /// It is the caller's responsibility to push the associated data via
+    /// `self.push_{memory,table,stack}` as appropriate.
+    ///
+    /// # Safety
+    ///
+    /// The enqueued memory regions must be safe to decommit when `flush` is
+    /// called (no other references, not in use, won't be otherwise unmapped,
+    /// etc...).
+    pub unsafe fn push_raw(&mut self, ptr: *mut u8, len: usize) {
+        self.raw.push(IoVec(iovec {
+            iov_base: ptr.cast(),
+            iov_len: len,
+        }));
+    }
+
+    /// Push a memory into the queue.
+    ///
+    /// # Safety
+    ///
+    /// This memory should not be in use, and its decommit regions must have
+    /// already been enqueued via `self.enqueue_raw`.
+    pub unsafe fn push_memory(
+        &mut self,
+        allocation_index: MemoryAllocationIndex,
+        image: MemoryImageSlot,
+    ) {
+        self.memories.push((allocation_index, image));
+    }
+
+    /// Push a table into the queue.
+    ///
+    /// # Safety
+    ///
+    /// This table should not be in use, and its decommit regions must have
+    /// already been enqueued via `self.enqueue_raw`.
+    pub unsafe fn push_table(&mut self, allocation_index: TableAllocationIndex, table: Table) {
+        self.tables.push((allocation_index, table));
+    }
+
+    /// Push a stack into the queue.
+    ///
+    /// # Safety
+    ///
+    /// This stack should not be in use, and its decommit regions must have
+    /// already been enqueued via `self.enqueue_raw`.
+    #[cfg(feature = "async")]
+    pub unsafe fn push_stack(&mut self, stack: FiberStack) {
+        self.stacks.push(SendSyncStack(stack));
+    }
+
+    fn decommit_all_raw(&mut self) {
+        for iovec in self.raw.drain(..) {
+            unsafe {
+                crate::vm::sys::vm::decommit_pages(iovec.0.iov_base.cast(), iovec.0.iov_len)
+                    .expect("failed to decommit pages");
+            }
+        }
+    }
+
+    /// Flush this queue, decommitting all enqueued regions in batch.
+    ///
+    /// Returns `true` if we did any decommits and returned their entities to
+    /// the associated free lists; `false` if the queue was empty.
+    pub fn flush(mut self, pool: &PoolingInstanceAllocator) -> bool {
+        // First, do the raw decommit syscall(s).
+        self.decommit_all_raw();
+
+        // Second, restore the various entities to their associated pools' free
+        // lists. This is safe, and they are ready for reuse, now that their
+        // memory regions have been decommitted.
+        let mut deallocated_any = false;
+        for (allocation_index, image) in self.memories {
+            deallocated_any = true;
+            unsafe {
+                pool.memories.deallocate(allocation_index, image);
+            }
+        }
+        for (allocation_index, table) in self.tables {
+            deallocated_any = true;
+            unsafe {
+                pool.tables.deallocate(allocation_index, table);
+            }
+        }
+        #[cfg(feature = "async")]
+        for stack in self.stacks {
+            deallocated_any = true;
+            unsafe {
+                pool.stacks.deallocate(stack.0);
+            }
+        }
+
+        deallocated_any
+    }
+}

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
@@ -40,6 +40,7 @@ impl GcHeapPool {
     }
 
     /// Are there zero slots in use right now?
+    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.index_allocator.is_empty()
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -31,6 +31,7 @@ impl SimpleIndexAllocator {
         SimpleIndexAllocator(ModuleAffinityIndexAllocator::new(capacity, 0))
     }
 
+    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -175,6 +176,7 @@ impl ModuleAffinityIndexAllocator {
     }
 
     /// Are zero slots in use right now?
+    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         let inner = self.0.lock().unwrap();
         !inner


### PR DESCRIPTION
This introduces a `DecommitQueue` for batching decommits together in the pooling allocator:

* Deallocating a memory/table/stack enqueues their associated regions of memory for decommit; it no longer immediately returns the associated slot to the pool's free list. If the queue's length has reached the configured batch size, then we flush the queue by running all the decommits, and finally returning the memory/table/stack slots to their respective pools and free lists.

* Additionally, if allocating a new memory/table/stack fails because the free list is empty (aka we've reached the max concurrently-allocated limit for this entity) then we fall back to a slow path before propagating the error. This slow path flushes the decommit queue and then retries allocation, hoping that the queue flush reclaimed slots and made them available for this fallback allocation attempt. This involved defining a new `PoolConcurrencyLimitError` to match on, which is also exposed in the public embedder API.

It is also worth noting that we *always* use this new decommit queue now. To keep the existing behavior, where e.g. a memory's decommits happen immediately on deallocation, you can use a batch size of one. This effectively disables queuing, forcing all decommits to be flushed immediately.

The default decommit batch size is one.

This commit, with batch size of one, consistently gives me an increase on `wasmtime serve`'s requests-per-second versus its parent commit, as measured by `benches/wasmtime-serve-rps.sh`. I get ~39K RPS on this commit compared to ~35K RPS on the parent commit. This is quite puzzling to me. I was expecting no change, and hoping there wouldn't be a regression. I was not expecting a speed up. I cannot explain this result at this time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
