### PR TITLE
cranelift: Delete all references to AllocationConsumer

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -300,19 +300,19 @@ impl BranchTarget {
 }
 
 impl PrettyPrint for ShiftOpAndAmt {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("{:?} {}", self.op(), self.amt().value())
     }
 }
 
 impl PrettyPrint for ExtendOp {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("{:?}", self)
     }
 }
 
 impl PrettyPrint for MemLabel {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         match self {
             MemLabel::PCRel(off) => format!("pc+{}", off),
             MemLabel::Mach(off) => format!("label({})", off.get()),
@@ -332,35 +332,35 @@ fn shift_for_type(size_bytes: u8) -> usize {
 }
 
 impl PrettyPrint for AMode {
-    fn pretty_print(&self, size_bytes: u8, allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, size_bytes: u8) -> String {
         debug_assert!(size_bytes != 0);
         match self {
             &AMode::Unscaled { rn, simm9 } => {
-                let reg = pretty_print_reg(rn, allocs);
+                let reg = pretty_print_reg(rn);
                 if simm9.value != 0 {
-                    let simm9 = simm9.pretty_print(8, allocs);
+                    let simm9 = simm9.pretty_print(8);
                     format!("[{}, {}]", reg, simm9)
                 } else {
                     format!("[{}]", reg)
                 }
             }
             &AMode::UnsignedOffset { rn, uimm12 } => {
-                let reg = pretty_print_reg(rn, allocs);
+                let reg = pretty_print_reg(rn);
                 if uimm12.value() != 0 {
-                    let uimm12 = uimm12.pretty_print(8, allocs);
+                    let uimm12 = uimm12.pretty_print(8);
                     format!("[{}, {}]", reg, uimm12)
                 } else {
                     format!("[{}]", reg)
                 }
             }
             &AMode::RegReg { rn, rm } => {
-                let r1 = pretty_print_reg(rn, allocs);
-                let r2 = pretty_print_reg(rm, allocs);
+                let r1 = pretty_print_reg(rn);
+                let r2 = pretty_print_reg(rm);
                 format!("[{}, {}]", r1, r2)
             }
             &AMode::RegScaled { rn, rm } => {
-                let r1 = pretty_print_reg(rn, allocs);
-                let r2 = pretty_print_reg(rm, allocs);
+                let r1 = pretty_print_reg(rn);
+                let r2 = pretty_print_reg(rm);
                 let shift = shift_for_type(size_bytes);
                 format!("[{}, {}, LSL #{}]", r1, r2, shift)
             }
@@ -370,9 +370,9 @@ impl PrettyPrint for AMode {
                     ExtendOp::SXTW | ExtendOp::UXTW => OperandSize::Size32,
                     _ => OperandSize::Size64,
                 };
-                let r1 = pretty_print_reg(rn, allocs);
-                let r2 = pretty_print_ireg(rm, size, allocs);
-                let op = extendop.pretty_print(0, allocs);
+                let r1 = pretty_print_reg(rn);
+                let r2 = pretty_print_ireg(rm, size);
+                let op = extendop.pretty_print(0);
                 format!("[{}, {}, {} #{}]", r1, r2, op, shift)
             }
             &AMode::RegExtended { rn, rm, extendop } => {
@@ -380,18 +380,18 @@ impl PrettyPrint for AMode {
                     ExtendOp::SXTW | ExtendOp::UXTW => OperandSize::Size32,
                     _ => OperandSize::Size64,
                 };
-                let r1 = pretty_print_reg(rn, allocs);
-                let r2 = pretty_print_ireg(rm, size, allocs);
-                let op = extendop.pretty_print(0, allocs);
+                let r1 = pretty_print_reg(rn);
+                let r2 = pretty_print_ireg(rm, size);
+                let op = extendop.pretty_print(0);
                 format!("[{}, {}, {}]", r1, r2, op)
             }
-            &AMode::Label { ref label } => label.pretty_print(0, allocs),
+            &AMode::Label { ref label } => label.pretty_print(0),
             &AMode::SPPreIndexed { simm9 } => {
-                let simm9 = simm9.pretty_print(8, allocs);
+                let simm9 = simm9.pretty_print(8);
                 format!("[sp, {}]!", simm9)
             }
             &AMode::SPPostIndexed { simm9 } => {
-                let simm9 = simm9.pretty_print(8, allocs);
+                let simm9 = simm9.pretty_print(8);
                 format!("[sp], {}", simm9)
             }
             AMode::Const { addr } => format!("[const({})]", addr.as_u32()),
@@ -409,23 +409,23 @@ impl PrettyPrint for AMode {
 }
 
 impl PrettyPrint for PairAMode {
-    fn pretty_print(&self, _: u8, allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         match self {
             &PairAMode::SignedOffset { reg, simm7 } => {
-                let reg = pretty_print_reg(reg, allocs);
+                let reg = pretty_print_reg(reg);
                 if simm7.value != 0 {
-                    let simm7 = simm7.pretty_print(8, allocs);
+                    let simm7 = simm7.pretty_print(8);
                     format!("[{}, {}]", reg, simm7)
                 } else {
                     format!("[{}]", reg)
                 }
             }
             &PairAMode::SPPreIndexed { simm7 } => {
-                let simm7 = simm7.pretty_print(8, allocs);
+                let simm7 = simm7.pretty_print(8);
                 format!("[sp, {}]!", simm7)
             }
             &PairAMode::SPPostIndexed { simm7 } => {
-                let simm7 = simm7.pretty_print(8, allocs);
+                let simm7 = simm7.pretty_print(8);
                 format!("[sp], {}", simm7)
             }
         }
@@ -433,7 +433,7 @@ impl PrettyPrint for PairAMode {
 }
 
 impl PrettyPrint for Cond {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         let mut s = format!("{:?}", self);
         s.make_ascii_lowercase();
         s
@@ -441,7 +441,7 @@ impl PrettyPrint for Cond {
 }
 
 impl PrettyPrint for BranchTarget {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         match self {
             &BranchTarget::Label(label) => format!("label{:?}", label.get()),
             &BranchTarget::ResolvedOffset(off) => format!("{}", off),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -7863,8 +7863,7 @@ fn test_aarch64_binemit() {
         );
 
         // Check the printed text is as expected.
-        let actual_printing =
-            insn.print_with_state(&mut EmitState::default(), &mut AllocationConsumer::new(&[]));
+        let actual_printing = insn.print_with_state(&mut EmitState::default());
         assert_eq!(expected_printing, actual_printing);
 
         let mut buffer = MachBuffer::new();

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -2,7 +2,7 @@
 
 use crate::ir::types::*;
 use crate::isa::aarch64::inst::{OperandSize, ScalarSize};
-use crate::machinst::{AllocationConsumer, PrettyPrint};
+use crate::machinst::PrettyPrint;
 
 use std::string::String;
 
@@ -827,7 +827,7 @@ impl ASIMDFPModImm {
 }
 
 impl PrettyPrint for NZCV {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         let fmt = |c: char, v| if v { c.to_ascii_uppercase() } else { c };
         format!(
             "#{}{}{}{}",
@@ -840,13 +840,13 @@ impl PrettyPrint for NZCV {
 }
 
 impl PrettyPrint for UImm5 {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.value)
     }
 }
 
 impl PrettyPrint for Imm12 {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         let shift = if self.shift12 { 12 } else { 0 };
         let value = u32::from(self.bits) << shift;
         format!("#{}", value)
@@ -854,49 +854,49 @@ impl PrettyPrint for Imm12 {
 }
 
 impl PrettyPrint for SImm7Scaled {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.value)
     }
 }
 
 impl PrettyPrint for FPULeftShiftImm {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.amount)
     }
 }
 
 impl PrettyPrint for FPURightShiftImm {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.amount)
     }
 }
 
 impl PrettyPrint for SImm9 {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.value)
     }
 }
 
 impl PrettyPrint for UImm12Scaled {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.value)
     }
 }
 
 impl PrettyPrint for ImmLogic {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.value())
     }
 }
 
 impl PrettyPrint for ImmShift {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("#{}", self.imm)
     }
 }
 
 impl PrettyPrint for MoveWideConst {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         if self.shift == 0 {
             format!("#{}", self.bits)
         } else {
@@ -906,7 +906,7 @@ impl PrettyPrint for MoveWideConst {
 }
 
 impl PrettyPrint for ASIMDMovModImm {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         if self.is_64bit {
             debug_assert_eq!(self.shift, 0);
 
@@ -930,7 +930,7 @@ impl PrettyPrint for ASIMDMovModImm {
 }
 
 impl PrettyPrint for ASIMDFPModImm {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         if self.is_64bit {
             format!("#{}", f64::from_bits(Self::value64(self.imm)))
         } else {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1218,23 +1218,19 @@ fn mem_finalize_for_show(mem: &AMode, access_ty: Type, state: &EmitState) -> (St
     let (mem_insts, mem) = mem_finalize(None, mem, access_ty, state);
     let mut mem_str = mem_insts
         .into_iter()
-        .map(|inst| {
-            inst.print_with_state(&mut EmitState::default(), &mut AllocationConsumer::new(&[]))
-        })
+        .map(|inst| inst.print_with_state(&mut EmitState::default()))
         .collect::<Vec<_>>()
         .join(" ; ");
     if !mem_str.is_empty() {
         mem_str += " ; ";
     }
 
-    let mem = mem.pretty_print(access_ty.bytes() as u8, &mut AllocationConsumer::new(&[]));
+    let mem = mem.pretty_print(access_ty.bytes() as u8);
     (mem_str, mem)
 }
 
 impl Inst {
-    fn print_with_state(&self, state: &mut EmitState, allocs: &mut AllocationConsumer) -> String {
-        let mut empty_allocs = AllocationConsumer::default();
-
+    fn print_with_state(&self, state: &mut EmitState) -> String {
         fn op_name(alu_op: ALUOp) -> &'static str {
             match alu_op {
                 ALUOp::Add => "add",
@@ -1274,9 +1270,9 @@ impl Inst {
                 rm,
             } => {
                 let op = op_name(alu_op);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let rm = pretty_print_ireg(rm, size, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size);
+                let rm = pretty_print_ireg(rm, size);
                 format!("{} {}, {}, {}", op, rd, rn, rm)
             }
             &Inst::AluRRRR {
@@ -1293,10 +1289,10 @@ impl Inst {
                     ALUOp3::UMAddL => ("umaddl", OperandSize::Size64),
                     ALUOp3::SMAddL => ("smaddl", OperandSize::Size64),
                 };
-                let rd = pretty_print_ireg(rd.to_reg(), da_size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let rm = pretty_print_ireg(rm, size, allocs);
-                let ra = pretty_print_ireg(ra, da_size, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), da_size);
+                let rn = pretty_print_ireg(rn, size);
+                let rm = pretty_print_ireg(rm, size);
+                let ra = pretty_print_ireg(ra, da_size);
 
                 format!("{} {}, {}, {}, {}", op, rd, rn, rm, ra)
             }
@@ -1308,14 +1304,14 @@ impl Inst {
                 ref imm12,
             } => {
                 let op = op_name(alu_op);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size);
 
                 if imm12.bits == 0 && alu_op == ALUOp::Add && size.is64() {
                     // special-case MOV (used for moving into SP).
                     format!("mov {}, {}", rd, rn)
                 } else {
-                    let imm12 = imm12.pretty_print(0, allocs);
+                    let imm12 = imm12.pretty_print(0);
                     format!("{} {}, {}, {}", op, rd, rn, imm12)
                 }
             }
@@ -1327,9 +1323,9 @@ impl Inst {
                 ref imml,
             } => {
                 let op = op_name(alu_op);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let imml = imml.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size);
+                let imml = imml.pretty_print(0);
                 format!("{} {}, {}, {}", op, rd, rn, imml)
             }
             &Inst::AluRRImmShift {
@@ -1340,9 +1336,9 @@ impl Inst {
                 ref immshift,
             } => {
                 let op = op_name(alu_op);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let immshift = immshift.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size);
+                let immshift = immshift.pretty_print(0);
                 format!("{} {}, {}, {}", op, rd, rn, immshift)
             }
             &Inst::AluRRRShift {
@@ -1354,10 +1350,10 @@ impl Inst {
                 ref shiftop,
             } => {
                 let op = op_name(alu_op);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let rm = pretty_print_ireg(rm, size, allocs);
-                let shiftop = shiftop.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size);
+                let rm = pretty_print_ireg(rm, size);
+                let shiftop = shiftop.pretty_print(0);
                 format!("{} {}, {}, {}, {}", op, rd, rn, rm, shiftop)
             }
             &Inst::AluRRRExtend {
@@ -1369,16 +1365,16 @@ impl Inst {
                 ref extendop,
             } => {
                 let op = op_name(alu_op);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let rm = pretty_print_ireg(rm, size, allocs);
-                let extendop = extendop.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size);
+                let rm = pretty_print_ireg(rm, size);
+                let extendop = extendop.pretty_print(0);
                 format!("{} {}, {}, {}, {}", op, rd, rn, rm, extendop)
             }
             &Inst::BitRR { op, size, rd, rn } => {
                 let op = op.op_str();
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size);
                 format!("{} {}, {}", op, rd, rn)
             }
             &Inst::ULoad8 { rd, ref mem, .. }
@@ -1410,7 +1406,7 @@ impl Inst {
                     _ => unreachable!(),
                 };
 
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
                 let (mem_str, mem) = mem_finalize_for_show(&mem, access_ty, state);
@@ -1437,7 +1433,7 @@ impl Inst {
                     _ => unreachable!(),
                 };
 
-                let rd = pretty_print_ireg(rd, size, allocs);
+                let rd = pretty_print_ireg(rd, size);
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
                 let (mem_str, mem) = mem_finalize_for_show(&mem, access_ty, state);
@@ -1447,8 +1443,8 @@ impl Inst {
             &Inst::StoreP64 {
                 rt, rt2, ref mem, ..
             } => {
-                let rt = pretty_print_ireg(rt, OperandSize::Size64, allocs);
-                let rt2 = pretty_print_ireg(rt2, OperandSize::Size64, allocs);
+                let rt = pretty_print_ireg(rt, OperandSize::Size64);
+                let rt2 = pretty_print_ireg(rt2, OperandSize::Size64);
                 let mem = mem.clone();
                 let mem = mem.pretty_print_default();
                 format!("stp {}, {}, {}", rt, rt2, mem)
@@ -1456,25 +1452,25 @@ impl Inst {
             &Inst::LoadP64 {
                 rt, rt2, ref mem, ..
             } => {
-                let rt = pretty_print_ireg(rt.to_reg(), OperandSize::Size64, allocs);
-                let rt2 = pretty_print_ireg(rt2.to_reg(), OperandSize::Size64, allocs);
+                let rt = pretty_print_ireg(rt.to_reg(), OperandSize::Size64);
+                let rt2 = pretty_print_ireg(rt2.to_reg(), OperandSize::Size64);
                 let mem = mem.clone();
                 let mem = mem.pretty_print_default();
                 format!("ldp {}, {}, {}", rt, rt2, mem)
             }
             &Inst::Mov { size, rd, rm } => {
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rm = pretty_print_ireg(rm, size, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rm = pretty_print_ireg(rm, size);
                 format!("mov {}, {}", rd, rm)
             }
             &Inst::MovFromPReg { rd, rm } => {
-                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64);
                 let rm = show_ireg_sized(rm.into(), OperandSize::Size64);
                 format!("mov {}, {}", rd, rm)
             }
             &Inst::MovToPReg { rd, rm } => {
                 let rd = show_ireg_sized(rd.into(), OperandSize::Size64);
-                let rm = pretty_print_ireg(rm, OperandSize::Size64, allocs);
+                let rm = pretty_print_ireg(rm, OperandSize::Size64);
                 format!("mov {}, {}", rd, rm)
             }
             &Inst::MovWide {
@@ -1487,8 +1483,8 @@ impl Inst {
                     MoveWideOp::MovZ => "movz",
                     MoveWideOp::MovN => "movn",
                 };
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let imm = imm.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let imm = imm.pretty_print(0);
                 format!("{} {}, {}", op_str, rd, imm)
             }
             &Inst::MovK {
@@ -1497,33 +1493,33 @@ impl Inst {
                 ref imm,
                 size,
             } => {
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let imm = imm.pretty_print(0, allocs);
+                let rn = pretty_print_ireg(rn, size);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let imm = imm.pretty_print(0);
                 format!("movk {}, {}, {}", rd, rn, imm)
             }
             &Inst::CSel { rd, rn, rm, cond } => {
-                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64, allocs);
-                let rn = pretty_print_ireg(rn, OperandSize::Size64, allocs);
-                let rm = pretty_print_ireg(rm, OperandSize::Size64, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64);
+                let rn = pretty_print_ireg(rn, OperandSize::Size64);
+                let rm = pretty_print_ireg(rm, OperandSize::Size64);
+                let cond = cond.pretty_print(0);
                 format!("csel {}, {}, {}, {}", rd, rn, rm, cond)
             }
             &Inst::CSNeg { rd, rn, rm, cond } => {
-                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64, allocs);
-                let rn = pretty_print_ireg(rn, OperandSize::Size64, allocs);
-                let rm = pretty_print_ireg(rm, OperandSize::Size64, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64);
+                let rn = pretty_print_ireg(rn, OperandSize::Size64);
+                let rm = pretty_print_ireg(rm, OperandSize::Size64);
+                let cond = cond.pretty_print(0);
                 format!("csneg {}, {}, {}, {}", rd, rn, rm, cond)
             }
             &Inst::CSet { rd, cond } => {
-                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64);
+                let cond = cond.pretty_print(0);
                 format!("cset {}, {}", rd, cond)
             }
             &Inst::CSetm { rd, cond } => {
-                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64);
+                let cond = cond.pretty_print(0);
                 format!("csetm {}, {}", rd, cond)
             }
             &Inst::CCmp {
@@ -1533,10 +1529,10 @@ impl Inst {
                 nzcv,
                 cond,
             } => {
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let rm = pretty_print_ireg(rm, size, allocs);
-                let nzcv = nzcv.pretty_print(0, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rn = pretty_print_ireg(rn, size);
+                let rm = pretty_print_ireg(rm, size);
+                let nzcv = nzcv.pretty_print(0);
+                let cond = cond.pretty_print(0);
                 format!("ccmp {}, {}, {}, {}", rn, rm, nzcv, cond)
             }
             &Inst::CCmpImm {
@@ -1546,10 +1542,10 @@ impl Inst {
                 nzcv,
                 cond,
             } => {
-                let rn = pretty_print_ireg(rn, size, allocs);
-                let imm = imm.pretty_print(0, allocs);
-                let nzcv = nzcv.pretty_print(0, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rn = pretty_print_ireg(rn, size);
+                let imm = imm.pretty_print(0);
+                let nzcv = nzcv.pretty_print(0);
+                let cond = cond.pretty_print(0);
                 format!("ccmp {}, {}, {}, {}", rn, imm, nzcv, cond)
             }
             &Inst::AtomicRMW {
@@ -1568,9 +1564,9 @@ impl Inst {
                 };
 
                 let size = OperandSize::from_ty(ty);
-                let rs = pretty_print_ireg(rs, size, allocs);
-                let rt = pretty_print_ireg(rt.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, OperandSize::Size64, allocs);
+                let rs = pretty_print_ireg(rs, size);
+                let rt = pretty_print_ireg(rt.to_reg(), size);
+                let rn = pretty_print_ireg(rn, OperandSize::Size64);
 
                 let ty_suffix = match ty {
                     I8 => "b",
@@ -1602,11 +1598,11 @@ impl Inst {
                     AtomicRMWLoopOp::Umax => "umax",
                     AtomicRMWLoopOp::Xchg => "xchg",
                 };
-                let addr = pretty_print_ireg(addr, OperandSize::Size64, allocs);
-                let operand = pretty_print_ireg(operand, OperandSize::Size64, allocs);
-                let oldval = pretty_print_ireg(oldval.to_reg(), OperandSize::Size64, allocs);
-                let scratch1 = pretty_print_ireg(scratch1.to_reg(), OperandSize::Size64, allocs);
-                let scratch2 = pretty_print_ireg(scratch2.to_reg(), OperandSize::Size64, allocs);
+                let addr = pretty_print_ireg(addr, OperandSize::Size64);
+                let operand = pretty_print_ireg(operand, OperandSize::Size64);
+                let oldval = pretty_print_ireg(oldval.to_reg(), OperandSize::Size64);
+                let scratch1 = pretty_print_ireg(scratch1.to_reg(), OperandSize::Size64);
+                let scratch2 = pretty_print_ireg(scratch2.to_reg(), OperandSize::Size64);
                 format!(
                     "atomic_rmw_loop_{}_{} addr={} operand={} oldval={} scratch1={} scratch2={}",
                     op,
@@ -1628,10 +1624,10 @@ impl Inst {
                     _ => panic!("Unsupported type: {}", ty),
                 };
                 let size = OperandSize::from_ty(ty);
-                let rd = pretty_print_ireg(rd.to_reg(), size, allocs);
-                let rs = pretty_print_ireg(rs, size, allocs);
-                let rt = pretty_print_ireg(rt, size, allocs);
-                let rn = pretty_print_ireg(rn, OperandSize::Size64, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size);
+                let rs = pretty_print_ireg(rs, size);
+                let rt = pretty_print_ireg(rt, size);
+                let rn = pretty_print_ireg(rn, OperandSize::Size64);
 
                 format!("{} {}, {}, {}, [{}]", op, rd, rs, rt, rn)
             }
@@ -1644,11 +1640,11 @@ impl Inst {
                 scratch,
                 ..
             } => {
-                let addr = pretty_print_ireg(addr, OperandSize::Size64, allocs);
-                let expected = pretty_print_ireg(expected, OperandSize::Size64, allocs);
-                let replacement = pretty_print_ireg(replacement, OperandSize::Size64, allocs);
-                let oldval = pretty_print_ireg(oldval.to_reg(), OperandSize::Size64, allocs);
-                let scratch = pretty_print_ireg(scratch.to_reg(), OperandSize::Size64, allocs);
+                let addr = pretty_print_ireg(addr, OperandSize::Size64);
+                let expected = pretty_print_ireg(expected, OperandSize::Size64);
+                let replacement = pretty_print_ireg(replacement, OperandSize::Size64);
+                let oldval = pretty_print_ireg(oldval.to_reg(), OperandSize::Size64);
+                let scratch = pretty_print_ireg(scratch.to_reg(), OperandSize::Size64);
                 format!(
                     "atomic_cas_loop_{} addr={}, expect={}, replacement={}, oldval={}, scratch={}",
                     ty.bits(),
@@ -1670,8 +1666,8 @@ impl Inst {
                     _ => panic!("Unsupported type: {}", access_ty),
                 };
                 let size = OperandSize::from_ty(ty);
-                let rn = pretty_print_ireg(rn, OperandSize::Size64, allocs);
-                let rt = pretty_print_ireg(rt.to_reg(), size, allocs);
+                let rn = pretty_print_ireg(rn, OperandSize::Size64);
+                let rt = pretty_print_ireg(rt.to_reg(), size);
                 format!("{} {}, [{}]", op, rt, rn)
             }
             &Inst::StoreRelease {
@@ -1685,8 +1681,8 @@ impl Inst {
                     _ => panic!("Unsupported type: {}", access_ty),
                 };
                 let size = OperandSize::from_ty(ty);
-                let rn = pretty_print_ireg(rn, OperandSize::Size64, allocs);
-                let rt = pretty_print_ireg(rt, size, allocs);
+                let rn = pretty_print_ireg(rn, OperandSize::Size64);
+                let rt = pretty_print_ireg(rt, size);
                 format!("{} {}, [{}]", op, rt, rn)
             }
             &Inst::Fence {} => {
@@ -1696,28 +1692,28 @@ impl Inst {
                 format!("csdb")
             }
             &Inst::FpuMove32 { rd, rn } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size32, allocs);
-                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size32, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size32);
+                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size32);
                 format!("fmov {}, {}", rd, rn)
             }
             &Inst::FpuMove64 { rd, rn } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64, allocs);
-                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size64, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64);
+                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size64);
                 format!("fmov {}, {}", rd, rn)
             }
             &Inst::FpuMove128 { rd, rn } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
-                let rn = pretty_print_reg(rn, allocs);
+                let rd = pretty_print_reg(rd.to_reg());
+                let rn = pretty_print_reg(rn);
                 format!("mov {}.16b, {}.16b", rd, rn)
             }
             &Inst::FpuMoveFromVec { rd, rn, idx, size } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size.lane_size(), allocs);
-                let rn = pretty_print_vreg_element(rn, idx as usize, size.lane_size(), allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size.lane_size());
+                let rn = pretty_print_vreg_element(rn, idx as usize, size.lane_size());
                 format!("mov {}, {}", rd, rn)
             }
             &Inst::FpuExtend { rd, rn, size } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_scalar(rn, size, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size);
+                let rn = pretty_print_vreg_scalar(rn, size);
                 format!("fmov {}, {}", rd, rn)
             }
             &Inst::FpuRR {
@@ -1737,8 +1733,8 @@ impl Inst {
                     FPUOp1::Cvt64To32 => ScalarSize::Size32,
                     _ => size,
                 };
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), dst_size, allocs);
-                let rn = pretty_print_vreg_scalar(rn, size, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), dst_size);
+                let rn = pretty_print_vreg_scalar(rn, size);
                 format!("{} {}, {}", op, rd, rn)
             }
             &Inst::FpuRRR {
@@ -1756,47 +1752,47 @@ impl Inst {
                     FPUOp2::Max => "fmax",
                     FPUOp2::Min => "fmin",
                 };
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_scalar(rn, size, allocs);
-                let rm = pretty_print_vreg_scalar(rm, size, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size);
+                let rn = pretty_print_vreg_scalar(rn, size);
+                let rm = pretty_print_vreg_scalar(rm, size);
                 format!("{} {}, {}, {}", op, rd, rn, rm)
             }
             &Inst::FpuRRI { fpu_op, rd, rn } => {
                 let (op, imm, vector) = match fpu_op {
-                    FPUOpRI::UShr32(imm) => ("ushr", imm.pretty_print(0, allocs), true),
-                    FPUOpRI::UShr64(imm) => ("ushr", imm.pretty_print(0, allocs), false),
+                    FPUOpRI::UShr32(imm) => ("ushr", imm.pretty_print(0), true),
+                    FPUOpRI::UShr64(imm) => ("ushr", imm.pretty_print(0), false),
                 };
 
                 let (rd, rn) = if vector {
                     (
-                        pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size32x2, allocs),
-                        pretty_print_vreg_vector(rn, VectorSize::Size32x2, allocs),
+                        pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size32x2),
+                        pretty_print_vreg_vector(rn, VectorSize::Size32x2),
                     )
                 } else {
                     (
-                        pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64, allocs),
-                        pretty_print_vreg_scalar(rn, ScalarSize::Size64, allocs),
+                        pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64),
+                        pretty_print_vreg_scalar(rn, ScalarSize::Size64),
                     )
                 };
                 format!("{} {}, {}, {}", op, rd, rn, imm)
             }
             &Inst::FpuRRIMod { fpu_op, rd, ri, rn } => {
                 let (op, imm, vector) = match fpu_op {
-                    FPUOpRIMod::Sli32(imm) => ("sli", imm.pretty_print(0, allocs), true),
-                    FPUOpRIMod::Sli64(imm) => ("sli", imm.pretty_print(0, allocs), false),
+                    FPUOpRIMod::Sli32(imm) => ("sli", imm.pretty_print(0), true),
+                    FPUOpRIMod::Sli64(imm) => ("sli", imm.pretty_print(0), false),
                 };
 
                 let (rd, ri, rn) = if vector {
                     (
-                        pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size32x2, allocs),
-                        pretty_print_vreg_vector(ri, VectorSize::Size32x2, allocs),
-                        pretty_print_vreg_vector(rn, VectorSize::Size32x2, allocs),
+                        pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size32x2),
+                        pretty_print_vreg_vector(ri, VectorSize::Size32x2),
+                        pretty_print_vreg_vector(rn, VectorSize::Size32x2),
                     )
                 } else {
                     (
-                        pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64, allocs),
-                        pretty_print_vreg_scalar(ri, ScalarSize::Size64, allocs),
-                        pretty_print_vreg_scalar(rn, ScalarSize::Size64, allocs),
+                        pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64),
+                        pretty_print_vreg_scalar(ri, ScalarSize::Size64),
+                        pretty_print_vreg_scalar(rn, ScalarSize::Size64),
                     )
                 };
                 format!("{} {}, {}, {}, {}", op, rd, ri, rn, imm)
@@ -1812,33 +1808,33 @@ impl Inst {
                 let op = match fpu_op {
                     FPUOp3::MAdd => "fmadd",
                 };
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_scalar(rn, size, allocs);
-                let rm = pretty_print_vreg_scalar(rm, size, allocs);
-                let ra = pretty_print_vreg_scalar(ra, size, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size);
+                let rn = pretty_print_vreg_scalar(rn, size);
+                let rm = pretty_print_vreg_scalar(rm, size);
+                let ra = pretty_print_vreg_scalar(ra, size);
                 format!("{} {}, {}, {}, {}", op, rd, rn, rm, ra)
             }
             &Inst::FpuCmp { size, rn, rm } => {
-                let rn = pretty_print_vreg_scalar(rn, size, allocs);
-                let rm = pretty_print_vreg_scalar(rm, size, allocs);
+                let rn = pretty_print_vreg_scalar(rn, size);
+                let rm = pretty_print_vreg_scalar(rm, size);
                 format!("fcmp {}, {}", rn, rm)
             }
             &Inst::FpuLoad32 { rd, ref mem, .. } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size32, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size32);
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
                 let (mem_str, mem) = mem_finalize_for_show(&mem, access_ty, state);
                 format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuLoad64 { rd, ref mem, .. } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64);
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
                 let (mem_str, mem) = mem_finalize_for_show(&mem, access_ty, state);
                 format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuLoad128 { rd, ref mem, .. } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                let rd = pretty_print_reg(rd.to_reg());
                 let rd = "q".to_string() + &rd[1..];
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
@@ -1846,21 +1842,21 @@ impl Inst {
                 format!("{}ldr {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore32 { rd, ref mem, .. } => {
-                let rd = pretty_print_vreg_scalar(rd, ScalarSize::Size32, allocs);
+                let rd = pretty_print_vreg_scalar(rd, ScalarSize::Size32);
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
                 let (mem_str, mem) = mem_finalize_for_show(&mem, access_ty, state);
                 format!("{}str {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore64 { rd, ref mem, .. } => {
-                let rd = pretty_print_vreg_scalar(rd, ScalarSize::Size64, allocs);
+                let rd = pretty_print_vreg_scalar(rd, ScalarSize::Size64);
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
                 let (mem_str, mem) = mem_finalize_for_show(&mem, access_ty, state);
                 format!("{}str {}, {}", mem_str, rd, mem)
             }
             &Inst::FpuStore128 { rd, ref mem, .. } => {
-                let rd = pretty_print_reg(rd, allocs);
+                let rd = pretty_print_reg(rd);
                 let rd = "q".to_string() + &rd[1..];
                 let mem = mem.clone();
                 let access_ty = self.mem_type().unwrap();
@@ -1870,8 +1866,8 @@ impl Inst {
             &Inst::FpuLoadP64 {
                 rt, rt2, ref mem, ..
             } => {
-                let rt = pretty_print_vreg_scalar(rt.to_reg(), ScalarSize::Size64, allocs);
-                let rt2 = pretty_print_vreg_scalar(rt2.to_reg(), ScalarSize::Size64, allocs);
+                let rt = pretty_print_vreg_scalar(rt.to_reg(), ScalarSize::Size64);
+                let rt2 = pretty_print_vreg_scalar(rt2.to_reg(), ScalarSize::Size64);
                 let mem = mem.clone();
                 let mem = mem.pretty_print_default();
 
@@ -1880,8 +1876,8 @@ impl Inst {
             &Inst::FpuStoreP64 {
                 rt, rt2, ref mem, ..
             } => {
-                let rt = pretty_print_vreg_scalar(rt, ScalarSize::Size64, allocs);
-                let rt2 = pretty_print_vreg_scalar(rt2, ScalarSize::Size64, allocs);
+                let rt = pretty_print_vreg_scalar(rt, ScalarSize::Size64);
+                let rt2 = pretty_print_vreg_scalar(rt2, ScalarSize::Size64);
                 let mem = mem.clone();
                 let mem = mem.pretty_print_default();
 
@@ -1890,8 +1886,8 @@ impl Inst {
             &Inst::FpuLoadP128 {
                 rt, rt2, ref mem, ..
             } => {
-                let rt = pretty_print_vreg_scalar(rt.to_reg(), ScalarSize::Size128, allocs);
-                let rt2 = pretty_print_vreg_scalar(rt2.to_reg(), ScalarSize::Size128, allocs);
+                let rt = pretty_print_vreg_scalar(rt.to_reg(), ScalarSize::Size128);
+                let rt2 = pretty_print_vreg_scalar(rt2.to_reg(), ScalarSize::Size128);
                 let mem = mem.clone();
                 let mem = mem.pretty_print_default();
 
@@ -1900,8 +1896,8 @@ impl Inst {
             &Inst::FpuStoreP128 {
                 rt, rt2, ref mem, ..
             } => {
-                let rt = pretty_print_vreg_scalar(rt, ScalarSize::Size128, allocs);
-                let rt2 = pretty_print_vreg_scalar(rt2, ScalarSize::Size128, allocs);
+                let rt = pretty_print_vreg_scalar(rt, ScalarSize::Size128);
+                let rt2 = pretty_print_vreg_scalar(rt2, ScalarSize::Size128);
                 let mem = mem.clone();
                 let mem = mem.pretty_print_default();
 
@@ -1918,8 +1914,8 @@ impl Inst {
                     FpuToIntOp::F64ToI64 => ("fcvtzs", ScalarSize::Size64, OperandSize::Size64),
                     FpuToIntOp::F64ToU64 => ("fcvtzu", ScalarSize::Size64, OperandSize::Size64),
                 };
-                let rd = pretty_print_ireg(rd.to_reg(), sizedest, allocs);
-                let rn = pretty_print_vreg_scalar(rn, sizesrc, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), sizedest);
+                let rn = pretty_print_vreg_scalar(rn, sizesrc);
                 format!("{} {}, {}", op, rd, rn)
             }
             &Inst::IntToFpu { op, rd, rn } => {
@@ -1933,22 +1929,22 @@ impl Inst {
                     IntToFpuOp::I64ToF64 => ("scvtf", OperandSize::Size64, ScalarSize::Size64),
                     IntToFpuOp::U64ToF64 => ("ucvtf", OperandSize::Size64, ScalarSize::Size64),
                 };
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), sizedest, allocs);
-                let rn = pretty_print_ireg(rn, sizesrc, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), sizedest);
+                let rn = pretty_print_ireg(rn, sizesrc);
                 format!("{} {}, {}", op, rd, rn)
             }
             &Inst::FpuCSel32 { rd, rn, rm, cond } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size32, allocs);
-                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size32, allocs);
-                let rm = pretty_print_vreg_scalar(rm, ScalarSize::Size32, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size32);
+                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size32);
+                let rm = pretty_print_vreg_scalar(rm, ScalarSize::Size32);
+                let cond = cond.pretty_print(0);
                 format!("fcsel {}, {}, {}, {}", rd, rn, rm, cond)
             }
             &Inst::FpuCSel64 { rd, rn, rm, cond } => {
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64, allocs);
-                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size64, allocs);
-                let rm = pretty_print_vreg_scalar(rm, ScalarSize::Size64, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64);
+                let rn = pretty_print_vreg_scalar(rn, ScalarSize::Size64);
+                let rm = pretty_print_vreg_scalar(rm, ScalarSize::Size64);
+                let cond = cond.pretty_print(0);
                 format!("fcsel {}, {}, {}, {}", rd, rn, rm, cond)
             }
             &Inst::FpuRound { op, rd, rn } => {
@@ -1962,19 +1958,19 @@ impl Inst {
                     FpuRoundMode::Nearest32 => ("frintn", ScalarSize::Size32),
                     FpuRoundMode::Nearest64 => ("frintn", ScalarSize::Size64),
                 };
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_scalar(rn, size, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size);
+                let rn = pretty_print_vreg_scalar(rn, size);
                 format!("{} {}, {}", inst, rd, rn)
             }
             &Inst::MovToFpu { rd, rn, size } => {
                 let operand_size = size.operand_size();
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, operand_size, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, operand_size);
                 format!("fmov {}, {}", rd, rn)
             }
             &Inst::FpuMoveFPImm { rd, imm, size } => {
-                let imm = imm.pretty_print(0, allocs);
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size, allocs);
+                let imm = imm.pretty_print(0);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size);
 
                 format!("fmov {}, {}", rd, imm)
             }
@@ -1985,10 +1981,9 @@ impl Inst {
                 idx,
                 size,
             } => {
-                let rd =
-                    pretty_print_vreg_element(rd.to_reg(), idx as usize, size.lane_size(), allocs);
-                let ri = pretty_print_vreg_element(ri, idx as usize, size.lane_size(), allocs);
-                let rn = pretty_print_ireg(rn, size.operand_size(), allocs);
+                let rd = pretty_print_vreg_element(rd.to_reg(), idx as usize, size.lane_size());
+                let ri = pretty_print_vreg_element(ri, idx as usize, size.lane_size());
+                let rn = pretty_print_ireg(rn, size.operand_size());
                 format!("mov {}, {}, {}", rd, ri, rn)
             }
             &Inst::MovFromVec { rd, rn, idx, size } => {
@@ -1999,8 +1994,8 @@ impl Inst {
                     ScalarSize::Size64 => "mov",
                     _ => unimplemented!(),
                 };
-                let rd = pretty_print_ireg(rd.to_reg(), size.operand_size(), allocs);
-                let rn = pretty_print_vreg_element(rn, idx as usize, size, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), size.operand_size());
+                let rn = pretty_print_vreg_element(rn, idx as usize, size);
                 format!("{} {}, {}", op, rd, rn)
             }
             &Inst::MovFromVecSigned {
@@ -2010,23 +2005,23 @@ impl Inst {
                 size,
                 scalar_size,
             } => {
-                let rd = pretty_print_ireg(rd.to_reg(), scalar_size, allocs);
-                let rn = pretty_print_vreg_element(rn, idx as usize, size.lane_size(), allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), scalar_size);
+                let rn = pretty_print_vreg_element(rn, idx as usize, size.lane_size());
                 format!("smov {}, {}", rd, rn)
             }
             &Inst::VecDup { rd, rn, size } => {
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let rn = pretty_print_ireg(rn, size.operand_size(), allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let rn = pretty_print_ireg(rn, size.operand_size());
                 format!("dup {}, {}", rd, rn)
             }
             &Inst::VecDupFromFpu { rd, rn, size, lane } => {
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_element(rn, lane.into(), size.lane_size(), allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let rn = pretty_print_vreg_element(rn, lane.into(), size.lane_size());
                 format!("dup {}, {}", rd, rn)
             }
             &Inst::VecDupFPImm { rd, imm, size } => {
-                let imm = imm.pretty_print(0, allocs);
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
+                let imm = imm.pretty_print(0);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
 
                 format!("fmov {}, {}", rd, imm)
             }
@@ -2036,9 +2031,9 @@ impl Inst {
                 invert,
                 size,
             } => {
-                let imm = imm.pretty_print(0, allocs);
+                let imm = imm.pretty_print(0);
                 let op = if invert { "mvni" } else { "movi" };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
 
                 format!("{} {}, {}", op, rd, imm)
             }
@@ -2058,8 +2053,8 @@ impl Inst {
                     (VecExtendOp::Uxtl, false) => ("uxtl", vec64),
                     (VecExtendOp::Uxtl, true) => ("uxtl2", vec128),
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), rd_size, allocs);
-                let rn = pretty_print_vreg_vector(rn, rn_size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), rd_size);
+                let rn = pretty_print_vreg_vector(rn, rn_size);
                 format!("{} {}, {}", op, rd, rn)
             }
             &Inst::VecMovElement {
@@ -2070,14 +2065,10 @@ impl Inst {
                 src_idx,
                 size,
             } => {
-                let rd = pretty_print_vreg_element(
-                    rd.to_reg(),
-                    dest_idx as usize,
-                    size.lane_size(),
-                    allocs,
-                );
-                let ri = pretty_print_vreg_element(ri, dest_idx as usize, size.lane_size(), allocs);
-                let rn = pretty_print_vreg_element(rn, src_idx as usize, size.lane_size(), allocs);
+                let rd =
+                    pretty_print_vreg_element(rd.to_reg(), dest_idx as usize, size.lane_size());
+                let ri = pretty_print_vreg_element(ri, dest_idx as usize, size.lane_size());
+                let rn = pretty_print_vreg_element(rn, src_idx as usize, size.lane_size());
                 format!("mov {}, {}, {}", rd, ri, rn)
             }
             &Inst::VecRRLong {
@@ -2118,8 +2109,8 @@ impl Inst {
                         ("shll2", VectorSize::Size64x2, VectorSize::Size32x4, ", #32")
                     }
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), rd_size, allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), rd_size);
+                let rn = pretty_print_vreg_vector(rn, size);
 
                 format!("{} {}, {}{}", op, rd, rn, suffix)
             }
@@ -2157,12 +2148,12 @@ impl Inst {
                     (VecRRNarrowOp::Fcvtn, false) => ("fcvtn", vec64),
                     (VecRRNarrowOp::Fcvtn, true) => ("fcvtn2", vec128),
                 };
-                let rn = pretty_print_vreg_vector(rn, rn_size, allocs);
-                let rd = pretty_print_vreg_vector(rd.to_reg(), rd_size, allocs);
+                let rn = pretty_print_vreg_vector(rn, rn_size);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), rd_size);
                 let ri = match self {
                     &Inst::VecRRNarrowLow { .. } => "".to_string(),
                     &Inst::VecRRNarrowHigh { ri, .. } => {
-                        format!("{}, ", pretty_print_vreg_vector(ri, rd_size, allocs))
+                        format!("{}, ", pretty_print_vreg_vector(ri, rd_size))
                     }
                     _ => unreachable!(),
                 };
@@ -2173,8 +2164,8 @@ impl Inst {
                 let op = match op {
                     VecPairOp::Addp => "addp",
                 };
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64, allocs);
-                let rn = pretty_print_vreg_vector(rn, VectorSize::Size64x2, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), ScalarSize::Size64);
+                let rn = pretty_print_vreg_vector(rn, VectorSize::Size64x2);
 
                 format!("{} {}, {}", op, rd, rn)
             }
@@ -2193,8 +2184,8 @@ impl Inst {
                         ("uaddlp", VectorSize::Size32x4, VectorSize::Size16x8)
                     }
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), dest, allocs);
-                let rn = pretty_print_vreg_vector(rn, src, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), dest);
+                let rn = pretty_print_vreg_vector(rn, src);
 
                 format!("{} {}, {}", op, rd, rn)
             }
@@ -2248,9 +2239,9 @@ impl Inst {
                     VecALUOp::Trn1 => ("trn1", size),
                     VecALUOp::Trn2 => ("trn2", size),
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
-                let rm = pretty_print_vreg_vector(rm, size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let rn = pretty_print_vreg_vector(rn, size);
+                let rm = pretty_print_vreg_vector(rm, size);
                 format!("{} {}, {}, {}", op, rd, rn, rm)
             }
             &Inst::VecRRRMod {
@@ -2266,10 +2257,10 @@ impl Inst {
                     VecALUModOp::Fmla => ("fmla", size),
                     VecALUModOp::Fmls => ("fmls", size),
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let ri = pretty_print_vreg_vector(ri, size, allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
-                let rm = pretty_print_vreg_vector(rm, size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let ri = pretty_print_vreg_vector(ri, size);
+                let rn = pretty_print_vreg_vector(rn, size);
+                let rm = pretty_print_vreg_vector(rm, size);
                 format!("{} {}, {}, {}, {}", op, rd, ri, rn, rm)
             }
             &Inst::VecFmlaElem {
@@ -2286,10 +2277,10 @@ impl Inst {
                     VecALUModOp::Fmls => ("fmls", size),
                     _ => unreachable!(),
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let ri = pretty_print_vreg_vector(ri, size, allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
-                let rm = pretty_print_vreg_element(rm, idx.into(), size.lane_size(), allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let ri = pretty_print_vreg_vector(ri, size);
+                let rn = pretty_print_vreg_vector(rn, size);
+                let rm = pretty_print_vreg_element(rm, idx.into(), size.lane_size());
                 format!("{} {}, {}, {}, {}", op, rd, ri, rn, rm)
             }
             &Inst::VecRRRLong {
@@ -2337,9 +2328,9 @@ impl Inst {
                         ("umull2", VectorSize::Size64x2, VectorSize::Size32x4)
                     }
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), dest_size, allocs);
-                let rn = pretty_print_vreg_vector(rn, src_size, allocs);
-                let rm = pretty_print_vreg_vector(rm, src_size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), dest_size);
+                let rn = pretty_print_vreg_vector(rn, src_size);
+                let rm = pretty_print_vreg_vector(rm, src_size);
                 format!("{} {}, {}, {}", op, rd, rn, rm)
             }
             &Inst::VecRRRLongMod {
@@ -2370,10 +2361,10 @@ impl Inst {
                         ("umlal2", VectorSize::Size64x2, VectorSize::Size32x4)
                     }
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), dest_size, allocs);
-                let ri = pretty_print_vreg_vector(ri, dest_size, allocs);
-                let rn = pretty_print_vreg_vector(rn, src_size, allocs);
-                let rm = pretty_print_vreg_vector(rm, src_size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), dest_size);
+                let ri = pretty_print_vreg_vector(ri, dest_size);
+                let rn = pretty_print_vreg_vector(rn, src_size);
+                let rm = pretty_print_vreg_vector(rm, src_size);
                 format!("{} {}, {}, {}, {}", op, rd, ri, rn, rm)
             }
             &Inst::VecMisc { op, rd, rn, size } => {
@@ -2415,8 +2406,8 @@ impl Inst {
                     VecMisc2::Fcmle0 => ("fcmle", size, ", #0.0"),
                     VecMisc2::Fcmlt0 => ("fcmlt", size, ", #0.0"),
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let rn = pretty_print_vreg_vector(rn, size);
                 format!("{} {}, {}{}", op, rd, rn, suffix)
             }
             &Inst::VecLanes { op, rd, rn, size } => {
@@ -2424,8 +2415,8 @@ impl Inst {
                     VecLanesOp::Uminv => "uminv",
                     VecLanesOp::Addv => "addv",
                 };
-                let rd = pretty_print_vreg_scalar(rd.to_reg(), size.lane_size(), allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
+                let rd = pretty_print_vreg_scalar(rd.to_reg(), size.lane_size());
+                let rn = pretty_print_vreg_vector(rn, size);
                 format!("{} {}, {}", op, rd, rn)
             }
             &Inst::VecShiftImm {
@@ -2440,8 +2431,8 @@ impl Inst {
                     VecShiftImmOp::Ushr => "ushr",
                     VecShiftImmOp::Sshr => "sshr",
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let rn = pretty_print_vreg_vector(rn, size);
                 format!("{} {}, {}, #{}", op, rd, rn, imm)
             }
             &Inst::VecShiftImmMod {
@@ -2455,35 +2446,35 @@ impl Inst {
                 let op = match op {
                     VecShiftImmModOp::Sli => "sli",
                 };
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let ri = pretty_print_vreg_vector(ri, size, allocs);
-                let rn = pretty_print_vreg_vector(rn, size, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let ri = pretty_print_vreg_vector(ri, size);
+                let rn = pretty_print_vreg_vector(rn, size);
                 format!("{} {}, {}, {}, #{}", op, rd, ri, rn, imm)
             }
             &Inst::VecExtract { rd, rn, rm, imm4 } => {
-                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16, allocs);
-                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16, allocs);
-                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16);
+                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16);
+                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16);
                 format!("ext {}, {}, {}, #{}", rd, rn, rm, imm4)
             }
             &Inst::VecTbl { rd, rn, rm } => {
-                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16, allocs);
-                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16, allocs);
-                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16, allocs);
+                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16);
+                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16);
                 format!("tbl {}, {{ {} }}, {}", rd, rn, rm)
             }
             &Inst::VecTblExt { rd, ri, rn, rm } => {
-                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16, allocs);
-                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16, allocs);
-                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16, allocs);
-                let ri = pretty_print_vreg_vector(ri, VectorSize::Size8x16, allocs);
+                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16);
+                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16);
+                let ri = pretty_print_vreg_vector(ri, VectorSize::Size8x16);
                 format!("tbx {}, {}, {{ {} }}, {}", rd, ri, rn, rm)
             }
             &Inst::VecTbl2 { rd, rn, rn2, rm } => {
-                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16, allocs);
-                let rn2 = pretty_print_vreg_vector(rn2, VectorSize::Size8x16, allocs);
-                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16, allocs);
-                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16, allocs);
+                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16);
+                let rn2 = pretty_print_vreg_vector(rn2, VectorSize::Size8x16);
+                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16);
                 format!("tbl {}, {{ {}, {} }}, {}", rd, rn, rn2, rm)
             }
             &Inst::VecTbl2Ext {
@@ -2493,35 +2484,35 @@ impl Inst {
                 rn2,
                 rm,
             } => {
-                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16, allocs);
-                let rn2 = pretty_print_vreg_vector(rn2, VectorSize::Size8x16, allocs);
-                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16, allocs);
-                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16, allocs);
-                let ri = pretty_print_vreg_vector(ri, VectorSize::Size8x16, allocs);
+                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16);
+                let rn2 = pretty_print_vreg_vector(rn2, VectorSize::Size8x16);
+                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16);
+                let ri = pretty_print_vreg_vector(ri, VectorSize::Size8x16);
                 format!("tbx {}, {}, {{ {}, {} }}, {}", rd, ri, rn, rn2, rm)
             }
             &Inst::VecLoadReplicate { rd, rn, size, .. } => {
-                let rd = pretty_print_vreg_vector(rd.to_reg(), size, allocs);
-                let rn = pretty_print_reg(rn, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), size);
+                let rn = pretty_print_reg(rn);
 
                 format!("ld1r {{ {} }}, [{}]", rd, rn)
             }
             &Inst::VecCSel { rd, rn, rm, cond } => {
-                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16, allocs);
-                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16, allocs);
-                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16, allocs);
-                let cond = cond.pretty_print(0, allocs);
+                let rd = pretty_print_vreg_vector(rd.to_reg(), VectorSize::Size8x16);
+                let rn = pretty_print_vreg_vector(rn, VectorSize::Size8x16);
+                let rm = pretty_print_vreg_vector(rm, VectorSize::Size8x16);
+                let cond = cond.pretty_print(0);
                 format!(
                     "vcsel {}, {}, {}, {} (if-then-else diamond)",
                     rd, rn, rm, cond
                 )
             }
             &Inst::MovToNZCV { rn } => {
-                let rn = pretty_print_reg(rn, allocs);
+                let rn = pretty_print_reg(rn);
                 format!("msr nzcv, {}", rn)
             }
             &Inst::MovFromNZCV { rd } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                let rd = pretty_print_reg(rd.to_reg());
                 format!("mrs {}, nzcv", rd)
             }
             &Inst::Extend {
@@ -2531,8 +2522,8 @@ impl Inst {
                 from_bits: 1,
                 ..
             } => {
-                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size32, allocs);
-                let rn = pretty_print_ireg(rn, OperandSize::Size32, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size32);
+                let rn = pretty_print_ireg(rn, OperandSize::Size32);
                 format!("and {}, {}, #1", rd, rn)
             }
             &Inst::Extend {
@@ -2545,8 +2536,8 @@ impl Inst {
                 // The case of a zero extension from 32 to 64 bits, is implemented
                 // with a "mov" to a 32-bit (W-reg) dest, because this zeroes
                 // the top 32 bits.
-                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size32, allocs);
-                let rn = pretty_print_ireg(rn, OperandSize::Size32, allocs);
+                let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size32);
+                let rn = pretty_print_ireg(rn, OperandSize::Size32);
                 format!("mov {}, {}", rd, rn)
             }
             &Inst::Extend {
@@ -2568,8 +2559,8 @@ impl Inst {
                 };
                 if op == "sbfx" || op == "ubfx" {
                     let dest_size = OperandSize::from_bits(to_bits);
-                    let rd = pretty_print_ireg(rd.to_reg(), dest_size, allocs);
-                    let rn = pretty_print_ireg(rn, dest_size, allocs);
+                    let rd = pretty_print_ireg(rd.to_reg(), dest_size);
+                    let rn = pretty_print_ireg(rn, dest_size);
                     format!("{} {}, {}, #0, #{}", op, rd, rn, from_bits)
                 } else {
                     let dest_size = if signed {
@@ -2577,14 +2568,14 @@ impl Inst {
                     } else {
                         OperandSize::Size32
                     };
-                    let rd = pretty_print_ireg(rd.to_reg(), dest_size, allocs);
-                    let rn = pretty_print_ireg(rn, OperandSize::from_bits(from_bits), allocs);
+                    let rd = pretty_print_ireg(rd.to_reg(), dest_size);
+                    let rn = pretty_print_ireg(rn, OperandSize::from_bits(from_bits));
                     format!("{} {}, {}", op, rd, rn)
                 }
             }
             &Inst::Call { .. } => format!("bl 0"),
             &Inst::CallInd { ref info, .. } => {
-                let rn = pretty_print_reg(info.rn, allocs);
+                let rn = pretty_print_reg(info.rn);
                 format!("blr {}", rn)
             }
             &Inst::ReturnCall {
@@ -2596,21 +2587,21 @@ impl Inst {
                     info.new_stack_arg_size
                 );
                 for ret in &info.uses {
-                    let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
-                    let vreg = pretty_print_reg(ret.vreg, allocs);
+                    let preg = pretty_print_reg(ret.preg);
+                    let vreg = pretty_print_reg(ret.vreg);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
             }
             &Inst::ReturnCallInd { callee, ref info } => {
-                let callee = pretty_print_reg(callee, allocs);
+                let callee = pretty_print_reg(callee);
                 let mut s = format!(
                     "return_call_ind {callee} new_stack_arg_size:{}",
                     info.new_stack_arg_size
                 );
                 for ret in &info.uses {
-                    let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
-                    let vreg = pretty_print_reg(ret.vreg, allocs);
+                    let preg = pretty_print_reg(ret.preg);
+                    let vreg = pretty_print_reg(ret.vreg);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
@@ -2618,8 +2609,8 @@ impl Inst {
             &Inst::Args { ref args } => {
                 let mut s = "args".to_string();
                 for arg in args {
-                    let preg = pretty_print_reg(arg.preg, &mut empty_allocs);
-                    let def = pretty_print_reg(arg.vreg.to_reg(), allocs);
+                    let preg = pretty_print_reg(arg.preg);
+                    let def = pretty_print_reg(arg.vreg.to_reg());
                     write!(&mut s, " {}={}", def, preg).unwrap();
                 }
                 s
@@ -2627,8 +2618,8 @@ impl Inst {
             &Inst::Rets { ref rets } => {
                 let mut s = "rets".to_string();
                 for ret in rets {
-                    let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
-                    let vreg = pretty_print_reg(ret.vreg, allocs);
+                    let preg = pretty_print_reg(ret.preg);
+                    let vreg = pretty_print_reg(ret.vreg);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
@@ -2647,7 +2638,7 @@ impl Inst {
                 }
             }
             &Inst::Jump { ref dest } => {
-                let dest = dest.pretty_print(0, allocs);
+                let dest = dest.pretty_print(0);
                 format!("b {}", dest)
             }
             &Inst::CondBr {
@@ -2655,19 +2646,19 @@ impl Inst {
                 ref not_taken,
                 ref kind,
             } => {
-                let taken = taken.pretty_print(0, allocs);
-                let not_taken = not_taken.pretty_print(0, allocs);
+                let taken = taken.pretty_print(0);
+                let not_taken = not_taken.pretty_print(0);
                 match kind {
                     &CondBrKind::Zero(reg) => {
-                        let reg = pretty_print_reg(reg, allocs);
+                        let reg = pretty_print_reg(reg);
                         format!("cbz {}, {} ; b {}", reg, taken, not_taken)
                     }
                     &CondBrKind::NotZero(reg) => {
-                        let reg = pretty_print_reg(reg, allocs);
+                        let reg = pretty_print_reg(reg);
                         format!("cbnz {}, {} ; b {}", reg, taken, not_taken)
                     }
                     &CondBrKind::Cond(c) => {
-                        let c = c.pretty_print(0, allocs);
+                        let c = c.pretty_print(0);
                         format!("b.{} {} ; b {}", c, taken, not_taken)
                     }
                 }
@@ -2683,13 +2674,13 @@ impl Inst {
                     TestBitAndBranchKind::Z => "z",
                     TestBitAndBranchKind::NZ => "nz",
                 };
-                let taken = taken.pretty_print(0, allocs);
-                let not_taken = not_taken.pretty_print(0, allocs);
-                let rn = pretty_print_reg(rn, allocs);
+                let taken = taken.pretty_print(0);
+                let not_taken = not_taken.pretty_print(0);
+                let rn = pretty_print_reg(rn);
                 format!("tb{cond} {rn}, #{bit}, {taken} ; b {not_taken}")
             }
             &Inst::IndirectBr { rn, .. } => {
-                let rn = pretty_print_reg(rn, allocs);
+                let rn = pretty_print_reg(rn);
                 format!("br {}", rn)
             }
             &Inst::Brk => "brk #0".to_string(),
@@ -2699,24 +2690,24 @@ impl Inst {
                 trap_code,
             } => match kind {
                 &CondBrKind::Zero(reg) => {
-                    let reg = pretty_print_reg(reg, allocs);
+                    let reg = pretty_print_reg(reg);
                     format!("cbz {reg}, #trap={trap_code}")
                 }
                 &CondBrKind::NotZero(reg) => {
-                    let reg = pretty_print_reg(reg, allocs);
+                    let reg = pretty_print_reg(reg);
                     format!("cbnz {reg}, #trap={trap_code}")
                 }
                 &CondBrKind::Cond(c) => {
-                    let c = c.pretty_print(0, allocs);
+                    let c = c.pretty_print(0);
                     format!("b.{c} #trap={trap_code}")
                 }
             },
             &Inst::Adr { rd, off } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                let rd = pretty_print_reg(rd.to_reg());
                 format!("adr {}, pc+{}", rd, off)
             }
             &Inst::Adrp { rd, off } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                let rd = pretty_print_reg(rd.to_reg());
                 // This instruction addresses 4KiB pages, so multiply it by the page size.
                 let byte_offset = off * 4096;
                 format!("adrp {}, pc+{}", rd, byte_offset)
@@ -2731,10 +2722,10 @@ impl Inst {
                 rtmp2,
                 ..
             } => {
-                let ridx = pretty_print_reg(ridx, allocs);
-                let rtmp1 = pretty_print_reg(rtmp1.to_reg(), allocs);
-                let rtmp2 = pretty_print_reg(rtmp2.to_reg(), allocs);
-                let default_target = BranchTarget::Label(default).pretty_print(0, allocs);
+                let ridx = pretty_print_reg(ridx);
+                let rtmp1 = pretty_print_reg(rtmp1.to_reg());
+                let rtmp2 = pretty_print_reg(rtmp2.to_reg());
+                let default_target = BranchTarget::Label(default).pretty_print(0);
                 format!(
                     concat!(
                         "b.hs {} ; ",
@@ -2765,7 +2756,7 @@ impl Inst {
                 ref name,
                 offset,
             } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                let rd = pretty_print_reg(rd.to_reg());
                 format!("load_ext_name {rd}, {name:?}+{offset}")
             }
             &Inst::LoadAddr { rd, ref mem } => {
@@ -2777,9 +2768,7 @@ impl Inst {
                 let (mem_insts, mem) = mem_finalize(None, &mem, I8, state);
                 let mut ret = String::new();
                 for inst in mem_insts.into_iter() {
-                    ret.push_str(
-                        &inst.print_with_state(&mut EmitState::default(), &mut empty_allocs),
-                    );
+                    ret.push_str(&inst.print_with_state(&mut EmitState::default()));
                 }
                 let (reg, index_reg, offset) = match mem {
                     AMode::RegExtended { rn, rm, extendop } => (rn, Some((rm, extendop)), 0),
@@ -2804,14 +2793,10 @@ impl Inst {
                         extendop,
                     };
 
-                    ret.push_str(
-                        &add.print_with_state(&mut EmitState::default(), &mut empty_allocs),
-                    );
+                    ret.push_str(&add.print_with_state(&mut EmitState::default()));
                 } else if offset == 0 {
                     let mov = Inst::gen_move(rd, reg, I64);
-                    ret.push_str(
-                        &mov.print_with_state(&mut EmitState::default(), &mut empty_allocs),
-                    );
+                    ret.push_str(&mov.print_with_state(&mut EmitState::default()));
                 } else if let Some(imm12) = Imm12::maybe_from_u64(abs_offset) {
                     let add = Inst::AluRRImm12 {
                         alu_op,
@@ -2820,15 +2805,11 @@ impl Inst {
                         rn: reg,
                         imm12,
                     };
-                    ret.push_str(
-                        &add.print_with_state(&mut EmitState::default(), &mut empty_allocs),
-                    );
+                    ret.push_str(&add.print_with_state(&mut EmitState::default()));
                 } else {
                     let tmp = writable_spilltmp_reg();
                     for inst in Inst::load_constant(tmp, abs_offset, &mut |_| tmp).into_iter() {
-                        ret.push_str(
-                            &inst.print_with_state(&mut EmitState::default(), &mut empty_allocs),
-                        );
+                        ret.push_str(&inst.print_with_state(&mut EmitState::default()));
                     }
                     let add = Inst::AluRRR {
                         alu_op,
@@ -2837,9 +2818,7 @@ impl Inst {
                         rn: reg,
                         rm: tmp.to_reg(),
                     };
-                    ret.push_str(
-                        &add.print_with_state(&mut EmitState::default(), &mut empty_allocs),
-                    );
+                    ret.push_str(&add.print_with_state(&mut EmitState::default()));
                 }
                 ret
             }
@@ -2875,25 +2854,25 @@ impl Inst {
                 rd,
                 tmp,
             } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
-                let tmp = pretty_print_reg(tmp.to_reg(), allocs);
+                let rd = pretty_print_reg(rd.to_reg());
+                let tmp = pretty_print_reg(tmp.to_reg());
                 format!("elf_tls_get_addr {}, {}, {}", rd, tmp, symbol.display(None))
             }
             &Inst::MachOTlsGetAddr { ref symbol, rd } => {
-                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                let rd = pretty_print_reg(rd.to_reg());
                 format!("macho_tls_get_addr {}, {}", rd, symbol.display(None))
             }
             &Inst::Unwind { ref inst } => {
                 format!("unwind {:?}", inst)
             }
             &Inst::DummyUse { reg } => {
-                let reg = pretty_print_reg(reg, allocs);
+                let reg = pretty_print_reg(reg);
                 format!("dummy_use {}", reg)
             }
             &Inst::StackProbeLoop { start, end, step } => {
-                let start = pretty_print_reg(start.to_reg(), allocs);
-                let end = pretty_print_reg(end, allocs);
-                let step = step.pretty_print(0, allocs);
+                let start = pretty_print_reg(start.to_reg());
+                let end = pretty_print_reg(end);
+                let step = step.pretty_print(0);
                 format!("stack_probe_loop {start}, {end}, {step}")
             }
         }

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -3,7 +3,6 @@
 use crate::isa::aarch64::inst::OperandSize;
 use crate::isa::aarch64::inst::ScalarSize;
 use crate::isa::aarch64::inst::VectorSize;
-use crate::machinst::AllocationConsumer;
 use crate::machinst::RealReg;
 use crate::machinst::{Reg, RegClass, Writable};
 use regalloc2::PReg;
@@ -176,7 +175,7 @@ fn show_reg(reg: Reg) -> String {
     }
 }
 
-pub fn pretty_print_reg(reg: Reg, _allocs: &mut AllocationConsumer) -> String {
+pub fn pretty_print_reg(reg: Reg) -> String {
     show_reg(reg)
 }
 
@@ -253,31 +252,18 @@ pub fn show_vreg_element(reg: Reg, idx: u8, size: ScalarSize) -> String {
     format!("{}{}[{}]", s, suffix, idx)
 }
 
-pub fn pretty_print_ireg(reg: Reg, size: OperandSize, _allocs: &mut AllocationConsumer) -> String {
+pub fn pretty_print_ireg(reg: Reg, size: OperandSize) -> String {
     show_ireg_sized(reg, size)
 }
 
-pub fn pretty_print_vreg_scalar(
-    reg: Reg,
-    size: ScalarSize,
-    _allocs: &mut AllocationConsumer,
-) -> String {
+pub fn pretty_print_vreg_scalar(reg: Reg, size: ScalarSize) -> String {
     show_vreg_scalar(reg, size)
 }
 
-pub fn pretty_print_vreg_vector(
-    reg: Reg,
-    size: VectorSize,
-    _allocs: &mut AllocationConsumer,
-) -> String {
+pub fn pretty_print_vreg_vector(reg: Reg, size: VectorSize) -> String {
     show_vreg_vector(reg, size)
 }
 
-pub fn pretty_print_vreg_element(
-    reg: Reg,
-    idx: usize,
-    size: ScalarSize,
-    _allocs: &mut AllocationConsumer,
-) -> String {
+pub fn pretty_print_vreg_element(reg: Reg, idx: usize, size: ScalarSize) -> String {
     show_vreg_element(reg, idx as u8, size)
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -265,9 +265,8 @@ impl MachInstEmit for Inst {
         );
     }
 
-    fn pretty_print_inst(&self, allocs: &[Allocation], state: &mut Self::State) -> String {
-        let mut allocs = AllocationConsumer::new(allocs);
-        self.print_with_state(state, &mut allocs)
+    fn pretty_print_inst(&self, _allocs: &[Allocation], state: &mut Self::State) -> String {
+        self.print_with_state(state)
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
@@ -2110,9 +2110,7 @@ fn test_riscv64_binemit() {
     for unit in insns.iter() {
         println!("Riscv64: {:?}, {}", unit.inst, unit.assembly);
         // Check the printed text is as expected.
-        let actual_printing = unit
-            .inst
-            .print_with_state(&mut EmitState::default(), &mut AllocationConsumer::new(&[]));
+        let actual_printing = unit.inst.print_with_state(&mut EmitState::default());
         assert_eq!(unit.assembly, actual_printing);
         let mut buffer = MachBuffer::new();
         unit.inst

--- a/cranelift/codegen/src/isa/s390x/inst/args.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/args.rs
@@ -216,7 +216,7 @@ impl Cond {
 }
 
 impl PrettyPrint for MemArg {
-    fn pretty_print(&self, _: u8, _allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         match self {
             &MemArg::BXD12 {
                 base, index, disp, ..
@@ -277,7 +277,7 @@ impl PrettyPrint for MemArg {
 }
 
 impl PrettyPrint for Cond {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         let s = match self.mask {
             1 => "o",
             2 => "h",

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -1366,25 +1366,22 @@ impl MachInstEmit for Inst {
 
     fn emit(
         &self,
-        allocs: &[Allocation],
+        _allocs: &[Allocation],
         sink: &mut MachBuffer<Inst>,
         emit_info: &Self::Info,
         state: &mut EmitState,
     ) {
-        let mut allocs = AllocationConsumer::new(allocs);
-        self.emit_with_alloc_consumer(&mut allocs, sink, emit_info, state)
+        self.emit_with_alloc_consumer(sink, emit_info, state)
     }
 
-    fn pretty_print_inst(&self, allocs: &[Allocation], state: &mut EmitState) -> String {
-        let mut allocs = AllocationConsumer::new(allocs);
-        self.print_with_state(state, &mut allocs)
+    fn pretty_print_inst(&self, _allocs: &[Allocation], state: &mut EmitState) -> String {
+        self.print_with_state(state)
     }
 }
 
 impl Inst {
     fn emit_with_alloc_consumer(
         &self,
-        allocs: &mut AllocationConsumer,
         sink: &mut MachBuffer<Inst>,
         emit_info: &EmitInfo,
         state: &mut EmitState,
@@ -2046,9 +2043,9 @@ impl Inst {
                                 target: done_label,
                                 cond: *cond,
                             };
-                            inst.emit_with_alloc_consumer(allocs, sink, emit_info, state);
+                            inst.emit_with_alloc_consumer(sink, emit_info, state);
                         }
-                        _ => inst.emit_with_alloc_consumer(allocs, sink, emit_info, state),
+                        _ => inst.emit_with_alloc_consumer(sink, emit_info, state),
                     };
                 }
 

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -13365,8 +13365,7 @@ fn test_s390x_binemit() {
         );
 
         // Check the printed text is as expected.
-        let actual_printing =
-            insn.print_with_state(&mut EmitState::default(), &mut AllocationConsumer::new(&[]));
+        let actual_printing = insn.print_with_state(&mut EmitState::default());
         assert_eq!(expected_printing, actual_printing);
 
         let mut buffer = MachBuffer::new();

--- a/cranelift/codegen/src/isa/s390x/inst/imms.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/imms.rs
@@ -1,6 +1,6 @@
 //! S390x ISA definitions: immediate constants.
 
-use crate::machinst::{AllocationConsumer, PrettyPrint};
+use crate::machinst::PrettyPrint;
 use std::string::String;
 
 /// An unsigned 12-bit immediate.
@@ -178,25 +178,25 @@ impl UImm32Shifted {
 }
 
 impl PrettyPrint for UImm12 {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("{}", self.value)
     }
 }
 
 impl PrettyPrint for SImm20 {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("{}", self.value)
     }
 }
 
 impl PrettyPrint for UImm16Shifted {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("{}", self.bits)
     }
 }
 
 impl PrettyPrint for UImm32Shifted {
-    fn pretty_print(&self, _: u8, _: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _: u8) -> String {
         format!("{}", self.bits)
     }
 }

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -99,11 +99,11 @@ pub fn maybe_show_fpr(reg: Reg) -> Option<String> {
     None
 }
 
-pub fn pretty_print_reg(reg: Reg, _allocs: &mut AllocationConsumer) -> String {
+pub fn pretty_print_reg(reg: Reg) -> String {
     show_reg(reg)
 }
 
-pub fn pretty_print_regpair(pair: RegPair, _allocs: &mut AllocationConsumer) -> String {
+pub fn pretty_print_regpair(pair: RegPair) -> String {
     let hi = pair.hi;
     let lo = pair.lo;
     if let Some(hi_reg) = hi.to_real_reg() {
@@ -121,11 +121,7 @@ pub fn pretty_print_regpair(pair: RegPair, _allocs: &mut AllocationConsumer) -> 
     format!("{}/{}", show_reg(hi), show_reg(lo))
 }
 
-pub fn pretty_print_reg_mod(
-    rd: Writable<Reg>,
-    ri: Reg,
-    _allocs: &mut AllocationConsumer,
-) -> String {
+pub fn pretty_print_reg_mod(rd: Writable<Reg>, ri: Reg) -> String {
     let output = rd.to_reg();
     let input = ri;
     if output == input {
@@ -135,11 +131,7 @@ pub fn pretty_print_reg_mod(
     }
 }
 
-pub fn pretty_print_regpair_mod(
-    rd: WritableRegPair,
-    ri: RegPair,
-    _allocs: &mut AllocationConsumer,
-) -> String {
+pub fn pretty_print_regpair_mod(rd: WritableRegPair, ri: RegPair) -> String {
     let rd_hi = rd.hi.to_reg();
     let rd_lo = rd.lo.to_reg();
     let ri_hi = ri.hi;
@@ -157,11 +149,7 @@ pub fn pretty_print_regpair_mod(
     }
 }
 
-pub fn pretty_print_regpair_mod_lo(
-    rd: WritableRegPair,
-    ri: Reg,
-    _allocs: &mut AllocationConsumer,
-) -> String {
+pub fn pretty_print_regpair_mod_lo(rd: WritableRegPair, ri: Reg) -> String {
     let rd_hi = rd.hi.to_reg();
     let rd_lo = rd.lo.to_reg();
     if rd_lo == ri {
@@ -176,6 +164,6 @@ pub fn pretty_print_regpair_mod_lo(
     }
 }
 
-pub fn pretty_print_fpr(reg: Reg, _allocs: &mut AllocationConsumer) -> (String, Option<String>) {
+pub fn pretty_print_fpr(reg: Reg) -> (String, Option<String>) {
     (show_reg(reg), maybe_show_fpr(reg))
 }

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -170,8 +170,8 @@ macro_rules! newtype_of_reg {
                 }
             }
             impl PrettyPrint for $newtype_reg_mem {
-                fn pretty_print(&self, size: u8, allocs: &mut AllocationConsumer) -> String {
-                    self.0.pretty_print(size, allocs)
+                fn pretty_print(&self, size: u8) -> String {
+                    self.0.pretty_print(size)
                 }
             }
         )*
@@ -236,8 +236,8 @@ macro_rules! newtype_of_reg {
             }
 
             impl PrettyPrint for $newtype_reg_mem_imm {
-                fn pretty_print(&self, size: u8, allocs: &mut AllocationConsumer) -> String {
-                    self.0.pretty_print(size, allocs)
+                fn pretty_print(&self, size: u8) -> String {
+                    self.0.pretty_print(size)
                 }
             }
         )*
@@ -424,12 +424,12 @@ impl Amode {
 }
 
 impl PrettyPrint for Amode {
-    fn pretty_print(&self, _size: u8, allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _size: u8) -> String {
         match self {
             Amode::ImmReg { simm32, base, .. } => {
                 // Note: size is always 8; the address is 64 bits,
                 // even if the addressed operand is smaller.
-                format!("{}({})", *simm32, pretty_print_reg(*base, 8, allocs))
+                format!("{}({})", *simm32, pretty_print_reg(*base, 8))
             }
             Amode::ImmRegRegShift {
                 simm32,
@@ -440,8 +440,8 @@ impl PrettyPrint for Amode {
             } => format!(
                 "{}({},{},{})",
                 *simm32,
-                pretty_print_reg(base.to_reg(), 8, allocs),
-                pretty_print_reg(index.to_reg(), 8, allocs),
+                pretty_print_reg(base.to_reg(), 8),
+                pretty_print_reg(index.to_reg(), 8),
                 1 << shift
             ),
             Amode::RipRelative { ref target } => format!("label{}(%rip)", target.get()),
@@ -558,10 +558,10 @@ impl Into<SyntheticAmode> for VCodeConstant {
 }
 
 impl PrettyPrint for SyntheticAmode {
-    fn pretty_print(&self, _size: u8, allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _size: u8) -> String {
         match self {
             // See note in `Amode` regarding constant size of `8`.
-            SyntheticAmode::Real(addr) => addr.pretty_print(8, allocs),
+            SyntheticAmode::Real(addr) => addr.pretty_print(8),
             &SyntheticAmode::IncomingArg { offset } => {
                 format!("rbp(stack args max - {offset})")
             }
@@ -646,10 +646,10 @@ impl From<Reg> for RegMemImm {
 }
 
 impl PrettyPrint for RegMemImm {
-    fn pretty_print(&self, size: u8, allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, size: u8) -> String {
         match self {
-            Self::Reg { reg } => pretty_print_reg(*reg, size, allocs),
-            Self::Mem { addr } => addr.pretty_print(size, allocs),
+            Self::Reg { reg } => pretty_print_reg(*reg, size),
+            Self::Mem { addr } => addr.pretty_print(size),
             Self::Imm { simm32 } => format!("${}", *simm32 as i32),
         }
     }
@@ -737,10 +737,10 @@ impl From<Writable<Reg>> for RegMem {
 }
 
 impl PrettyPrint for RegMem {
-    fn pretty_print(&self, size: u8, allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, size: u8) -> String {
         match self {
-            RegMem::Reg { reg } => pretty_print_reg(*reg, size, allocs),
-            RegMem::Mem { addr, .. } => addr.pretty_print(size, allocs),
+            RegMem::Reg { reg } => pretty_print_reg(*reg, size),
+            RegMem::Mem { addr, .. } => addr.pretty_print(size),
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -108,7 +108,6 @@ fn emit_reloc(sink: &mut MachBuffer<Inst>, kind: Reloc, name: &ExternalName, add
 ///   care?)
 pub(crate) fn emit(
     inst: &Inst,
-    allocs: &mut AllocationConsumer,
     sink: &mut MachBuffer<Inst>,
     info: &EmitInfo,
     state: &mut EmitState,
@@ -246,7 +245,6 @@ pub(crate) fn emit(
                     src1: dst.to_reg(),
                     src2: dst.to_reg().into(),
                 },
-                allocs,
                 sink,
                 info,
                 state,
@@ -1619,7 +1617,7 @@ pub(crate) fn emit(
             callee,
             info: call_info,
         } => {
-            emit_return_call_common_sequence(allocs, sink, info, state, &call_info);
+            emit_return_call_common_sequence(sink, info, state, &call_info);
 
             // Finally, jump to the callee!
             //
@@ -1640,7 +1638,7 @@ pub(crate) fn emit(
         } => {
             let callee = *callee;
 
-            emit_return_call_common_sequence(allocs, sink, info, state, &call_info);
+            emit_return_call_common_sequence(sink, info, state, &call_info);
 
             Inst::JmpUnknown {
                 target: RegMem::reg(callee),
@@ -1910,7 +1908,6 @@ pub(crate) fn emit(
                     src: XmmMem::new(src.clone().into()).unwrap(),
                     dst: *dst,
                 },
-                allocs,
                 sink,
                 info,
                 state,
@@ -2068,7 +2065,6 @@ pub(crate) fn emit(
                 src1: *src1,
                 src2: XmmMem::new(src2.clone().to_reg_mem()).unwrap(),
             },
-            allocs,
             sink,
             info,
             state,
@@ -4218,7 +4214,6 @@ pub(crate) fn emit(
 ///
 /// * Move the return address into its stack slot.
 fn emit_return_call_common_sequence(
-    _allocs: &mut AllocationConsumer,
     sink: &mut MachBuffer<Inst>,
     info: &EmitInfo,
     state: &mut EmitState,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -673,7 +673,7 @@ impl Inst {
 // Instructions: printing
 
 impl PrettyPrint for Inst {
-    fn pretty_print(&self, _size: u8, allocs: &mut AllocationConsumer) -> String {
+    fn pretty_print(&self, _size: u8) -> String {
         fn ljustify(s: String) -> String {
             let w = 7;
             if s.len() >= w {
@@ -727,15 +727,15 @@ impl PrettyPrint for Inst {
                 dst,
             } => {
                 let size_bytes = size.to_bytes();
-                let src1 = pretty_print_reg(src1.to_reg(), size_bytes, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size_bytes, allocs);
-                let src2 = src2.pretty_print(size_bytes, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), size_bytes);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size_bytes);
+                let src2 = src2.pretty_print(size_bytes);
                 let op = ljustify2(op.to_string(), suffix_bwlq(*size));
                 format!("{op} {src1}, {src2}, {dst}")
             }
             Inst::AluConstOp { op, dst, size } => {
                 let size_bytes = size.to_bytes();
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size_bytes, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size_bytes);
                 let op = ljustify2(op.to_string(), suffix_lqb(*size));
                 format!("{op} {dst}, {dst}, {dst}")
             }
@@ -746,8 +746,8 @@ impl PrettyPrint for Inst {
                 src2,
             } => {
                 let size_bytes = size.to_bytes();
-                let src2 = pretty_print_reg(src2.to_reg(), size_bytes, allocs);
-                let src1_dst = src1_dst.pretty_print(size_bytes, allocs);
+                let src2 = pretty_print_reg(src2.to_reg(), size_bytes);
+                let src1_dst = src1_dst.pretty_print(size_bytes);
                 let op = ljustify2(op.to_string(), suffix_bwlq(*size));
                 format!("{op} {src2}, {src1_dst}")
             }
@@ -759,22 +759,22 @@ impl PrettyPrint for Inst {
                 dst,
             } => {
                 let size_bytes = size.to_bytes();
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let src1 = pretty_print_reg(src1.to_reg(), size_bytes, allocs);
-                let src2 = src2.pretty_print(size_bytes, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let src1 = pretty_print_reg(src1.to_reg(), size_bytes);
+                let src2 = src2.pretty_print(size_bytes);
                 let op = ljustify2(op.to_string(), String::new());
                 format!("{op} {src2}, {src1}, {dst}")
             }
             Inst::UnaryRmR { src, dst, op, size } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let src = src.pretty_print(size.to_bytes(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let src = src.pretty_print(size.to_bytes());
                 let op = ljustify2(op.to_string(), suffix_bwlq(*size));
                 format!("{op} {src}, {dst}")
             }
 
             Inst::UnaryRmRVex { src, dst, op, size } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let src = src.pretty_print(size.to_bytes(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let src = src.pretty_print(size.to_bytes());
                 let op = ljustify2(op.to_string(), suffix_bwlq(*size));
                 format!("{op} {src}, {dst}")
             }
@@ -786,8 +786,8 @@ impl PrettyPrint for Inst {
                 size,
                 imm,
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let src = src.pretty_print(size.to_bytes(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let src = src.pretty_print(size.to_bytes());
                 format!(
                     "{} ${imm}, {src}, {dst}",
                     ljustify2(op.to_string(), suffix_bwlq(*size))
@@ -795,15 +795,15 @@ impl PrettyPrint for Inst {
             }
 
             Inst::Not { size, src, dst } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
+                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
                 let op = ljustify2("not".to_string(), suffix_bwlq(*size));
                 format!("{op} {src}, {dst}")
             }
 
             Inst::Neg { size, src, dst } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
+                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
                 let op = ljustify2("neg".to_string(), suffix_bwlq(*size));
                 format!("{op} {src}, {dst}")
             }
@@ -818,13 +818,13 @@ impl PrettyPrint for Inst {
                 dst_quotient,
                 dst_remainder,
             } => {
-                let divisor = divisor.pretty_print(size.to_bytes(), allocs);
-                let dividend_lo = pretty_print_reg(dividend_lo.to_reg(), size.to_bytes(), allocs);
-                let dividend_hi = pretty_print_reg(dividend_hi.to_reg(), size.to_bytes(), allocs);
+                let divisor = divisor.pretty_print(size.to_bytes());
+                let dividend_lo = pretty_print_reg(dividend_lo.to_reg(), size.to_bytes());
+                let dividend_hi = pretty_print_reg(dividend_hi.to_reg(), size.to_bytes());
                 let dst_quotient =
-                    pretty_print_reg(dst_quotient.to_reg().to_reg(), size.to_bytes(), allocs);
+                    pretty_print_reg(dst_quotient.to_reg().to_reg(), size.to_bytes());
                 let dst_remainder =
-                    pretty_print_reg(dst_remainder.to_reg().to_reg(), size.to_bytes(), allocs);
+                    pretty_print_reg(dst_remainder.to_reg().to_reg(), size.to_bytes());
                 let op = ljustify(match sign {
                     DivSignedness::Signed => "idiv".to_string(),
                     DivSignedness::Unsigned => "div".to_string(),
@@ -841,9 +841,9 @@ impl PrettyPrint for Inst {
                 dividend,
                 dst,
             } => {
-                let divisor = divisor.pretty_print(1, allocs);
-                let dividend = pretty_print_reg(dividend.to_reg(), 1, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1, allocs);
+                let divisor = divisor.pretty_print(1);
+                let dividend = pretty_print_reg(dividend.to_reg(), 1);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1);
                 let op = ljustify(match sign {
                     DivSignedness::Signed => "idiv".to_string(),
                     DivSignedness::Unsigned => "div".to_string(),
@@ -859,10 +859,10 @@ impl PrettyPrint for Inst {
                 dst_lo,
                 dst_hi,
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), size.to_bytes(), allocs);
-                let dst_lo = pretty_print_reg(dst_lo.to_reg().to_reg(), size.to_bytes(), allocs);
-                let dst_hi = pretty_print_reg(dst_hi.to_reg().to_reg(), size.to_bytes(), allocs);
-                let src2 = src2.pretty_print(size.to_bytes(), allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), size.to_bytes());
+                let dst_lo = pretty_print_reg(dst_lo.to_reg().to_reg(), size.to_bytes());
+                let dst_hi = pretty_print_reg(dst_hi.to_reg().to_reg(), size.to_bytes());
+                let src2 = src2.pretty_print(size.to_bytes());
                 let suffix = suffix_bwlq(*size);
                 let op = ljustify(if *signed {
                     format!("imul{suffix}")
@@ -878,9 +878,9 @@ impl PrettyPrint for Inst {
                 src2,
                 dst,
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 1, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1, allocs);
-                let src2 = src2.pretty_print(1, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 1);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1);
+                let src2 = src2.pretty_print(1);
                 let op = ljustify(if *signed {
                     "imulb".to_string()
                 } else {
@@ -895,9 +895,9 @@ impl PrettyPrint for Inst {
                 src2,
                 dst,
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let src2 = src2.pretty_print(size.to_bytes(), allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let src2 = src2.pretty_print(size.to_bytes());
                 let suffix = suffix_bwlq(*size);
                 let op = ljustify(format!("imul{suffix}"));
                 format!("{op} {src1}, {src2}, {dst}")
@@ -909,8 +909,8 @@ impl PrettyPrint for Inst {
                 src2,
                 dst,
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let src1 = src1.pretty_print(size.to_bytes(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let src1 = src1.pretty_print(size.to_bytes());
                 let suffix = suffix_bwlq(*size);
                 let op = ljustify(format!("imul{suffix}"));
                 format!("{op} {src1}, {src2:#x}, {dst}")
@@ -924,13 +924,13 @@ impl PrettyPrint for Inst {
                 dst_quotient,
                 dst_remainder,
             } => {
-                let divisor = pretty_print_reg(divisor.to_reg(), size.to_bytes(), allocs);
-                let dividend_lo = pretty_print_reg(dividend_lo.to_reg(), size.to_bytes(), allocs);
-                let dividend_hi = pretty_print_reg(dividend_hi.to_reg(), size.to_bytes(), allocs);
+                let divisor = pretty_print_reg(divisor.to_reg(), size.to_bytes());
+                let dividend_lo = pretty_print_reg(dividend_lo.to_reg(), size.to_bytes());
+                let dividend_hi = pretty_print_reg(dividend_hi.to_reg(), size.to_bytes());
                 let dst_quotient =
-                    pretty_print_reg(dst_quotient.to_reg().to_reg(), size.to_bytes(), allocs);
+                    pretty_print_reg(dst_quotient.to_reg().to_reg(), size.to_bytes());
                 let dst_remainder =
-                    pretty_print_reg(dst_remainder.to_reg().to_reg(), size.to_bytes(), allocs);
+                    pretty_print_reg(dst_remainder.to_reg().to_reg(), size.to_bytes());
                 format!(
                     "checked_srem_seq {dividend_lo}, {dividend_hi}, \
                         {divisor}, {dst_quotient}, {dst_remainder}",
@@ -942,15 +942,15 @@ impl PrettyPrint for Inst {
                 dividend,
                 dst,
             } => {
-                let divisor = pretty_print_reg(divisor.to_reg(), 1, allocs);
-                let dividend = pretty_print_reg(dividend.to_reg(), 1, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1, allocs);
+                let divisor = pretty_print_reg(divisor.to_reg(), 1);
+                let dividend = pretty_print_reg(dividend.to_reg(), 1);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1);
                 format!("checked_srem_seq {dividend}, {divisor}, {dst}")
             }
 
             Inst::SignExtendData { size, src, dst } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
+                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
                 let op = match size {
                     OperandSize::Size8 => "cbw",
                     OperandSize::Size16 => "cwd",
@@ -961,15 +961,15 @@ impl PrettyPrint for Inst {
             }
 
             Inst::XmmUnaryRmR { op, src, dst, .. } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size(), allocs);
-                let src = src.pretty_print(op.src_size(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size());
+                let src = src.pretty_print(op.src_size());
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
 
             Inst::XmmUnaryRmRUnaligned { op, src, dst, .. } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size(), allocs);
-                let src = src.pretty_print(op.src_size(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size());
+                let src = src.pretty_print(op.src_size());
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
@@ -977,15 +977,15 @@ impl PrettyPrint for Inst {
             Inst::XmmUnaryRmRImm {
                 op, src, dst, imm, ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size(), allocs);
-                let src = src.pretty_print(op.src_size(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size());
+                let src = src.pretty_print(op.src_size());
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmUnaryRmRVex { op, src, dst, .. } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src = src.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src = src.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
@@ -993,15 +993,15 @@ impl PrettyPrint for Inst {
             Inst::XmmUnaryRmRImmVex {
                 op, src, dst, imm, ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src = src.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src = src.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmUnaryRmREvex { op, src, dst, .. } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src = src.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src = src.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
@@ -1009,22 +1009,22 @@ impl PrettyPrint for Inst {
             Inst::XmmUnaryRmRImmEvex {
                 op, src, dst, imm, ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src = src.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src = src.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmMovRM { op, src, dst, .. } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = dst.pretty_print(8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = dst.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
 
             Inst::XmmMovRMVex { op, src, dst, .. } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = dst.pretty_print(8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = dst.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
@@ -1032,8 +1032,8 @@ impl PrettyPrint for Inst {
             Inst::XmmMovRMImm {
                 op, src, dst, imm, ..
             } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = dst.pretty_print(8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = dst.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src}, {dst}")
             }
@@ -1041,8 +1041,8 @@ impl PrettyPrint for Inst {
             Inst::XmmMovRMImmVex {
                 op, src, dst, imm, ..
             } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = dst.pretty_print(8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = dst.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src}, {dst}")
             }
@@ -1054,9 +1054,9 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {dst}")
             }
@@ -1068,9 +1068,9 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {dst}")
             }
@@ -1082,7 +1082,7 @@ impl PrettyPrint for Inst {
                 mask,
                 dst,
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
                 let mask = mask.to_reg();
                 let mask = if mask.is_virtual() {
                     format!(" <{}>", show_ireg_sized(mask, 8))
@@ -1090,8 +1090,8 @@ impl PrettyPrint for Inst {
                     debug_assert_eq!(mask, regs::xmm0());
                     String::new()
                 };
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {dst}{mask}")
             }
@@ -1103,9 +1103,9 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {dst}")
             }
@@ -1118,9 +1118,9 @@ impl PrettyPrint for Inst {
                 imm,
                 ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src1}, {src2}, {dst}")
             }
@@ -1133,9 +1133,9 @@ impl PrettyPrint for Inst {
                 imm,
                 ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src1}, {src2}, {dst}")
             }
@@ -1148,10 +1148,10 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src2 = pretty_print_reg(src2.to_reg(), 8, allocs);
-                let src3 = src3.pretty_print(8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src2 = pretty_print_reg(src2.to_reg(), 8);
+                let src3 = src3.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {src3}, {dst}")
             }
@@ -1164,10 +1164,10 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
-                let mask = pretty_print_reg(mask.to_reg(), 8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src2 = src2.pretty_print(8);
+                let mask = pretty_print_reg(mask.to_reg(), 8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {mask}, {dst}")
             }
@@ -1179,9 +1179,9 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = src2.pretty_print(8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src2}, {src1}, {dst}")
             }
@@ -1194,10 +1194,10 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = pretty_print_reg(src2.to_reg(), 8, allocs);
-                let src3 = src3.pretty_print(8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = pretty_print_reg(src2.to_reg(), 8);
+                let src3 = src3.pretty_print(8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src3}, {src2}, {src1}, {dst}")
             }
@@ -1209,9 +1209,9 @@ impl PrettyPrint for Inst {
                 is_min,
                 size,
             } => {
-                let rhs = pretty_print_reg(rhs.to_reg(), 8, allocs);
-                let lhs = pretty_print_reg(lhs.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let rhs = pretty_print_reg(rhs.to_reg(), 8);
+                let lhs = pretty_print_reg(lhs.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify2(
                     if *is_min {
                         "xmm min seq ".to_string()
@@ -1232,9 +1232,9 @@ impl PrettyPrint for Inst {
                 size,
                 ..
             } => {
-                let src1 = pretty_print_reg(*src1, 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let src1 = pretty_print_reg(*src1, 8);
+                let dst = pretty_print_reg(dst.to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(format!(
                     "{}{}",
                     op.to_string(),
@@ -1248,7 +1248,7 @@ impl PrettyPrint for Inst {
             }
 
             Inst::XmmUninitializedValue { dst } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify("uninit".into());
                 format!("{op} {dst}")
             }
@@ -1260,8 +1260,8 @@ impl PrettyPrint for Inst {
                 dst_size,
             } => {
                 let dst_size = dst_size.to_bytes();
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
@@ -1273,22 +1273,22 @@ impl PrettyPrint for Inst {
                 dst_size,
             } => {
                 let dst_size = dst_size.to_bytes();
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
 
             Inst::XmmToGprImm { op, src, dst, imm } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmToGprImmVex { op, src, dst, imm } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify(op.to_string());
                 format!("{op} ${imm}, {src}, {dst}")
             }
@@ -1299,8 +1299,8 @@ impl PrettyPrint for Inst {
                 src_size,
                 dst,
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src = src.pretty_print(src_size.to_bytes(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src = src.pretty_print(src_size.to_bytes());
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
@@ -1311,15 +1311,15 @@ impl PrettyPrint for Inst {
                 src_size,
                 dst,
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src = src.pretty_print(src_size.to_bytes(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src = src.pretty_print(src_size.to_bytes());
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
             }
 
             Inst::XmmCmpRmR { op, src1, src2 } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src2}, {src1}")
             }
@@ -1331,9 +1331,9 @@ impl PrettyPrint for Inst {
                 dst,
                 src2_size,
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(*dst.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(src2_size.to_bytes(), allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let dst = pretty_print_reg(*dst.to_reg(), 8);
+                let src2 = src2.pretty_print(src2_size.to_bytes());
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {dst}")
             }
@@ -1345,16 +1345,16 @@ impl PrettyPrint for Inst {
                 dst,
                 src2_size,
             } => {
-                let dst = pretty_print_reg(*dst.to_reg(), 8, allocs);
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(src2_size.to_bytes(), allocs);
+                let dst = pretty_print_reg(*dst.to_reg(), 8);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = src2.pretty_print(src2_size.to_bytes());
                 let op = ljustify(op.to_string());
                 format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::XmmCmpRmRVex { op, src1, src2 } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 format!("{} {src2}, {src1}", ljustify(op.to_string()))
             }
 
@@ -1366,10 +1366,10 @@ impl PrettyPrint for Inst {
                 tmp_gpr2,
                 ..
             } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes(), allocs);
-                let tmp_gpr1 = pretty_print_reg(tmp_gpr1.to_reg().to_reg(), 8, allocs);
-                let tmp_gpr2 = pretty_print_reg(tmp_gpr2.to_reg().to_reg(), 8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes());
+                let tmp_gpr1 = pretty_print_reg(tmp_gpr1.to_reg().to_reg(), 8);
+                let tmp_gpr2 = pretty_print_reg(tmp_gpr2.to_reg().to_reg(), 8);
                 let op = ljustify(format!(
                     "u64_to_{}_seq",
                     if *dst_size == OperandSize::Size64 {
@@ -1390,10 +1390,10 @@ impl PrettyPrint for Inst {
                 tmp_gpr,
                 is_saturating,
             } => {
-                let src = pretty_print_reg(src.to_reg(), src_size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes(), allocs);
-                let tmp_gpr = pretty_print_reg(tmp_gpr.to_reg().to_reg(), 8, allocs);
-                let tmp_xmm = pretty_print_reg(tmp_xmm.to_reg().to_reg(), 8, allocs);
+                let src = pretty_print_reg(src.to_reg(), src_size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes());
+                let tmp_gpr = pretty_print_reg(tmp_gpr.to_reg().to_reg(), 8);
+                let tmp_xmm = pretty_print_reg(tmp_xmm.to_reg().to_reg(), 8);
                 let op = ljustify(format!(
                     "cvt_float{}_to_sint{}{}_seq",
                     src_size.to_bits(),
@@ -1413,11 +1413,11 @@ impl PrettyPrint for Inst {
                 tmp_xmm2,
                 is_saturating,
             } => {
-                let src = pretty_print_reg(src.to_reg(), src_size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes(), allocs);
-                let tmp_gpr = pretty_print_reg(tmp_gpr.to_reg().to_reg(), 8, allocs);
-                let tmp_xmm = pretty_print_reg(tmp_xmm.to_reg().to_reg(), 8, allocs);
-                let tmp_xmm2 = pretty_print_reg(tmp_xmm2.to_reg().to_reg(), 8, allocs);
+                let src = pretty_print_reg(src.to_reg(), src_size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes());
+                let tmp_gpr = pretty_print_reg(tmp_gpr.to_reg().to_reg(), 8);
+                let tmp_xmm = pretty_print_reg(tmp_xmm.to_reg().to_reg(), 8);
+                let tmp_xmm2 = pretty_print_reg(tmp_xmm2.to_reg().to_reg(), 8);
                 let op = ljustify(format!(
                     "cvt_float{}_to_uint{}{}_seq",
                     src_size.to_bits(),
@@ -1432,7 +1432,7 @@ impl PrettyPrint for Inst {
                 simm64,
                 dst,
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes());
                 if *dst_size == OperandSize::Size64 {
                     let op = ljustify("movabsq".to_string());
                     let imm = *simm64 as i64;
@@ -1445,7 +1445,7 @@ impl PrettyPrint for Inst {
             }
 
             Inst::MovImmM { size, simm32, dst } => {
-                let dst = dst.pretty_print(size.to_bytes(), allocs);
+                let dst = dst.pretty_print(size.to_bytes());
                 let suffix = suffix_bwlq(*size);
                 let imm = match *size {
                     OperandSize::Size8 => ((*simm32 as u8) as i8).to_string(),
@@ -1458,8 +1458,8 @@ impl PrettyPrint for Inst {
             }
 
             Inst::MovRR { size, src, dst } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
+                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
                 let op = ljustify2("mov".to_string(), suffix_lq(*size));
                 format!("{op} {src}, {dst}")
             }
@@ -1467,13 +1467,13 @@ impl PrettyPrint for Inst {
             Inst::MovFromPReg { src, dst } => {
                 let src: Reg = (*src).into();
                 let src = regs::show_ireg_sized(src, 8);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify("movq".to_string());
                 format!("{op} {src}, {dst}")
             }
 
             Inst::MovToPReg { src, dst } => {
-                let src = pretty_print_reg(src.to_reg(), 8, allocs);
+                let src = pretty_print_reg(src.to_reg(), 8);
                 let dst: Reg = (*dst).into();
                 let dst = regs::show_ireg_sized(dst, 8);
                 let op = ljustify("movq".to_string());
@@ -1488,8 +1488,8 @@ impl PrettyPrint for Inst {
                 } else {
                     ext_mode.dst_size()
                 };
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size, allocs);
-                let src = src.pretty_print(ext_mode.src_size(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size);
+                let src = src.pretty_print(ext_mode.src_size());
 
                 if *ext_mode == ExtMode::LQ {
                     let op = ljustify("movl".to_string());
@@ -1501,15 +1501,15 @@ impl PrettyPrint for Inst {
             }
 
             Inst::Mov64MR { src, dst, .. } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src = src.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src = src.pretty_print(8);
                 let op = ljustify("movq".to_string());
                 format!("{op} {src}, {dst}")
             }
 
             Inst::LoadEffectiveAddress { addr, dst, size } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let addr = addr.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let addr = addr.pretty_print(8);
                 let op = ljustify("lea".to_string());
                 format!("{op} {addr}, {dst}")
             }
@@ -1517,15 +1517,15 @@ impl PrettyPrint for Inst {
             Inst::MovsxRmR {
                 ext_mode, src, dst, ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), ext_mode.dst_size(), allocs);
-                let src = src.pretty_print(ext_mode.src_size(), allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), ext_mode.dst_size());
+                let src = src.pretty_print(ext_mode.src_size());
                 let op = ljustify2("movs".to_string(), ext_mode.to_string());
                 format!("{op} {src}, {dst}")
             }
 
             Inst::MovRM { size, src, dst, .. } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
-                let dst = dst.pretty_print(size.to_bytes(), allocs);
+                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
+                let dst = dst.pretty_print(size.to_bytes());
                 let op = ljustify2("mov".to_string(), suffix_bwlq(*size));
                 format!("{op} {src}, {dst}")
             }
@@ -1538,11 +1538,11 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
+                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
                 match num_bits.as_imm8_reg() {
                     &Imm8Reg::Reg { reg } => {
-                        let reg = pretty_print_reg(reg, 1, allocs);
+                        let reg = pretty_print_reg(reg, 1);
                         let op = ljustify2(kind.to_string(), suffix_bwlq(*size));
                         format!("{op} {reg}, {src}, {dst}")
                     }
@@ -1561,9 +1561,9 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src2 = src2.pretty_print(8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let src2 = src2.pretty_print(8);
                 let op = ljustify(opcode.to_string());
                 format!("{op} {src1}, {src2}, {dst}")
             }
@@ -1574,8 +1574,8 @@ impl PrettyPrint for Inst {
                 src2,
                 opcode,
             } => {
-                let src1 = pretty_print_reg(src1.to_reg(), size.to_bytes(), allocs);
-                let src2 = src2.pretty_print(size.to_bytes(), allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), size.to_bytes());
+                let src2 = src2.pretty_print(size.to_bytes());
                 let op = match opcode {
                     CmpOpcode::Cmp => "cmp",
                     CmpOpcode::Test => "test",
@@ -1585,14 +1585,14 @@ impl PrettyPrint for Inst {
             }
 
             Inst::Setcc { cc, dst } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 1);
                 let op = ljustify2("set".to_string(), cc.to_string());
                 format!("{op} {dst}")
             }
 
             Inst::Bswap { size, src, dst } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
+                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
                 let op = ljustify2("bswap".to_string(), suffix_bwlq(*size));
                 format!("{op} {src}, {dst}")
             }
@@ -1604,9 +1604,9 @@ impl PrettyPrint for Inst {
                 alternative,
                 dst,
             } => {
-                let alternative = pretty_print_reg(alternative.to_reg(), size.to_bytes(), allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                let consequent = consequent.pretty_print(size.to_bytes(), allocs);
+                let alternative = pretty_print_reg(alternative.to_reg(), size.to_bytes());
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
+                let consequent = consequent.pretty_print(size.to_bytes());
                 let op = ljustify(format!("cmov{}{}", cc.to_string(), suffix_bwlq(*size)));
                 format!("{op} {consequent}, {alternative}, {dst}")
             }
@@ -1620,9 +1620,9 @@ impl PrettyPrint for Inst {
                 ..
             } => {
                 let size = u8::try_from(ty.bytes()).unwrap();
-                let alternative = pretty_print_reg(alternative.to_reg(), size, allocs);
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size, allocs);
-                let consequent = pretty_print_reg(consequent.to_reg(), size, allocs);
+                let alternative = pretty_print_reg(alternative.to_reg(), size);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size);
+                let consequent = pretty_print_reg(consequent.to_reg(), size);
                 let suffix = match *ty {
                     types::F64 => "sd",
                     types::F32 => "ss",
@@ -1640,7 +1640,7 @@ impl PrettyPrint for Inst {
             }
 
             Inst::Push64 { src } => {
-                let src = src.pretty_print(8, allocs);
+                let src = src.pretty_print(8);
                 let op = ljustify("pushq".to_string());
                 format!("{op} {src}")
             }
@@ -1650,13 +1650,13 @@ impl PrettyPrint for Inst {
                 frame_size,
                 guard_size,
             } => {
-                let tmp = pretty_print_reg(tmp.to_reg(), 8, allocs);
+                let tmp = pretty_print_reg(tmp.to_reg(), 8);
                 let op = ljustify("stack_probe_loop".to_string());
                 format!("{op} {tmp}, frame_size={frame_size}, guard_size={guard_size}")
             }
 
             Inst::Pop64 { dst } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify("popq".to_string());
                 format!("{op} {dst}")
             }
@@ -1667,7 +1667,7 @@ impl PrettyPrint for Inst {
             }
 
             Inst::CallUnknown { dest, .. } => {
-                let dest = dest.pretty_print(8, allocs);
+                let dest = dest.pretty_print(8);
                 let op = ljustify("call".to_string());
                 format!("{op} *{dest}")
             }
@@ -1678,12 +1678,12 @@ impl PrettyPrint for Inst {
                     new_stack_arg_size,
                     tmp,
                 } = &**info;
-                let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8, allocs);
+                let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8);
                 let mut s =
                     format!("return_call_known {callee:?} ({new_stack_arg_size}) tmp={tmp}");
                 for ret in uses {
                     let preg = regs::show_reg(ret.preg);
-                    let vreg = pretty_print_reg(ret.vreg, 8, allocs);
+                    let vreg = pretty_print_reg(ret.vreg, 8);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
@@ -1695,13 +1695,13 @@ impl PrettyPrint for Inst {
                     new_stack_arg_size,
                     tmp,
                 } = &**info;
-                let callee = pretty_print_reg(*callee, 8, allocs);
-                let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8, allocs);
+                let callee = pretty_print_reg(*callee, 8);
+                let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8);
                 let mut s =
                     format!("return_call_unknown {callee} ({new_stack_arg_size}) tmp={tmp}");
                 for ret in uses {
                     let preg = regs::show_reg(ret.preg);
-                    let vreg = pretty_print_reg(ret.vreg, 8, allocs);
+                    let vreg = pretty_print_reg(ret.vreg, 8);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
@@ -1711,7 +1711,7 @@ impl PrettyPrint for Inst {
                 let mut s = "args".to_string();
                 for arg in args {
                     let preg = regs::show_reg(arg.preg);
-                    let def = pretty_print_reg(arg.vreg.to_reg(), 8, allocs);
+                    let def = pretty_print_reg(arg.vreg.to_reg(), 8);
                     write!(&mut s, " {def}={preg}").unwrap();
                 }
                 s
@@ -1721,7 +1721,7 @@ impl PrettyPrint for Inst {
                 let mut s = "rets".to_string();
                 for ret in rets {
                     let preg = regs::show_reg(ret.preg);
-                    let vreg = pretty_print_reg(ret.vreg, 8, allocs);
+                    let vreg = pretty_print_reg(ret.vreg, 8);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
@@ -1761,15 +1761,15 @@ impl PrettyPrint for Inst {
             Inst::JmpTableSeq {
                 idx, tmp1, tmp2, ..
             } => {
-                let idx = pretty_print_reg(*idx, 8, allocs);
-                let tmp1 = pretty_print_reg(tmp1.to_reg(), 8, allocs);
-                let tmp2 = pretty_print_reg(tmp2.to_reg(), 8, allocs);
+                let idx = pretty_print_reg(*idx, 8);
+                let tmp1 = pretty_print_reg(tmp1.to_reg(), 8);
+                let tmp2 = pretty_print_reg(tmp2.to_reg(), 8);
                 let op = ljustify("br_table".into());
                 format!("{op} {idx}, {tmp1}, {tmp2}")
             }
 
             Inst::JmpUnknown { target } => {
-                let target = target.pretty_print(8, allocs);
+                let target = target.pretty_print(8);
                 let op = ljustify("jmp".to_string());
                 format!("{op} *{target}")
             }
@@ -1802,7 +1802,7 @@ impl PrettyPrint for Inst {
             Inst::LoadExtName {
                 dst, name, offset, ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg(), 8, allocs);
+                let dst = pretty_print_reg(dst.to_reg(), 8);
                 let name = name.display(None);
                 let op = ljustify("load_ext_name".into());
                 format!("{op} {name}+{offset}, {dst}")
@@ -1817,10 +1817,10 @@ impl PrettyPrint for Inst {
                 ..
             } => {
                 let size = ty.bytes() as u8;
-                let replacement = pretty_print_reg(*replacement, size, allocs);
-                let expected = pretty_print_reg(*expected, size, allocs);
-                let dst_old = pretty_print_reg(dst_old.to_reg(), size, allocs);
-                let mem = mem.pretty_print(size, allocs);
+                let replacement = pretty_print_reg(*replacement, size);
+                let expected = pretty_print_reg(*expected, size);
+                let dst_old = pretty_print_reg(dst_old.to_reg(), size);
+                let mem = mem.pretty_print(size);
                 let suffix = suffix_bwlq(OperandSize::from_bytes(size as u32));
                 format!(
                     "lock cmpxchg{suffix} {replacement}, {mem}, expected={expected}, dst_old={dst_old}"
@@ -1847,12 +1847,12 @@ impl PrettyPrint for Inst {
             Inst::Ud2 { trap_code } => format!("ud2 {trap_code}"),
 
             Inst::ElfTlsGetAddr { ref symbol, dst } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 format!("{dst} = elf_tls_get_addr {symbol:?}")
             }
 
             Inst::MachOTlsGetAddr { ref symbol, dst } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 format!("{dst} = macho_tls_get_addr {symbol:?}")
             }
 
@@ -1861,7 +1861,7 @@ impl PrettyPrint for Inst {
                 dst,
                 tmp,
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let tmp = tmp.to_reg().to_reg();
 
                 let mut s = format!("{dst} = coff_tls_get_addr {symbol:?}");
@@ -1876,7 +1876,7 @@ impl PrettyPrint for Inst {
             Inst::Unwind { inst } => format!("unwind {inst:?}"),
 
             Inst::DummyUse { reg } => {
-                let reg = pretty_print_reg(*reg, 8, allocs);
+                let reg = pretty_print_reg(*reg, 8);
                 format!("dummy_use {reg}")
             }
         }
@@ -2736,17 +2736,16 @@ impl MachInstEmit for Inst {
 
     fn emit(
         &self,
-        allocs: &[Allocation],
+        _allocs: &[Allocation],
         sink: &mut MachBuffer<Inst>,
         info: &Self::Info,
         state: &mut Self::State,
     ) {
-        let mut allocs = AllocationConsumer::new(allocs);
-        emit::emit(self, &mut allocs, sink, info, state);
+        emit::emit(self, sink, info, state);
     }
 
-    fn pretty_print_inst(&self, allocs: &[Allocation], _: &mut Self::State) -> String {
-        PrettyPrint::pretty_print(self, 0, &mut AllocationConsumer::new(allocs))
+    fn pretty_print_inst(&self, _allocs: &[Allocation], _: &mut Self::State) -> String {
+        PrettyPrint::pretty_print(self, 0)
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -5,7 +5,7 @@
 //!
 //! Note also that we make use of pinned VRegs to refer to PRegs.
 
-use crate::machinst::{AllocationConsumer, RealReg, Reg};
+use crate::machinst::{RealReg, Reg};
 use alloc::string::ToString;
 use regalloc2::{PReg, RegClass, VReg};
 use std::string::String;
@@ -270,6 +270,6 @@ pub fn show_ireg_sized(reg: Reg, size: u8) -> String {
 // words, we can't pretty-print a `Reg` all by itself in a build that
 // may have multiple backends; but we can pretty-print one as part of
 // an x64 Inst or x64 RegMemImm.)
-pub fn pretty_print_reg(reg: Reg, size: u8, _allocs: &mut AllocationConsumer) -> String {
+pub fn pretty_print_reg(reg: Reg, size: u8) -> String {
     show_ireg_sized(reg, size)
 }

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -4,9 +4,7 @@
 
 use alloc::{string::String, vec::Vec};
 use core::{fmt::Debug, hash::Hash};
-use regalloc2::{
-    Allocation, Operand, OperandConstraint, OperandKind, OperandPos, PReg, PRegSet, VReg,
-};
+use regalloc2::{Operand, OperandConstraint, OperandKind, OperandPos, PReg, PRegSet, VReg};
 
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
@@ -476,37 +474,9 @@ impl<T: FnMut(&mut Reg, OperandConstraint, OperandKind, OperandPos)> OperandVisi
 /// `eax` for the register by those names on x86-64, depending on a
 /// 64- or 32-bit context.
 pub trait PrettyPrint {
-    fn pretty_print(&self, size_bytes: u8, allocs: &mut AllocationConsumer) -> String;
+    fn pretty_print(&self, size_bytes: u8) -> String;
 
     fn pretty_print_default(&self) -> String {
-        self.pretty_print(0, &mut AllocationConsumer::new(&[]))
-    }
-}
-
-/// A consumer of an (optional) list of Allocations along with Regs
-/// that provides RealRegs where available.
-///
-/// This is meant to be used during code emission or
-/// pretty-printing. In at least the latter case, regalloc results may
-/// or may not be available, so we may end up printing either vregs or
-/// rregs. Even pre-regalloc, though, some registers may be RealRegs
-/// that were provided when the instruction was created.
-///
-/// This struct should be used in a specific way: when matching on an
-/// instruction, provide it the Regs in the same order as they were
-/// provided to the OperandCollector.
-#[derive(Clone)]
-pub struct AllocationConsumer;
-
-impl AllocationConsumer {
-    pub fn new(allocs: &[Allocation]) -> Self {
-        debug_assert!(allocs.is_empty());
-        Self
-    }
-}
-
-impl std::default::Default for AllocationConsumer {
-    fn default() -> Self {
-        Self::new(&[])
+        self.pretty_print(0)
     }
 }


### PR DESCRIPTION
Since there are no calls left to AllocationConsumer's methods, this commit just deletes all the arguments of this type, as well as the definition of the type itself.