### PR TITLE
Parse object files with `ElfFile64` rather than `object::File`

### DIFF
--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -25,9 +25,10 @@ use crate::prelude::*;
 use crate::{Engine, ModuleVersionStrategy, Precompiled};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use core::str::FromStr;
+use object::endian::NativeEndian;
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 use object::write::{Object, StandardSegment};
-use object::{File, FileFlags, Object as _, ObjectSection, SectionKind};
+use object::{read::elf::ElfFile64, FileFlags, Object as _, ObjectSection, SectionKind};
 use serde_derive::{Deserialize, Serialize};
 use wasmtime_environ::obj;
 use wasmtime_environ::{FlagValue, ObjectKind, Tunables};
@@ -56,7 +57,7 @@ pub fn check_compatible(engine: &Engine, mmap: &[u8], expected: ObjectKind) -> R
     // structured well enough to make this easy and additionally it's not really
     // a perf issue right now so doing that is left for another day's
     // refactoring.
-    let obj = File::parse(mmap)
+    let obj = ElfFile64::<NativeEndian>::parse(mmap)
         .err2anyhow()
         .context("failed to parse precompiled artifact as an ELF")?;
     let expected_e_flags = match expected {
@@ -145,7 +146,7 @@ pub fn append_compiler_info(engine: &Engine, obj: &mut Object<'_>, metadata: &Me
 }
 
 fn detect_precompiled<'data, R: object::ReadRef<'data>>(
-    obj: File<'data, R>,
+    obj: ElfFile64<'data, NativeEndian, R>,
 ) -> Option<Precompiled> {
     match obj.flags() {
         FileFlags::Elf {
@@ -163,13 +164,13 @@ fn detect_precompiled<'data, R: object::ReadRef<'data>>(
 }
 
 pub fn detect_precompiled_bytes(bytes: &[u8]) -> Option<Precompiled> {
-    detect_precompiled(File::parse(bytes).ok()?)
+    detect_precompiled(ElfFile64::parse(bytes).ok()?)
 }
 
 #[cfg(feature = "std")]
 pub fn detect_precompiled_file(path: impl AsRef<std::path::Path>) -> Result<Option<Precompiled>> {
     let read_cache = object::ReadCache::new(std::fs::File::open(path)?);
-    let obj = File::parse(&read_cache)?;
+    let obj = ElfFile64::parse(&read_cache)?;
     Ok(detect_precompiled(obj))
 }
 

--- a/crates/wasmtime/src/runtime/code_memory.rs
+++ b/crates/wasmtime/src/runtime/code_memory.rs
@@ -5,7 +5,8 @@ use crate::runtime::vm::{libcalls, MmapVec, UnwindRegistration};
 use anyhow::{anyhow, bail, Context, Result};
 use core::mem::ManuallyDrop;
 use core::ops::Range;
-use object::read::{File, Object, ObjectSection};
+use object::endian::NativeEndian;
+use object::read::{elf::ElfFile64, Object, ObjectSection};
 use object::ObjectSymbol;
 use wasmtime_environ::obj;
 use wasmtime_jit_icache_coherence as icache_coherence;
@@ -57,7 +58,7 @@ impl CodeMemory {
     /// The returned `CodeMemory` manages the internal `MmapVec` and the
     /// `publish` method is used to actually make the memory executable.
     pub fn new(mmap: MmapVec) -> Result<Self> {
-        let obj = File::parse(&mmap[..])
+        let obj = ElfFile64::<NativeEndian>::parse(&mmap[..])
             .err2anyhow()
             .with_context(|| "failed to parse internal compilation artifact")?;
 


### PR DESCRIPTION
The latter is what Wasmtime uses today but it pulls in parsers for all object formats supported by `object`. In the context of Wasmtime, however, we know that all objects produced are 64-bit ELF files so there's no need to pull in, for example, a COFF parser as that'll always return an error anyway. This commit switches uses of the `object::File` convenience to `ElfFile64` instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
