### PR TITLE
Allow env/args/preopens to exceed 64k in size

### DIFF
--- a/crates/test-programs/src/bin/cli_large_env.rs
+++ b/crates/test-programs/src/bin/cli_large_env.rs
@@ -1,0 +1,5 @@
+fn main() {
+    for (k, v) in std::env::vars() {
+        println!("{k}={v}");
+    }
+}

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -1,8 +1,9 @@
 use crate::bindings::wasi::cli::{stderr, stdin, stdout};
 use crate::bindings::wasi::io::streams::{InputStream, OutputStream};
-use crate::{BlockingMode, BumpArena, ImportAlloc, TrappingUnwrap, WasmStr};
+use crate::{BlockingMode, BumpAlloc, ImportAlloc, State, TrappingUnwrap, WasmStr};
 use core::cell::{Cell, OnceCell, UnsafeCell};
 use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
 use wasi::{Errno, Fd};
 
 #[cfg(not(feature = "proxy"))]
@@ -145,21 +146,21 @@ pub struct Descriptors {
 
     /// Points to the head of a free-list of closed file descriptors.
     closed: Option<Fd>,
+}
 
-    /// Preopened directories. Initialized lazily. Access with `State::get_preopens`
-    /// to take care of initialization.
-    #[cfg(not(feature = "proxy"))]
-    preopens: Cell<Option<&'static [Preopen]>>,
+#[cfg(not(feature = "proxy"))]
+#[link(wasm_import_module = "wasi:filesystem/preopens@0.2.0")]
+extern "C" {
+    #[link_name = "get-directories"]
+    fn wasi_filesystem_get_directories(rval: *mut PreopenList);
 }
 
 impl Descriptors {
-    pub fn new(import_alloc: &ImportAlloc, arena: &BumpArena) -> Self {
+    pub fn new(state: &State) -> Self {
         let d = Descriptors {
             table: UnsafeCell::new(MaybeUninit::uninit()),
             table_len: Cell::new(0),
             closed: None,
-            #[cfg(not(feature = "proxy"))]
-            preopens: Cell::new(None),
         };
 
         fn new_once<T>(val: T) -> OnceCell<T> {
@@ -188,52 +189,66 @@ impl Descriptors {
         .trapping_unwrap();
 
         #[cfg(not(feature = "proxy"))]
-        d.open_preopens(import_alloc, arena);
+        d.open_preopens(state);
         d
     }
 
     #[cfg(not(feature = "proxy"))]
-    fn open_preopens(&self, import_alloc: &ImportAlloc, arena: &BumpArena) {
-        #[link(wasm_import_module = "wasi:filesystem/preopens@0.2.0")]
-        #[allow(improper_ctypes)] // FIXME(bytecodealliance/wit-bindgen#684)
-        extern "C" {
-            #[link_name = "get-directories"]
-            fn get_preopens_import(rval: *mut PreopenList);
+    fn open_preopens(&self, state: &State) {
+        unsafe {
+            let alloc = ImportAlloc::CountAndDiscardStrings {
+                strings_size: 0,
+                alloc: state.temporary_alloc(),
+            };
+            let (preopens, _) = state.with_import_alloc(alloc, || {
+                let mut preopens = PreopenList {
+                    base: std::ptr::null(),
+                    len: 0,
+                };
+                wasi_filesystem_get_directories(&mut preopens);
+                preopens
+            });
+            for i in 0..preopens.len {
+                let preopen = preopens.base.add(i).read();
+                // Expectation is that the descriptor index is initialized with
+                // stdio (0,1,2) and no others, so that preopens are 3..
+                let descriptor_type = preopen.descriptor.get_type().trapping_unwrap();
+                self.push(Descriptor::Streams(Streams {
+                    input: OnceCell::new(),
+                    output: OnceCell::new(),
+                    type_: StreamType::File(File {
+                        fd: preopen.descriptor,
+                        descriptor_type,
+                        position: Cell::new(0),
+                        append: false,
+                        blocking_mode: BlockingMode::Blocking,
+                        preopen_name_len: NonZeroUsize::new(preopen.path.len),
+                    }),
+                }))
+                .trapping_unwrap();
+            }
         }
-        let mut list = PreopenList {
-            base: std::ptr::null(),
-            len: 0,
-        };
-        import_alloc.with_arena(arena, || unsafe {
-            get_preopens_import(&mut list as *mut _)
-        });
-        let preopens: &'static [Preopen] = unsafe {
-            // allocation comes from long lived arena, so it is safe to
-            // cast this to a &'static slice:
-            std::slice::from_raw_parts(list.base, list.len)
-        };
-        for preopen in preopens {
-            // Acquire ownership of the descriptor, leaving the rest of the
-            // `Preopen` struct in place.
-            let descriptor = unsafe { preopen.descriptor.assume_init_read() };
-            // Expectation is that the descriptor index is initialized with
-            // stdio (0,1,2) and no others, so that preopens are 3..
-            let descriptor_type = descriptor.get_type().trapping_unwrap();
-            self.push(Descriptor::Streams(Streams {
-                input: OnceCell::new(),
-                output: OnceCell::new(),
-                type_: StreamType::File(File {
-                    fd: descriptor,
-                    descriptor_type,
-                    position: Cell::new(0),
-                    append: false,
-                    blocking_mode: BlockingMode::Blocking,
-                }),
-            }))
-            .trapping_unwrap();
-        }
+    }
 
-        self.preopens.set(Some(preopens));
+    #[cfg(not(feature = "proxy"))]
+    pub unsafe fn get_preopen_path(&self, state: &State, fd: Fd, path: *mut u8, len: usize) {
+        let alloc = ImportAlloc::GetPreopenPath {
+            path: Some(BumpAlloc { base: path, len }),
+            nth: fd - 3,
+            alloc: state.temporary_alloc(),
+        };
+        let (preopens, _) = state.with_import_alloc(alloc, || {
+            let mut preopens = PreopenList {
+                base: std::ptr::null(),
+                len: 0,
+            };
+            wasi_filesystem_get_directories(&mut preopens);
+            preopens
+        });
+        for i in 0..preopens.len {
+            let preopen = preopens.base.add(i).read();
+            drop(preopen.descriptor);
+        }
     }
 
     fn push(&self, desc: Descriptor) -> Result<Fd, Errno> {
@@ -297,14 +312,6 @@ impl Descriptors {
         self.table_mut()
             .get_mut(usize::try_from(fd).trapping_unwrap())
             .ok_or(wasi::ERRNO_BADF)
-    }
-
-    #[cfg(not(feature = "proxy"))]
-    pub fn get_preopen(&self, fd: Fd) -> Option<&Preopen> {
-        let preopens = self.preopens.get().trapping_unwrap();
-        // Subtract 3 for the stdio indices to compute the preopen index.
-        let index = fd.checked_sub(3)? as usize;
-        preopens.get(index)
     }
 
     // Internal: close a fd, returning the descriptor.
@@ -437,9 +444,7 @@ impl Descriptors {
 #[cfg(not(feature = "proxy"))]
 #[repr(C)]
 pub struct Preopen {
-    /// This is `MaybeUninit` because we take ownership of the `Descriptor` to
-    /// put it in our own table.
-    pub descriptor: MaybeUninit<filesystem::Descriptor>,
+    pub descriptor: filesystem::Descriptor,
     pub path: WasmStr,
 }
 

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -247,7 +247,7 @@ impl Descriptors {
         });
 
         // NB: we just got owned handles for all preopened directories. We're
-        // only intereted in one individual string allocation, however, so
+        // only interested in one individual string allocation, however, so
         // discard all of the descriptors and close them since we otherwise
         // don't want to leak them.
         for i in 0..preopens.len {

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -245,6 +245,11 @@ impl Descriptors {
             wasi_filesystem_get_directories(&mut preopens);
             preopens
         });
+
+        // NB: we just got owned handles for all preopened directories. We're
+        // only intereted in one individual string allocation, however, so
+        // discard all of the descriptors and close them since we otherwise
+        // don't want to leak them.
         for i in 0..preopens.len {
             let preopen = preopens.base.add(i).read();
             drop(preopen.descriptor);

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1827,7 +1827,7 @@ mod test_programs {
             cmd.arg("run").arg("-Sinherit-env").arg(wasm);
 
             let debug_cmd = format!("{cmd:?}");
-            for i in 0..1024 {
+            for i in 0..512 {
                 let var = format!("KEY{i}");
                 let val = (0..1024).map(|_| 'x').collect::<String>();
                 cmd.env(&var, &val);

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1818,6 +1818,30 @@ mod test_programs {
         );
         Ok(())
     }
+
+    #[test]
+    fn cli_large_env() -> Result<()> {
+        for wasm in [CLI_LARGE_ENV, CLI_LARGE_ENV_COMPONENT] {
+            println!("run {wasm:?}");
+            let mut cmd = get_wasmtime_command()?;
+            cmd.arg("run").arg("-Sinherit-env").arg(wasm);
+
+            let debug_cmd = format!("{cmd:?}");
+            for i in 0..1024 {
+                let var = format!("KEY{i}");
+                let val = (0..1024).map(|_| 'x').collect::<String>();
+                cmd.env(&var, &val);
+            }
+            let output = cmd.output()?;
+            if !output.status.success() {
+                bail!(
+                    "Failed to execute wasmtime with: {debug_cmd}\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
This commit fixes an issue with the wasip1 adapter published with Wasmtime which current limits the size of environment variables, arguments, and preopens to not exceed 64k. This bug comes from the fact that we more-or-less forgot to account for this when designing the adapter initially. The adapter allocates a single WebAssembly page for itself but does not have a means of allocating much more than that. It's technically possible to continue to call `memory.grow` or possibly `cabi_realloc` from the original main module but it's pretty awkward.

The solution in this commit is to take an alternative approach to how these properties are all processed. Previously arguments/env vars/preopens were all allocated once within the adapter and stored statically. This means that after startup they're copied from where they reside in-memory, but the downside is that we have to have enough memory to hold everything. This commit instead tries to "stream" the items so they're never held entirely within the adapter itself.

The general idea in this commit is to use the "align" parameter to `cabi_import_realloc` to figure out what's being allocated and route the allocation to the destination. For example an allocation with alignment 1 is a string and can go directly into a user-supplied pointer where an allocation with alignment 4 is a pointer-based allocation which must be stored within the adapter, but only temporarily.

With this redesign it's now possible to have the sum total of args/envs/preopens to exceed 64k. The new limitation is that the max-length string plus size of the max length of these arrays must be less than 64k. This should be a more reasonable limit than before where any one individual argument/env var is unlikely to exceed 64k (or get close).

Closes #8556

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
