### PR TITLE
Add Android release binaries to CI

### DIFF
--- a/.github/actions/android-ndk/action.yml
+++ b/.github/actions/android-ndk/action.yml
@@ -1,0 +1,31 @@
+# This is a small action which uses the pre-installed Android NDK on GitHub
+# Actions builders, configured with `$ANDROID_NDK`, to compile and link Android
+# code. For Rust we mostly need to configure the linker to Cargo and the C
+# compiler to the `cc` crate, so this sets various environment variables to the
+# appropriate tool within `$ANDROID_NDK`.
+
+name: 'Setup Rust to use the Android NDK'
+description: 'Setup Rust to use the android NDK'
+
+inputs:
+  target:
+    description: 'Rust target being used'
+    required: true
+  android-platform:
+    description: 'Platform version to use for the C compiler'
+    required: false
+    default: '26'
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        rust=${{ inputs.target }}
+        upcase=$(echo $rust | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        ndk_bin=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin
+        linker=$ndk_bin/${rust}${{ inputs.android-platform }}-clang
+        echo CARGO_TARGET_${upcase}_LINKER=$linker >> $GITHUB_ENV
+        echo CC_${rust}=$linker >> $GITHUB_ENV
+        echo RANLIB_${rust}=$ndk_bin/llvm-ranlib >> $GITHUB_ENV
+        echo AR_${rust}=$ndk_bin/llvm-ar >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/android-ndk/action.yml
+++ b/.github/actions/android-ndk/action.yml
@@ -20,12 +20,12 @@ runs:
   using: composite
   steps:
     - run: |
-        rust=${{ inputs.target }}
-        upcase=$(echo $rust | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        target=${{ inputs.target }}
+        upcase=$(echo $target | tr a-z- A-Z_)
         ndk_bin=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin
-        linker=$ndk_bin/${rust}${{ inputs.android-platform }}-clang
+        linker=$ndk_bin/${target}${{ inputs.android-platform }}-clang
         echo CARGO_TARGET_${upcase}_LINKER=$linker >> $GITHUB_ENV
-        echo CC_${rust}=$linker >> $GITHUB_ENV
-        echo RANLIB_${rust}=$ndk_bin/llvm-ranlib >> $GITHUB_ENV
-        echo AR_${rust}=$ndk_bin/llvm-ar >> $GITHUB_ENV
+        echo CC_${target}=$linker >> $GITHUB_ENV
+        echo RANLIB_${target}=$ndk_bin/llvm-ranlib >> $GITHUB_ENV
+        echo AR_${target}=$ndk_bin/llvm-ar >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -21,6 +21,12 @@ if (process.platform == 'win32') {
   return;
 }
 
+// Android doesn't use a container as it's controlled by the installation of the
+// SDK/NDK.
+if (process.env.INPUT_NAME && process.env.INPUT_NAME.indexOf("android") >= 0) {
+  return;
+}
+
 // ... and on Linux we do fancy things with containers. We'll spawn an old
 // CentOS container in the background with a super old glibc, and then we'll run
 // commands in there with the `$CENTOS` env var.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -306,8 +306,6 @@ jobs:
     needs: determine
     name: Check
     runs-on: ubuntu-latest
-    env:
-      CARGO_NDK_VERSION: 2.12.2
     steps:
     - uses: actions/checkout@v4
       with:
@@ -388,23 +386,6 @@ jobs:
     # TODO: We aren't building with default features since the `ittapi` crate fails to compile on freebsd.
     - run: rustup target add x86_64-unknown-freebsd
     - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache --target x86_64-unknown-freebsd
-
-    # Check whether `wasmtime` cross-compiles to aarch64-linux-android
-    - run: rustup target add aarch64-linux-android
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-    - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
-    - uses: actions/cache@v4
-      with:
-        path: ${{ runner.tool_cache }}/cargo-ndk
-        key: cargo-ndk-bin-${{ env.CARGO_NDK_VERSION }}
-    - run: echo "${{ runner.tool_cache }}/cargo-ndk/bin" >> $GITHUB_PATH
-    - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk --locked
-    - run: cargo ndk -t arm64-v8a check -p wasmtime
 
     # Run clippy configuration
     - run: rustup component add clippy
@@ -880,6 +861,11 @@ jobs:
     - uses: ./.github/actions/binary-compatible-builds
       with:
         name: ${{ matrix.build }}
+
+    - uses: ./.github/actions/android-ndk
+      if: contains(matrix.target, 'android')
+      with:
+        target: ${{ matrix.target }}
 
     - run: $CENTOS ./ci/build-release-artifacts.sh "${{ matrix.build }}" "${{ matrix.target }}"
 

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -49,6 +49,16 @@ const array = [
     "os": "windows-latest",
     "target": "x86_64-pc-windows-gnu",
   },
+  {
+    "build": "aarch64-android",
+    "os": "ubuntu-latest",
+    "target": "aarch64-linux-android",
+  },
+  {
+    "build": "x86_64-android",
+    "os": "ubuntu-latest",
+    "target": "x86_64-linux-android",
+  },
 ];
 
 const builds = [];

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -89,6 +89,8 @@ For explanations of what each tier means see below.
 | Target               | `aarch64-pc-windows-msvc`         | CI testing, unwinding, full-time maintainer |
 | Target               | `riscv64gc-unknown-linux-gnu`     | full-time maintainer        |
 | Target               | `wasm32-wasi` [^3]                | Supported but not tested    |
+| Target               | `aarch64-linux-android`           | CI testing, full-time maintainer |
+| Target               | `x86_64-linux-android`            | CI testing, full-time maintainer |
 | Compiler Backend     | Winch on aarch64                  | finished implementation     |
 | WebAssembly Proposal | [`gc`]                            | Complete implementation     |
 | WASI Proposal        | [`wasi-nn`]                       | More expansive CI testing   |


### PR DESCRIPTION
This commit is inspired by #6480 and historical asks for Android binaries. This does the bare minimum necessary to configure C compilers such that we can produce binaries but I'll admit that I'm no Android developer myself so I have no idea if these are actually suitable for use anywhere. Otherwise though this build subsumes the preexisting check in CI that the build works for Android, so that part is removed too.

This additionally changes how the NDK is managed from before. Previously a GitHub Action was used to download Java and the NDK and additionally used the `cargo ndk` subcommand. That's all removed now in favor of configuring C compilers directly with a pre-installed version of the NDK which should help reduce the CI dependencies a bit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
