### PR TITLE
cranelift: Resolve CLIF aliases before lowering

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -189,6 +189,8 @@ impl Context {
 
         self.remove_constant_phis(isa)?;
 
+        self.func.dfg.resolve_all_aliases();
+
         if opt_level != OptLevel::None {
             self.egraph_pass(isa, ctrl_plane)?;
         }

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -567,10 +567,6 @@ impl<'a> EgraphPass<'a> {
     /// only refer to its subset that exists at this stage, to
     /// maintain acyclicity.)
     fn remove_pure_and_optimize(&mut self) {
-        // This pass relies on every value having a unique name, so first
-        // eliminate any value aliases.
-        self.func.dfg.resolve_all_aliases();
-
         let mut cursor = FuncCursor::new(self.func);
         let mut value_to_opt_value: SecondaryMap<Value, Value> =
             SecondaryMap::with_default(Value::reserved_value());


### PR DESCRIPTION
The egraph pass was already doing this, when it ran, and it never adds any aliases. So do it slightly earlier and unconditionally, and avoid needing to resolve any aliases during lowering.