### PR TITLE
Change `MemoryStyle::Static` to store bytes, not pages

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2132,12 +2132,14 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                     )
                 }
                 MemoryPlan {
-                    style: MemoryStyle::Static { bound: bound_pages },
+                    style:
+                        MemoryStyle::Static {
+                            byte_reservation: bound_bytes,
+                        },
                     offset_guard_size,
                     pre_guard_size: _,
                     memory: _,
                 } => {
-                    let bound_bytes = u64::from(bound_pages) * u64::from(WASM_PAGE_SIZE);
                     let (base_fact, data_mt) = if let Some(ptr_memtype) = ptr_memtype {
                         // Create a memtype representing the untyped memory region.
                         let data_mt = func.create_memory_type(ir::MemoryTypeData::Memory {

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -147,15 +147,5 @@ pub mod fact;
 pub use cranelift_entity::*;
 pub use wasmtime_types::*;
 
-/// WebAssembly page sizes are defined to be 64KiB.
-pub const WASM_PAGE_SIZE: u32 = 0x10000;
-
-/// The number of pages (for 32-bit modules) we can have before we run out of
-/// byte index space.
-pub const WASM32_MAX_PAGES: u64 = 1 << 16;
-/// The number of pages (for 64-bit modules) we can have before we run out of
-/// byte index space.
-pub const WASM64_MAX_PAGES: u64 = 1 << 48;
-
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1463,6 +1463,87 @@ pub struct Memory {
     pub memory64: bool,
 }
 
+/// WebAssembly page sizes are defined to be 64KiB.
+pub const WASM_PAGE_SIZE: u32 = 0x10000;
+
+/// Maximum size, in bytes, of 32-bit memories (4G)
+pub const WASM32_MAX_SIZE: u64 = 1 << 32;
+
+/// Maximum size, in bytes, of 64-bit memories.
+///
+/// Note that the true maximum size of a 64-bit linear memory, in bytes, cannot
+/// be represented in a `u64`. That would require a u65 to store `1<<64`.
+/// Despite that no system can actually allocate a full 64-bit linear memory so
+/// this is instead emulated as "what if the kernel fit in a single wasm page
+/// of linear memory". Shouldn't ever actually be possible but it provides a
+/// number to serve as an effective maximum.
+pub const WASM64_MAX_SIZE: u64 = 0u64.wrapping_sub(0x10000);
+
+impl Memory {
+    /// Returns the minimum size, in bytes, that this memory must be.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the calculation of the minimum size overflows the
+    /// `u64` return type. This means that the memory can't be allocated but
+    /// it's deferred to the caller to how to deal with that.
+    pub fn minimum_byte_size(&self) -> Result<u64, SizeOverflow> {
+        self.minimum
+            .checked_mul(u64::from(WASM_PAGE_SIZE))
+            .ok_or(SizeOverflow)
+    }
+
+    /// Returns the maximum size, in bytes, that this memory is allowed to be.
+    ///
+    /// Note that the return value here is not an `Option` despite the maximum
+    /// size of a linear memory being optional in wasm. If a maximum size
+    /// is not present in the memory's type then a maximum size is selected for
+    /// it. For example the maximum size of a 32-bit memory is `1<<32`. The
+    /// maximum size of a 64-bit linear memory is chosen to be a value that
+    /// won't ever be allowed at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the calculation of the maximum size overflows the
+    /// `u64` return type. This means that the memory can't be allocated but
+    /// it's deferred to the caller to how to deal with that.
+    pub fn maximum_byte_size(&self) -> Result<u64, SizeOverflow> {
+        match self.maximum {
+            Some(max) => max
+                .checked_mul(u64::from(WASM_PAGE_SIZE))
+                .ok_or(SizeOverflow),
+            None => {
+                let min = self.minimum_byte_size()?;
+                Ok(min.max(self.max_size_based_on_index_type()))
+            }
+        }
+    }
+
+    /// Returns the maximum size memory is allowed to be only based on the
+    /// index type used by this memory.
+    ///
+    /// For example 32-bit linear memories return `1<<32` from this method.
+    pub fn max_size_based_on_index_type(&self) -> u64 {
+        if self.memory64 {
+            WASM64_MAX_SIZE
+        } else {
+            WASM32_MAX_SIZE
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct SizeOverflow;
+
+impl fmt::Display for SizeOverflow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("size overflow calculating memory size")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SizeOverflow {}
+
 impl From<wasmparser::MemoryType> for Memory {
     fn from(ty: wasmparser::MemoryType) -> Memory {
         Memory {

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -15,7 +15,7 @@ use anyhow::{anyhow, Result};
 use core::ops::Range;
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, EntityIndex, HostPtr, MemoryPlan, MemoryStyle, Module,
-    VMOffsets, WASM_PAGE_SIZE,
+    VMOffsets,
 };
 
 #[cfg(feature = "component-model")]
@@ -129,8 +129,8 @@ impl RuntimeMemoryCreator for MemoryCreatorProxy {
     ) -> Result<Box<dyn RuntimeLinearMemory>> {
         let ty = MemoryType::from_wasmtime_memory(&plan.memory);
         let reserved_size_in_bytes = match plan.style {
-            MemoryStyle::Static { bound } => {
-                Some(usize::try_from(bound * (WASM_PAGE_SIZE as u64)).unwrap())
+            MemoryStyle::Static { byte_reservation } => {
+                Some(usize::try_from(byte_reservation).unwrap())
             }
             MemoryStyle::Dynamic { .. } => None,
         };

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -738,7 +738,9 @@ mod test {
 
     #[test]
     fn instantiate_no_image() {
-        let plan = dummy_memory_plan(MemoryStyle::Static { bound: 4 << 30 });
+        let plan = dummy_memory_plan(MemoryStyle::Static {
+            bytes_reserved: 4 << 30,
+        });
         // 4 MiB mmap'd area, not accessible
         let mut mmap = Mmap::accessible_reserved(0, 4 << 20).unwrap();
         // Create a MemoryImageSlot on top of it
@@ -771,7 +773,9 @@ mod test {
 
     #[test]
     fn instantiate_image() {
-        let plan = dummy_memory_plan(MemoryStyle::Static { bound: 4 << 30 });
+        let plan = dummy_memory_plan(MemoryStyle::Static {
+            bytes_reserved: 4 << 30,
+        });
         // 4 MiB mmap'd area, not accessible
         let mut mmap = Mmap::accessible_reserved(0, 4 << 20).unwrap();
         // Create a MemoryImageSlot on top of it
@@ -819,7 +823,9 @@ mod test {
     #[test]
     #[cfg(target_os = "linux")]
     fn memset_instead_of_madvise() {
-        let plan = dummy_memory_plan(MemoryStyle::Static { bound: 100 });
+        let plan = dummy_memory_plan(MemoryStyle::Static {
+            bytes_reserved: 100 << 16,
+        });
         let mut mmap = Mmap::accessible_reserved(0, 4 << 20).unwrap();
         let mut memfd = MemoryImageSlot::create(mmap.as_mut_ptr() as *mut _, 0, 4 << 20);
         memfd.no_clear_on_drop();

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -739,7 +739,7 @@ mod test {
     #[test]
     fn instantiate_no_image() {
         let plan = dummy_memory_plan(MemoryStyle::Static {
-            bytes_reserved: 4 << 30,
+            byte_reservation: 4 << 30,
         });
         // 4 MiB mmap'd area, not accessible
         let mut mmap = Mmap::accessible_reserved(0, 4 << 20).unwrap();
@@ -774,7 +774,7 @@ mod test {
     #[test]
     fn instantiate_image() {
         let plan = dummy_memory_plan(MemoryStyle::Static {
-            bytes_reserved: 4 << 30,
+            byte_reservation: 4 << 30,
         });
         // 4 MiB mmap'd area, not accessible
         let mut mmap = Mmap::accessible_reserved(0, 4 << 20).unwrap();
@@ -824,7 +824,7 @@ mod test {
     #[cfg(target_os = "linux")]
     fn memset_instead_of_madvise() {
         let plan = dummy_memory_plan(MemoryStyle::Static {
-            bytes_reserved: 100 << 16,
+            byte_reservation: 100 << 16,
         });
         let mut mmap = Mmap::accessible_reserved(0, 4 << 20).unwrap();
         let mut memfd = MemoryImageSlot::create(mmap.as_mut_ptr() as *mut _, 0, 4 << 20);

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -276,7 +276,7 @@ impl MemoryPool {
                     {
                         bail!(
                             "memory size allocated per-memory is too small to \
-                             satisfy static bound of {byte_reservation:#x} pages"
+                             satisfy static bound of {byte_reservation:#x} bytes"
                         );
                     }
                 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -270,11 +270,13 @@ impl MemoryPool {
             .skip(module.num_imported_memories)
         {
             match plan.style {
-                MemoryStyle::Static { bound } => {
-                    if self.layout.pages_to_next_stripe_slot() < bound {
+                MemoryStyle::Static { byte_reservation } => {
+                    if u64::try_from(self.layout.bytes_to_next_stripe_slot()).unwrap()
+                        < byte_reservation
+                    {
                         bail!(
                             "memory size allocated per-memory is too small to \
-                             satisfy static bound of {bound:#x} pages"
+                             satisfy static bound of {byte_reservation:#x} pages"
                         );
                     }
                 }
@@ -336,8 +338,11 @@ impl MemoryPool {
             // should be returned as an error through `validate_memory_plans`
             // but double-check here to be sure.
             match memory_plan.style {
-                MemoryStyle::Static { bound } => {
-                    assert!(bound <= self.layout.pages_to_next_stripe_slot());
+                MemoryStyle::Static { byte_reservation } => {
+                    assert!(
+                        byte_reservation
+                            <= u64::try_from(self.layout.bytes_to_next_stripe_slot()).unwrap()
+                    );
                 }
                 MemoryStyle::Dynamic { .. } => {}
             }
@@ -641,13 +646,6 @@ impl SlabLayout {
     /// ```
     fn bytes_to_next_stripe_slot(&self) -> usize {
         self.slot_bytes * self.num_stripes
-    }
-
-    /// Same as `bytes_to_next_stripe_slot` but in Wasm pages.
-    fn pages_to_next_stripe_slot(&self) -> u64 {
-        let bytes = self.bytes_to_next_stripe_slot();
-        let pages = bytes / WASM_PAGE_SIZE as usize;
-        u64::try_from(pages).unwrap()
     }
 }
 

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -1,7 +1,7 @@
 #[cfg(all(not(target_os = "windows"), not(miri)))]
 mod not_for_windows {
     use wasmtime::*;
-    use wasmtime_environ::{WASM32_MAX_PAGES, WASM_PAGE_SIZE};
+    use wasmtime_environ::{WASM32_MAX_SIZE, WASM_PAGE_SIZE};
 
     use rustix::mm::{mmap_anonymous, mprotect, munmap, MapFlags, MprotectFlags, ProtFlags};
 
@@ -114,9 +114,7 @@ mod not_for_windows {
             unsafe {
                 let mem = Box::new(CustomMemory::new(
                     minimum,
-                    maximum.unwrap_or(
-                        usize::try_from(WASM32_MAX_PAGES * u64::from(WASM_PAGE_SIZE)).unwrap(),
-                    ),
+                    maximum.unwrap_or(usize::try_from(WASM32_MAX_SIZE).unwrap()),
                     self.num_total_bytes.clone(),
                 ));
                 *self.num_created_memories.lock().unwrap() += 1;

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -405,12 +405,12 @@ impl<'a, 'data> TypeConverter<'a, 'data> {
 fn heap_style_and_offset_guard_size(plan: &MemoryPlan) -> (HeapStyle, u64) {
     match plan {
         MemoryPlan {
-            style: MemoryStyle::Static { bound },
+            style: MemoryStyle::Static { byte_reservation },
             offset_guard_size,
             ..
         } => (
             HeapStyle::Static {
-                bound: bound * u64::from(WASM_PAGE_SIZE),
+                bound: *byte_reservation,
             },
             *offset_guard_size,
         ),


### PR DESCRIPTION
This commit is inspired by me looking at some configuration in the pooling allocator and noticing that configuration of wasm pages vs bytes of linear memory is somewhat inconsistent in `Config`. In the end I'd like to remove or update the `memory_pages` configuration in the pooling allocator to being bytes of linear memory instead to be more consistent with `Config` (and additionally anticipate the custom-page-sizes wasm proposal where terms-of-pages will become ambiguous). The first step in this change is to update one of the lowest layered usages of pages, the `MemoryStyle::Static` configuration.

Note that this is not a trivial conversion because the purpose of carrying around pages instead of bytes is that bytes may overflow where overflow-with-pages typically happens during validation. This means that extra care is taken to handle errors related to overflow to ensure that everything is still reported at the same time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
