### PR TITLE
Change all WASI impls to being concrete, not blanket

### DIFF
--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -15,7 +15,7 @@ use http_body_util::{BodyExt, Empty};
 use hyper::Method;
 use wasmtime::component::Resource;
 
-impl<T: WasiHttpView> outgoing_handler::Host for T {
+impl outgoing_handler::Host for dyn WasiHttpView + '_ {
     fn handle(
         &mut self,
         request_id: Resource<HostOutgoingRequest>,

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -78,7 +78,6 @@ pub mod bindings {
         trappable_error_type: {
             "wasi:http/types/error-code" => crate::HttpError,
         },
-        skip_mut_forwarding_impls: true,
     });
 
     pub use wasi::http;

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -19,7 +19,7 @@ use wasmtime_wasi::{
     Pollable, ResourceTableError,
 };
 
-impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
+impl crate::bindings::http::types::Host for dyn WasiHttpView + '_ {
     fn convert_error_code(&mut self, err: crate::HttpError) -> wasmtime::Result<types::ErrorCode> {
         err.downcast()
     }
@@ -98,7 +98,7 @@ fn get_fields_mut<'a>(
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostFields for T {
+impl crate::bindings::http::types::HostFields for dyn WasiHttpView + '_ {
     fn new(&mut self) -> wasmtime::Result<Resource<HostFields>> {
         let id = self
             .table()
@@ -285,7 +285,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFields for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostIncomingRequest for T {
+impl crate::bindings::http::types::HostIncomingRequest for dyn WasiHttpView + '_ {
     fn method(&mut self, id: Resource<HostIncomingRequest>) -> wasmtime::Result<Method> {
         let method = self.table().get(&id)?.parts.method.clone();
         Ok(method.into())
@@ -370,7 +370,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostIncomingRequest for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingRequest for T {
+impl crate::bindings::http::types::HostOutgoingRequest for dyn WasiHttpView + '_ {
     fn new(
         &mut self,
         headers: Resource<Headers>,
@@ -556,7 +556,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingRequest for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostResponseOutparam for T {
+impl crate::bindings::http::types::HostResponseOutparam for dyn WasiHttpView + '_ {
     fn drop(&mut self, id: Resource<HostResponseOutparam>) -> wasmtime::Result<()> {
         let _ = self.table().delete(id)?;
         Ok(())
@@ -579,7 +579,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostResponseOutparam for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostIncomingResponse for T {
+impl crate::bindings::http::types::HostIncomingResponse for dyn WasiHttpView + '_ {
     fn drop(&mut self, response: Resource<HostIncomingResponse>) -> wasmtime::Result<()> {
         let _ = self
             .table()
@@ -640,7 +640,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostIncomingResponse for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostFutureTrailers for T {
+impl crate::bindings::http::types::HostFutureTrailers for dyn WasiHttpView + '_ {
     fn drop(&mut self, id: Resource<HostFutureTrailers>) -> wasmtime::Result<()> {
         let _ = self
             .table()
@@ -687,7 +687,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureTrailers for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostIncomingBody for T {
+impl crate::bindings::http::types::HostIncomingBody for dyn WasiHttpView + '_ {
     fn stream(
         &mut self,
         id: Resource<HostIncomingBody>,
@@ -718,7 +718,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostIncomingBody for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingResponse for T {
+impl crate::bindings::http::types::HostOutgoingResponse for dyn WasiHttpView + '_ {
     fn new(
         &mut self,
         headers: Resource<Headers>,
@@ -807,7 +807,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingResponse for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse for T {
+impl crate::bindings::http::types::HostFutureIncomingResponse for dyn WasiHttpView + '_ {
     fn drop(&mut self, id: Resource<HostFutureIncomingResponse>) -> wasmtime::Result<()> {
         let _ = self.table().delete(id)?;
         Ok(())
@@ -866,7 +866,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingBody for T {
+impl crate::bindings::http::types::HostOutgoingBody for dyn WasiHttpView + '_ {
     fn write(
         &mut self,
         id: Resource<HostOutgoingBody>,
@@ -903,7 +903,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingBody for T {
     }
 }
 
-impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
+impl crate::bindings::http::types::HostRequestOptions for dyn WasiHttpView + '_ {
     fn new(&mut self) -> wasmtime::Result<Resource<types::RequestOptions>> {
         let id = self.table().push(types::RequestOptions::default())?;
         Ok(id)

--- a/crates/wasi/src/bindings.rs
+++ b/crates/wasi/src/bindings.rs
@@ -34,7 +34,6 @@ pub mod sync {
                 "wasi:io/streams/input-stream": super::super::io::streams::InputStream,
                 "wasi:io/streams/output-stream": super::super::io::streams::OutputStream,
             },
-            skip_mut_forwarding_impls: true,
         });
     }
     pub use self::generated::exports;
@@ -199,7 +198,6 @@ mod async_io {
             "wasi:cli/terminal-input/terminal-input": crate::stdio::TerminalInput,
             "wasi:cli/terminal-output/terminal-output": crate::stdio::TerminalOutput,
         },
-        skip_mut_forwarding_impls: true,
     });
 }
 

--- a/crates/wasi/src/host/clocks.rs
+++ b/crates/wasi/src/host/clocks.rs
@@ -24,7 +24,7 @@ impl TryFrom<SystemTime> for Datetime {
     }
 }
 
-impl<T: WasiView> wall_clock::Host for T {
+impl wall_clock::Host for dyn WasiView + '_ {
     fn now(&mut self) -> anyhow::Result<Datetime> {
         let now = self.ctx().wall_clock.now();
         Ok(Datetime {
@@ -61,7 +61,7 @@ fn subscribe_to_duration(
     subscribe(table, sleep)
 }
 
-impl<T: WasiView> monotonic_clock::Host for T {
+impl monotonic_clock::Host for dyn WasiView + '_ {
     fn now(&mut self) -> anyhow::Result<Instant> {
         Ok(self.ctx().monotonic_clock.now())
     }

--- a/crates/wasi/src/host/env.rs
+++ b/crates/wasi/src/host/env.rs
@@ -1,7 +1,7 @@
 use crate::bindings::cli::environment;
 use crate::WasiView;
 
-impl<T: WasiView> environment::Host for T {
+impl environment::Host for dyn WasiView + '_ {
     fn get_environment(&mut self) -> anyhow::Result<Vec<(String, String)>> {
         Ok(self.ctx().env.clone())
     }

--- a/crates/wasi/src/host/exit.rs
+++ b/crates/wasi/src/host/exit.rs
@@ -1,6 +1,6 @@
 use crate::{bindings::cli::exit, I32Exit, WasiView};
 
-impl<T: WasiView> exit::Host for T {
+impl exit::Host for dyn WasiView + '_ {
     fn exit(&mut self, status: Result<(), ()>) -> anyhow::Result<()> {
         let status = match status {
             Ok(()) => 0,

--- a/crates/wasi/src/host/filesystem.rs
+++ b/crates/wasi/src/host/filesystem.rs
@@ -13,7 +13,7 @@ use wasmtime::component::Resource;
 
 mod sync;
 
-impl<T: WasiView> preopens::Host for T {
+impl preopens::Host for dyn WasiView + '_ {
     fn get_directories(
         &mut self,
     ) -> Result<Vec<(Resource<types::Descriptor>, String)>, anyhow::Error> {
@@ -30,7 +30,7 @@ impl<T: WasiView> preopens::Host for T {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> types::Host for T {
+impl types::Host for dyn WasiView + '_ {
     fn convert_error_code(&mut self, err: FsError) -> anyhow::Result<ErrorCode> {
         err.downcast()
     }
@@ -52,7 +52,7 @@ impl<T: WasiView> types::Host for T {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> HostDescriptor for T {
+impl HostDescriptor for dyn WasiView + '_ {
     async fn advise(
         &mut self,
         fd: Resource<types::Descriptor>,
@@ -846,7 +846,7 @@ impl<T: WasiView> HostDescriptor for T {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> HostDirectoryEntryStream for T {
+impl HostDirectoryEntryStream for dyn WasiView + '_ {
     async fn read_directory_entry(
         &mut self,
         stream: Resource<types::DirectoryEntryStream>,

--- a/crates/wasi/src/host/filesystem/sync.rs
+++ b/crates/wasi/src/host/filesystem/sync.rs
@@ -2,10 +2,10 @@ use crate::bindings::filesystem::types as async_filesystem;
 use crate::bindings::sync::filesystem::types as sync_filesystem;
 use crate::bindings::sync::io::streams;
 use crate::runtime::in_tokio;
-use crate::{FsError, FsResult};
+use crate::{FsError, FsResult, WasiView};
 use wasmtime::component::Resource;
 
-impl<T: async_filesystem::Host> sync_filesystem::Host for T {
+impl sync_filesystem::Host for dyn WasiView + '_ {
     fn convert_error_code(&mut self, err: FsError) -> anyhow::Result<sync_filesystem::ErrorCode> {
         Ok(async_filesystem::Host::convert_error_code(self, err)?.into())
     }
@@ -18,7 +18,7 @@ impl<T: async_filesystem::Host> sync_filesystem::Host for T {
     }
 }
 
-impl<T: async_filesystem::HostDescriptor> sync_filesystem::HostDescriptor for T {
+impl sync_filesystem::HostDescriptor for dyn WasiView + '_ {
     fn advise(
         &mut self,
         fd: Resource<sync_filesystem::Descriptor>,
@@ -302,9 +302,7 @@ impl<T: async_filesystem::HostDescriptor> sync_filesystem::HostDescriptor for T 
     }
 }
 
-impl<T: async_filesystem::HostDirectoryEntryStream> sync_filesystem::HostDirectoryEntryStream
-    for T
-{
+impl sync_filesystem::HostDirectoryEntryStream for dyn WasiView + '_ {
     fn read_directory_entry(
         &mut self,
         stream: Resource<sync_filesystem::DirectoryEntryStream>,

--- a/crates/wasi/src/host/instance_network.rs
+++ b/crates/wasi/src/host/instance_network.rs
@@ -3,7 +3,7 @@ use crate::network::Network;
 use crate::WasiView;
 use wasmtime::component::Resource;
 
-impl<T: WasiView> instance_network::Host for T {
+impl instance_network::Host for dyn WasiView + '_ {
     fn instance_network(&mut self) -> Result<Resource<Network>, anyhow::Error> {
         let network = Network {
             socket_addr_check: self.ctx().socket_addr_check.clone(),

--- a/crates/wasi/src/host/io.rs
+++ b/crates/wasi/src/host/io.rs
@@ -6,9 +6,9 @@ use crate::{
 };
 use wasmtime::component::Resource;
 
-impl<T: WasiView> error::Host for T {}
+impl error::Host for dyn WasiView + '_ {}
 
-impl<T: WasiView> streams::Host for T {
+impl streams::Host for dyn WasiView + '_ {
     fn convert_stream_error(&mut self, err: StreamError) -> anyhow::Result<streams::StreamError> {
         match err {
             StreamError::Closed => Ok(streams::StreamError::Closed),
@@ -20,7 +20,7 @@ impl<T: WasiView> streams::Host for T {
     }
 }
 
-impl<T: WasiView> error::HostError for T {
+impl error::HostError for dyn WasiView + '_ {
     fn drop(&mut self, err: Resource<streams::Error>) -> anyhow::Result<()> {
         self.table().delete(err)?;
         Ok(())
@@ -32,7 +32,7 @@ impl<T: WasiView> error::HostError for T {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> streams::HostOutputStream for T {
+impl streams::HostOutputStream for dyn WasiView + '_ {
     fn drop(&mut self, stream: Resource<OutputStream>) -> anyhow::Result<()> {
         self.table().delete(stream)?;
         Ok(())
@@ -172,7 +172,7 @@ impl<T: WasiView> streams::HostOutputStream for T {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> streams::HostInputStream for T {
+impl streams::HostInputStream for dyn WasiView + '_ {
     fn drop(&mut self, stream: Resource<InputStream>) -> anyhow::Result<()> {
         self.table().delete(stream)?;
         Ok(())
@@ -246,7 +246,7 @@ pub mod sync {
         }
     }
 
-    impl<T: WasiView> streams::Host for T {
+    impl streams::Host for dyn WasiView + '_ {
         fn convert_stream_error(
             &mut self,
             err: StreamError,
@@ -255,7 +255,7 @@ pub mod sync {
         }
     }
 
-    impl<T: WasiView> streams::HostOutputStream for T {
+    impl streams::HostOutputStream for dyn WasiView + '_ {
         fn drop(&mut self, stream: Resource<OutputStream>) -> anyhow::Result<()> {
             AsyncHostOutputStream::drop(self, stream)
         }
@@ -332,7 +332,7 @@ pub mod sync {
         }
     }
 
-    impl<T: WasiView> streams::HostInputStream for T {
+    impl streams::HostInputStream for dyn WasiView + '_ {
         fn drop(&mut self, stream: Resource<InputStream>) -> anyhow::Result<()> {
             AsyncHostInputStream::drop(self, stream)
         }

--- a/crates/wasi/src/host/network.rs
+++ b/crates/wasi/src/host/network.rs
@@ -8,13 +8,13 @@ use rustix::io::Errno;
 use std::io;
 use wasmtime::component::Resource;
 
-impl<T: WasiView> network::Host for T {
+impl network::Host for dyn WasiView + '_ {
     fn convert_error_code(&mut self, error: SocketError) -> anyhow::Result<ErrorCode> {
         error.downcast()
     }
 }
 
-impl<T: WasiView> crate::bindings::sockets::network::HostNetwork for T {
+impl crate::bindings::sockets::network::HostNetwork for dyn WasiView + '_ {
     fn drop(&mut self, this: Resource<network::Network>) -> Result<(), anyhow::Error> {
         let table = self.table();
 

--- a/crates/wasi/src/host/random.rs
+++ b/crates/wasi/src/host/random.rs
@@ -2,7 +2,7 @@ use crate::bindings::random::{insecure, insecure_seed, random};
 use crate::WasiView;
 use cap_rand::{distributions::Standard, Rng};
 
-impl<T: WasiView> random::Host for T {
+impl random::Host for dyn WasiView + '_ {
     fn get_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
         Ok((&mut self.ctx().random)
             .sample_iter(Standard)
@@ -15,7 +15,7 @@ impl<T: WasiView> random::Host for T {
     }
 }
 
-impl<T: WasiView> insecure::Host for T {
+impl insecure::Host for dyn WasiView + '_ {
     fn get_insecure_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
         Ok((&mut self.ctx().insecure_random)
             .sample_iter(Standard)
@@ -28,7 +28,7 @@ impl<T: WasiView> insecure::Host for T {
     }
 }
 
-impl<T: WasiView> insecure_seed::Host for T {
+impl insecure_seed::Host for dyn WasiView + '_ {
     fn insecure_seed(&mut self) -> anyhow::Result<(u64, u64)> {
         let seed: u128 = self.ctx().insecure_random_seed;
         Ok((seed as u64, (seed >> 64) as u64))

--- a/crates/wasi/src/host/tcp.rs
+++ b/crates/wasi/src/host/tcp.rs
@@ -12,9 +12,9 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use wasmtime::component::Resource;
 
-impl<T: WasiView> tcp::Host for T {}
+impl tcp::Host for dyn WasiView + '_ {}
 
-impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
+impl crate::host::tcp::tcp::HostTcpSocket for dyn WasiView + '_ {
     fn start_bind(
         &mut self,
         this: Resource<tcp::TcpSocket>,

--- a/crates/wasi/src/host/tcp_create_socket.rs
+++ b/crates/wasi/src/host/tcp_create_socket.rs
@@ -3,7 +3,7 @@ use crate::tcp::TcpSocket;
 use crate::{SocketResult, WasiView};
 use wasmtime::component::Resource;
 
-impl<T: WasiView> tcp_create_socket::Host for T {
+impl tcp_create_socket::Host for dyn WasiView + '_ {
     fn create_tcp_socket(
         &mut self,
         address_family: IpAddressFamily,

--- a/crates/wasi/src/host/udp.rs
+++ b/crates/wasi/src/host/udp.rs
@@ -22,9 +22,9 @@ use wasmtime::component::Resource;
 /// In practice, datagrams are typically less than 1500 bytes.
 const MAX_UDP_DATAGRAM_SIZE: usize = u16::MAX as usize;
 
-impl<T: WasiView> udp::Host for T {}
+impl udp::Host for dyn WasiView + '_ {}
 
-impl<T: WasiView> udp::HostUdpSocket for T {
+impl udp::HostUdpSocket for dyn WasiView + '_ {
     fn start_bind(
         &mut self,
         this: Resource<udp::UdpSocket>,
@@ -300,7 +300,7 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     }
 }
 
-impl<T: WasiView> udp::HostIncomingDatagramStream for T {
+impl udp::HostIncomingDatagramStream for dyn WasiView + '_ {
     fn receive(
         &mut self,
         this: Resource<udp::IncomingDatagramStream>,
@@ -391,7 +391,7 @@ impl Subscribe for IncomingDatagramStream {
     }
 }
 
-impl<T: WasiView> udp::HostOutgoingDatagramStream for T {
+impl udp::HostOutgoingDatagramStream for dyn WasiView + '_ {
     fn check_send(&mut self, this: Resource<udp::OutgoingDatagramStream>) -> SocketResult<u64> {
         let table = self.table();
         let stream = table.get_mut(&this)?;

--- a/crates/wasi/src/host/udp_create_socket.rs
+++ b/crates/wasi/src/host/udp_create_socket.rs
@@ -3,7 +3,7 @@ use crate::udp::UdpSocket;
 use crate::{SocketResult, WasiView};
 use wasmtime::component::Resource;
 
-impl<T: WasiView> udp_create_socket::Host for T {
+impl udp_create_socket::Host for dyn WasiView + '_ {
     fn create_udp_socket(
         &mut self,
         address_family: IpAddressFamily,

--- a/crates/wasi/src/ip_name_lookup.rs
+++ b/crates/wasi/src/ip_name_lookup.rs
@@ -20,7 +20,7 @@ pub enum ResolveAddressStream {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> Host for T {
+impl Host for dyn WasiView + '_ {
     fn resolve_addresses(
         &mut self,
         network: Resource<Network>,
@@ -41,7 +41,7 @@ impl<T: WasiView> Host for T {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> HostResolveAddressStream for T {
+impl HostResolveAddressStream for dyn WasiView + '_ {
     fn resolve_next_address(
         &mut self,
         resource: Resource<ResolveAddressStream>,

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -285,15 +285,6 @@ pub use wasmtime::component::{ResourceTable, ResourceTableError};
 /// ```
 pub fn add_to_linker_async<T: WasiView>(linker: &mut Linker<T>) -> anyhow::Result<()> {
     let l = linker;
-
-    // NB: workaround some rustc inference - a future refactoring may make this
-    // obsolete.
-    fn type_annotate<T, F>(val: F) -> F
-    where
-        F: Fn(&mut T) -> &mut T,
-    {
-        val
-    }
     let closure = type_annotate::<T, _>(|t| t);
 
     crate::bindings::clocks::wall_clock::add_to_linker_get_host(l, closure)?;
@@ -384,15 +375,6 @@ pub fn add_to_linker_sync<T: WasiView>(
     linker: &mut wasmtime::component::Linker<T>,
 ) -> anyhow::Result<()> {
     let l = linker;
-
-    // NB: workaround some rustc inference - a future refactoring may make this
-    // obsolete.
-    fn type_annotate<T, F>(val: F) -> F
-    where
-        F: Fn(&mut T) -> &mut T,
-    {
-        val
-    }
     let closure = type_annotate::<T, _>(|t| t);
 
     crate::bindings::clocks::wall_clock::add_to_linker_get_host(l, closure)?;
@@ -423,4 +405,13 @@ pub fn add_to_linker_sync<T: WasiView>(
     crate::bindings::sockets::network::add_to_linker_get_host(l, closure)?;
     crate::bindings::sockets::ip_name_lookup::add_to_linker_get_host(l, closure)?;
     Ok(())
+}
+
+// NB: workaround some rustc inference - a future refactoring may make this
+// obsolete.
+fn type_annotate<T: WasiView, F>(val: F) -> F
+where
+    F: Fn(&mut T) -> &mut dyn WasiView,
+{
+    val
 }

--- a/crates/wasi/src/poll.rs
+++ b/crates/wasi/src/poll.rs
@@ -117,7 +117,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> poll::Host for T {
+impl poll::Host for dyn WasiView + '_ {
     async fn poll(&mut self, pollables: Vec<Resource<Pollable>>) -> Result<Vec<u32>> {
         type ReadylistIndex = u32;
 
@@ -176,7 +176,7 @@ impl<T: WasiView> poll::Host for T {
 }
 
 #[async_trait::async_trait]
-impl<T: WasiView> crate::bindings::io::poll::HostPollable for T {
+impl crate::bindings::io::poll::HostPollable for dyn WasiView + '_ {
     async fn block(&mut self, pollable: Resource<Pollable>) -> Result<()> {
         let table = self.table();
         let pollable = table.get(&pollable)?;
@@ -213,13 +213,13 @@ pub mod sync {
     use anyhow::Result;
     use wasmtime::component::Resource;
 
-    impl<T: WasiView> poll::Host for T {
+    impl poll::Host for dyn WasiView + '_ {
         fn poll(&mut self, pollables: Vec<Resource<Pollable>>) -> Result<Vec<u32>> {
             in_tokio(async { async_poll::Host::poll(self, pollables).await })
         }
     }
 
-    impl<T: WasiView> crate::bindings::sync::io::poll::HostPollable for T {
+    impl crate::bindings::sync::io::poll::HostPollable for dyn WasiView + '_ {
         fn ready(&mut self, pollable: Resource<Pollable>) -> Result<bool> {
             in_tokio(async { async_poll::HostPollable::ready(self, pollable).await })
         }

--- a/crates/wasi/src/stdio.rs
+++ b/crates/wasi/src/stdio.rs
@@ -367,21 +367,21 @@ pub enum IsATTY {
     No,
 }
 
-impl<T: WasiView> stdin::Host for T {
+impl stdin::Host for dyn WasiView + '_ {
     fn get_stdin(&mut self) -> Result<Resource<streams::InputStream>, anyhow::Error> {
         let stream = self.ctx().stdin.stream();
         Ok(self.table().push(streams::InputStream::Host(stream))?)
     }
 }
 
-impl<T: WasiView> stdout::Host for T {
+impl stdout::Host for dyn WasiView + '_ {
     fn get_stdout(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
         let stream = self.ctx().stdout.stream();
         Ok(self.table().push(stream)?)
     }
 }
 
-impl<T: WasiView> stderr::Host for T {
+impl stderr::Host for dyn WasiView + '_ {
     fn get_stderr(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
         let stream = self.ctx().stderr.stream();
         Ok(self.table().push(stream)?)
@@ -391,21 +391,21 @@ impl<T: WasiView> stderr::Host for T {
 pub struct TerminalInput;
 pub struct TerminalOutput;
 
-impl<T: WasiView> terminal_input::Host for T {}
-impl<T: WasiView> terminal_input::HostTerminalInput for T {
+impl terminal_input::Host for dyn WasiView + '_ {}
+impl terminal_input::HostTerminalInput for dyn WasiView + '_ {
     fn drop(&mut self, r: Resource<TerminalInput>) -> anyhow::Result<()> {
         self.table().delete(r)?;
         Ok(())
     }
 }
-impl<T: WasiView> terminal_output::Host for T {}
-impl<T: WasiView> terminal_output::HostTerminalOutput for T {
+impl terminal_output::Host for dyn WasiView + '_ {}
+impl terminal_output::HostTerminalOutput for dyn WasiView + '_ {
     fn drop(&mut self, r: Resource<TerminalOutput>) -> anyhow::Result<()> {
         self.table().delete(r)?;
         Ok(())
     }
 }
-impl<T: WasiView> terminal_stdin::Host for T {
+impl terminal_stdin::Host for dyn WasiView + '_ {
     fn get_terminal_stdin(&mut self) -> anyhow::Result<Option<Resource<TerminalInput>>> {
         if self.ctx().stdin.isatty() {
             let fd = self.table().push(TerminalInput)?;
@@ -415,7 +415,7 @@ impl<T: WasiView> terminal_stdin::Host for T {
         }
     }
 }
-impl<T: WasiView> terminal_stdout::Host for T {
+impl terminal_stdout::Host for dyn WasiView + '_ {
     fn get_terminal_stdout(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stdout.isatty() {
             let fd = self.table().push(TerminalOutput)?;
@@ -425,7 +425,7 @@ impl<T: WasiView> terminal_stdout::Host for T {
         }
     }
 }
-impl<T: WasiView> terminal_stderr::Host for T {
+impl terminal_stderr::Host for dyn WasiView + '_ {
     fn get_terminal_stderr(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stderr.isatty() {
             let fd = self.table().push(TerminalOutput)?;


### PR DESCRIPTION
This commit builds on the support from #8448 to remove all blanket impls from the WASI crates and instead replace them with concrete impls. This is slightly functionally different from before where impls are now on trait objects meaning dynamic dispatch is involved where previously dynamic dispatch was used. That being said the perf hit here is expected to be negligible-to-nonexistent since the implementations are large enough that the dynamic dispatch won't be the hot path.

The motivations for this commit are:

* Removes the need for an odd `skip_mut_forwarding_impls` option - but this'll be left for a bit in case others need it.
* Improves incremental compile time of these crates where the crates themselves now contain all object code for all of WASI instead of forcing the final consume to codegen everything (although there's still a significant amount monomorphized).
* Improves future compatibility with refactorings of bindgen-generated-traits and such because blanket impls are pretty hard to work around where concrete impls are easier to reason about (and document).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
