### PR TITLE
wasi: Handle read(0) with file streams

### DIFF
--- a/crates/test-programs/src/bin/preview2_file_read_write.rs
+++ b/crates/test-programs/src/bin/preview2_file_read_write.rs
@@ -31,6 +31,12 @@ fn main() {
     loop {
         ready.block();
 
+        match stream.read(0) {
+            Ok(chunk) => assert!(chunk.is_empty()),
+            Err(wasi::io::streams::StreamError::Closed) => break,
+            Err(e) => panic!("Failed checking stream state: {e:?}"),
+        }
+
         match stream.read(4) {
             Ok(chunk) => buf.extend(chunk),
             Err(wasi::io::streams::StreamError::Closed) => break,

--- a/crates/test-programs/src/bin/preview2_file_read_write.rs
+++ b/crates/test-programs/src/bin/preview2_file_read_write.rs
@@ -31,15 +31,11 @@ fn main() {
     loop {
         ready.block();
 
-        if let Err(e) = stream.read(0) {
-            if matches!(e, wasi::io::streams::StreamError::Closed) {
-                break;
-            }
-
-            panic!("Failed when checking stream state: {e:?}");
+        match stream.read(4) {
+            Ok(chunk) => buf.extend(chunk),
+            Err(wasi::io::streams::StreamError::Closed) => break,
+            Err(e) => panic!("Failed reading stream: {e:?}"),
         }
-
-        buf.extend(stream.read(4).unwrap());
     }
     assert_eq!(buf, b"\0\0\0\0\0Hello, World!");
     drop(ready);


### PR DESCRIPTION
The `read` method on streams should support a size argument of zero, to test if the stream is still open. However, the implementation of `read` for open files was unconditionally treating a read that would return zero bytes as an indication that the stream was closed.

This PR fixes this bug by handling a `read(0)` as an explicit test to see if the current position is at the end of the file.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
