### PR TITLE
Added OpenBSD support to wasmtime's signals.rs

### DIFF
--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -255,6 +255,12 @@ unsafe fn get_pc_and_fp(cx: *mut libc::c_void, _signum: libc::c_int) -> (*const 
                 cx.mc_gpregs.gp_elr as *const u8,
                 cx.mc_gpregs.gp_x[29] as usize,
             )
+        } else if #[cfg(all(target_os = "openbsd", target_arch = "x86_64"))] {
+            let cx = &*(cx as *const libc::ucontext_t);
+            (
+                cx.sc_rip as *const u8,
+                cx.sc_rbp as usize,
+            )
         }
         else {
             compile_error!("unsupported platform");


### PR DESCRIPTION
This pull request adds support for OpenBSD to the wasmtime-runtime crate. The change is very small. It just adds a case for OpenBSD on x86_64. I'm not trying to port the entire project to OpenBSD. I'm just trying to get this crate to work because I am trying to get the Zed editor to run on OpenBSD.
