### PR TITLE
Change `Tunables::static_memory_bound` to bytes

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -5,9 +5,9 @@ use target_lexicon::{PointerWidth, Triple};
 /// Tunable parameters for WebAssembly compilation.
 #[derive(Clone, Hash, Serialize, Deserialize, Debug)]
 pub struct Tunables {
-    /// For static heaps, the size in wasm pages of the heap protected by bounds
-    /// checking.
-    pub static_memory_bound: u64,
+    /// For static heaps, the size in bytes of virtual memory reservation for
+    /// the heap.
+    pub static_memory_reservation: u64,
 
     /// The size in bytes of the offset guard for static heaps.
     pub static_memory_offset_guard_size: u64,
@@ -100,7 +100,7 @@ impl Tunables {
         Tunables {
             // No virtual memory tricks are available on miri so make these
             // limits quite conservative.
-            static_memory_bound: (1 << 20) / crate::WASM_PAGE_SIZE as u64,
+            static_memory_reservation: 1 << 20,
             static_memory_offset_guard_size: 0,
             dynamic_memory_offset_guard_size: 0,
             dynamic_memory_growth_reserve: 0,
@@ -129,7 +129,7 @@ impl Tunables {
             // For 32-bit we scale way down to 10MB of reserved memory. This
             // impacts performance severely but allows us to have more than a
             // few instances running around.
-            static_memory_bound: (10 * (1 << 20)) / crate::WASM_PAGE_SIZE as u64,
+            static_memory_reservation: 10 * (1 << 20),
             static_memory_offset_guard_size: 0x1_0000,
             dynamic_memory_offset_guard_size: 0x1_0000,
             dynamic_memory_growth_reserve: 1 << 20, // 1MB
@@ -147,7 +147,7 @@ impl Tunables {
             //
             // Coupled with a 2 GiB address space guard it lets us translate
             // wasm offsets into x86 offsets as aggressively as we can.
-            static_memory_bound: 0x1_0000,
+            static_memory_reservation: 1 << 32,
             static_memory_offset_guard_size: 0x8000_0000,
 
             // Size in bytes of the offset guard for dynamic memories.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -139,7 +139,7 @@ pub struct Config {
 
 #[derive(Default, Clone)]
 struct ConfigTunables {
-    static_memory_bound: Option<u64>,
+    static_memory_reservation: Option<u64>,
     static_memory_offset_guard_size: Option<u64>,
     dynamic_memory_offset_guard_size: Option<u64>,
     dynamic_memory_growth_reserve: Option<u64>,
@@ -1367,8 +1367,7 @@ impl Config {
     /// for pooling allocation by using memory protection; see
     /// `PoolingAllocatorConfig::memory_protection_keys` for details.
     pub fn static_memory_maximum_size(&mut self, max_size: u64) -> &mut Self {
-        let max_pages = max_size / u64::from(wasmtime_environ::WASM_PAGE_SIZE);
-        self.tunables.static_memory_bound = Some(max_pages);
+        self.tunables.static_memory_reservation = Some(max_size);
         self
     }
 
@@ -1800,7 +1799,7 @@ impl Config {
         }
 
         set_fields! {
-            static_memory_bound
+            static_memory_reservation
             static_memory_offset_guard_size
             dynamic_memory_offset_guard_size
             dynamic_memory_growth_reserve
@@ -2159,11 +2158,8 @@ impl fmt::Debug for Config {
         if let Some(enable) = self.tunables.parse_wasm_debuginfo {
             f.field("parse_wasm_debuginfo", &enable);
         }
-        if let Some(size) = self.tunables.static_memory_bound {
-            f.field(
-                "static_memory_maximum_size",
-                &(u64::from(size) * u64::from(wasmtime_environ::WASM_PAGE_SIZE)),
-            );
+        if let Some(size) = self.tunables.static_memory_reservation {
+            f.field("static_memory_maximum_reservation", &size);
         }
         if let Some(size) = self.tunables.static_memory_offset_guard_size {
             f.field("static_memory_guard_size", &size);

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -346,7 +346,7 @@ impl Metadata<'_> {
 
     fn check_tunables(&mut self, other: &Tunables) -> Result<()> {
         let Tunables {
-            static_memory_bound,
+            static_memory_reservation,
             static_memory_offset_guard_size,
             dynamic_memory_offset_guard_size,
             generate_native_debuginfo,
@@ -375,9 +375,9 @@ impl Metadata<'_> {
         } = self.tunables;
 
         Self::check_int(
-            static_memory_bound,
-            other.static_memory_bound,
-            "static memory bound",
+            static_memory_reservation,
+            other.static_memory_reservation,
+            "static memory reservation",
         )?;
         Self::check_int(
             static_memory_offset_guard_size,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -712,7 +712,7 @@ mod test {
             PoolingInstanceAllocator::new(
                 &config,
                 &Tunables {
-                    static_memory_bound: 1,
+                    static_memory_reservation: 65536,
                     ..Tunables::default_host()
                 },
             )

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -564,7 +564,7 @@ impl SlabConstraints {
         // most bounds checks. `MemoryPool` must respect this bound, though not
         // explicitly: if we can achieve the same effect via MPK-protected
         // stripes, the slot size can be lower than the `static_memory_bound`.
-        let expected_slot_bytes = tunables.static_memory_bound * u64::from(WASM_PAGE_SIZE);
+        let expected_slot_bytes = tunables.static_memory_reservation;
 
         let constraints = SlabConstraints {
             max_memory_bytes: max_memory_bytes

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -773,7 +773,7 @@ mod tests {
                 ..Default::default()
             },
             &Tunables {
-                static_memory_bound: 1,
+                static_memory_reservation: 65536,
                 static_memory_offset_guard_size: 0,
                 ..Tunables::default_host()
             },
@@ -807,7 +807,7 @@ mod tests {
         let pool = PoolingInstanceAllocator::new(
             &config,
             &Tunables {
-                static_memory_bound: 1,
+                static_memory_reservation: 65536,
                 static_memory_offset_guard_size: 0,
                 ..Tunables::default_host()
             },


### PR DESCRIPTION
This commit changes the wasm-page-sized `static_memory_bound` field to instead being a byte-defined unit rather than a page-defined unit. To accomplish this the field is renamed to `static_memory_reservation` and all references are updated. This builds on the support from #8608 to remove another page-based variable from the internals of Wasmtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
