### PR TITLE
Backport 8611 to 21.0.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -80,6 +80,10 @@ Unreleased.
   subcommand.
   [#8525](https://github.com/bytecodealliance/wasmtime/issues/8525)
 
+* The `read` implementation for file input streams in wasmtime-wasi now
+  correctly handles zero-length reads.
+  [#8611](https://github.com/bytecodealliance/wasmtime/issues/8611)
+
 --------------------------------------------------------------------------------
 
 ## 20.0.1

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -248,6 +248,7 @@ impl FileInputStream {
     pub async fn read(&mut self, size: usize) -> Result<Bytes, StreamError> {
         use system_interface::fs::FileIoExt;
         let p = self.position;
+
         let (r, mut buf) = self
             .file
             .spawn_blocking(move |f| {
@@ -256,7 +257,7 @@ impl FileInputStream {
                 (r, buf)
             })
             .await;
-        let n = read_result(r)?;
+        let n = read_result(r, size)?;
         buf.truncate(n);
         self.position += n as u64;
         Ok(buf.freeze())
@@ -268,9 +269,9 @@ impl FileInputStream {
     }
 }
 
-fn read_result(r: io::Result<usize>) -> Result<usize, StreamError> {
+fn read_result(r: io::Result<usize>, size: usize) -> Result<usize, StreamError> {
     match r {
-        Ok(0) => Err(StreamError::Closed),
+        Ok(0) if size > 0 => Err(StreamError::Closed),
         Ok(n) => Ok(n),
         Err(e) if e.kind() == std::io::ErrorKind::Interrupted => Ok(0),
         Err(e) => Err(StreamError::LastOperationFailed(e.into())),


### PR DESCRIPTION
Backport #8611 and update release notes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
