### PR TITLE
Improve check for concurrency limits in fuzzing

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -368,10 +368,7 @@ fn unwrap_instance(
     }
 
     // Also allow failures to instantiate as a result of hitting pooling limits.
-    if string.contains("maximum concurrent core instance limit")
-        || string.contains("maximum concurrent memory limit")
-        || string.contains("maximum concurrent table limit")
-    {
+    if e.is::<wasmtime::PoolConcurrencyLimitError>() {
         log::debug!("failed to instantiate: {}", string);
         return None;
     }


### PR DESCRIPTION
Fixes an accidental fuzz regression from #8590 where error messages were changed slightly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
