### PR TITLE
Use WASM function names in compiled objects

### DIFF
--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -428,7 +428,7 @@ impl<'a> CompileInputs<'a> {
         // like "perf" or "objdump", and filter the name.  Let only characters usually
         // used for function names, plus some characters that might be used in name
         // mangling.
-        let bad_char = |c: char| !c.is_alphanumeric() && !r"<>[]_-:@$".contains(c);
+        let bad_char = |c: char| !c.is_ascii_alphanumeric() && !r"<>[]_-:@$".contains(c);
         if name.chars().any(bad_char) {
             let mut last_char_seen = '\u{0000}';
             Cow::Owned(

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -471,12 +471,16 @@ impl<'a> CompileInputs<'a> {
                         .get(&func_index)
                     {
                         Some(name) => format!(
-                            "wasm[{}]::func[{}]::{}",
+                            "wasm[{}]::function[{}]::{}",
                             module.as_u32(),
                             func_index.as_u32(),
                             Self::clean_symbol(&name)
                         ),
-                        None => format!("wasm[{}]::func[{}]", module.as_u32(), func_index.as_u32()),
+                        None => format!(
+                            "wasm[{}]::function[{}]",
+                            module.as_u32(),
+                            func_index.as_u32()
+                        ),
                     };
 
                     Ok(CompileOutput {

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -442,6 +442,8 @@ impl<'a> CompileInputs<'a> {
                     .take(MAX_SYMBOL_LEN)
                     .collect::<String>(),
             )
+        } else if name.len() <= MAX_SYMBOL_LEN {
+            Cow::Borrowed(&name[..])
         } else {
             Cow::Borrowed(&name[..MAX_SYMBOL_LEN])
         }

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -27,6 +27,7 @@ use crate::Engine;
 use anyhow::{Context, Result};
 use std::{
     any::Any,
+    borrow::Cow,
     collections::{btree_map, BTreeMap, BTreeSet, HashMap, HashSet},
     mem,
 };
@@ -346,6 +347,9 @@ struct CompileInputs<'a> {
 }
 
 impl<'a> CompileInputs<'a> {
+    /// Maximum length of symbols generated in objects.
+    const MAX_SYMBOL_LEN: usize = 96;
+
     fn push_input(&mut self, f: impl FnOnce(&dyn Compiler) -> Result<CompileOutput> + Send + 'a) {
         self.inputs.push(Box::new(f));
     }
@@ -419,6 +423,26 @@ impl<'a> CompileInputs<'a> {
         ret
     }
 
+    fn clean_symbol(name: &str) -> Cow<str> {
+        // Just to be on the safe side, avoid passing user-provided data to tools
+        // like "perf" or "objdump", and filter the name.  Let only characters usually
+        // used for function names, plus some characters that might be used in name
+        // mangling.
+        let bad_char = |c: char| !c.is_alphanumeric() && !r"<>[]_-:@$".contains(c);
+        if name.chars().any(bad_char) {
+            let mut name = name
+                .chars()
+                .map(|c| if bad_char(c) { '?' } else { c })
+                .collect::<String>()
+                .trim_matches('?')
+                .to_string();
+            name.truncate(Self::MAX_SYMBOL_LEN);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed(&name[..])
+        }
+    }
+
     fn collect_inputs_in_translations(
         &mut self,
         types: &'a ModuleTypesBuilder,
@@ -442,13 +466,15 @@ impl<'a> CompileInputs<'a> {
                         .func_names
                         .get(&func_index)
                     {
-                        Some(name) => format!("wasm[{}]::{}", module.as_u32(), name),
-                        None => format!(
-                            "wasm[{}]::function[{}]",
+                        Some(name) => format!(
+                            "wasm[{}]::func[{}]::{}",
                             module.as_u32(),
-                            func_index.as_u32()
+                            func_index.as_u32(),
+                            Self::clean_symbol(&name)
                         ),
+                        None => format!("wasm[{}]::func[{}]", module.as_u32(), func_index.as_u32()),
                     };
+
                     Ok(CompileOutput {
                         key: CompileKey::wasm_function(module, def_func_index),
                         symbol,

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -436,13 +436,22 @@ impl<'a> CompileInputs<'a> {
                     let func_index = translation.module.func_index(def_func_index);
                     let (info, function) =
                         compiler.compile_function(translation, def_func_index, func_body, types)?;
-                    Ok(CompileOutput {
-                        key: CompileKey::wasm_function(module, def_func_index),
-                        symbol: format!(
+                    let symbol = match translation
+                        .debuginfo
+                        .name_section
+                        .func_names
+                        .get(&func_index)
+                    {
+                        Some(name) => format!("wasm[{}]::{}", module.as_u32(), name),
+                        None => format!(
                             "wasm[{}]::function[{}]",
                             module.as_u32(),
                             func_index.as_u32()
                         ),
+                    };
+                    Ok(CompileOutput {
+                        key: CompileKey::wasm_function(module, def_func_index),
+                        symbol,
                         function: CompiledFunction::Function(function),
                         info: Some(info),
                     })

--- a/tests/disas/winch/x64/block/as_if_cond.wat
+++ b/tests/disas/winch/x64/block/as_if_cond.wat
@@ -8,7 +8,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/block/deep.wat
+++ b/tests/disas/winch/x64/block/deep.wat
@@ -45,7 +45,7 @@
     ))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/block/empty.wat
+++ b/tests/disas/winch/x64/block/empty.wat
@@ -9,7 +9,7 @@
     (block $l)
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/block/nested.wat
+++ b/tests/disas/winch/x64/block/nested.wat
@@ -10,7 +10,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_block_first.wat
+++ b/tests/disas/winch/x64/br/as_block_first.wat
@@ -7,7 +7,7 @@
     (block (br 0) (call $dummy))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_block_last.wat
+++ b/tests/disas/winch/x64/br/as_block_last.wat
@@ -7,7 +7,7 @@
     (block (nop) (call $dummy) (br 0))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_block_mid.wat
+++ b/tests/disas/winch/x64/br/as_block_mid.wat
@@ -7,7 +7,7 @@
     (block (call $dummy) (br 0) (call $dummy))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_block_value.wat
+++ b/tests/disas/winch/x64/br/as_block_value.wat
@@ -7,7 +7,7 @@
     (block (result i32) (nop) (call $dummy) (br 0 (i32.const 2)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_call_all.wat
+++ b/tests/disas/winch/x64/br/as_call_all.wat
@@ -6,7 +6,7 @@
     (block (result i32) (call $f (br 0 (i32.const 15))))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_call_first.wat
+++ b/tests/disas/winch/x64/br/as_call_first.wat
@@ -9,7 +9,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_call_last.wat
+++ b/tests/disas/winch/x64/br/as_call_last.wat
@@ -8,7 +8,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_call_mid.wat
+++ b/tests/disas/winch/x64/br/as_call_mid.wat
@@ -9,7 +9,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_loop_last.wat
+++ b/tests/disas/winch/x64/br/as_loop_last.wat
@@ -8,7 +8,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br/as_loop_mid.wat
+++ b/tests/disas/winch/x64/br/as_loop_mid.wat
@@ -9,7 +9,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_block_last.wat
+++ b/tests/disas/winch/x64/br_if/as_block_last.wat
@@ -6,7 +6,7 @@
     (block (call $dummy) (call $dummy) (br_if 0 (local.get 0)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_block_last_value.wat
+++ b/tests/disas/winch/x64/br_if/as_block_last_value.wat
@@ -8,7 +8,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_call_first.wat
+++ b/tests/disas/winch/x64/br_if/as_call_first.wat
@@ -10,7 +10,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_call_last.wat
+++ b/tests/disas/winch/x64/br_if/as_call_last.wat
@@ -10,7 +10,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_call_mid.wat
+++ b/tests/disas/winch/x64/br_if/as_call_mid.wat
@@ -10,7 +10,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_if_else.wat
+++ b/tests/disas/winch/x64/br_if/as_if_else.wat
@@ -9,7 +9,7 @@
   )
 )
 
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_if_then.wat
+++ b/tests/disas/winch/x64/br_if/as_if_then.wat
@@ -8,7 +8,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/br_if/as_loop_last.wat
+++ b/tests/disas/winch/x64/br_if/as_loop_last.wat
@@ -6,7 +6,7 @@
     (loop (call $dummy) (br_if 1 (local.get 0)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/call/params.wat
+++ b/tests/disas/winch/x64/call/params.wat
@@ -119,7 +119,7 @@
 ;;       retq
 ;;  152: ud2
 ;;
-;; wasm[0]::function[1]:
+;; wasm[0]::function[1]::add:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/call/recursive.wat
+++ b/tests/disas/winch/x64/call/recursive.wat
@@ -23,7 +23,7 @@
   )
   (export "fib" (func $fibonacci8))
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::fibonacci8:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/call/simple.wat
+++ b/tests/disas/winch/x64/call/simple.wat
@@ -14,7 +14,7 @@
     (local.get 1)
     (i32.mul))
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::main:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
@@ -53,7 +53,7 @@
 ;;       retq
 ;;   8b: ud2
 ;;
-;; wasm[0]::function[1]:
+;; wasm[0]::function[1]::product:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/f32_const/call_id.wat
+++ b/tests/disas/winch/x64/f32_const/call_id.wat
@@ -5,7 +5,7 @@
   (func $id-f32 (param f32) (result f32) (local.get 0))
   (func (export "type-first-f32") (result f32) (call $id-f32 (f32.const 1.32)))
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::id-f32:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/f64_const/call_id.wat
+++ b/tests/disas/winch/x64/f64_const/call_id.wat
@@ -5,7 +5,7 @@
   (func $id-f64 (param f64) (result f64) (local.get 0))
   (func (export "type-first-f64") (result f64) (call $id-f64 (f64.const 1.32)))
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::id-f64:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/if/as_binop.wat
+++ b/tests/disas/winch/x64/if/as_binop.wat
@@ -16,7 +16,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/if/as_br_if_last.wat
+++ b/tests/disas/winch/x64/if/as_br_if_last.wat
@@ -15,7 +15,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/if/as_if_cond.wat
+++ b/tests/disas/winch/x64/if/as_if_cond.wat
@@ -13,7 +13,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/if/as_testop.wat
+++ b/tests/disas/winch/x64/if/as_testop.wat
@@ -11,7 +11,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/if/nested.wat
+++ b/tests/disas/winch/x64/if/nested.wat
@@ -23,7 +23,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/if/singular.wat
+++ b/tests/disas/winch/x64/if/singular.wat
@@ -9,7 +9,7 @@
     (if (result i32) (local.get 0) (then (i32.const 7)) (else (i32.const 8)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/as_binary_operand.wat
+++ b/tests/disas/winch/x64/loop/as_binary_operand.wat
@@ -9,7 +9,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/as_call_value.wat
+++ b/tests/disas/winch/x64/loop/as_call_value.wat
@@ -6,7 +6,7 @@
     (call $f (loop (result i32) (i32.const 1)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/as_if_condition.wat
+++ b/tests/disas/winch/x64/loop/as_if_condition.wat
@@ -6,7 +6,7 @@
     (loop (result i32) (i32.const 1)) (if (then (call $dummy)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/as_test_operand.wat
+++ b/tests/disas/winch/x64/loop/as_test_operand.wat
@@ -6,7 +6,7 @@
     (i32.eqz (loop (result i32) (call $dummy) (i32.const 13)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/as_unary_operand.wat
+++ b/tests/disas/winch/x64/loop/as_unary_operand.wat
@@ -6,7 +6,7 @@
     (i32.ctz (loop (result i32) (call $dummy) (i32.const 13)))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/deep.wat
+++ b/tests/disas/winch/x64/loop/deep.wat
@@ -47,7 +47,7 @@
     ))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/effects.wat
+++ b/tests/disas/winch/x64/loop/effects.wat
@@ -16,7 +16,7 @@
     (i32.eq (local.get 0) (i32.const -14))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::fx:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/multi.wat
+++ b/tests/disas/winch/x64/loop/multi.wat
@@ -8,7 +8,7 @@
     (loop (result i32) (call $dummy) (call $dummy) (i32.const 8) (call $dummy))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/loop/nested.wat
+++ b/tests/disas/winch/x64/loop/nested.wat
@@ -9,7 +9,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_block_first.wat
+++ b/tests/disas/winch/x64/return/as_block_first.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_block_last.wat
+++ b/tests/disas/winch/x64/return/as_block_last.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_block_mid.wat
+++ b/tests/disas/winch/x64/return/as_block_mid.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_block_value.wat
+++ b/tests/disas/winch/x64/return/as_block_value.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_br_if_cond.wat
+++ b/tests/disas/winch/x64/return/as_br_if_cond.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_br_value.wat
+++ b/tests/disas/winch/x64/return/as_br_value.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_call_fist.wat
+++ b/tests/disas/winch/x64/return/as_call_fist.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_call_last.wat
+++ b/tests/disas/winch/x64/return/as_call_last.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_call_mid.wat
+++ b/tests/disas/winch/x64/return/as_call_mid.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_func_first.wat
+++ b/tests/disas/winch/x64/return/as_func_first.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_func_last.wat
+++ b/tests/disas/winch/x64/return/as_func_last.wat
@@ -4,7 +4,7 @@
   (func $dummy)
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_func_mid.wat
+++ b/tests/disas/winch/x64/return/as_func_mid.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_func_value.wat
+++ b/tests/disas/winch/x64/return/as_func_value.wat
@@ -7,7 +7,7 @@
     )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_if_cond.wat
+++ b/tests/disas/winch/x64/return/as_if_cond.wat
@@ -9,7 +9,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_if_else.wat
+++ b/tests/disas/winch/x64/return/as_if_else.wat
@@ -10,7 +10,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_if_then.wat
+++ b/tests/disas/winch/x64/return/as_if_then.wat
@@ -10,7 +10,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_loop_first.wat
+++ b/tests/disas/winch/x64/return/as_loop_first.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_loop_last.wat
+++ b/tests/disas/winch/x64/return/as_loop_last.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_loop_mid.wat
+++ b/tests/disas/winch/x64/return/as_loop_mid.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/as_return_value.wat
+++ b/tests/disas/winch/x64/return/as_return_value.wat
@@ -7,7 +7,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/nullary.wat
+++ b/tests/disas/winch/x64/return/nullary.wat
@@ -5,7 +5,7 @@
   (func (export "nullary") (return))
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/type_i32.wat
+++ b/tests/disas/winch/x64/return/type_i32.wat
@@ -8,7 +8,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/return/type_i64_value.wat
+++ b/tests/disas/winch/x64/return/type_i64_value.wat
@@ -8,7 +8,7 @@
   )
 )
   
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -20,7 +20,7 @@
     (table.fill $t2 (local.get $i) (local.get $ref) (local.get $n))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::f1:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
@@ -37,7 +37,7 @@
 ;;       retq
 ;;   31: ud2
 ;;
-;; wasm[0]::function[1]:
+;; wasm[0]::function[1]::f2:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
@@ -54,7 +54,7 @@
 ;;       retq
 ;;   71: ud2
 ;;
-;; wasm[0]::function[2]:
+;; wasm[0]::function[2]::f3:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -10,7 +10,7 @@
 )
 
 
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
@@ -27,7 +27,7 @@
 ;;       retq
 ;;   31: ud2
 ;;
-;; wasm[0]::function[1]:
+;; wasm[0]::function[1]::f3:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -15,7 +15,7 @@
   )
 )
 
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_block_broke.wat
+++ b/tests/disas/winch/x64/unreachable/as_block_broke.wat
@@ -7,7 +7,7 @@
     (block (result i32) (call $dummy) (br 0 (i32.const 1)) (unreachable))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_block_last.wat
+++ b/tests/disas/winch/x64/unreachable/as_block_last.wat
@@ -6,7 +6,7 @@
     (block (nop) (call $dummy) (unreachable))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_block_mid.wat
+++ b/tests/disas/winch/x64/unreachable/as_block_mid.wat
@@ -7,7 +7,7 @@
     (block (result i32) (call $dummy) (unreachable) (i32.const 2))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_block_value.wat
+++ b/tests/disas/winch/x64/unreachable/as_block_value.wat
@@ -6,7 +6,7 @@
     (block (result i32) (nop) (call $dummy) (unreachable))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_call_first.wat
+++ b/tests/disas/winch/x64/unreachable/as_call_first.wat
@@ -7,7 +7,7 @@
     (call $dummy3 (unreachable) (i32.const 2) (i32.const 3))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy3:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_call_last.wat
+++ b/tests/disas/winch/x64/unreachable/as_call_last.wat
@@ -8,7 +8,7 @@
     (call $dummy3 (i32.const 1) (i32.const 2) (unreachable))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy3:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_call_mid.wat
+++ b/tests/disas/winch/x64/unreachable/as_call_mid.wat
@@ -7,7 +7,7 @@
     (call $dummy3 (i32.const 1) (unreachable) (i32.const 3))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy3:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_func_first.wat
+++ b/tests/disas/winch/x64/unreachable/as_func_first.wat
@@ -6,7 +6,7 @@
     (unreachable) (i32.const -1)
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_func_last.wat
+++ b/tests/disas/winch/x64/unreachable/as_func_last.wat
@@ -6,7 +6,7 @@
     (call $dummy) (unreachable)
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_func_mid.wat
+++ b/tests/disas/winch/x64/unreachable/as_func_mid.wat
@@ -7,7 +7,7 @@
     (call $dummy) (unreachable) (i32.const -1)
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_func_value.wat
+++ b/tests/disas/winch/x64/unreachable/as_func_value.wat
@@ -7,7 +7,7 @@
     (call $dummy) (unreachable)
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_loop_broke.wat
+++ b/tests/disas/winch/x64/unreachable/as_loop_broke.wat
@@ -9,7 +9,7 @@
     )
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_loop_last.wat
+++ b/tests/disas/winch/x64/unreachable/as_loop_last.wat
@@ -8,7 +8,7 @@
     (loop (nop) (call $dummy) (unreachable))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11

--- a/tests/disas/winch/x64/unreachable/as_loop_mid.wat
+++ b/tests/disas/winch/x64/unreachable/as_loop_mid.wat
@@ -8,7 +8,7 @@
     (loop (result i32) (call $dummy) (unreachable) (i32.const 2))
   )
 )
-;; wasm[0]::function[0]:
+;; wasm[0]::function[0]::dummy:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11


### PR DESCRIPTION
Instead of generating symbol names in the format
"wasm[$MODULE_ID]::function[$FUNCTION_INDEX]", generate (if possible) something more readable, such as "wasm[$MODULE_ID]::$FUNCTION_NAME". This helps when debugging or profiling the generated code.
