### PR TITLE
Use bytes for maximum size of linear memory with pooling

### DIFF
--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -219,7 +219,7 @@ fn strategies() -> impl Iterator<Item = InstanceAllocationStrategy> {
         InstanceAllocationStrategy::OnDemand,
         InstanceAllocationStrategy::Pooling({
             let mut config = PoolingAllocationConfig::default();
-            config.memory_pages(10_000);
+            config.max_memory_size(10_000 << 16);
             config
         }),
     ]

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -112,6 +112,10 @@ wasmtime_option_group! {
         /// the pooling allocator.
         pub pooling_total_stacks: Option<u32>,
 
+        /// The maximum runtime size of linear memories in the pooling
+        /// allocator.
+        pub pooling_max_memory_size: Option<usize>,
+
         /// Whether to enable call-indirect caching.
         pub cache_call_indirects: Option<bool>,
 
@@ -604,6 +608,9 @@ impl CommonOptions {
                     }
                     if let Some(limit) = self.opts.pooling_total_stacks {
                         cfg.total_stacks(limit);
+                    }
+                    if let Some(limit) = self.opts.pooling_max_memory_size {
+                        cfg.max_memory_size(limit);
                     }
                     if let Some(enable) = self.opts.memory_protection_keys {
                         if enable {

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -112,8 +112,8 @@ wasmtime_option_group! {
         /// the pooling allocator.
         pub pooling_total_stacks: Option<u32>,
 
-        /// The maximum runtime size of linear memories in the pooling
-        /// allocator.
+        /// The maximum runtime size of each linear memory in the pooling
+        /// allocator, in bytes.
         pub pooling_max_memory_size: Option<usize>,
 
         /// Whether to enable call-indirect caching.

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -76,7 +76,7 @@ impl Config {
         if let InstanceAllocationStrategy::Pooling(pooling) = &mut self.wasmtime.strategy {
             // One single-page memory
             pooling.total_memories = config.max_memories as u32;
-            pooling.max_memory_size = 10 * 65535;
+            pooling.max_memory_size = 10 << 16;
             pooling.max_memories_per_module = config.max_memories as u32;
 
             pooling.total_tables = config.max_tables as u32;
@@ -135,7 +135,7 @@ impl Config {
             if pooling.total_memories < 1
                 || pooling.total_tables < 5
                 || pooling.table_elements < 1_000
-                || pooling.max_memory_size < (900 * 65536)
+                || pooling.max_memory_size < (900 << 16)
                 || pooling.total_core_instances < 500
                 || pooling.core_instance_size < 64 * 1024
             {
@@ -415,17 +415,17 @@ impl<'a> Arbitrary<'a> for Config {
             // Ensure the pooling allocator can support the maximal size of
             // memory, picking the smaller of the two to win.
             let min_pages = cfg.max_memory32_pages.min(cfg.max_memory64_pages);
-            let min = (min_pages * 65536).min(pooling.max_memory_size as u64);
+            let min = (min_pages << 16).min(pooling.max_memory_size as u64);
             pooling.max_memory_size = min as usize;
-            cfg.max_memory32_pages = min / 65536;
-            cfg.max_memory64_pages = min / 65535;
+            cfg.max_memory32_pages = min >> 16;
+            cfg.max_memory64_pages = min >> 16;
 
             // If traps are disallowed then memories must have at least one page
             // of memory so if we still are only allowing 0 pages of memory then
             // increase that to one here.
             if cfg.disallow_traps {
                 if pooling.max_memory_size == 0 {
-                    pooling.max_memory_size = 65535;
+                    pooling.max_memory_size = 1 << 16;
                     cfg.max_memory32_pages = 1;
                     cfg.max_memory64_pages = 1;
                 }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -76,7 +76,7 @@ impl Config {
         if let InstanceAllocationStrategy::Pooling(pooling) = &mut self.wasmtime.strategy {
             // One single-page memory
             pooling.total_memories = config.max_memories as u32;
-            pooling.memory_pages = 10;
+            pooling.max_memory_size = 10 * 65535;
             pooling.max_memories_per_module = config.max_memories as u32;
 
             pooling.total_tables = config.max_tables as u32;
@@ -135,7 +135,7 @@ impl Config {
             if pooling.total_memories < 1
                 || pooling.total_tables < 5
                 || pooling.table_elements < 1_000
-                || pooling.memory_pages < 900
+                || pooling.max_memory_size < (900 * 65536)
                 || pooling.total_core_instances < 500
                 || pooling.core_instance_size < 64 * 1024
             {
@@ -414,20 +414,18 @@ impl<'a> Arbitrary<'a> for Config {
 
             // Ensure the pooling allocator can support the maximal size of
             // memory, picking the smaller of the two to win.
-            let min = cfg
-                .max_memory32_pages
-                .min(cfg.max_memory64_pages)
-                .min(pooling.memory_pages);
-            pooling.memory_pages = min;
-            cfg.max_memory32_pages = min;
-            cfg.max_memory64_pages = min;
+            let min_pages = cfg.max_memory32_pages.min(cfg.max_memory64_pages);
+            let min = (min_pages * 65536).min(pooling.max_memory_size as u64);
+            pooling.max_memory_size = min as usize;
+            cfg.max_memory32_pages = min / 65536;
+            cfg.max_memory64_pages = min / 65535;
 
             // If traps are disallowed then memories must have at least one page
             // of memory so if we still are only allowing 0 pages of memory then
             // increase that to one here.
             if cfg.disallow_traps {
-                if pooling.memory_pages == 0 {
-                    pooling.memory_pages = 1;
+                if pooling.max_memory_size == 0 {
+                    pooling.max_memory_size = 65535;
                     cfg.max_memory32_pages = 1;
                     cfg.max_memory64_pages = 1;
                 }

--- a/crates/fuzzing/src/generators/pooling_config.rs
+++ b/crates/fuzzing/src/generators/pooling_config.rs
@@ -13,7 +13,7 @@ pub struct PoolingAllocationConfig {
     pub total_tables: u32,
     pub total_stacks: u32,
 
-    pub memory_pages: u64,
+    pub max_memory_size: usize,
     pub table_elements: u32,
 
     pub component_instance_size: usize,
@@ -48,7 +48,7 @@ impl PoolingAllocationConfig {
         cfg.total_tables(self.total_tables);
         cfg.total_stacks(self.total_stacks);
 
-        cfg.memory_pages(self.memory_pages);
+        cfg.max_memory_size(self.max_memory_size);
         cfg.table_elements(self.table_elements);
 
         cfg.max_component_instance_size(self.component_instance_size);
@@ -80,7 +80,7 @@ impl<'a> Arbitrary<'a> for PoolingAllocationConfig {
         const MAX_TABLES: u32 = 100;
         const MAX_MEMORIES: u32 = 100;
         const MAX_ELEMENTS: u32 = 1000;
-        const MAX_MEMORY_PAGES: u64 = 160; // 10 MiB
+        const MAX_MEMORY_SIZE: usize = 10 * (1 << 20); // 10 MiB
         const MAX_SIZE: usize = 1 << 20; // 1 MiB
         const MAX_INSTANCE_MEMORIES: u32 = 10;
         const MAX_INSTANCE_TABLES: u32 = 10;
@@ -94,7 +94,7 @@ impl<'a> Arbitrary<'a> for PoolingAllocationConfig {
             total_tables: u.int_in_range(1..=MAX_TABLES)?,
             total_stacks: u.int_in_range(1..=MAX_COUNT)?,
 
-            memory_pages: u.int_in_range(0..=MAX_MEMORY_PAGES)?,
+            max_memory_size: u.int_in_range(0..=MAX_MEMORY_SIZE)?,
             table_elements: u.int_in_range(0..=MAX_ELEMENTS)?,
 
             component_instance_size: u.int_in_range(0..=MAX_SIZE)?,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2757,18 +2757,16 @@ impl PoolingAllocationConfig {
         self
     }
 
-    /// The maximum number of Wasm pages for any linear memory defined in a
-    /// module (default is `160`).
+    /// The maximum size that any WebAssembly linear memory may grow to.
     ///
-    /// The default of `160` means at most 10 MiB of host memory may be
-    /// committed for each instance.
+    /// This option defaults to 10 MiB.
     ///
-    /// If a memory's minimum page limit is greater than this value, the module
-    /// will fail to instantiate.
+    /// If a memory's minimum size is greater than this value, the module will
+    /// fail to instantiate.
     ///
-    /// If a memory's maximum page limit is unbounded or greater than this
-    /// value, the maximum will be `memory_pages` for the purpose of any
-    /// `memory.grow` instruction.
+    /// If a memory's maximum size is unbounded or greater than this value, the
+    /// maximum will be `max_memory_size` for the purpose of any `memory.grow`
+    /// instruction.
     ///
     /// This value is used to control the maximum accessible space for each
     /// linear memory of a core instance.
@@ -2776,8 +2774,8 @@ impl PoolingAllocationConfig {
     /// The reservation size of each linear memory is controlled by the
     /// `static_memory_maximum_size` setting and this value cannot exceed the
     /// configured static memory maximum size.
-    pub fn memory_pages(&mut self, pages: u64) -> &mut Self {
-        self.config.limits.memory_pages = pages;
+    pub fn max_memory_size(&mut self, bytes: usize) -> &mut Self {
+        self.config.limits.max_memory_size = bytes;
         self
     }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2757,7 +2757,7 @@ impl PoolingAllocationConfig {
         self
     }
 
-    /// The maximum size that any WebAssembly linear memory may grow to.
+    /// The maximum byte size that any WebAssembly linear memory may grow to.
     ///
     /// This option defaults to 10 MiB.
     ///

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -704,7 +704,7 @@ mod test {
         let config = PoolingInstanceAllocatorConfig {
             limits: InstanceLimits {
                 total_memories: 1,
-                max_memory_size: (1 << 32) + 65536,
+                max_memory_size: 0x100010000,
                 ..Default::default()
             },
             ..PoolingInstanceAllocatorConfig::default()
@@ -713,7 +713,7 @@ mod test {
             PoolingInstanceAllocator::new(
                 &config,
                 &Tunables {
-                    static_memory_reservation: 65536,
+                    static_memory_reservation: 0x10000,
                     ..Tunables::default_host()
                 },
             )

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -763,13 +763,13 @@ mod tests {
                     max_tables_per_module: 0,
                     max_memories_per_module: 3,
                     table_elements: 0,
-                    max_memory_size: 65536,
+                    max_memory_size: WASM_PAGE_SIZE as usize,
                     ..Default::default()
                 },
                 ..Default::default()
             },
             &Tunables {
-                static_memory_reservation: 65536,
+                static_memory_reservation: WASM_PAGE_SIZE as u64,
                 static_memory_offset_guard_size: 0,
                 ..Tunables::default_host()
             },

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -218,7 +218,7 @@ mod tests {
             limits: InstanceLimits {
                 total_tables: 7,
                 table_elements: 100,
-                memory_pages: 0,
+                max_memory_size: 0,
                 max_memories_per_module: 0,
                 ..Default::default()
             },

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -66,7 +66,7 @@ struct Args {
     /// The maximum number of bytes for each WebAssembly linear memory in the
     /// pool.
     #[arg(long, default_value = "128MiB", value_parser = parse_byte_size)]
-    memory_size: u64,
+    memory_size: usize,
 
     /// The maximum number of bytes a memory is considered static; see
     /// `Config::static_memory_maximum_size` for more details and the default
@@ -186,8 +186,7 @@ impl ExponentialSearch {
 fn build_engine(args: &Args, num_memories: u32, enable_mpk: MpkEnabled) -> Result<usize> {
     // Configure the memory pool.
     let mut pool = PoolingAllocationConfig::default();
-    let memory_pages = args.memory_size / u64::from(wasmtime_environ::WASM_PAGE_SIZE);
-    pool.memory_pages(memory_pages);
+    pool.max_memory_size(args.memory_size);
     pool.total_memories(num_memories)
         .memory_protection_keys(enable_mpk);
 

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -345,14 +345,14 @@ async fn fuel_eventually_finishes() {
 async fn async_with_pooling_stacks() {
     let mut pool = crate::small_pool_config();
     pool.total_stacks(1)
-        .max_memory_size(65536)
+        .max_memory_size(1 << 16)
         .table_elements(0);
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::new(&engine, ());
@@ -370,14 +370,14 @@ async fn async_host_func_with_pooling_stacks() -> Result<()> {
     let mut pooling = crate::small_pool_config();
     pooling
         .total_stacks(1)
-        .max_memory_size(65536)
+        .max_memory_size(1 << 16)
         .table_elements(0);
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pooling));
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
 
     let mut store = Store::new(&Engine::new(&config)?, ());
     let mut linker = Linker::new(store.engine());
@@ -404,7 +404,7 @@ async fn async_mpk_protection() -> Result<()> {
     pooling
         .total_memories(10)
         .total_stacks(2)
-        .max_memory_size(65536)
+        .max_memory_size(1 << 16)
         .table_elements(0);
     let mut config = Config::new();
     config.async_support(true);

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -344,7 +344,9 @@ async fn fuel_eventually_finishes() {
 #[tokio::test]
 async fn async_with_pooling_stacks() {
     let mut pool = crate::small_pool_config();
-    pool.total_stacks(1).memory_pages(1).table_elements(0);
+    pool.total_stacks(1)
+        .max_memory_size(65536)
+        .table_elements(0);
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
@@ -366,7 +368,10 @@ async fn async_with_pooling_stacks() {
 #[tokio::test]
 async fn async_host_func_with_pooling_stacks() -> Result<()> {
     let mut pooling = crate::small_pool_config();
-    pooling.total_stacks(1).memory_pages(1).table_elements(0);
+    pooling
+        .total_stacks(1)
+        .max_memory_size(65536)
+        .table_elements(0);
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pooling));
@@ -399,7 +404,7 @@ async fn async_mpk_protection() -> Result<()> {
     pooling
         .total_memories(10)
         .total_stacks(2)
-        .memory_pages(1)
+        .max_memory_size(65536)
         .table_elements(0);
     let mut config = Config::new();
     config.async_support(true);

--- a/tests/all/instance.rs
+++ b/tests/all/instance.rs
@@ -42,7 +42,7 @@ fn linear_memory_limits() -> Result<()> {
     }
     test(&Engine::default())?;
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(65536);
+    pool.max_memory_size(1 << 32);
     test(&Engine::new(Config::new().allocation_strategy(
         InstanceAllocationStrategy::Pooling(pool),
     ))?)?;

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -354,7 +354,7 @@ fn test_pooling_allocator_initial_limits_exceeded() -> Result<()> {
     let mut pool = crate::small_pool_config();
     pool.total_memories(2)
         .max_memories_per_module(2)
-        .max_memory_size(5 * 65536)
+        .max_memory_size(5 << 16)
         .memory_protection_keys(MpkEnabled::Disable);
     let mut config = Config::new();
     config.wasm_multi_memory(true);
@@ -742,7 +742,7 @@ fn custom_limiter_detect_grow_failure() -> Result<()> {
         return Ok(());
     }
     let mut pool = crate::small_pool_config();
-    pool.max_memory_size(10 * 65536).table_elements(10);
+    pool.max_memory_size(10 << 16).table_elements(10);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     let engine = Engine::new(&config).unwrap();
@@ -853,7 +853,7 @@ async fn custom_limiter_async_detect_grow_failure() -> Result<()> {
         return Ok(());
     }
     let mut pool = crate::small_pool_config();
-    pool.max_memory_size(10 * 65536).table_elements(10);
+    pool.max_memory_size(10 << 16).table_elements(10);
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -354,7 +354,7 @@ fn test_pooling_allocator_initial_limits_exceeded() -> Result<()> {
     let mut pool = crate::small_pool_config();
     pool.total_memories(2)
         .max_memories_per_module(2)
-        .memory_pages(5)
+        .max_memory_size(5 * 65536)
         .memory_protection_keys(MpkEnabled::Disable);
     let mut config = Config::new();
     config.wasm_multi_memory(true);
@@ -742,7 +742,7 @@ fn custom_limiter_detect_grow_failure() -> Result<()> {
         return Ok(());
     }
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(10).table_elements(10);
+    pool.max_memory_size(10 * 65536).table_elements(10);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     let engine = Engine::new(&config).unwrap();
@@ -853,7 +853,7 @@ async fn custom_limiter_async_detect_grow_failure() -> Result<()> {
         return Ok(());
     }
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(10).table_elements(10);
+    pool.max_memory_size(10 * 65536).table_elements(10);
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -91,7 +91,7 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
     let mut config = wasmtime::PoolingAllocationConfig::default();
 
     config.total_memories(1);
-    config.memory_pages(1);
+    config.max_memory_size(65536);
     config.total_tables(1);
     config.table_elements(10);
 

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -91,7 +91,7 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
     let mut config = wasmtime::PoolingAllocationConfig::default();
 
     config.total_memories(1);
-    config.max_memory_size(65536);
+    config.max_memory_size(1 << 16);
     config.total_tables(1);
     config.table_elements(10);
 

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -192,7 +192,7 @@ fn guards_present_pooling() -> Result<()> {
 
     let mut pool = crate::small_pool_config();
     pool.total_memories(2)
-        .memory_pages(10)
+        .max_memory_size(10 * 65536)
         .memory_protection_keys(MpkEnabled::Disable);
     let mut config = Config::new();
     config.static_memory_maximum_size(1 << 20);
@@ -254,7 +254,7 @@ fn guards_present_pooling_mpk() -> Result<()> {
     const GUARD_SIZE: u64 = 65536;
     let mut pool = crate::small_pool_config();
     pool.total_memories(4)
-        .memory_pages(10)
+        .max_memory_size(10 * 65536)
         .memory_protection_keys(MpkEnabled::Enable)
         .max_memory_protection_keys(2);
     let mut config = Config::new();

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -192,7 +192,7 @@ fn guards_present_pooling() -> Result<()> {
 
     let mut pool = crate::small_pool_config();
     pool.total_memories(2)
-        .max_memory_size(10 * 65536)
+        .max_memory_size(10 << 16)
         .memory_protection_keys(MpkEnabled::Disable);
     let mut config = Config::new();
     config.static_memory_maximum_size(1 << 20);
@@ -254,7 +254,7 @@ fn guards_present_pooling_mpk() -> Result<()> {
     const GUARD_SIZE: u64 = 65536;
     let mut pool = crate::small_pool_config();
     pool.total_memories(4)
-        .max_memory_size(10 * 65536)
+        .max_memory_size(10 << 16)
         .memory_protection_keys(MpkEnabled::Enable)
         .max_memory_protection_keys(2);
     let mut config = Config::new();
@@ -396,7 +396,7 @@ fn tiny_static_heap() -> Result<()> {
     // specifically test that a load of all the valid addresses of the memory
     // all pass bounds-checks in cranelift to help weed out any off-by-one bugs.
     let mut config = Config::new();
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
 
@@ -429,7 +429,7 @@ fn tiny_static_heap() -> Result<()> {
 #[test]
 fn static_forced_max() -> Result<()> {
     let mut config = Config::new();
-    config.static_memory_maximum_size(5 * 65536);
+    config.static_memory_maximum_size(5 << 16);
     config.static_memory_forced(true);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -24,7 +24,7 @@ fn successful_instantiation() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn memory_limit() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(3);
+    pool.max_memory_size(3 * 65536);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
@@ -97,7 +97,7 @@ fn memory_limit() -> Result<()> {
 #[test]
 fn memory_init() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(2).table_elements(0);
+    pool.max_memory_size(2 * 65536).table_elements(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 
@@ -131,7 +131,7 @@ fn memory_init() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn memory_guard_page_trap() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(2).table_elements(0);
+    pool.max_memory_size(2 * 65536).table_elements(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 
@@ -198,7 +198,7 @@ fn memory_zeroed() -> Result<()> {
     }
 
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(1).table_elements(0);
+    pool.max_memory_size(65536).table_elements(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
@@ -318,7 +318,7 @@ fn table_limit() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn table_init() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(0).table_elements(6);
+    pool.max_memory_size(0).table_elements(6);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 
@@ -700,7 +700,7 @@ fn dynamic_memory_pooling_allocator() -> Result<()> {
     for guard_size in [0, 1 << 16] {
         let max_size = 128 << 20;
         let mut pool = crate::small_pool_config();
-        pool.memory_pages(max_size / (64 * 1024));
+        pool.max_memory_size(max_size as usize);
         let mut config = Config::new();
         config.static_memory_maximum_size(max_size);
         config.dynamic_memory_guard_size(guard_size);
@@ -806,7 +806,7 @@ fn dynamic_memory_pooling_allocator() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn zero_memory_pages_disallows_oob() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.memory_pages(0);
+    pool.max_memory_size(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -8,7 +8,7 @@ fn successful_instantiation() -> Result<()> {
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
     let module = Module::new(&engine, r#"(module (memory 1) (table 10 funcref))"#)?;
@@ -24,12 +24,12 @@ fn successful_instantiation() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn memory_limit() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.max_memory_size(3 * 65536);
+    pool.max_memory_size(3 << 16);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(65536);
-    config.static_memory_maximum_size(3 * 65536);
+    config.static_memory_guard_size(1 << 16);
+    config.static_memory_maximum_size(3 << 16);
     config.wasm_multi_memory(true);
 
     let engine = Engine::new(&config)?;
@@ -97,7 +97,7 @@ fn memory_limit() -> Result<()> {
 #[test]
 fn memory_init() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.max_memory_size(2 * 65536).table_elements(0);
+    pool.max_memory_size(2 << 16).table_elements(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 
@@ -131,7 +131,7 @@ fn memory_init() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn memory_guard_page_trap() -> Result<()> {
     let mut pool = crate::small_pool_config();
-    pool.max_memory_size(2 * 65536).table_elements(0);
+    pool.max_memory_size(2 << 16).table_elements(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 
@@ -198,12 +198,12 @@ fn memory_zeroed() -> Result<()> {
     }
 
     let mut pool = crate::small_pool_config();
-    pool.max_memory_size(65536).table_elements(0);
+    pool.max_memory_size(1 << 16).table_elements(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
 
@@ -241,7 +241,7 @@ fn table_limit() -> Result<()> {
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
 
@@ -377,7 +377,7 @@ fn table_zeroed() -> Result<()> {
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
 
@@ -415,7 +415,7 @@ fn total_core_instances_limit() -> Result<()> {
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     config.dynamic_memory_guard_size(0);
     config.static_memory_guard_size(0);
-    config.static_memory_maximum_size(65536);
+    config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
     let module = Module::new(&engine, r#"(module)"#)?;

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -290,7 +290,7 @@ fn run_wast(wast: &Path, strategy: Strategy, pooling: bool) -> anyhow::Result<()
         // When multiple memories are used and are configured in the pool then
         // force the usage of static memories without guards to reduce the VM
         // impact.
-        let max_memory_size = 805 * 65536;
+        let max_memory_size = 805 << 16;
         if multi_memory {
             cfg.static_memory_maximum_size(max_memory_size as u64);
             cfg.dynamic_memory_reserved_for_growth(0);

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -290,8 +290,9 @@ fn run_wast(wast: &Path, strategy: Strategy, pooling: bool) -> anyhow::Result<()
         // When multiple memories are used and are configured in the pool then
         // force the usage of static memories without guards to reduce the VM
         // impact.
+        let max_memory_size = 805 * 65536;
         if multi_memory {
-            cfg.static_memory_maximum_size(0);
+            cfg.static_memory_maximum_size(max_memory_size as u64);
             cfg.dynamic_memory_reserved_for_growth(0);
             cfg.static_memory_guard_size(0);
             cfg.dynamic_memory_guard_size(0);
@@ -305,7 +306,7 @@ fn run_wast(wast: &Path, strategy: Strategy, pooling: bool) -> anyhow::Result<()
         let mut pool = PoolingAllocationConfig::default();
         pool.total_memories(450 * 2)
             .max_memory_protection_keys(2)
-            .memory_pages(805)
+            .max_memory_size(max_memory_size)
             .max_memories_per_module(if multi_memory { 9 } else { 1 })
             .max_tables_per_module(5);
 


### PR DESCRIPTION
This commit changes configuration of the pooling allocator to use a byte-based unit rather than a page based unit. The previous `PoolingAllocatorConfig::memory_pages` configuration option configures the maximum size that a linear memory may grow to at runtime. This is an important factor in calculation of stripes for MPK and is also a coarse-grained knob apart from `StoreLimiter` to limit memory consumption. This configuration option has been renamed to `max_memory_size` and documented that it's in terms of bytes rather than pages as before.

Additionally the documented constraint of `max_memory_size` must be smaller than `static_memory_bound` is now additionally enforced as a minor clean-up as part of this PR as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
