### PR TITLE
Remove the native ABI calling convention from Wasmtime

### DIFF
--- a/crates/environ/src/compile/module_artifacts.rs
+++ b/crates/environ/src/compile/module_artifacts.rs
@@ -106,8 +106,8 @@ impl<'a> ObjectBuilder<'a> {
     ///   as well as where the functions are located in the text section and any
     ///   associated trampolines.
     ///
-    /// * `wasm_to_native_trampolines` - list of all trampolines necessary for
-    ///   Wasm callers calling native callees (e.g. `Func::wrap`). One for each
+    /// * `wasm_to_array_trampolines` - list of all trampolines necessary for
+    ///   Wasm callers calling array callees (e.g. `Func::wrap`). One for each
     ///   function signature in the module. Must be sorted by `SignatureIndex`.
     ///
     /// Returns the `CompiledModuleInfo` corresponding to this core Wasm module
@@ -117,7 +117,7 @@ impl<'a> ObjectBuilder<'a> {
         &mut self,
         translation: ModuleTranslation<'_>,
         funcs: PrimaryMap<DefinedFuncIndex, CompiledFunctionInfo>,
-        wasm_to_native_trampolines: Vec<(ModuleInternedTypeIndex, FunctionLoc)>,
+        wasm_to_array_trampolines: Vec<(ModuleInternedTypeIndex, FunctionLoc)>,
     ) -> Result<CompiledModuleInfo> {
         let ModuleTranslation {
             mut module,
@@ -220,7 +220,7 @@ impl<'a> ObjectBuilder<'a> {
         Ok(CompiledModuleInfo {
             module,
             funcs,
-            wasm_to_native_trampolines,
+            wasm_to_array_trampolines,
             func_names,
             meta: Metadata {
                 native_debug_info_present: self.tunables.generate_native_debuginfo,

--- a/crates/environ/src/component/artifacts.rs
+++ b/crates/environ/src/component/artifacts.rs
@@ -32,20 +32,19 @@ pub struct CompiledComponentInfo {
     /// These are the
     ///
     /// 1. Wasm-call,
-    /// 2. array-call, and
-    /// 3. native-call
+    /// 2. array-call
     ///
     /// function pointers that end up in a `VMFuncRef` for each
     /// lowering.
     pub trampolines: PrimaryMap<TrampolineIndex, AllCallFunc<FunctionLoc>>,
 
-    /// The location of the wasm-to-native trampoline for the `resource.drop`
+    /// The location of the wasm-to-array trampoline for the `resource.drop`
     /// intrinsic.
-    pub resource_drop_wasm_to_native_trampoline: Option<FunctionLoc>,
+    pub resource_drop_wasm_to_array_trampoline: Option<FunctionLoc>,
 }
 
 /// A triple of related functions/trampolines variants with differing calling
-/// conventions: `{wasm,array,native}_call`.
+/// conventions: `{wasm,array}_call`.
 ///
 /// Generic so we can use this with either the `Box<dyn Any + Send>`s that
 /// implementations of the compiler trait return or with `FunctionLoc`s inside
@@ -56,8 +55,6 @@ pub struct AllCallFunc<T> {
     pub wasm_call: T,
     /// The function exposing the array calling convention.
     pub array_call: T,
-    /// The function exposing the native calling convention.
-    pub native_call: T,
 }
 
 impl<T> AllCallFunc<T> {
@@ -66,7 +63,6 @@ impl<T> AllCallFunc<T> {
         AllCallFunc {
             wasm_call: f(self.wasm_call),
             array_call: f(self.array_call),
-            native_call: f(self.native_call),
         }
     }
 }

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -19,8 +19,6 @@ pub struct CompiledFunctionInfo {
     pub wasm_func_loc: FunctionLoc,
     /// A trampoline for array callers (e.g. `Func::new`) calling into this function (if needed).
     pub array_to_wasm_trampoline: Option<FunctionLoc>,
-    /// A trampoline for native callers (e.g. `Func::wrap`) calling into this function (if needed).
-    pub native_to_wasm_trampoline: Option<FunctionLoc>,
 }
 
 /// Information about a function, such as trap information, address map,
@@ -70,9 +68,9 @@ pub struct CompiledModuleInfo {
     /// Sorted list, by function index, of names we have for this module.
     pub func_names: Vec<FunctionName>,
 
-    /// Metadata about wasm-to-native trampolines. Used when exposing a native
+    /// Metadata about wasm-to-array trampolines. Used when exposing a native
     /// callee (e.g. `Func::wrap`) to a Wasm caller. Sorted by signature index.
-    pub wasm_to_native_trampolines: Vec<(ModuleInternedTypeIndex, FunctionLoc)>,
+    pub wasm_to_array_trampolines: Vec<(ModuleInternedTypeIndex, FunctionLoc)>,
 
     /// General compilation metadata.
     pub meta: Metadata,

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -119,40 +119,34 @@ pub trait PtrSize {
         self.vmcontext_runtime_limits() + self.size()
     }
 
-    /// The offset of the `native_call` field.
-    #[inline]
-    fn vm_func_ref_native_call(&self) -> u8 {
-        0 * self.size()
-    }
-
     /// The offset of the `array_call` field.
     #[inline]
     fn vm_func_ref_array_call(&self) -> u8 {
-        1 * self.size()
+        0 * self.size()
     }
 
     /// The offset of the `wasm_call` field.
     #[inline]
     fn vm_func_ref_wasm_call(&self) -> u8 {
-        2 * self.size()
+        1 * self.size()
     }
 
     /// The offset of the `type_index` field.
     #[inline]
     fn vm_func_ref_type_index(&self) -> u8 {
-        3 * self.size()
+        2 * self.size()
     }
 
     /// The offset of the `vmctx` field.
     #[inline]
     fn vm_func_ref_vmctx(&self) -> u8 {
-        4 * self.size()
+        3 * self.size()
     }
 
     /// Return the size of `VMFuncRef`.
     #[inline]
     fn size_of_vm_func_ref(&self) -> u8 {
-        5 * self.size()
+        4 * self.size()
     }
 
     /// Return the size of `VMGlobalDefinition`; this is the size of the largest value type (i.e. a
@@ -225,10 +219,8 @@ pub trait PtrSize {
 
     // Offsets within `VMArrayCallHostFuncContext`.
 
-    // Offsets within `VMNativeCallHostFuncContext`.
-
-    /// Return the offset of `VMNativeCallHostFuncContext::func_ref`.
-    fn vmnative_call_host_func_context_func_ref(&self) -> u8 {
+    /// Return the offset of `VMArrayCallHostFuncContext::func_ref`.
+    fn vmarray_call_host_func_context_func_ref(&self) -> u8 {
         u8::try_from(align(
             u32::try_from(core::mem::size_of::<u32>()).unwrap(),
             u32::from(self.size()),
@@ -526,28 +518,22 @@ impl<P: PtrSize> VMOffsets<P> {
         0 * self.pointer_size()
     }
 
-    /// The offset of the `native_call` field.
-    #[inline]
-    pub fn vmfunction_import_native_call(&self) -> u8 {
-        1 * self.pointer_size()
-    }
-
     /// The offset of the `array_call` field.
     #[inline]
     pub fn vmfunction_import_array_call(&self) -> u8 {
-        2 * self.pointer_size()
+        1 * self.pointer_size()
     }
 
     /// The offset of the `vmctx` field.
     #[inline]
     pub fn vmfunction_import_vmctx(&self) -> u8 {
-        3 * self.pointer_size()
+        2 * self.pointer_size()
     }
 
     /// Return the size of `VMFunctionImport`.
     #[inline]
     pub fn size_of_vmfunction_import(&self) -> u8 {
-        4 * self.pointer_size()
+        3 * self.pointer_size()
     }
 }
 
@@ -860,12 +846,6 @@ impl<P: PtrSize> VMOffsets<P> {
         self.vmctx_vmfunction_import(index) + u32::from(self.vmfunction_import_wasm_call())
     }
 
-    /// Return the offset to the `native_call` field in `*const VMFunctionBody` index `index`.
-    #[inline]
-    pub fn vmctx_vmfunction_import_native_call(&self, index: FuncIndex) -> u32 {
-        self.vmctx_vmfunction_import(index) + u32::from(self.vmfunction_import_native_call())
-    }
-
     /// Return the offset to the `array_call` field in `*const VMFunctionBody` index `index`.
     #[inline]
     pub fn vmctx_vmfunction_import_array_call(&self, index: FuncIndex) -> u32 {
@@ -991,12 +971,6 @@ pub const VMCONTEXT_MAGIC: u32 = u32::from_le_bytes(*b"core");
 /// This is stored at the start of all `VMArrayCallHostFuncContext` structures
 /// and double-checked on `VMArrayCallHostFuncContext::from_opaque`.
 pub const VM_ARRAY_CALL_HOST_FUNC_MAGIC: u32 = u32::from_le_bytes(*b"ACHF");
-
-/// Equivalent of `VMCONTEXT_MAGIC` except for native-call host functions.
-///
-/// This is stored at the start of all `VMNativeCallHostFuncContext` structures
-/// and double-checked on `VMNativeCallHostFuncContext::from_opaque`.
-pub const VM_NATIVE_CALL_HOST_FUNC_MAGIC: u32 = u32::from_le_bytes(*b"NCHF");
 
 #[cfg(test)]
 mod tests {

--- a/crates/wasmtime/src/compile/runtime.rs
+++ b/crates/wasmtime/src/compile/runtime.rs
@@ -98,15 +98,6 @@ fn publish_mmap(mmap: MmapVec) -> Result<Arc<CodeMemory>> {
     Ok(Arc::new(code))
 }
 
-/// Write an object out to an [`MmapVec`] so that it can be marked executable
-/// before running.
-///
-/// The returned `MmapVec` will contain the serialized version of `obj`
-/// and is sized appropriately to the exact size of the object serialized.
-pub fn finish_object(obj: ObjectBuilder<'_>) -> Result<MmapVec> {
-    Ok(<MmapVecWrapper as FinishedObject>::finish_object(obj)?.0)
-}
-
 pub(crate) struct MmapVecWrapper(pub MmapVec);
 
 impl FinishedObject for MmapVecWrapper {

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -2,9 +2,7 @@ use crate::component::matching::InstanceType;
 use crate::component::types;
 use crate::prelude::*;
 use crate::runtime::vm::component::ComponentRuntimeInfo;
-use crate::runtime::vm::{
-    VMArrayCallFunction, VMFuncRef, VMFunctionBody, VMNativeCallFunction, VMWasmCallFunction,
-};
+use crate::runtime::vm::{VMArrayCallFunction, VMFuncRef, VMFunctionBody, VMWasmCallFunction};
 use crate::{
     code::CodeObject, code_memory::CodeMemory, type_registry::TypeCollection, Engine, Module,
     ResourcesRequired,
@@ -87,7 +85,6 @@ struct ComponentInner {
 pub(crate) struct AllCallFuncPointers {
     pub wasm_call: NonNull<VMWasmCallFunction>,
     pub array_call: VMArrayCallFunction,
-    pub native_call: NonNull<VMNativeCallFunction>,
 }
 
 impl Component {
@@ -450,7 +447,6 @@ impl Component {
         let AllCallFunc {
             wasm_call,
             array_call,
-            native_call,
         } = &self.inner.info.trampolines[index];
         AllCallFuncPointers {
             wasm_call: self.func(wasm_call).cast(),
@@ -459,7 +455,6 @@ impl Component {
                     self.func(array_call),
                 )
             },
-            native_call: self.func(native_call).cast(),
         }
     }
 
@@ -505,7 +500,7 @@ impl Component {
         let wasm_call = self
             .inner
             .info
-            .resource_drop_wasm_to_native_trampoline
+            .resource_drop_wasm_to_array_trampoline
             .as_ref()
             .map(|i| self.func(i).cast());
         VMFuncRef {

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -16,63 +16,6 @@ use wasmtime_environ::component::{
     TypeFuncIndex, TypeTuple, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
 };
 
-/// A helper macro to safely map `MaybeUninit<T>` to `MaybeUninit<U>` where `U`
-/// is a field projection within `T`.
-///
-/// This is intended to be invoked as:
-///
-/// ```ignore
-/// struct MyType {
-///     field: u32,
-/// }
-///
-/// let initial: &mut MaybeUninit<MyType> = ...;
-/// let field: &mut MaybeUninit<u32> = map_maybe_uninit!(initial.field);
-/// ```
-///
-/// Note that array accesses are also supported:
-///
-/// ```ignore
-///
-/// let initial: &mut MaybeUninit<[u32; 2]> = ...;
-/// let element: &mut MaybeUninit<u32> = map_maybe_uninit!(initial[1]);
-/// ```
-#[doc(hidden)]
-#[macro_export]
-macro_rules! map_maybe_uninit {
-    ($maybe_uninit:ident $($field:tt)*) => ({
-        #[allow(unused_unsafe)]
-        {
-            unsafe {
-                use $crate::component::__internal::MaybeUninitExt;
-
-                let m: &mut core::mem::MaybeUninit<_> = $maybe_uninit;
-                // Note the usage of `addr_of_mut!` here which is an attempt to "stay
-                // safe" here where we never accidentally create `&mut T` where `T` is
-                // actually uninitialized, hopefully appeasing the Rust unsafe
-                // guidelines gods.
-                m.map(|p| core::ptr::addr_of_mut!((*p)$($field)*))
-            }
-        }
-    })
-}
-
-#[doc(hidden)]
-pub trait MaybeUninitExt<T> {
-    /// Maps `MaybeUninit<T>` to `MaybeUninit<U>` using the closure provided.
-    ///
-    /// Note that this is `unsafe` as there is no guarantee that `U` comes from
-    /// `T`.
-    unsafe fn map<U>(&mut self, f: impl FnOnce(*mut T) -> *mut U) -> &mut MaybeUninit<U>;
-}
-
-impl<T> MaybeUninitExt<T> for MaybeUninit<T> {
-    unsafe fn map<U>(&mut self, f: impl FnOnce(*mut T) -> *mut U) -> &mut MaybeUninit<U> {
-        let new_ptr = f(self.as_mut_ptr());
-        core::mem::transmute::<*mut U, &mut MaybeUninit<U>>(new_ptr)
-    }
-}
-
 mod host;
 mod options;
 mod typed;

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -324,13 +324,9 @@ impl<'a> Instantiator<'a> {
                 None => panic!("found unregistered signature: {sig:?}"),
             };
 
-            self.data.state.set_trampoline(
-                idx,
-                ptrs.wasm_call,
-                ptrs.native_call,
-                ptrs.array_call,
-                signature,
-            );
+            self.data
+                .state
+                .set_trampoline(idx, ptrs.wasm_call, ptrs.array_call, signature);
         }
 
         for initializer in env_component.initializers.iter() {

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -131,12 +131,12 @@ pub(crate) use self::resources::HostResourceData;
 pub mod __internal {
     pub use super::func::{
         bad_type_info, format_flags, lower_payload, typecheck_enum, typecheck_flags,
-        typecheck_record, typecheck_variant, ComponentVariant, LiftContext, LowerContext,
-        MaybeUninitExt, Options,
+        typecheck_record, typecheck_variant, ComponentVariant, LiftContext, LowerContext, Options,
     };
     pub use super::matching::InstanceType;
     pub use crate::map_maybe_uninit;
     pub use crate::store::StoreOpaque;
+    pub use crate::MaybeUninitExt;
     pub use alloc::boxed::Box;
     pub use alloc::string::String;
     pub use alloc::vec::Vec;

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -1,5 +1,5 @@
-use super::{invoke_wasm_and_catch_traps, HostAbi};
-use crate::runtime::vm::{VMContext, VMFuncRef, VMNativeCallFunction, VMOpaqueContext};
+use super::invoke_wasm_and_catch_traps;
+use crate::runtime::vm::{VMFuncRef, VMOpaqueContext};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{
     AsContext, AsContextMut, Engine, Func, FuncType, HeapType, NoFunc, RefType, StoreContextMut,
@@ -10,7 +10,7 @@ use core::ffi::c_void;
 use core::marker;
 use core::mem::{self, MaybeUninit};
 use core::num::NonZeroUsize;
-use core::ptr::{self, NonNull};
+use core::ptr::{self};
 use wasmtime_environ::VMSharedTypeIndex;
 
 /// A statically typed WebAssembly function.
@@ -190,33 +190,44 @@ where
         // belong within this store, otherwise it would be unsafe for store
         // values to cross each other.
 
-        let params = {
-            let mut store = AutoAssertNoGc::new(store.0);
-            params.into_abi(&mut store, ty)?
+        union Storage<T: Copy, U: Copy> {
+            params: MaybeUninit<T>,
+            results: U,
+            raw: [ValRaw; 0],
+        }
+
+        let mut storage = Storage::<Params::ValRawStorage, Results::ValRawStorage> {
+            params: MaybeUninit::uninit(),
         };
+
+        {
+            let mut store = AutoAssertNoGc::new(store.0);
+            params.store(&mut store, ty, &mut storage.params)?;
+        }
 
         // Try to capture only a single variable (a tuple) in the closure below.
         // This means the size of the closure is one pointer and is much more
         // efficient to move in memory. This closure is actually invoked on the
         // other side of a C++ shim, so it can never be inlined enough to make
         // the memory go away, so the size matters here for performance.
-        let mut captures = (func, MaybeUninit::uninit(), params, false);
+        let mut captures = (func, storage);
 
         let result = invoke_wasm_and_catch_traps(store, |caller| {
-            let (func_ref, ret, params, returned) = &mut captures;
+            let (func_ref, storage) = &mut captures;
             let func_ref = func_ref.as_ref();
-            let result =
-                Params::invoke::<Results>(func_ref.native_call, func_ref.vmctx, caller, *params);
-            ptr::write(ret.as_mut_ptr(), result);
-            *returned = true
+            (func_ref.array_call)(
+                func_ref.vmctx,
+                VMOpaqueContext::from_vmcontext(caller),
+                storage.raw.as_mut_ptr(),
+                mem::size_of_val::<Storage<_, _>>(&storage) / mem::size_of::<ValRaw>(),
+            );
         });
 
-        let (_, ret, _, returned) = captures;
-        debug_assert_eq!(result.is_ok(), returned);
+        let (_, storage) = captures;
         result?;
 
         let mut store = AutoAssertNoGc::new(store.0);
-        Ok(Results::from_abi(&mut store, ret.assume_init()))
+        Ok(Results::load(&mut store, &storage.results))
     }
 
     /// Purely a debug-mode assertion, not actually used in release builds.
@@ -245,11 +256,6 @@ pub enum TypeCheckPosition {
 ///
 /// For more information see [`Func::wrap`] and [`Func::typed`]
 pub unsafe trait WasmTy: Send {
-    // The raw ABI type that values of this type can be converted to and passed
-    // to Wasm, or given from Wasm and converted back from.
-    #[doc(hidden)]
-    type Abi: 'static + Copy;
-
     // Do a "static" (aka at time of `func.typed::<P, R>()`) ahead-of-time type
     // check for this type at the given position. You probably don't need to
     // override this trait method.
@@ -342,15 +348,7 @@ pub unsafe trait WasmTy: Send {
         Self::valtype().is_vmgcref_type_and_points_to_object()
     }
 
-    // Construct a `Self::Abi` from the given `ValRaw`.
-    #[doc(hidden)]
-    unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi;
-
-    // Stuff our given `Self::Abi` into a `ValRaw`.
-    #[doc(hidden)]
-    unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw);
-
-    // Convert `self` into `Self::Abi`.
+    // Store `self` into `ptr`.
     //
     // NB: We _must not_ trigger a GC when passing refs from host code into Wasm
     // (e.g. returned from a host function or passed as arguments to a Wasm
@@ -379,17 +377,21 @@ pub unsafe trait WasmTy: Send {
     // In conclusion, to prevent uses-after-free bugs, we cannot GC while
     // converting types into their raw ABI forms.
     #[doc(hidden)]
-    fn into_abi(self, store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi>;
+    fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()>;
 
-    // Convert back from `Self::Abi` into `Self`.
+    // Load a version of `Self` from the `ptr` provided.
+    //
+    // # Safety
+    //
+    // This function is unsafe as it's up to the caller to ensure that `ptr` is
+    // valid for this given type.
     #[doc(hidden)]
-    unsafe fn from_abi(abi: Self::Abi, store: &mut AutoAssertNoGc<'_>) -> Self;
+    unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self;
 }
 
 macro_rules! integers {
     ($($primitive:ident/$get_primitive:ident => $ty:ident)*) => ($(
         unsafe impl WasmTy for $primitive {
-            type Abi = $primitive;
             #[inline]
             fn valtype() -> ValType {
                 ValType::$ty
@@ -403,21 +405,13 @@ macro_rules! integers {
                 unreachable!()
             }
             #[inline]
-            unsafe fn abi_from_raw(raw: *mut ValRaw) -> $primitive {
-                (*raw).$get_primitive()
+            fn store(self, _store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
+                ptr.write(ValRaw::$primitive(self));
+                Ok(())
             }
             #[inline]
-            unsafe fn abi_into_raw(abi: $primitive, raw: *mut ValRaw) {
-                *raw = ValRaw::$primitive(abi);
-            }
-            #[inline]
-            fn into_abi(self, _store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi>
-            {
-                Ok(self)
-            }
-            #[inline]
-            unsafe fn from_abi(abi: Self::Abi, _store: &mut AutoAssertNoGc<'_>) -> Self {
-                abi
+            unsafe fn load(_store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
+                ptr.$get_primitive()
             }
         }
     )*)
@@ -433,7 +427,6 @@ integers! {
 macro_rules! floats {
     ($($float:ident/$int:ident/$get_float:ident => $ty:ident)*) => ($(
         unsafe impl WasmTy for $float {
-            type Abi = $float;
             #[inline]
             fn valtype() -> ValType {
                 ValType::$ty
@@ -447,21 +440,13 @@ macro_rules! floats {
                 unreachable!()
             }
             #[inline]
-            unsafe fn abi_from_raw(raw: *mut ValRaw) -> $float {
-                $float::from_bits((*raw).$get_float())
+            fn store(self, _store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
+                ptr.write(ValRaw::$float(self.to_bits()));
+                Ok(())
             }
             #[inline]
-            unsafe fn abi_into_raw(abi: $float, raw: *mut ValRaw) {
-                *raw = ValRaw::$float(abi.to_bits());
-            }
-            #[inline]
-            fn into_abi(self, _store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi>
-            {
-                Ok(self)
-            }
-            #[inline]
-            unsafe fn from_abi(abi: Self::Abi, _store: &mut AutoAssertNoGc<'_>) -> Self {
-                abi
+            unsafe fn load(_store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
+                $float::from_bits(ptr.$get_float())
             }
         }
     )*)
@@ -473,8 +458,6 @@ floats! {
 }
 
 unsafe impl WasmTy for NoFunc {
-    type Abi = NoFunc;
-
     #[inline]
     fn valtype() -> ValType {
         ValType::Ref(RefType::new(false, HeapType::NoFunc))
@@ -496,29 +479,17 @@ unsafe impl WasmTy for NoFunc {
     }
 
     #[inline]
-    unsafe fn abi_from_raw(_raw: *mut ValRaw) -> Self::Abi {
-        unreachable!("NoFunc is uninhabited")
+    fn store(self, _store: &mut AutoAssertNoGc<'_>, _ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
+        match self._inner {}
     }
 
     #[inline]
-    unsafe fn abi_into_raw(_abi: Self::Abi, _raw: *mut ValRaw) {
-        unreachable!("NoFunc is uninhabited")
-    }
-
-    #[inline]
-    fn into_abi(self, _store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi> {
-        unreachable!("NoFunc is uninhabited")
-    }
-
-    #[inline]
-    unsafe fn from_abi(_abi: Self::Abi, _store: &mut AutoAssertNoGc<'_>) -> Self {
+    unsafe fn load(_store: &mut AutoAssertNoGc<'_>, _ptr: &ValRaw) -> Self {
         unreachable!("NoFunc is uninhabited")
     }
 }
 
 unsafe impl WasmTy for Option<NoFunc> {
-    type Abi = *mut NoFunc;
-
     #[inline]
     fn valtype() -> ValType {
         ValType::Ref(RefType::new(true, HeapType::NoFunc))
@@ -545,29 +516,18 @@ unsafe impl WasmTy for Option<NoFunc> {
     }
 
     #[inline]
-    unsafe fn abi_from_raw(_raw: *mut ValRaw) -> Self::Abi {
-        ptr::null_mut()
+    fn store(self, _store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
+        ptr.write(ValRaw::funcref(ptr::null_mut()));
+        Ok(())
     }
 
     #[inline]
-    unsafe fn abi_into_raw(_abi: Self::Abi, raw: *mut ValRaw) {
-        *raw = ValRaw::funcref(ptr::null_mut());
-    }
-
-    #[inline]
-    fn into_abi(self, _store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi> {
-        Ok(ptr::null_mut())
-    }
-
-    #[inline]
-    unsafe fn from_abi(_abi: Self::Abi, _store: &mut AutoAssertNoGc<'_>) -> Self {
+    unsafe fn load(_store: &mut AutoAssertNoGc<'_>, _ptr: &ValRaw) -> Self {
         None
     }
 }
 
 unsafe impl WasmTy for Func {
-    type Abi = NonNull<crate::runtime::vm::VMFuncRef>;
-
     #[inline]
     fn valtype() -> ValType {
         ValType::Ref(RefType::new(false, HeapType::Func))
@@ -591,31 +551,21 @@ unsafe impl WasmTy for Func {
     }
 
     #[inline]
-    unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi {
-        let p = (*raw).get_funcref();
+    fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
+        let abi = self.vm_func_ref(store);
+        ptr.write(ValRaw::funcref(abi.cast::<c_void>().as_ptr()));
+        Ok(())
+    }
+
+    #[inline]
+    unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
+        let p = ptr.get_funcref();
         debug_assert!(!p.is_null());
-        NonNull::new_unchecked(p.cast::<crate::runtime::vm::VMFuncRef>())
-    }
-
-    #[inline]
-    unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw) {
-        *raw = ValRaw::funcref(abi.cast::<c_void>().as_ptr());
-    }
-
-    #[inline]
-    fn into_abi(self, store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi> {
-        Ok(self.vm_func_ref(store))
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, store: &mut AutoAssertNoGc<'_>) -> Self {
-        Func::from_vm_func_ref(store, abi.as_ptr()).unwrap()
+        Func::from_vm_func_ref(store, p.cast()).unwrap()
     }
 }
 
 unsafe impl WasmTy for Option<Func> {
-    type Abi = *mut crate::runtime::vm::VMFuncRef;
-
     #[inline]
     fn valtype() -> ValType {
         ValType::FUNCREF
@@ -648,27 +598,19 @@ unsafe impl WasmTy for Option<Func> {
     }
 
     #[inline]
-    unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi {
-        (*raw).get_funcref() as Self::Abi
-    }
-
-    #[inline]
-    unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw) {
-        *raw = ValRaw::funcref(abi.cast());
-    }
-
-    #[inline]
-    fn into_abi(self, store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi> {
-        Ok(if let Some(f) = self {
+    fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
+        let raw = if let Some(f) = self {
             f.vm_func_ref(store).as_ptr()
         } else {
             ptr::null_mut()
-        })
+        };
+        ptr.write(ValRaw::funcref(raw.cast::<c_void>()));
+        Ok(())
     }
 
     #[inline]
-    unsafe fn from_abi(abi: Self::Abi, store: &mut AutoAssertNoGc<'_>) -> Self {
-        Func::from_vm_func_ref(store, abi)
+    unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
+        Func::from_vm_func_ref(store, ptr.get_funcref().cast())
     }
 }
 
@@ -679,7 +621,7 @@ unsafe impl WasmTy for Option<Func> {
 /// tuples of those types.
 pub unsafe trait WasmParams: Send {
     #[doc(hidden)]
-    type Abi: Copy;
+    type ValRawStorage: Copy;
 
     #[doc(hidden)]
     fn typecheck(
@@ -692,15 +634,12 @@ pub unsafe trait WasmParams: Send {
     fn vmgcref_pointing_to_object_count(&self) -> usize;
 
     #[doc(hidden)]
-    fn into_abi(self, store: &mut AutoAssertNoGc<'_>, func_ty: &FuncType) -> Result<Self::Abi>;
-
-    #[doc(hidden)]
-    unsafe fn invoke<R: WasmResults>(
-        func: NonNull<VMNativeCallFunction>,
-        vmctx1: *mut VMOpaqueContext,
-        vmctx2: *mut VMContext,
-        abi: Self::Abi,
-    ) -> R::ResultAbi;
+    fn store(
+        self,
+        store: &mut AutoAssertNoGc<'_>,
+        func_ty: &FuncType,
+        dst: &mut MaybeUninit<Self::ValRawStorage>,
+    ) -> Result<()>;
 }
 
 // Forward an impl from `T` to `(T,)` for convenience if there's only one
@@ -709,7 +648,7 @@ unsafe impl<T> WasmParams for T
 where
     T: WasmTy,
 {
-    type Abi = <(T,) as WasmParams>::Abi;
+    type ValRawStorage = <(T,) as WasmParams>::ValRawStorage;
 
     fn typecheck(
         engine: &Engine,
@@ -725,17 +664,13 @@ where
     }
 
     #[inline]
-    fn into_abi(self, store: &mut AutoAssertNoGc<'_>, func_ty: &FuncType) -> Result<Self::Abi> {
-        <(T,) as WasmParams>::into_abi((self,), store, func_ty)
-    }
-
-    unsafe fn invoke<R: WasmResults>(
-        func: NonNull<VMNativeCallFunction>,
-        vmctx1: *mut VMOpaqueContext,
-        vmctx2: *mut VMContext,
-        abi: Self::Abi,
-    ) -> R::ResultAbi {
-        <(T,) as WasmParams>::invoke::<R>(func, vmctx1, vmctx2, abi)
+    fn store(
+        self,
+        store: &mut AutoAssertNoGc<'_>,
+        func_ty: &FuncType,
+        dst: &mut MaybeUninit<Self::ValRawStorage>,
+    ) -> Result<()> {
+        <(T,) as WasmParams>::store((self,), store, func_ty, dst)
     }
 }
 
@@ -743,7 +678,7 @@ macro_rules! impl_wasm_params {
     ($n:tt $($t:ident)*) => {
         #[allow(non_snake_case)]
         unsafe impl<$($t: WasmTy,)*> WasmParams for ($($t,)*) {
-            type Abi = ($($t::Abi,)*);
+            type ValRawStorage = [ValRaw; $n];
 
             fn typecheck(
                 _engine: &Engine,
@@ -781,11 +716,12 @@ macro_rules! impl_wasm_params {
 
 
             #[inline]
-            fn into_abi(
+            fn store(
                 self,
                 _store: &mut AutoAssertNoGc<'_>,
                 _func_ty: &FuncType,
-            ) -> Result<Self::Abi> {
+                _ptr: &mut MaybeUninit<Self::ValRawStorage>,
+            ) -> Result<()> {
                 let ($($t,)*) = self;
 
                 let mut _i = 0;
@@ -803,39 +739,12 @@ macro_rules! impl_wasm_params {
                         }
                     }
 
-                    let $t = $t.into_abi(_store)?;
+                    let dst = map_maybe_uninit!(_ptr[_i]);
+                    $t.store(_store, dst)?;
 
                     _i += 1;
                 )*
-                Ok(($($t,)*))
-            }
-
-            unsafe fn invoke<R: WasmResults>(
-                func: NonNull<VMNativeCallFunction>,
-                vmctx1: *mut VMOpaqueContext,
-                vmctx2: *mut VMContext,
-                abi: Self::Abi,
-            ) -> R::ResultAbi {
-                let fnptr = mem::transmute::<
-                    NonNull<VMNativeCallFunction>,
-                    unsafe extern "C" fn(
-                        *mut VMOpaqueContext,
-                        *mut VMContext,
-                        $($t::Abi,)*
-                        <R::ResultAbi as HostAbi>::Retptr,
-                    ) -> <R::ResultAbi as HostAbi>::Abi,
-                    >(func);
-                let ($($t,)*) = abi;
-                // Use the `call` function to acquire a `retptr` which we'll
-                // forward to the native function. Once we have it we also
-                // convert all our arguments to abi arguments to go to the raw
-                // function.
-                //
-                // Upon returning `R::call` will convert all the returns back
-                // into `R`.
-                <R::ResultAbi as HostAbi>::call(|retptr| {
-                    fnptr(vmctx1, vmctx2, $($t,)* retptr)
-                })
+                Ok(())
             }
         }
     };
@@ -847,36 +756,23 @@ for_each_function_signature!(impl_wasm_params);
 /// results for wasm functions.
 pub unsafe trait WasmResults: WasmParams {
     #[doc(hidden)]
-    type ResultAbi: HostAbi;
-
-    #[doc(hidden)]
-    unsafe fn from_abi(store: &mut AutoAssertNoGc<'_>, abi: Self::ResultAbi) -> Self;
+    unsafe fn load(store: &mut AutoAssertNoGc<'_>, abi: &Self::ValRawStorage) -> Self;
 }
 
 // Forwards from a bare type `T` to the 1-tuple type `(T,)`
-unsafe impl<T: WasmTy> WasmResults for T
-where
-    (T::Abi,): HostAbi,
-{
-    type ResultAbi = <(T,) as WasmResults>::ResultAbi;
-
-    unsafe fn from_abi(store: &mut AutoAssertNoGc<'_>, abi: Self::ResultAbi) -> Self {
-        <(T,) as WasmResults>::from_abi(store, abi).0
+unsafe impl<T: WasmTy> WasmResults for T {
+    unsafe fn load(store: &mut AutoAssertNoGc<'_>, abi: &Self::ValRawStorage) -> Self {
+        <(T,) as WasmResults>::load(store, abi).0
     }
 }
 
 macro_rules! impl_wasm_results {
     ($n:tt $($t:ident)*) => {
         #[allow(non_snake_case, unused_variables)]
-        unsafe impl<$($t: WasmTy,)*> WasmResults for ($($t,)*)
-            where ($($t::Abi,)*): HostAbi
-        {
-            type ResultAbi = ($($t::Abi,)*);
-
-            #[inline]
-            unsafe fn from_abi(store: &mut AutoAssertNoGc<'_>, abi: Self::ResultAbi) -> Self {
-                let ($($t,)*) = abi;
-                ($($t::from_abi($t, store),)*)
+        unsafe impl<$($t: WasmTy,)*> WasmResults for ($($t,)*) {
+            unsafe fn load(store: &mut AutoAssertNoGc<'_>, abi: &Self::ValRawStorage) -> Self {
+                let [$($t,)*] = abi;
+                ($($t::load(store, $t),)*)
             }
         }
     };

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -193,7 +193,6 @@ where
         union Storage<T: Copy, U: Copy> {
             params: MaybeUninit<T>,
             results: U,
-            raw: [ValRaw; 0],
         }
 
         let mut storage = Storage::<Params::ValRawStorage, Results::ValRawStorage> {
@@ -218,8 +217,8 @@ where
             (func_ref.array_call)(
                 func_ref.vmctx,
                 VMOpaqueContext::from_vmcontext(caller),
-                storage.raw.as_mut_ptr(),
-                mem::size_of_val::<Storage<_, _>>(&storage) / mem::size_of::<ValRaw>(),
+                (storage as *mut Storage<_, _>) as *mut ValRaw,
+                mem::size_of_val::<Storage<_, _>>(storage) / mem::size_of::<ValRaw>(),
             );
         });
 

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::runtime::vm::{
     CompiledModuleId, MemoryImage, MmapVec, ModuleMemoryImages, VMArrayCallFunction,
-    VMNativeCallFunction, VMWasmCallFunction,
+    VMWasmCallFunction,
 };
 use crate::sync::OnceLock;
 use crate::{
@@ -1095,25 +1095,12 @@ impl crate::runtime::vm::ModuleRuntimeInfo for ModuleInner {
         NonNull::new(ptr).unwrap()
     }
 
-    fn native_to_wasm_trampoline(
-        &self,
-        index: DefinedFuncIndex,
-    ) -> Option<NonNull<VMNativeCallFunction>> {
-        let ptr = self
-            .module
-            .native_to_wasm_trampoline(index)?
-            .as_ptr()
-            .cast::<VMNativeCallFunction>()
-            .cast_mut();
-        Some(NonNull::new(ptr).unwrap())
-    }
-
     fn array_to_wasm_trampoline(&self, index: DefinedFuncIndex) -> Option<VMArrayCallFunction> {
         let ptr = self.module.array_to_wasm_trampoline(index)?.as_ptr();
         Some(unsafe { mem::transmute::<*const u8, VMArrayCallFunction>(ptr) })
     }
 
-    fn wasm_to_native_trampoline(
+    fn wasm_to_array_trampoline(
         &self,
         signature: VMSharedTypeIndex,
     ) -> Option<NonNull<VMWasmCallFunction>> {
@@ -1138,7 +1125,7 @@ impl crate::runtime::vm::ModuleRuntimeInfo for ModuleInner {
 
         let ptr = self
             .module
-            .wasm_to_native_trampoline(trampoline_module_ty)
+            .wasm_to_array_trampoline(trampoline_module_ty)
             .as_ptr()
             .cast::<VMWasmCallFunction>()
             .cast_mut();
@@ -1244,14 +1231,7 @@ impl crate::runtime::vm::ModuleRuntimeInfo for BareModuleInfo {
         unreachable!()
     }
 
-    fn native_to_wasm_trampoline(
-        &self,
-        _index: DefinedFuncIndex,
-    ) -> Option<NonNull<VMNativeCallFunction>> {
-        unreachable!()
-    }
-
-    fn wasm_to_native_trampoline(
+    fn wasm_to_array_trampoline(
         &self,
         _signature: VMSharedTypeIndex,
     ) -> Option<NonNull<VMWasmCallFunction>> {

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -177,7 +177,7 @@ impl ModuleRegistry {
         Some((info, module))
     }
 
-    pub fn wasm_to_native_trampoline(
+    pub fn wasm_to_array_trampoline(
         &self,
         sig: VMSharedTypeIndex,
     ) -> Option<NonNull<VMWasmCallFunction>> {
@@ -190,7 +190,7 @@ impl ModuleRegistry {
         // See also the comment in `ModuleInner::wasm_to_native_trampoline`.
         for (_, code) in self.loaded_code.values() {
             for module in code.modules.values() {
-                if let Some(trampoline) = module.runtime_info().wasm_to_native_trampoline(sig) {
+                if let Some(trampoline) = module.runtime_info().wasm_to_array_trampoline(sig) {
                     return Some(trampoline);
                 }
             }

--- a/crates/wasmtime/src/runtime/store/func_refs.rs
+++ b/crates/wasmtime/src/runtime/store/func_refs.rs
@@ -3,7 +3,7 @@
 
 use crate::module::ModuleRegistry;
 use crate::prelude::*;
-use crate::runtime::vm::{SendSyncPtr, VMFuncRef, VMNativeCallHostFuncContext};
+use crate::runtime::vm::{SendSyncPtr, VMArrayCallHostFuncContext, VMFuncRef};
 use alloc::sync::Arc;
 use core::ptr::NonNull;
 
@@ -55,9 +55,9 @@ impl FuncRefs {
     /// `FuncRefs` and only while the store holding this `FuncRefs` exists.
     pub unsafe fn push(&mut self, func_ref: VMFuncRef) -> NonNull<VMFuncRef> {
         debug_assert!(func_ref.wasm_call.is_none());
-        // Debug assert that the vmctx is a `VMNativeCallHostFuncContext` as
+        // Debug assert that the vmctx is a `VMArrayCallHostFuncContext` as
         // that is the only kind that can have holes.
-        let _ = unsafe { VMNativeCallHostFuncContext::from_opaque(func_ref.vmctx) };
+        let _ = unsafe { VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx) };
 
         let func_ref = self.bump.alloc(func_ref);
         let unpatched = SendSyncPtr::from(func_ref);
@@ -73,11 +73,11 @@ impl FuncRefs {
                 let func_ref = f.as_mut();
                 debug_assert!(func_ref.wasm_call.is_none());
 
-                // Debug assert that the vmctx is a `VMNativeCallHostFuncContext` as
+                // Debug assert that the vmctx is a `VMArrayCallHostFuncContext` as
                 // that is the only kind that can have holes.
-                let _ = VMNativeCallHostFuncContext::from_opaque(func_ref.vmctx);
+                let _ = VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx);
 
-                func_ref.wasm_call = modules.wasm_to_native_trampoline(func_ref.type_index);
+                func_ref.wasm_call = modules.wasm_to_array_trampoline(func_ref.type_index);
                 func_ref.wasm_call.is_none()
             }
         });

--- a/crates/wasmtime/src/runtime/v128.rs
+++ b/crates/wasmtime/src/runtime/v128.rs
@@ -8,6 +8,7 @@ use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{Result, ValRaw, ValType, WasmTy};
 use core::cmp::Ordering;
 use core::fmt;
+use core::mem::MaybeUninit;
 
 /// Representation of a 128-bit vector type, `v128`, for WebAssembly.
 ///
@@ -83,8 +84,6 @@ impl Ord for V128 {
 // the documentation above in the `cfg_if!` for why this is conditional.
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 unsafe impl WasmTy for V128 {
-    type Abi = V128Abi;
-
     #[inline]
     fn valtype() -> ValType {
         ValType::V128
@@ -105,22 +104,13 @@ unsafe impl WasmTy for V128 {
     }
 
     #[inline]
-    unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi {
-        V128::from((*raw).get_v128()).0
+    fn store(self, _store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
+        ptr.write(ValRaw::v128(self.as_u128()));
+        Ok(())
     }
 
     #[inline]
-    unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw) {
-        *raw = ValRaw::v128(V128(abi).as_u128());
-    }
-
-    #[inline]
-    fn into_abi(self, _store: &mut AutoAssertNoGc<'_>) -> Result<Self::Abi> {
-        Ok(self.0)
-    }
-
-    #[inline]
-    unsafe fn from_abi(abi: Self::Abi, _store: &mut AutoAssertNoGc<'_>) -> Self {
-        V128(abi)
+    unsafe fn load(_store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
+        V128::from(ptr.get_v128())
     }
 }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -69,8 +69,7 @@ pub use crate::runtime::vm::traphandlers::*;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
-    VMNativeCallFunction, VMNativeCallHostFuncContext, VMOpaqueContext, VMRuntimeLimits,
-    VMTableImport, VMWasmCallFunction, ValRaw,
+    VMOpaqueContext, VMRuntimeLimits, VMTableImport, VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
 
@@ -195,16 +194,6 @@ pub trait ModuleRuntimeInfo: Send + Sync + 'static {
     fn function(&self, index: DefinedFuncIndex) -> NonNull<VMWasmCallFunction>;
 
     /// Returns the address, in memory, of the trampoline that allows the given
-    /// defined Wasm function to be called by the native calling convention.
-    ///
-    /// Returns `None` for Wasm functions which do not escape, and therefore are
-    /// not callable from outside the Wasm module itself.
-    fn native_to_wasm_trampoline(
-        &self,
-        index: DefinedFuncIndex,
-    ) -> Option<NonNull<VMNativeCallFunction>>;
-
-    /// Returns the address, in memory, of the trampoline that allows the given
     /// defined Wasm function to be called by the array calling convention.
     ///
     /// Returns `None` for Wasm functions which do not escape, and therefore are
@@ -212,8 +201,8 @@ pub trait ModuleRuntimeInfo: Send + Sync + 'static {
     fn array_to_wasm_trampoline(&self, index: DefinedFuncIndex) -> Option<VMArrayCallFunction>;
 
     /// Return the address, in memory, of the trampoline that allows Wasm to
-    /// call a native function of the given signature.
-    fn wasm_to_native_trampoline(
+    /// call a array function of the given signature.
+    fn wasm_to_array_trampoline(
         &self,
         signature: VMSharedTypeIndex,
     ) -> Option<NonNull<VMWasmCallFunction>>;

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -8,7 +8,7 @@
 
 use crate::runtime::vm::{
     SendSyncPtr, Store, VMArrayCallFunction, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition,
-    VMNativeCallFunction, VMOpaqueContext, VMWasmCallFunction, ValRaw,
+    VMOpaqueContext, VMWasmCallFunction, ValRaw,
 };
 use alloc::alloc::Layout;
 use alloc::sync::Arc;
@@ -389,7 +389,6 @@ impl ComponentInstance {
         &mut self,
         idx: TrampolineIndex,
         wasm_call: NonNull<VMWasmCallFunction>,
-        native_call: NonNull<VMNativeCallFunction>,
         array_call: VMArrayCallFunction,
         type_index: VMSharedTypeIndex,
     ) {
@@ -399,7 +398,6 @@ impl ComponentInstance {
             let vmctx = VMOpaqueContext::from_vmcomponent(self.vmctx());
             *self.vmctx_plus_offset_mut(offset) = VMFuncRef {
                 wasm_call: Some(wasm_call),
-                native_call,
                 array_call,
                 type_index,
                 vmctx,
@@ -731,13 +729,12 @@ impl OwnedComponentInstance {
         &mut self,
         idx: TrampolineIndex,
         wasm_call: NonNull<VMWasmCallFunction>,
-        native_call: NonNull<VMNativeCallFunction>,
         array_call: VMArrayCallFunction,
         type_index: VMSharedTypeIndex,
     ) {
         unsafe {
             self.instance_mut()
-                .set_trampoline(idx, wasm_call, native_call, array_call, type_index)
+                .set_trampoline(idx, wasm_call, array_call, type_index)
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -719,10 +719,6 @@ impl Instance {
 
         let func_ref = if let Some(def_index) = self.module().defined_func_index(index) {
             VMFuncRef {
-                native_call: self
-                    .runtime_info
-                    .native_to_wasm_trampoline(def_index)
-                    .expect("should have native-to-Wasm trampoline for escaping function"),
                 array_call: self
                     .runtime_info
                     .array_to_wasm_trampoline(def_index)
@@ -734,7 +730,6 @@ impl Instance {
         } else {
             let import = self.imported_function(index);
             VMFuncRef {
-                native_call: import.native_call,
                 array_call: import.array_call,
                 wasm_call: Some(import.wasm_call),
                 vmctx: import.vmctx,

--- a/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
@@ -6,7 +6,7 @@ use super::VMOpaqueContext;
 use crate::prelude::*;
 use crate::runtime::vm::{StoreBox, VMFuncRef};
 use core::any::Any;
-use wasmtime_environ::{VM_ARRAY_CALL_HOST_FUNC_MAGIC, VM_NATIVE_CALL_HOST_FUNC_MAGIC};
+use wasmtime_environ::VM_ARRAY_CALL_HOST_FUNC_MAGIC;
 
 /// The `VM*Context` for array-call host functions.
 ///
@@ -68,71 +68,12 @@ impl VMArrayCallHostFuncContext {
     }
 }
 
-/// The `VM*Context` for native-call host functions.
-///
-/// Its `magic` field must always be
-/// `wasmtime_environ::VM_NATIVE_CALL_HOST_FUNC_MAGIC`, and this is how you can
-/// determine whether a `VM*Context` is a `VMNativeCallHostFuncContext` versus a
-/// different kind of context.
-#[repr(C)]
-pub struct VMNativeCallHostFuncContext {
-    magic: u32,
-    // _padding: u32, // (on 64-bit systems)
-    func_ref: VMFuncRef,
-    host_state: Box<dyn Any + Send + Sync>,
-}
-
 #[test]
-fn vmnative_call_host_func_context_offsets() {
+fn vmarray_call_host_func_context_offsets() {
     use memoffset::offset_of;
     use wasmtime_environ::{HostPtr, PtrSize};
     assert_eq!(
-        usize::from(HostPtr.vmnative_call_host_func_context_func_ref()),
-        offset_of!(VMNativeCallHostFuncContext, func_ref)
+        usize::from(HostPtr.vmarray_call_host_func_context_func_ref()),
+        offset_of!(VMArrayCallHostFuncContext, func_ref)
     );
-}
-
-impl VMNativeCallHostFuncContext {
-    /// Create the context for the given host function.
-    ///
-    /// # Safety
-    ///
-    /// The `host_func` must be a pointer to a host (not Wasm) function and it
-    /// must be `Send` and `Sync`.
-    pub unsafe fn new(
-        func_ref: VMFuncRef,
-        host_state: Box<dyn Any + Send + Sync>,
-    ) -> StoreBox<VMNativeCallHostFuncContext> {
-        let ctx = StoreBox::new(VMNativeCallHostFuncContext {
-            magic: wasmtime_environ::VM_NATIVE_CALL_HOST_FUNC_MAGIC,
-            func_ref,
-            host_state,
-        });
-        let vmctx = VMOpaqueContext::from_vm_native_call_host_func_context(ctx.get());
-        unsafe {
-            (*ctx.get()).func_ref.vmctx = vmctx;
-        }
-        ctx
-    }
-
-    /// Get the host state for this host function context.
-    #[inline]
-    pub fn host_state(&self) -> &(dyn Any + Send + Sync) {
-        &*self.host_state
-    }
-
-    /// Get this context's `VMFuncRef`.
-    #[inline]
-    pub fn func_ref(&self) -> &VMFuncRef {
-        &self.func_ref
-    }
-
-    /// Helper function to cast between context types using a debug assertion to
-    /// protect against some mistakes.
-    #[inline]
-    pub unsafe fn from_opaque(opaque: *mut VMOpaqueContext) -> *mut VMNativeCallHostFuncContext {
-        // See comments in `VMContext::from_opaque` for this debug assert
-        debug_assert_eq!((*opaque).magic, VM_NATIVE_CALL_HOST_FUNC_MAGIC);
-        opaque.cast()
-    }
 }

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -144,22 +144,12 @@ impl wasmtime_environ::Compiler for Compiler {
             .compile_array_to_wasm_trampoline(translation, types, index)
     }
 
-    fn compile_native_to_wasm_trampoline(
-        &self,
-        translation: &ModuleTranslation<'_>,
-        types: &ModuleTypesBuilder,
-        index: DefinedFuncIndex,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
-        self.trampolines
-            .compile_native_to_wasm_trampoline(translation, types, index)
-    }
-
-    fn compile_wasm_to_native_trampoline(
+    fn compile_wasm_to_array_trampoline(
         &self,
         wasm_func_ty: &wasmtime_environ::WasmFuncType,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
         self.trampolines
-            .compile_wasm_to_native_trampoline(wasm_func_ty)
+            .compile_wasm_to_array_trampoline(wasm_func_ty)
     }
 
     fn append_code(
@@ -195,18 +185,6 @@ impl wasmtime_environ::Compiler for Compiler {
         }
         traps.append_to(obj);
         Ok(ret)
-    }
-
-    fn emit_trampolines_for_array_call_host_func(
-        &self,
-        ty: &wasmtime_environ::WasmFuncType,
-        // Actually `host_fn: VMArrayCallFunction` but that type is not
-        // available in `wasmtime-environ`.
-        host_fn: usize,
-        obj: &mut Object<'static>,
-    ) -> Result<(FunctionLoc, FunctionLoc)> {
-        drop((ty, host_fn, obj));
-        todo!()
     }
 
     fn triple(&self) -> &target_lexicon::Triple {

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -61,7 +61,7 @@
 ;; @002b                               jump block5(v17)
 ;;
 ;;                                 block5(v14: i64):
-;; @002b                               v21 = load.i32 icall_null aligned readonly v14+24
+;; @002b                               v21 = load.i32 icall_null aligned readonly v14+16
 ;; @002b                               v22 = icmp eq v21, v20
 ;; @002b                               brif v22, block7, block6
 ;;
@@ -69,8 +69,8 @@
 ;; @002b                               trap bad_sig
 ;;
 ;;                                 block7:
-;; @002b                               v23 = load.i64 notrap aligned readonly v14+16
-;; @002b                               v24 = load.i64 notrap aligned readonly v14+32
+;; @002b                               v23 = load.i64 notrap aligned readonly v14+8
+;; @002b                               v24 = load.i64 notrap aligned readonly v14+24
 ;; @002b                               v25 = call_indirect sig0, v23(v24, v0)
 ;; @002e                               jump block2
 ;; }
@@ -111,7 +111,7 @@
 ;; @0038                               jump block5(v16)
 ;;
 ;;                                 block5(v13: i64):
-;; @0038                               v20 = load.i32 icall_null aligned readonly v13+24
+;; @0038                               v20 = load.i32 icall_null aligned readonly v13+16
 ;; @0038                               v21 = icmp eq v20, v19
 ;; @0038                               brif v21, block7, block6
 ;;
@@ -119,8 +119,8 @@
 ;; @0038                               trap bad_sig
 ;;
 ;;                                 block7:
-;; @0038                               v22 = load.i64 notrap aligned readonly v13+16
-;; @0038                               v23 = load.i64 notrap aligned readonly v13+32
+;; @0038                               v22 = load.i64 notrap aligned readonly v13+8
+;; @0038                               v23 = load.i64 notrap aligned readonly v13+24
 ;; @0038                               v24 = call_indirect sig0, v22(v23, v0)
 ;; @003b                               jump block2
 ;; }

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -42,11 +42,11 @@
 ;; @0033                               v19 = global_value.i64 gv3
 ;; @0033                               v20 = load.i64 notrap aligned readonly v19+80
 ;; @0033                               v21 = load.i32 notrap aligned readonly v20
-;; @0033                               v22 = load.i32 icall_null aligned readonly v15+24
+;; @0033                               v22 = load.i32 icall_null aligned readonly v15+16
 ;; @0033                               v23 = icmp eq v22, v21
 ;; @0033                               trapz v23, bad_sig
-;; @0033                               v24 = load.i64 notrap aligned readonly v15+16
-;; @0033                               v25 = load.i64 notrap aligned readonly v15+32
+;; @0033                               v24 = load.i64 notrap aligned readonly v15+8
+;; @0033                               v25 = load.i64 notrap aligned readonly v15+24
 ;; @0033                               v26 = call_indirect sig0, v24(v25, v0, v3)
 ;; @0036                               jump block1(v26)
 ;;

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -42,11 +42,11 @@
 ;; @0033                               v19 = global_value.i64 gv3
 ;; @0033                               v20 = load.i64 notrap aligned readonly v19+80
 ;; @0033                               v21 = load.i32 notrap aligned readonly v20
-;; @0033                               v22 = load.i32 icall_null aligned readonly v15+24
+;; @0033                               v22 = load.i32 icall_null aligned readonly v15+16
 ;; @0033                               v23 = icmp eq v22, v21
 ;; @0033                               trapz v23, bad_sig
-;; @0033                               v24 = load.i64 notrap aligned readonly v15+16
-;; @0033                               v25 = load.i64 notrap aligned readonly v15+32
+;; @0033                               v24 = load.i64 notrap aligned readonly v15+8
+;; @0033                               v25 = load.i64 notrap aligned readonly v15+24
 ;; @0033                               v26 = call_indirect sig0, v24(v25, v0, v3)
 ;; @0036                               jump block1(v26)
 ;;

--- a/tests/disas/indirect-call-caching-exclude-0-index.wat
+++ b/tests/disas/indirect-call-caching-exclude-0-index.wat
@@ -94,11 +94,11 @@
 ;; @0050                               v18 = global_value.i64 gv3
 ;; @0050                               v19 = load.i64 notrap aligned readonly v18+80
 ;; @0050                               v20 = load.i32 notrap aligned readonly v19
-;; @0050                               v21 = load.i32 icall_null aligned readonly v14+24
+;; @0050                               v21 = load.i32 icall_null aligned readonly v14+16
 ;; @0050                               v22 = icmp eq v21, v20
 ;; @0050                               trapz v22, bad_sig
-;; @0050                               v23 = load.i64 notrap aligned readonly v14+16
-;; @0050                               v24 = load.i64 notrap aligned readonly v14+32
+;; @0050                               v23 = load.i64 notrap aligned readonly v14+8
+;; @0050                               v24 = load.i64 notrap aligned readonly v14+24
 ;; @0050                               v25 = call_indirect sig0, v23(v24, v0)
 ;; @0053                               jump block1(v25)
 ;;

--- a/tests/disas/indirect-call-caching-exclude-table-export.wat
+++ b/tests/disas/indirect-call-caching-exclude-table-export.wat
@@ -93,11 +93,11 @@
 ;; @0054                               v18 = global_value.i64 gv3
 ;; @0054                               v19 = load.i64 notrap aligned readonly v18+80
 ;; @0054                               v20 = load.i32 notrap aligned readonly v19
-;; @0054                               v21 = load.i32 icall_null aligned readonly v14+24
+;; @0054                               v21 = load.i32 icall_null aligned readonly v14+16
 ;; @0054                               v22 = icmp eq v21, v20
 ;; @0054                               trapz v22, bad_sig
-;; @0054                               v23 = load.i64 notrap aligned readonly v14+16
-;; @0054                               v24 = load.i64 notrap aligned readonly v14+32
+;; @0054                               v23 = load.i64 notrap aligned readonly v14+8
+;; @0054                               v24 = load.i64 notrap aligned readonly v14+24
 ;; @0054                               v25 = call_indirect sig0, v23(v24, v0)
 ;; @0057                               jump block1(v25)
 ;;

--- a/tests/disas/indirect-call-caching-exclude-table-writes.wat
+++ b/tests/disas/indirect-call-caching-exclude-table-writes.wat
@@ -98,11 +98,11 @@
 ;; @0063                               v18 = global_value.i64 gv3
 ;; @0063                               v19 = load.i64 notrap aligned readonly v18+80
 ;; @0063                               v20 = load.i32 notrap aligned readonly v19
-;; @0063                               v21 = load.i32 icall_null aligned readonly v14+24
+;; @0063                               v21 = load.i32 icall_null aligned readonly v14+16
 ;; @0063                               v22 = icmp eq v21, v20
 ;; @0063                               trapz v22, bad_sig
-;; @0063                               v23 = load.i64 notrap aligned readonly v14+16
-;; @0063                               v24 = load.i64 notrap aligned readonly v14+32
+;; @0063                               v23 = load.i64 notrap aligned readonly v14+8
+;; @0063                               v24 = load.i64 notrap aligned readonly v14+24
 ;; @0063                               v25 = call_indirect sig0, v23(v24, v0)
 ;; @0066                               jump block1(v25)
 ;;

--- a/tests/disas/indirect-call-caching-slot-limit-1.wat
+++ b/tests/disas/indirect-call-caching-slot-limit-1.wat
@@ -33,7 +33,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               v4 = global_value.i64 gv3
-;; @0033                               v5 = iadd_imm v4, 152
+;; @0033                               v5 = iadd_imm v4, 144
 ;; @0033                               v6 = load.i32 notrap aligned v5+8
 ;; @0033                               v7 = load.i64 notrap aligned v5
 ;; @0033                               v8 = icmp eq v6, v2
@@ -60,7 +60,7 @@
 ;;                                 block3(v31: i64, v32: i64):
 ;; @0033                               v33 = call_indirect sig0, v31(v32, v0)
 ;; @0036                               v34 = global_value.i64 gv3
-;; @0036                               v35 = iadd_imm v34, 168
+;; @0036                               v35 = iadd_imm v34, 160
 ;; @0036                               v36 = load.i32 notrap aligned v35+8
 ;; @0036                               v37 = load.i64 notrap aligned v35
 ;; @0036                               v38 = icmp eq v36, v33
@@ -108,11 +108,11 @@
 ;; @0033                               v23 = global_value.i64 gv3
 ;; @0033                               v24 = load.i64 notrap aligned readonly v23+80
 ;; @0033                               v25 = load.i32 notrap aligned readonly v24+4
-;; @0033                               v26 = load.i32 icall_null aligned readonly v19+24
+;; @0033                               v26 = load.i32 icall_null aligned readonly v19+16
 ;; @0033                               v27 = icmp eq v26, v25
 ;; @0033                               trapz v27, bad_sig
-;; @0033                               v28 = load.i64 notrap aligned readonly v19+16
-;; @0033                               v29 = load.i64 notrap aligned readonly v19+32
+;; @0033                               v28 = load.i64 notrap aligned readonly v19+8
+;; @0033                               v29 = load.i64 notrap aligned readonly v19+24
 ;; @0033                               v30 = icmp eq v29, v4
 ;; @0033                               brif v30, block4, block3(v28, v29)
 ;;
@@ -126,11 +126,11 @@
 ;; @0036                               v53 = global_value.i64 gv3
 ;; @0036                               v54 = load.i64 notrap aligned readonly v53+80
 ;; @0036                               v55 = load.i32 notrap aligned readonly v54+4
-;; @0036                               v56 = load.i32 icall_null aligned readonly v49+24
+;; @0036                               v56 = load.i32 icall_null aligned readonly v49+16
 ;; @0036                               v57 = icmp eq v56, v55
 ;; @0036                               trapz v57, bad_sig
-;; @0036                               v58 = load.i64 notrap aligned readonly v49+16
-;; @0036                               v59 = load.i64 notrap aligned readonly v49+32
+;; @0036                               v58 = load.i64 notrap aligned readonly v49+8
+;; @0036                               v59 = load.i64 notrap aligned readonly v49+24
 ;; @0036                               v60 = icmp eq v59, v34
 ;; @0036                               brif v60, block9, block8(v58, v59)
 ;;
@@ -144,11 +144,11 @@
 ;; @0039                               v78 = global_value.i64 gv3
 ;; @0039                               v79 = load.i64 notrap aligned readonly v78+80
 ;; @0039                               v80 = load.i32 notrap aligned readonly v79+4
-;; @0039                               v81 = load.i32 icall_null aligned readonly v74+24
+;; @0039                               v81 = load.i32 icall_null aligned readonly v74+16
 ;; @0039                               v82 = icmp eq v81, v80
 ;; @0039                               trapz v82, bad_sig
-;; @0039                               v83 = load.i64 notrap aligned readonly v74+16
-;; @0039                               v84 = load.i64 notrap aligned readonly v74+32
+;; @0039                               v83 = load.i64 notrap aligned readonly v74+8
+;; @0039                               v84 = load.i64 notrap aligned readonly v74+24
 ;; @0039                               v85 = call_indirect sig0, v83(v84, v0)
 ;; @003c                               jump block1(v85)
 ;;

--- a/tests/disas/indirect-call-caching-slot-limit-2.wat
+++ b/tests/disas/indirect-call-caching-slot-limit-2.wat
@@ -38,7 +38,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0040                               v4 = global_value.i64 gv3
-;; @0040                               v5 = iadd_imm v4, 192
+;; @0040                               v5 = iadd_imm v4, 176
 ;; @0040                               v6 = load.i32 notrap aligned v5+8
 ;; @0040                               v7 = load.i64 notrap aligned v5
 ;; @0040                               v8 = icmp eq v6, v2
@@ -65,7 +65,7 @@
 ;;                                 block3(v31: i64, v32: i64):
 ;; @0040                               v33 = call_indirect sig0, v31(v32, v0)
 ;; @0043                               v34 = global_value.i64 gv3
-;; @0043                               v35 = iadd_imm v34, 208
+;; @0043                               v35 = iadd_imm v34, 192
 ;; @0043                               v36 = load.i32 notrap aligned v35+8
 ;; @0043                               v37 = load.i64 notrap aligned v35
 ;; @0043                               v38 = icmp eq v36, v33
@@ -103,11 +103,11 @@
 ;; @0040                               v23 = global_value.i64 gv3
 ;; @0040                               v24 = load.i64 notrap aligned readonly v23+80
 ;; @0040                               v25 = load.i32 notrap aligned readonly v24+4
-;; @0040                               v26 = load.i32 icall_null aligned readonly v19+24
+;; @0040                               v26 = load.i32 icall_null aligned readonly v19+16
 ;; @0040                               v27 = icmp eq v26, v25
 ;; @0040                               trapz v27, bad_sig
-;; @0040                               v28 = load.i64 notrap aligned readonly v19+16
-;; @0040                               v29 = load.i64 notrap aligned readonly v19+32
+;; @0040                               v28 = load.i64 notrap aligned readonly v19+8
+;; @0040                               v29 = load.i64 notrap aligned readonly v19+24
 ;; @0040                               v30 = icmp eq v29, v4
 ;; @0040                               brif v30, block4, block3(v28, v29)
 ;;
@@ -121,11 +121,11 @@
 ;; @0043                               v53 = global_value.i64 gv3
 ;; @0043                               v54 = load.i64 notrap aligned readonly v53+80
 ;; @0043                               v55 = load.i32 notrap aligned readonly v54+4
-;; @0043                               v56 = load.i32 icall_null aligned readonly v49+24
+;; @0043                               v56 = load.i32 icall_null aligned readonly v49+16
 ;; @0043                               v57 = icmp eq v56, v55
 ;; @0043                               trapz v57, bad_sig
-;; @0043                               v58 = load.i64 notrap aligned readonly v49+16
-;; @0043                               v59 = load.i64 notrap aligned readonly v49+32
+;; @0043                               v58 = load.i64 notrap aligned readonly v49+8
+;; @0043                               v59 = load.i64 notrap aligned readonly v49+24
 ;; @0043                               v60 = icmp eq v59, v34
 ;; @0043                               brif v60, block9, block8(v58, v59)
 ;;
@@ -167,11 +167,11 @@
 ;; @004b                               v18 = global_value.i64 gv3
 ;; @004b                               v19 = load.i64 notrap aligned readonly v18+80
 ;; @004b                               v20 = load.i32 notrap aligned readonly v19+4
-;; @004b                               v21 = load.i32 icall_null aligned readonly v14+24
+;; @004b                               v21 = load.i32 icall_null aligned readonly v14+16
 ;; @004b                               v22 = icmp eq v21, v20
 ;; @004b                               trapz v22, bad_sig
-;; @004b                               v23 = load.i64 notrap aligned readonly v14+16
-;; @004b                               v24 = load.i64 notrap aligned readonly v14+32
+;; @004b                               v23 = load.i64 notrap aligned readonly v14+8
+;; @004b                               v24 = load.i64 notrap aligned readonly v14+24
 ;; @004b                               v25 = call_indirect sig0, v23(v24, v0)
 ;; @004e                               jump block1(v25)
 ;;

--- a/tests/disas/indirect-call-caching.wat
+++ b/tests/disas/indirect-call-caching.wat
@@ -74,7 +74,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0050                               v4 = global_value.i64 gv3
-;; @0050                               v5 = iadd_imm v4, 272
+;; @0050                               v5 = iadd_imm v4, 240
 ;; @0050                               v6 = load.i32 notrap aligned v5+8
 ;; @0050                               v7 = load.i64 notrap aligned v5
 ;; @0050                               v8 = icmp eq v6, v2
@@ -112,11 +112,11 @@
 ;; @0050                               v23 = global_value.i64 gv3
 ;; @0050                               v24 = load.i64 notrap aligned readonly v23+80
 ;; @0050                               v25 = load.i32 notrap aligned readonly v24
-;; @0050                               v26 = load.i32 icall_null aligned readonly v19+24
+;; @0050                               v26 = load.i32 icall_null aligned readonly v19+16
 ;; @0050                               v27 = icmp eq v26, v25
 ;; @0050                               trapz v27, bad_sig
-;; @0050                               v28 = load.i64 notrap aligned readonly v19+16
-;; @0050                               v29 = load.i64 notrap aligned readonly v19+32
+;; @0050                               v28 = load.i64 notrap aligned readonly v19+8
+;; @0050                               v29 = load.i64 notrap aligned readonly v19+24
 ;; @0050                               v30 = icmp eq v29, v4
 ;; @0050                               brif v30, block4, block3(v28, v29)
 ;;

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -96,11 +96,11 @@
 ;; @0050                               v18 = global_value.i64 gv3
 ;; @0050                               v19 = load.i64 notrap aligned readonly v18+80
 ;; @0050                               v20 = load.i32 notrap aligned readonly v19
-;; @0050                               v21 = load.i32 icall_null aligned readonly v14+24
+;; @0050                               v21 = load.i32 icall_null aligned readonly v14+16
 ;; @0050                               v22 = icmp eq v21, v20
 ;; @0050                               trapz v22, bad_sig
-;; @0050                               v23 = load.i64 notrap aligned readonly v14+16
-;; @0050                               v24 = load.i64 notrap aligned readonly v14+32
+;; @0050                               v23 = load.i64 notrap aligned readonly v14+8
+;; @0050                               v24 = load.i64 notrap aligned readonly v14+24
 ;; @0050                               v25 = call_indirect sig0, v23(v24, v0)
 ;; @0053                               jump block1(v25)
 ;;

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -63,7 +63,7 @@
 ;; @0031                               jump block3(v16)
 ;;
 ;;                                 block3(v13: i64):
-;; @0031                               v20 = load.i32 icall_null aligned readonly v13+24
+;; @0031                               v20 = load.i32 icall_null aligned readonly v13+16
 ;; @0031                               v18 = load.i64 notrap aligned readonly v0+80
 ;; @0031                               v19 = load.i32 notrap aligned readonly v18
 ;; @0031                               v21 = icmp eq v20, v19
@@ -73,8 +73,8 @@
 ;; @0031                               trap bad_sig
 ;;
 ;;                                 block5:
-;; @0031                               v22 = load.i64 notrap aligned readonly v13+16
-;; @0031                               v23 = load.i64 notrap aligned readonly v13+32
+;; @0031                               v22 = load.i64 notrap aligned readonly v13+8
+;; @0031                               v23 = load.i64 notrap aligned readonly v13+24
 ;; @0031                               call_indirect sig0, v22(v23, v0)
 ;; @0034                               jump block1
 ;;

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -30,9 +30,9 @@
 ;; @0091                               v10 = iconst.i32 1
 ;; @0091                               v11 = call fn0(v9, v10)  ; v10 = 1
 ;; @0093                               v12 = global_value.i64 gv3
-;; @0093                               v13 = load.i64 notrap aligned table v12+160
+;; @0093                               v13 = load.i64 notrap aligned table v12+144
 ;; @0095                               v14 = global_value.i64 gv3
-;; @0095                               v15 = load.i64 notrap aligned table v14+176
+;; @0095                               v15 = load.i64 notrap aligned table v14+160
 ;; @0097                               jump block1(v8, v11, v13, v15)
 ;;
 ;;                                 block1(v2: r64, v3: r64, v4: i64, v5: i64):

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -140,14 +140,14 @@
 ;;                                     v48 = iconst.i64 8
 ;; @0048                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0048                               v17 = load.i64 table_oob aligned table v14
-;; @004a                               v18 = load.i64 null_reference aligned readonly v17+16
-;; @004a                               v19 = load.i64 notrap aligned readonly v17+32
+;; @004a                               v18 = load.i64 null_reference aligned readonly v17+8
+;; @004a                               v19 = load.i64 notrap aligned readonly v17+24
 ;; @004a                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
 ;;                                     v56 = iconst.i64 16
 ;; @005b                               v28 = iadd v12, v56  ; v56 = 16
 ;; @005b                               v31 = load.i64 table_oob aligned table v28
-;; @005d                               v32 = load.i64 null_reference aligned readonly v31+16
-;; @005d                               v33 = load.i64 notrap aligned readonly v31+32
+;; @005d                               v32 = load.i64 null_reference aligned readonly v31+8
+;; @005d                               v33 = load.i64 notrap aligned readonly v31+24
 ;; @005d                               v34 = call_indirect sig0, v32(v33, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
@@ -170,14 +170,14 @@
 ;;                                     v48 = iconst.i64 8
 ;; @0075                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0075                               v17 = load.i64 table_oob aligned table v14
-;; @0075                               v18 = load.i64 icall_null aligned readonly v17+16
-;; @0075                               v19 = load.i64 notrap aligned readonly v17+32
+;; @0075                               v18 = load.i64 icall_null aligned readonly v17+8
+;; @0075                               v19 = load.i64 notrap aligned readonly v17+24
 ;; @0075                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
 ;;                                     v56 = iconst.i64 16
 ;; @0087                               v28 = iadd v12, v56  ; v56 = 16
 ;; @0087                               v31 = load.i64 table_oob aligned table v28
-;; @0087                               v32 = load.i64 icall_null aligned readonly v31+16
-;; @0087                               v33 = load.i64 notrap aligned readonly v31+32
+;; @0087                               v32 = load.i64 icall_null aligned readonly v31+8
+;; @0087                               v33 = load.i64 notrap aligned readonly v31+24
 ;; @0087                               v34 = call_indirect sig0, v32(v33, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
@@ -196,12 +196,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @009e                               v9 = load.i64 notrap aligned table v0+112
-;; @00a0                               v10 = load.i64 null_reference aligned readonly v9+16
-;; @00a0                               v11 = load.i64 notrap aligned readonly v9+32
+;; @00a0                               v10 = load.i64 null_reference aligned readonly v9+8
+;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
 ;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
 ;; @00af                               v15 = load.i64 notrap aligned table v0+128
-;; @00b1                               v16 = load.i64 null_reference aligned readonly v15+16
-;; @00b1                               v17 = load.i64 notrap aligned readonly v15+32
+;; @00b1                               v16 = load.i64 null_reference aligned readonly v15+8
+;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
 ;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -153,8 +153,8 @@
 ;; @0048                               jump block3(v22)
 ;;
 ;;                                 block3(v19: i64):
-;; @004a                               v23 = load.i64 null_reference aligned readonly v19+16
-;; @004a                               v24 = load.i64 notrap aligned readonly v19+32
+;; @004a                               v23 = load.i64 null_reference aligned readonly v19+8
+;; @004a                               v24 = load.i64 notrap aligned readonly v19+24
 ;; @004a                               v25 = call_indirect sig1, v23(v24, v0, v2, v3, v4, v5)
 ;;                                     v74 = iconst.i64 16
 ;; @005b                               v38 = iadd.i64 v12, v74  ; v74 = 16
@@ -170,8 +170,8 @@
 ;; @005b                               jump block5(v46)
 ;;
 ;;                                 block5(v43: i64):
-;; @005d                               v47 = load.i64 null_reference aligned readonly v43+16
-;; @005d                               v48 = load.i64 notrap aligned readonly v43+32
+;; @005d                               v47 = load.i64 null_reference aligned readonly v43+8
+;; @005d                               v48 = load.i64 notrap aligned readonly v43+24
 ;; @005d                               v49 = call_indirect sig1, v47(v48, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
@@ -207,8 +207,8 @@
 ;; @0075                               jump block3(v22)
 ;;
 ;;                                 block3(v19: i64):
-;; @0075                               v23 = load.i64 icall_null aligned readonly v19+16
-;; @0075                               v24 = load.i64 notrap aligned readonly v19+32
+;; @0075                               v23 = load.i64 icall_null aligned readonly v19+8
+;; @0075                               v24 = load.i64 notrap aligned readonly v19+24
 ;; @0075                               v25 = call_indirect sig0, v23(v24, v0, v2, v3, v4, v5)
 ;;                                     v74 = iconst.i64 16
 ;; @0087                               v38 = iadd.i64 v12, v74  ; v74 = 16
@@ -224,8 +224,8 @@
 ;; @0087                               jump block5(v46)
 ;;
 ;;                                 block5(v43: i64):
-;; @0087                               v47 = load.i64 icall_null aligned readonly v43+16
-;; @0087                               v48 = load.i64 notrap aligned readonly v43+32
+;; @0087                               v47 = load.i64 icall_null aligned readonly v43+8
+;; @0087                               v48 = load.i64 notrap aligned readonly v43+24
 ;; @0087                               v49 = call_indirect sig0, v47(v48, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
@@ -244,12 +244,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @009e                               v9 = load.i64 notrap aligned table v0+112
-;; @00a0                               v10 = load.i64 null_reference aligned readonly v9+16
-;; @00a0                               v11 = load.i64 notrap aligned readonly v9+32
+;; @00a0                               v10 = load.i64 null_reference aligned readonly v9+8
+;; @00a0                               v11 = load.i64 notrap aligned readonly v9+24
 ;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
 ;; @00af                               v15 = load.i64 notrap aligned table v0+128
-;; @00b1                               v16 = load.i64 null_reference aligned readonly v15+16
-;; @00b1                               v17 = load.i64 notrap aligned readonly v15+32
+;; @00b1                               v16 = load.i64 null_reference aligned readonly v15+8
+;; @00b1                               v17 = load.i64 notrap aligned readonly v15+24
 ;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)
 ;; @00ba                               jump block1
 ;;

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -76,11 +76,11 @@
 ;; @0047                               v26 = global_value.i64 gv3
 ;; @0047                               v27 = load.i64 notrap aligned readonly v26+80
 ;; @0047                               v28 = load.i32 notrap aligned readonly v27
-;; @0047                               v29 = load.i32 icall_null aligned readonly v22+24
+;; @0047                               v29 = load.i32 icall_null aligned readonly v22+16
 ;; @0047                               v30 = icmp eq v29, v28
 ;; @0047                               trapz v30, bad_sig
-;; @0047                               v31 = load.i64 notrap aligned readonly v22+16
-;; @0047                               v32 = load.i64 notrap aligned readonly v22+32
+;; @0047                               v31 = load.i64 notrap aligned readonly v22+8
+;; @0047                               v32 = load.i64 notrap aligned readonly v22+24
 ;; @0047                               v33 = call_indirect sig0, v31(v32, v0, v10)
 ;; @004c                               v35 = iconst.i32 1
 ;; @004e                               v36 = isub.i32 v2, v35  ; v35 = 1
@@ -107,11 +107,11 @@
 ;; @0051                               v52 = global_value.i64 gv3
 ;; @0051                               v53 = load.i64 notrap aligned readonly v52+80
 ;; @0051                               v54 = load.i32 notrap aligned readonly v53
-;; @0051                               v55 = load.i32 icall_null aligned readonly v48+24
+;; @0051                               v55 = load.i32 icall_null aligned readonly v48+16
 ;; @0051                               v56 = icmp eq v55, v54
 ;; @0051                               trapz v56, bad_sig
-;; @0051                               v57 = load.i64 notrap aligned readonly v48+16
-;; @0051                               v58 = load.i64 notrap aligned readonly v48+32
+;; @0051                               v57 = load.i64 notrap aligned readonly v48+8
+;; @0051                               v58 = load.i64 notrap aligned readonly v48+24
 ;; @0051                               v59 = call_indirect sig0, v57(v58, v0, v36)
 ;; @0054                               v60 = iadd.i32 v33, v59
 ;; @0055                               jump block3(v60)

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -65,11 +65,11 @@
 ;; @003b                               v18 = global_value.i64 gv3
 ;; @003b                               v19 = load.i64 notrap aligned readonly v18+80
 ;; @003b                               v20 = load.i32 notrap aligned readonly v19
-;; @003b                               v21 = load.i32 icall_null aligned readonly v14+24
+;; @003b                               v21 = load.i32 icall_null aligned readonly v14+16
 ;; @003b                               v22 = icmp eq v21, v20
 ;; @003b                               trapz v22, bad_sig
-;; @003b                               v23 = load.i64 notrap aligned readonly v14+16
-;; @003b                               v24 = load.i64 notrap aligned readonly v14+32
+;; @003b                               v23 = load.i64 notrap aligned readonly v14+8
+;; @003b                               v24 = load.i64 notrap aligned readonly v14+24
 ;; @003b                               call_indirect sig0, v23(v24, v0, v2)  ; v2 = 0
 ;; @003e                               jump block1
 ;;

--- a/tests/disas/winch/x64/load/grow_load.wat
+++ b/tests/disas/winch/x64/load/grow_load.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
 ;;       movl    $0, %edx
-;;       callq   0x2f7
+;;       callq   0x2b0
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x48(%rsp), %r14

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -113,7 +113,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x5f4
+;;       callq   0x4c9
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x20(%rsp), %r14
@@ -134,7 +134,7 @@
 ;;       movl    0x14(%rsp), %edx
 ;;       movq    0xc(%rsp), %rcx
 ;;       movl    8(%rsp), %r8d
-;;       callq   0x636
+;;       callq   0x50b
 ;;       addq    $8, %rsp
 ;;       addq    $0x10, %rsp
 ;;       movq    0x20(%rsp), %r14

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x33f
+;;       callq   0x2da
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x10(%rsp), %r14

--- a/tests/disas/winch/x64/table/grow.wat
+++ b/tests/disas/winch/x64/table/grow.wat
@@ -29,7 +29,7 @@
 ;;       movl    $0, %esi
 ;;       movl    $0xa, %edx
 ;;       movq    (%rsp), %rcx
-;;       callq   0x18c
+;;       callq   0x165
 ;;       addq    $8, %rsp
 ;;       movq    0x10(%rsp), %r14
 ;;       addq    $0x18, %rsp

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0xaef
+;;       callq   0x8d5
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0xb38
+;;       callq   0x91e
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0xaef
+;;       callq   0x8d5
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0xb38
+;;       callq   0x91e
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0xb77
+;;       callq   0x95d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0xb77
+;;       callq   0x95d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0xb77
+;;       callq   0x95d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0xb77
+;;       callq   0x95d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0xb77
+;;       callq   0x95d
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -224,12 +224,12 @@
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
 ;;       movq    %r14, %rdx
-;;       movl    0x100(%rdx), %ebx
+;;       movl    0xd8(%rdx), %ebx
 ;;       cmpl    %ebx, %ecx
 ;;       jae     0x39f
 ;;  305: movl    %ecx, %r11d
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xf8(%rdx), %rdx
+;;       movq    0xd0(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
 ;;       cmpl    %ebx, %ecx
@@ -243,7 +243,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0xbc0
+;;       callq   0x9a6
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x10(%rsp), %r14
@@ -253,13 +253,13 @@
 ;;       je      0x3a1
 ;;  366: movq    0x50(%r14), %r11
 ;;       movl    (%r11), %ecx
-;;       movl    0x18(%rax), %edx
+;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
 ;;       jne     0x3a3
 ;;  378: pushq   %rax
 ;;       popq    %rcx
-;;       movq    0x20(%rcx), %rbx
-;;       movq    0x10(%rcx), %rdx
+;;       movq    0x18(%rcx), %rbx
+;;       movq    8(%rcx), %rdx
 ;;       subq    $8, %rsp
 ;;       movq    %rbx, %rdi
 ;;       movq    %r14, %rsi

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -108,7 +108,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    (%rsp), %edx
-;;       callq   0x517
+;;       callq   0x48c
 ;;       addq    $4, %rsp
 ;;       movq    0x14(%rsp), %r14
 ;;       jmp     0x16e


### PR DESCRIPTION
This commit proposes removing the "native abi" calling convention used in Wasmtime. For background this ABI dates back to the origins of Wasmtime. Originally Wasmtime only had `Func::call` and eventually I added `TypedFunc` with `TypedFunc::call` and `Func::wrap` for a faster path. At the time given the state of trampolines it was easiest to call WebAssembly code directly without any trampolines using the native ABI that wasm used at the time. This is the original source of the native ABI and it's persisted over time under the assumption that it's faster than the array ABI due to keeping arguments in registers rather than spilling them to the stack.

Over time, however, this design decision of using the native ABI has not aged well. Trampolines have changed quite a lot in the meantime and it's no longer possible for the host to call wasm without a trampoline, for example. Compilations nowadays maintain both native and array trampolines for wasm functions in addition to host functions. There's a large split between `Func::new` and `Func::wrap`. Overall, there's quite a lot of weight that we're pulling for the design decision of using the native ABI.

Functionally this hasn't ever really been the end of the world. Trampolines aren't a known issue in terms of performance or code size. There's no known faster way to invoke WebAssembly from the host (or vice-versa). One major downside of this design, however, is that `Func::new` requires Cranelift as a backend to exist. This is due to the fact that it needs to synthesize various entries in the matrix of ABIs we have that aren't available at any other time. While this is itself not the worst of issues it means that the C API cannot be built without a compiler because the C API does not have access to `Func::wrap`.

Overall I'd like to reevaluate given where Wasmtime is today whether it makes sense to keep the native ABI trampolines. Sure they're supposed to be fast, but are they really that much faster than the array-call ABI as an alternative? This commit is intended to measure this.

This commit removes the native ABI calling convention entirely. For example `VMFuncRef` is now one pointer smaller. All of `TypedFunc` now uses `*mut ValRaw` for loads/stores rather than dealing with ABI business. The benchmarks with this PR are:

* `sync/no-hook/core - host-to-wasm - typed - nop` - 5% faster
* `sync/no-hook/core - host-to-wasm - typed - nop-params-and-results` - 10% slower
* `sync/no-hook/core - wasm-to-host - typed - nop` - no change
* `sync/no-hook/core - wasm-to-host - typed - nop-params-and-results` - 7% faster

These numbers are a bit surprising as I would have suspected no change in both "nop" benchmarks as well as both being slower in the params-and-results benchmarks. Regardless it is apparent that this is not a major change in terms of performance given Wasmtime's current state. In general my hunch is that there are more expensive sources of overhead than reads/writes from the stack when dealing with wasm values (e.g. trap handling, store management, etc).

Overall this commit feels like a large simplification of what we currently do in `TypedFunc`:

* The number of ABIs that Wasmtime deals with is reduced by one. ABIs are pretty much always tricky and having fewer moving parts should help improve the understandability of the system.
* All of the `WasmTy` trait methods and `TypedFunc` infrastructure is simplified. Traits now work with simple `load`/`store` methods rather than various other flavors of conversion.
* The multi-return-value handling of the native ABI is all gone now which gave rise to significant complexity within Wasmtime's Cranelift translation layer in addition to the `TypedFunc` backing traits.
* This aligns components and core wasm where components always use the array ABI and now core wasm additionally will always use the array ABI when communicating with the host.

I'll note that this still leaves a major ABI "complexity" with respect to native functions do not have a wasm ABI function pointer until they're "attached" to a `Store` with a `Module`. That's required to avoid needing Cranelift for creating host functions and that property is still true today. This is a bit simpler to understand though now that `Func::new` and `Func::wrap` are treated uniformly rather than one being special-cased.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
