### PR TITLE
Page align the static memory maximum size

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1368,7 +1368,7 @@ impl Config {
     /// for pooling allocation by using memory protection; see
     /// `PoolingAllocatorConfig::memory_protection_keys` for details.
     pub fn static_memory_maximum_size(&mut self, max_size: u64) -> &mut Self {
-        self.tunables.static_memory_reservation = Some(max_size);
+        self.tunables.static_memory_reservation = Some(round_up_to_pages(max_size));
         self
     }
 

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -658,3 +658,14 @@ fn init_with_negative_segment() -> Result<()> {
     Instance::new(&mut store, &module, &[])?;
     Ok(())
 }
+
+#[test]
+fn non_page_aligned_static_memory() -> Result<()> {
+    let mut config = Config::new();
+    config.static_memory_maximum_size(100_000);
+    config.static_memory_forced(true);
+    let engine = Engine::new(&config)?;
+    let ty = MemoryType::new(1, None);
+    Memory::new(&mut Store::new(&engine, ()), ty)?;
+    Ok(())
+}


### PR DESCRIPTION
This fixes an accidental regression from #8616 where page alignment was implicitly happening due to how configuration was processed but it wasn't re-added in the refactoring.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
