### PR TITLE
Change the function alignment of x86 to 32-bytes

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2702,9 +2702,9 @@ impl MachInst for Inst {
     fn function_alignment() -> FunctionAlignment {
         FunctionAlignment {
             minimum: 1,
-            // Prefer an alignment of 16-bytes to hypothetically get the whole
-            // function into a minimum number of lines.
-            preferred: 16,
+            // Change the alignment from 16-bytes to 32-bytes for better performance.
+            // fix-8573: https://github.com/bytecodealliance/wasmtime/issues/8573
+            preferred: 32,
         }
     }
 

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -40,10 +40,10 @@
 ;;       movl    %edx, %r10d
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %r10
-;;       ja      0x55
-;;   48: movq    0x60(%rdi), %rsi
+;;       ja      0x65
+;;   58: movq    0x60(%rdi), %rsi
 ;;       movl    (%rsi, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -40,10 +40,10 @@
 ;;       movl    %edx, %r10d
 ;;       subq    $0x1004, %r8
 ;;       cmpq    %r8, %r10
-;;       ja      0x5c
-;;   4b: movq    0x60(%rdi), %rsi
+;;       ja      0x6c
+;;   5b: movq    0x60(%rdi), %rsi
 ;;       movl    0x1000(%rsi, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5c: ud2
+;;   6c: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -47,19 +47,19 @@
 ;;       movl    %edx, %r8d
 ;;       movq    %r8, %r11
 ;;       addq    0x2f(%rip), %r11
-;;       jb      0x88
-;;   67: movq    0x68(%rdi), %rsi
+;;       jb      0x98
+;;   77: movq    0x68(%rdi), %rsi
 ;;       cmpq    %rsi, %r11
-;;       ja      0x86
-;;   74: addq    0x60(%rdi), %r8
+;;       ja      0x96
+;;   84: addq    0x60(%rdi), %r8
 ;;       movl    $0xffff0000, %eax
 ;;       movl    (%r8, %rax), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   86: ud2
-;;   88: ud2
-;;   8a: addb    %al, (%rax)
-;;   8c: addb    %al, (%rax)
-;;   8e: addb    %al, (%rax)
-;;   90: addb    $0, %al
+;;   96: ud2
+;;   98: ud2
+;;   9a: addb    %al, (%rax)
+;;   9c: addb    %al, (%rax)
+;;   9e: addb    %al, (%rax)
+;;   a0: addb    $0, %al

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r10
 ;;       movl    %edx, %r9d
 ;;       cmpq    %r10, %r9
-;;       jae     0x52
-;;   44: movq    0x60(%rdi), %r11
+;;       jae     0x62
+;;   54: movq    0x60(%rdi), %r11
 ;;       movzbq  (%r11, %r9), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
+;;   62: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -40,10 +40,10 @@
 ;;       movl    %edx, %r10d
 ;;       subq    $0x1001, %r8
 ;;       cmpq    %r8, %r10
-;;       ja      0x5d
-;;   4b: movq    0x60(%rdi), %rsi
+;;       ja      0x6d
+;;   5b: movq    0x60(%rdi), %rsi
 ;;       movzbq  0x1000(%rsi, %r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5d: ud2
+;;   6d: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -47,21 +47,21 @@
 ;;       movl    %edx, %r8d
 ;;       movq    %r8, %r11
 ;;       addq    0x2f(%rip), %r11
-;;       jb      0x89
-;;   67: movq    0x68(%rdi), %rsi
+;;       jb      0x99
+;;   77: movq    0x68(%rdi), %rsi
 ;;       cmpq    %rsi, %r11
-;;       ja      0x87
-;;   74: addq    0x60(%rdi), %r8
+;;       ja      0x97
+;;   84: addq    0x60(%rdi), %r8
 ;;       movl    $0xffff0000, %eax
 ;;       movzbq  (%r8, %rax), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   87: ud2
-;;   89: ud2
-;;   8b: addb    %al, (%rax)
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rcx)
-;;   91: addb    %bh, %bh
-;;   93: incl    (%rax)
-;;   95: addb    %al, (%rax)
+;;   97: ud2
+;;   99: ud2
+;;   9b: addb    %al, (%rax)
+;;   9d: addb    %al, (%rax)
+;;   9f: addb    %al, (%rcx)
+;;   a1: addb    %bh, %bh
+;;   a3: incl    (%rax)
+;;   a5: addb    %al, (%rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -47,8 +47,8 @@
 ;;       movl    %edx, %r10d
 ;;       movq    %r10, %rax
 ;;       addq    0x2f(%rip), %rax
-;;       jb      0x8a
-;;   67: movq    0x68(%rdi), %rdx
+;;       jb      0x9a
+;;   77: movq    0x68(%rdi), %rdx
 ;;       xorq    %rcx, %rcx
 ;;       addq    0x60(%rdi), %r10
 ;;       movl    $0xffff0000, %r8d
@@ -59,7 +59,7 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8a: ud2
-;;   8c: addb    %al, (%rax)
-;;   8e: addb    %al, (%rax)
-;;   90: addb    $0, %al
+;;   9a: ud2
+;;   9c: addb    %al, (%rax)
+;;   9e: addb    %al, (%rax)
+;;   a0: addb    $0, %al

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -47,8 +47,8 @@
 ;;       movl    %edx, %r10d
 ;;       movq    %r10, %rax
 ;;       addq    0x2f(%rip), %rax
-;;       jb      0x8b
-;;   67: movq    0x68(%rdi), %rdx
+;;       jb      0x9b
+;;   77: movq    0x68(%rdi), %rdx
 ;;       xorq    %rcx, %rcx
 ;;       addq    0x60(%rdi), %r10
 ;;       movl    $0xffff0000, %r8d
@@ -59,9 +59,9 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8b: ud2
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rcx)
-;;   91: addb    %bh, %bh
-;;   93: incl    (%rax)
-;;   95: addb    %al, (%rax)
+;;   9b: ud2
+;;   9d: addb    %al, (%rax)
+;;   9f: addb    %al, (%rcx)
+;;   a1: addb    %bh, %bh
+;;   a3: incl    (%rax)
+;;   a5: addb    %al, (%rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r10
 ;;       movl    %edx, %r9d
 ;;       cmpq    %r10, %r9
-;;       ja      0x51
-;;   44: movq    0x60(%rdi), %r11
+;;       ja      0x61
+;;   54: movq    0x60(%rdi), %r11
 ;;       movl    (%r11, %r9), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   51: ud2
+;;   61: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r10
 ;;       movl    %edx, %r9d
 ;;       cmpq    %r10, %r9
-;;       ja      0x55
-;;   44: movq    0x60(%rdi), %r11
+;;       ja      0x65
+;;   54: movq    0x60(%rdi), %r11
 ;;       movl    0x1000(%r11, %r9), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -39,11 +39,11 @@
 ;;       movq    0x68(%rdi), %r10
 ;;       movl    %edx, %r9d
 ;;       cmpq    %r10, %r9
-;;       ja      0x56
-;;   44: addq    0x60(%rdi), %r9
+;;       ja      0x66
+;;   54: addq    0x60(%rdi), %r9
 ;;       movl    $0xffff0000, %esi
 ;;       movl    (%r9, %rsi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   56: ud2
+;;   66: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r10
 ;;       movl    %edx, %r9d
 ;;       cmpq    %r10, %r9
-;;       jae     0x52
-;;   44: movq    0x60(%rdi), %r11
+;;       jae     0x62
+;;   54: movq    0x60(%rdi), %r11
 ;;       movzbq  (%r11, %r9), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
+;;   62: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r10
 ;;       movl    %edx, %r9d
 ;;       cmpq    %r10, %r9
-;;       ja      0x56
-;;   44: movq    0x60(%rdi), %r11
+;;       ja      0x66
+;;   54: movq    0x60(%rdi), %r11
 ;;       movzbq  0x1000(%r11, %r9), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   56: ud2
+;;   66: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -39,11 +39,11 @@
 ;;       movq    0x68(%rdi), %r10
 ;;       movl    %edx, %r9d
 ;;       cmpq    %r10, %r9
-;;       ja      0x57
-;;   44: addq    0x60(%rdi), %r9
+;;       ja      0x67
+;;   54: addq    0x60(%rdi), %r9
 ;;       movl    $0xffff0000, %esi
 ;;       movzbq  (%r9, %rsi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   57: ud2
+;;   67: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r8
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x52
-;;   45: movq    0x60(%rdi), %r11
+;;       ja      0x62
+;;   55: movq    0x60(%rdi), %r11
 ;;       movl    (%r11, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
+;;   62: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r8
 ;;       subq    $0x1004, %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x59
-;;   48: movq    0x60(%rdi), %r11
+;;       ja      0x69
+;;   58: movq    0x60(%rdi), %r11
 ;;       movl    0x1000(%r11, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   59: ud2
+;;   69: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    0x68(%rdi), %r8
 ;;       subq    $0x1001, %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x5a
-;;   48: movq    0x60(%rdi), %r11
+;;       ja      0x6a
+;;   58: movq    0x60(%rdi), %r11
 ;;       movzbq  0x1000(%r11, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5a: ud2
+;;   6a: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -46,8 +46,8 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    %rdx, %rcx
 ;;       addq    0x32(%rip), %rcx
-;;       jb      0x87
-;;   64: movq    0x68(%rdi), %r8
+;;       jb      0x97
+;;   74: movq    0x68(%rdi), %r8
 ;;       xorq    %rax, %rax
 ;;       addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r9d
@@ -58,8 +58,8 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   87: ud2
-;;   89: addb    %al, (%rax)
-;;   8b: addb    %al, (%rax)
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rax, %rax)
+;;   97: ud2
+;;   99: addb    %al, (%rax)
+;;   9b: addb    %al, (%rax)
+;;   9d: addb    %al, (%rax)
+;;   9f: addb    %al, (%rax, %rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -49,8 +49,8 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    %rdx, %rcx
 ;;       addq    0x32(%rip), %rcx
-;;       jb      0x89
-;;   64: movq    0x68(%rdi), %r8
+;;       jb      0x99
+;;   74: movq    0x68(%rdi), %r8
 ;;       xorq    %rax, %rax
 ;;       addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r9d
@@ -61,10 +61,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   89: ud2
-;;   8b: addb    %al, (%rax)
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rcx)
-;;   91: addb    %bh, %bh
-;;   93: incl    (%rax)
-;;   95: addb    %al, (%rax)
+;;   99: ud2
+;;   9b: addb    %al, (%rax)
+;;   9d: addb    %al, (%rax)
+;;   9f: addb    %al, (%rcx)
+;;   a1: addb    %bh, %bh
+;;   a3: incl    (%rax)
+;;   a5: addb    %al, (%rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -36,10 +36,10 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    0x68(%rdi), %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x52
-;;   41: movq    0x60(%rdi), %r10
+;;       ja      0x62
+;;   51: movq    0x60(%rdi), %r10
 ;;       movl    0x1000(%r10, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
+;;   62: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -37,11 +37,11 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    0x68(%rdi), %r9
 ;;       cmpq    %r9, %rdx
-;;       ja      0x54
-;;   41: addq    0x60(%rdi), %rdx
+;;       ja      0x64
+;;   51: addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r11d
 ;;       movl    (%rdx, %r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
+;;   64: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -36,10 +36,10 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    0x68(%rdi), %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x53
-;;   41: movq    0x60(%rdi), %r10
+;;       ja      0x63
+;;   51: movq    0x60(%rdi), %r10
 ;;       movzbq  0x1000(%r10, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   53: ud2
+;;   63: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -37,11 +37,11 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    0x68(%rdi), %r9
 ;;       cmpq    %r9, %rdx
-;;       ja      0x55
-;;   41: addq    0x60(%rdi), %rdx
+;;       ja      0x65
+;;   51: addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r11d
 ;;       movzbq  (%rdx, %r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -39,13 +39,13 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    0x1a(%rip), %r8
-;;       ja      0x51
-;;   44: movq    0x60(%rdi), %r10
+;;       ja      0x61
+;;   54: movq    0x60(%rdi), %r10
 ;;       movl    (%r10, %r8), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   51: ud2
-;;   53: addb    %al, (%rax)
-;;   55: addb    %al, (%rax)
-;;   57: addb    %bh, %ah
+;;   61: ud2
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %ah

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -38,12 +38,12 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    0x1a(%rip), %r8
-;;       ja      0x55
-;;   44: movq    0x60(%rdi), %r10
+;;       ja      0x65
+;;   54: movq    0x60(%rdi), %r10
 ;;       movl    0x1000(%r10, %r8), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
-;;   57: addb    %bh, %ah
-;;   59: outl    %eax, %dx
+;;   65: ud2
+;;   67: addb    %bh, %ah
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -37,11 +37,11 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    $0xfffc, %r8
-;;       ja      0x57
-;;   44: addq    0x60(%rdi), %r8
+;;       ja      0x67
+;;   54: addq    0x60(%rdi), %r8
 ;;       movl    $0xffff0000, %r11d
 ;;       movl    (%r8, %r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   57: ud2
+;;   67: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -38,10 +38,10 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    0x1a(%rip), %r8
-;;       ja      0x56
-;;   44: movq    0x60(%rdi), %r10
+;;       ja      0x66
+;;   54: movq    0x60(%rdi), %r10
 ;;       movzbq  0x1000(%r10, %r8), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   56: ud2
+;;   66: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -37,11 +37,11 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    $0xffff, %r8
-;;       ja      0x58
-;;   44: addq    0x60(%rdi), %r8
+;;       ja      0x68
+;;   54: addq    0x60(%rdi), %r8
 ;;       movl    $0xffff0000, %r11d
 ;;       movzbq  (%r8, %r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   58: ud2
+;;   68: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -48,6 +48,6 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: addb    %al, (%rax)
-;;   56: addb    %al, (%rax)
-;;   58: cld
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)
+;;   68: cld

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -47,5 +47,5 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   58: cld
-;;   59: outl    %eax, %dx
+;;   68: cld
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -45,8 +45,8 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   59: addb    %al, (%rax)
-;;   5b: addb    %al, (%rax)
-;;   5d: addb    %al, (%rax)
-;;   5f: addb    %bh, %bh
-;;   61: outl    %eax, %dx
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)
+;;   6f: addb    %bh, %bh
+;;   71: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -35,11 +35,11 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x15(%rip), %rdx
-;;       ja      0x4e
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x5e
+;;   51: movq    0x60(%rdi), %r9
 ;;       movl    (%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4e: ud2
-;;   50: cld
+;;   5e: ud2
+;;   60: cld

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -38,14 +38,14 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       ja      0x52
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x62
+;;   51: movq    0x60(%rdi), %r9
 ;;       movl    0x1000(%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
-;;   54: addb    %al, (%rax)
-;;   56: addb    %al, (%rax)
-;;   58: cld
-;;   59: outl    %eax, %dx
+;;   62: ud2
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)
+;;   68: cld
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -35,11 +35,11 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xfffc, %rdx
-;;       ja      0x54
-;;   41: addq    0x60(%rdi), %rdx
+;;       ja      0x64
+;;   51: addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r10d
 ;;       movl    (%rdx, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
+;;   64: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -34,14 +34,14 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       ja      0x4f
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x5f
+;;   51: movq    0x60(%rdi), %r9
 ;;       movzbq  (%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4f: ud2
-;;   51: addb    %al, (%rax)
-;;   53: addb    %al, (%rax)
-;;   55: addb    %al, (%rax)
-;;   57: addb    %bh, %bh
+;;   5f: ud2
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -36,13 +36,13 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       ja      0x53
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x63
+;;   51: movq    0x60(%rdi), %r9
 ;;       movzbq  0x1000(%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   53: ud2
-;;   55: addb    %al, (%rax)
-;;   57: addb    %bh, %bh
-;;   59: outl    %eax, %dx
+;;   63: ud2
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -35,11 +35,11 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xffff, %rdx
-;;       ja      0x55
-;;   41: addq    0x60(%rdi), %rdx
+;;       ja      0x65
+;;   51: addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r10d
 ;;       movzbq  (%rdx, %r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -47,7 +47,7 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   51: addb    %al, (%rax)
-;;   53: addb    %al, (%rax)
-;;   55: addb    %al, (%rax)
-;;   57: addb    %bh, %ah
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %ah

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -46,6 +46,6 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   56: addb    %al, (%rax)
-;;   58: cld
-;;   59: outl    %eax, %dx
+;;   66: addb    %al, (%rax)
+;;   68: cld
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -47,6 +47,6 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: addb    %al, (%rax)
-;;   54: addb    %al, (%rax)
-;;   56: addb    %al, (%rax)
+;;   62: addb    %al, (%rax)
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -44,5 +44,5 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   57: addb    %bh, %bh
-;;   59: outl    %eax, %dx
+;;   67: addb    %bh, %bh
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -35,11 +35,11 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x15(%rip), %rdx
-;;       ja      0x4e
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x5e
+;;   51: movq    0x60(%rdi), %r9
 ;;       movl    (%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4e: ud2
-;;   50: cld
+;;   5e: ud2
+;;   60: cld

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -38,14 +38,14 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       ja      0x52
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x62
+;;   51: movq    0x60(%rdi), %r9
 ;;       movl    0x1000(%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
-;;   54: addb    %al, (%rax)
-;;   56: addb    %al, (%rax)
-;;   58: cld
-;;   59: outl    %eax, %dx
+;;   62: ud2
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)
+;;   68: cld
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -35,11 +35,11 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xfffc, %rdx
-;;       ja      0x54
-;;   41: addq    0x60(%rdi), %rdx
+;;       ja      0x64
+;;   51: addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r10d
 ;;       movl    (%rdx, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
+;;   64: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -34,14 +34,14 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       ja      0x4f
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x5f
+;;   51: movq    0x60(%rdi), %r9
 ;;       movzbq  (%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4f: ud2
-;;   51: addb    %al, (%rax)
-;;   53: addb    %al, (%rax)
-;;   55: addb    %al, (%rax)
-;;   57: addb    %bh, %bh
+;;   5f: ud2
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -36,13 +36,13 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       ja      0x53
-;;   41: movq    0x60(%rdi), %r9
+;;       ja      0x63
+;;   51: movq    0x60(%rdi), %r9
 ;;       movzbq  0x1000(%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   53: ud2
-;;   55: addb    %al, (%rax)
-;;   57: addb    %bh, %bh
-;;   59: outl    %eax, %dx
+;;   63: ud2
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -35,11 +35,11 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xffff, %rdx
-;;       ja      0x55
-;;   41: addq    0x60(%rdi), %rdx
+;;       ja      0x65
+;;   51: addq    0x60(%rdi), %rdx
 ;;       movl    $0xffff0000, %r10d
 ;;       movzbq  (%rdx, %r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -47,7 +47,7 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   51: addb    %al, (%rax)
-;;   53: addb    %al, (%rax)
-;;   55: addb    %al, (%rax)
-;;   57: addb    %bh, %ah
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %ah

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -46,6 +46,6 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   56: addb    %al, (%rax)
-;;   58: cld
-;;   59: outl    %eax, %dx
+;;   66: addb    %al, (%rax)
+;;   68: cld
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -47,6 +47,6 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: addb    %al, (%rax)
-;;   54: addb    %al, (%rax)
-;;   56: addb    %al, (%rax)
+;;   62: addb    %al, (%rax)
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -44,5 +44,5 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   57: addb    %bh, %bh
-;;   59: outl    %eax, %dx
+;;   67: addb    %bh, %bh
+;;   69: outl    %eax, %dx

--- a/tests/disas/pcc-insertlane-x64-avx.wat
+++ b/tests/disas/pcc-insertlane-x64-avx.wat
@@ -90,10 +90,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4f: addb    %ch, (%rax)
-;;   51: subl    %ebp, (%rcx)
-;;   53: subl    %ebp, (%rax)
-;;   55: imull   $0x616d286d, 0x20(%rsi), %ebp
+;;   5f: addb    %ch, (%rax)
+;;   61: subl    %ebp, (%rcx)
+;;   63: subl    %ebp, (%rax)
+;;   65: imull   $0x616d286d, 0x20(%rsi), %ebp
 ;;
 ;; wasm[0]::function[2]:
 ;;       pushq   %rbp
@@ -105,10 +105,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7f: addb    %ch, (%rax)
-;;   81: subl    %ebp, (%rcx)
-;;   83: subl    %ebp, (%rax)
-;;   85: imull   $0x616d286d, 0x20(%rsi), %ebp
+;;   9f: addb    %ch, (%rax)
+;;   a1: subl    %ebp, (%rcx)
+;;   a3: subl    %ebp, (%rax)
+;;   a5: imull   $0x616d286d, 0x20(%rsi), %ebp
 ;;
 ;; wasm[0]::function[3]:
 ;;       pushq   %rbp
@@ -120,10 +120,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   af: addb    %ch, (%rax)
-;;   b1: subl    %ebp, (%rcx)
-;;   b3: subl    %ebp, (%rax)
-;;   b5: imull   $0x616d286d, 0x20(%rsi), %ebp
+;;   df: addb    %ch, (%rax)
+;;   e1: subl    %ebp, (%rcx)
+;;   e3: subl    %ebp, (%rax)
+;;   e5: imull   $0x616d286d, 0x20(%rsi), %ebp
 ;;
 ;; wasm[0]::function[4]:
 ;;       pushq   %rbp

--- a/tests/disas/pcc-insertlane-x64.wat
+++ b/tests/disas/pcc-insertlane-x64.wat
@@ -91,10 +91,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4f: addb    %ch, (%rax)
-;;   51: subl    %ebp, (%rcx)
-;;   53: subl    %ebp, (%rax)
-;;   55: imull   $0x616d286d, 0x20(%rsi), %ebp
+;;   5f: addb    %ch, (%rax)
+;;   61: subl    %ebp, (%rcx)
+;;   63: subl    %ebp, (%rax)
+;;   65: imull   $0x616d286d, 0x20(%rsi), %ebp
 ;;
 ;; wasm[0]::function[2]:
 ;;       pushq   %rbp
@@ -106,11 +106,11 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   80: subb    %ch, (%rcx)
-;;   82: subl    %ebp, (%rcx)
-;;   84: subb    %ch, 0x6e(%rcx)
-;;   87: andb    %ch, 0x28(%rbp)
-;;   8a: insl    %dx, (%rdi)
+;;   a0: subb    %ch, (%rcx)
+;;   a2: subl    %ebp, (%rcx)
+;;   a4: subb    %ch, 0x6e(%rcx)
+;;   a7: andb    %ch, 0x28(%rbp)
+;;   aa: insl    %dx, (%rdi)
 ;;
 ;; wasm[0]::function[3]:
 ;;       pushq   %rbp
@@ -122,11 +122,11 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   b0: subb    %ch, (%rcx)
-;;   b2: subl    %ebp, (%rcx)
-;;   b4: subb    %ch, 0x6e(%rcx)
-;;   b7: andb    %ch, 0x28(%rbp)
-;;   ba: insl    %dx, (%rdi)
+;;   e0: subb    %ch, (%rcx)
+;;   e2: subl    %ebp, (%rcx)
+;;   e4: subb    %ch, 0x6e(%rcx)
+;;   e7: andb    %ch, 0x28(%rbp)
+;;   ea: insl    %dx, (%rdi)
 ;;
 ;; wasm[0]::function[4]:
 ;;       pushq   %rbp

--- a/tests/disas/x64-relaxed-simd-deterministic.wat
+++ b/tests/disas/x64-relaxed-simd-deterministic.wat
@@ -81,9 +81,9 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8e: addb    %al, (%rax)
-;;   90: addb    %al, (%rax)
-;;   92: sarb    $0xff, %bh
+;;   9e: addb    %al, (%rax)
+;;   a0: addb    %al, (%rax)
+;;   a2: sarb    $0xff, %bh
 ;;
 ;; wasm[0]::function[3]:
 ;;       pushq   %rbp
@@ -97,10 +97,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   cc: addb    %al, (%rax)
-;;   ce: addb    %al, (%rax)
-;;   d0: addb    %al, (%rax)
-;;   d2: loopne  0xd3
+;;   ec: addb    %al, (%rax)
+;;   ee: addb    %al, (%rax)
+;;   f0: addb    %al, (%rax)
+;;   f2: loopne  0xf3
 ;;
 ;; wasm[0]::function[4]:
 ;;       pushq   %rbp
@@ -135,18 +135,18 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  172: addb    %al, (%rax)
-;;  174: addb    %al, (%rax)
-;;  176: addb    %al, (%rax)
-;;  178: addb    %al, (%rax)
-;;  17a: addb    %al, (%rax)
-;;  17c: addb    %al, (%rax)
-;;  17e: addb    %al, (%rax)
-;;  180: addl    %eax, (%rax)
-;;  182: addl    %eax, (%rax)
-;;  184: addl    %eax, (%rax)
-;;  186: addl    %eax, (%rax)
-;;  188: addl    %eax, (%rax)
-;;  18a: addl    %eax, (%rax)
-;;  18c: addl    %eax, (%rax)
-;;  18e: addl    %eax, (%rax)
+;;  1a2: addb    %al, (%rax)
+;;  1a4: addb    %al, (%rax)
+;;  1a6: addb    %al, (%rax)
+;;  1a8: addb    %al, (%rax)
+;;  1aa: addb    %al, (%rax)
+;;  1ac: addb    %al, (%rax)
+;;  1ae: addb    %al, (%rax)
+;;  1b0: addl    %eax, (%rax)
+;;  1b2: addl    %eax, (%rax)
+;;  1b4: addl    %eax, (%rax)
+;;  1b6: addl    %eax, (%rax)
+;;  1b8: addl    %eax, (%rax)
+;;  1ba: addl    %eax, (%rax)
+;;  1bc: addl    %eax, (%rax)
+;;  1be: addl    %eax, (%rax)

--- a/tests/disas/x64-relaxed-simd.wat
+++ b/tests/disas/x64-relaxed-simd.wat
@@ -85,10 +85,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8b: addb    %al, (%rax)
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rax)
-;;   91: addb    %ah, %al
+;;   ab: addb    %al, (%rax)
+;;   ad: addb    %al, (%rax)
+;;   af: addb    %al, (%rax)
+;;   b1: addb    %ah, %al
 ;;
 ;; wasm[0]::function[4]:
 ;;       pushq   %rbp
@@ -110,12 +110,12 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   ee: addb    %al, (%rax)
-;;   f0: addl    %eax, (%rax)
-;;   f2: addl    %eax, (%rax)
-;;   f4: addl    %eax, (%rax)
-;;   f6: addl    %eax, (%rax)
-;;   f8: addl    %eax, (%rax)
-;;   fa: addl    %eax, (%rax)
-;;   fc: addl    %eax, (%rax)
-;;   fe: addl    %eax, (%rax)
+;;  11e: addb    %al, (%rax)
+;;  120: addl    %eax, (%rax)
+;;  122: addl    %eax, (%rax)
+;;  124: addl    %eax, (%rax)
+;;  126: addl    %eax, (%rax)
+;;  128: addl    %eax, (%rax)
+;;  12a: addl    %eax, (%rax)
+;;  12c: addl    %eax, (%rax)
+;;  12e: addl    %eax, (%rax)


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

The current default 16-bytes function alignment for x86-64 would cause suboptimal execution performance under some cases which are reported in https://github.com/bytecodealliance/wasmtime/issues/8573.

Based on the discussion "the CPU frontend grabs an aligned 32B or 64B chunk at a time" in https://github.com/bytecodealliance/wasmtime/issues/8573, this PR changes the default alignment from 16-bytes to 32-bytes for better performance. 

Also rerun the cases reported in https://github.com/bytecodealliance/wasmtime/issues/8573 and the execution time will back to normal.
```shell
# After changes
➜  case ✗ wasmtime compile good.wasm -o good.cwasm
➜  case ✗ wasmtime compile bad.wasm -o bad.cwasm
➜  case ✗ time wasmtime run --allow-precompiled good.cwasm
~/wasmtime/target/release/wasmtime run  good.cwasm  4.68s user 0.00s system 100% cpu 4.680 total
➜  case ✗ time wasmtime run --allow-precompiled bad.cwasm
~/wasmtime/target/release/wasmtime run  bad.cwasm  4.67s user 0.01s system 99% cpu 4.681 total


# Before changes
➜  case ✗ wasmtime compile good.wasm -o good.cwasm
➜  case ✗ wasmtime compile bad.wasm -o bad.cwasm
➜  case ✗ time wasmtime run --allow-precompiled good.cwasm
~/wasmtime/target/release/wasmtime run  good.cwasm  4.67s user 0.00s system 100% cpu 4.674 total
➜  case ✗ time wasmtime run --allow-precompiled bad.cwasm
~/wasmtime/target/release/wasmtime run  bad.cwasm  9.36s user 0.01s system 100% cpu 9.365 total
```
