### PR TITLE
cranelift: expand umbrella crate with more crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,11 @@ version = "0.108.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
+ "cranelift-interpreter",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
+ "cranelift-object",
 ]
 
 [[package]]

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -39,6 +39,6 @@ selinux-fix = ['memmap2']
 default = []
 
 [dev-dependencies]
-cranelift = { workspace = true }
+cranelift = { path = "../umbrella" }
 cranelift-frontend = { workspace = true }
 cranelift-entity = { workspace = true }

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -13,9 +13,28 @@ edition.workspace = true
 
 [dependencies]
 cranelift-codegen = { workspace = true }
-cranelift-frontend = { workspace = true }
+cranelift-frontend = { workspace = true, optional = true }
+cranelift-interpreter = { workspace = true, optional = true }
+cranelift-jit = { workspace = true, optional = true }
+cranelift-module = { workspace = true, optional = true }
+cranelift-native = { workspace = true, optional = true }
+cranelift-object = { workspace = true, optional = true }
 
 [features]
-default = ["std"]
-std = ["cranelift-codegen/std", "cranelift-frontend/std"]
-core = ["cranelift-codegen/core", "cranelift-frontend/core"]
+default = ["std", "frontend"]
+frontend = ["dep:cranelift-frontend"]
+interpreter = ["dep:cranelift-interpreter"]
+jit = ["dep:cranelift-jit"]
+module = ["dep:cranelift-module"]
+native = ["dep:cranelift-native"]
+object = ["dep:cranelift-object"]
+std = [
+    "cranelift-codegen/std",
+    "cranelift-frontend?/std",
+    "cranelift-module?/std",
+]
+core = [
+    "cranelift-codegen/core",
+    "cranelift-frontend?/core",
+    "cranelift-module?/core",
+]

--- a/cranelift/umbrella/src/lib.rs
+++ b/cranelift/umbrella/src/lib.rs
@@ -5,7 +5,18 @@
 
 /// Provide these crates, renamed to reduce stutter.
 pub use cranelift_codegen as codegen;
+#[cfg(feature = "frontend")]
 pub use cranelift_frontend as frontend;
+#[cfg(feature = "interpreter")]
+pub use cranelift_interpreter as interpreter;
+#[cfg(feature = "jit")]
+pub use cranelift_jit as jit;
+#[cfg(feature = "module")]
+pub use cranelift_module as module;
+#[cfg(feature = "native")]
+pub use cranelift_native as native;
+#[cfg(feature = "object")]
+pub use cranelift_object as object;
 
 /// A prelude providing convenient access to commonly-used cranelift features. Use
 /// as `use cranelift::prelude::*`.
@@ -22,6 +33,7 @@ pub mod prelude {
     pub use crate::codegen::isa;
     pub use crate::codegen::settings::{self, Configurable};
 
+    #[cfg(feature = "frontend")]
     pub use crate::frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 }
 

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -35,9 +35,9 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "cranelift-native",
     "cranelift-object",
     "cranelift-interpreter",
-    "cranelift",
     "wasmtime-jit-icache-coherence",
     "cranelift-jit",
+    "cranelift",
     // wiggle
     "wiggle-generate",
     "wiggle-macro",


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Closes https://github.com/bytecodealliance/wasmtime/issues/7772

This adds the `interpreter`, `jit`, `module`, `native` & `object` crates to the umbrella crate. All crates (including the existing `codegen` and `frontend` crates) are feature gated. However, `codegen` and `frontend` are default features, so backwards compatibility is retained if default features is not set to false. I wasn't quite sure which crates to include, but in my own project, I already depend on `jit`, `module` and `native`. Based on their descriptions, `interpreter` and `object` also seemed relevant as public API. I might have missed some other important crate.

I figured this would be an easy fix, although I understand if the umbrella crate should not have all these crates. In that case, feel free to close this PR :)