### PR TITLE
Including the outgoing arguments area when computing the caller's sp

### DIFF
--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1938,12 +1938,13 @@ impl<M: ABIMachineSpec> Callee<M> {
         frame_layout.clobber_size + frame_layout.fixed_frame_storage_size
     }
 
-    /// Returns offset from the nominal SP to caller's SP.
-    pub fn nominal_sp_to_caller_sp_offset(&self) -> u32 {
+    /// Returns offset from the SP to caller's SP.
+    pub fn sp_to_caller_sp_offset(&self) -> u32 {
         let frame_layout = self.frame_layout();
         frame_layout.clobber_size
             + frame_layout.fixed_frame_storage_size
             + frame_layout.setup_area_size
+            + frame_layout.outgoing_args_size
     }
 
     /// Returns the size of arguments expected on the stack.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1138,7 +1138,7 @@ impl<I: VCodeInst> VCode<I> {
             } else {
                 let slot = alloc.as_stack().unwrap();
                 let sp_offset = self.abi.get_spillslot_offset(slot);
-                let sp_to_caller_sp_offset = self.abi.nominal_sp_to_caller_sp_offset();
+                let sp_to_caller_sp_offset = self.abi.sp_to_caller_sp_offset();
                 let caller_sp_to_cfa_offset =
                     crate::isa::unwind::systemv::caller_sp_to_cfa_offset();
                 let cfa_to_sp_offset = -((sp_to_caller_sp_offset + caller_sp_to_cfa_offset) as i64);


### PR DESCRIPTION
After the recent changes to eagerly allocate space for outgoing arguments in the stack frame, the definition of the `nominal_sp_to_caller_sp_offset` function no longer seems correct: it assumes the old behavior where SP was always at the end of the fixed allocation area, and not at the end of the outoging args.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
