### PR TITLE
Display symbol names "compile -D"

### DIFF
--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -128,7 +128,7 @@ fn handle_module(
             let result = context.compiled_code().unwrap();
             print_all(
                 isa,
-                &context.func.params,
+                &context.func,
                 &mem,
                 code_info.total_size,
                 options.print,


### PR DESCRIPTION
Another one in the series to improve the debuggability quality of life: display the symbol name in the "compile -D" command.

No tests seems to expect anything with the string "Disassembly of {num} bytes", so no tests have been updated.

Here's an output sample (excerpt from `compile -D cranelift/filetests/filetests/wasm/f64-arith.clif`):

```
Disassembly of 44 bytes <%f64_copysign>:
   0:	55                   	pushq	%rbp
   1:	48 89 e5             	movq	%rsp, %rbp
   4:	48 b9 00 00 00 00 00 00 00 80	
				movabsq	$9223372036854775808, %rcx
   e:	66 48 0f 6e f9       	movq	%rcx, %xmm7
  13:	66 0f 6f d0          	movdqa	%xmm0, %xmm2
  17:	66 0f 6f c7          	movdqa	%xmm7, %xmm0
  1b:	66 0f 55 c2          	andnpd	%xmm2, %xmm0
  1f:	66 0f 54 f9          	andpd	%xmm1, %xmm7
  23:	66 0f 56 c7          	orpd	%xmm7, %xmm0
  27:	48 89 ec             	movq	%rbp, %rsp
  2a:	5d                   	popq	%rbp
  2b:	c3                   	retq		
```