### PR TITLE
Fix the change introduced in #8636, as the offset is to the CFA

### DIFF
--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1942,13 +1942,12 @@ impl<M: ABIMachineSpec> Callee<M> {
         frame_layout.clobber_size + frame_layout.fixed_frame_storage_size
     }
 
-    /// Returns offset from the SP to caller's SP.
-    pub fn sp_to_caller_sp_offset(&self) -> u32 {
+    /// Returns offset from the slot base in the current frame to the caller's SP.
+    pub fn slot_base_to_caller_sp_offset(&self) -> u32 {
         let frame_layout = self.frame_layout();
         frame_layout.clobber_size
             + frame_layout.fixed_frame_storage_size
             + frame_layout.setup_area_size
-            + frame_layout.outgoing_args_size
     }
 
     /// Returns the size of arguments expected on the stack.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1137,12 +1137,14 @@ impl<I: VCodeInst> VCode<I> {
                 LabelValueLoc::Reg(Reg::from(preg))
             } else {
                 let slot = alloc.as_stack().unwrap();
-                let sp_offset = self.abi.get_spillslot_offset(slot);
-                let sp_to_caller_sp_offset = self.abi.sp_to_caller_sp_offset();
+                let slot_offset = self.abi.get_spillslot_offset(slot);
+                let slot_base_to_caller_sp_offset = self.abi.slot_base_to_caller_sp_offset();
                 let caller_sp_to_cfa_offset =
                     crate::isa::unwind::systemv::caller_sp_to_cfa_offset();
-                let cfa_to_sp_offset = -((sp_to_caller_sp_offset + caller_sp_to_cfa_offset) as i64);
-                LabelValueLoc::CFAOffset(cfa_to_sp_offset + sp_offset)
+                // NOTE: this is a negative offset because it's relative to the caller's SP
+                let cfa_to_sp_offset =
+                    -((slot_base_to_caller_sp_offset + caller_sp_to_cfa_offset) as i64);
+                LabelValueLoc::CFAOffset(cfa_to_sp_offset + slot_offset)
             };
 
             // ValueLocRanges are recorded by *instruction-end


### PR DESCRIPTION
The offset computed in `compute_value_labels_ranges` is relative to the CFA, not the current value of SP, which means that the change introduced in #8636 is incorrect. This PR fixes that misunderstanding, and renames the `sp_to_caller_sp_offset` function to `slot_base_to_caller_sp_offset` to make it really clear what the value being computed is used for.

cc @jameysharp
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
