### PR TITLE
 Show function names in explore tool instead of only function indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,6 +3720,7 @@ dependencies = [
  "target-lexicon",
  "wasmprinter",
  "wasmtime",
+ "wasmtime-environ",
 ]
 
 [[package]]

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -20,3 +20,4 @@ serde_json = { workspace = true }
 target-lexicon = { workspace = true, features = ['std'] }
 wasmprinter = { workspace = true }
 wasmtime = { workspace = true, features = ["cranelift", "runtime"] }
+wasmtime-environ = { workspace = true }

--- a/crates/explorer/src/index.js
+++ b/crates/explorer/src/index.js
@@ -191,12 +191,12 @@ const renderInst = (mnemonic, operands) => {
 
 // Render the ASM.
 
-let nthFunc = 0;
 for (const func of state.asm.functions) {
   const funcElem = document.createElement("div");
 
   const funcHeader = document.createElement("h3");
-  funcHeader.textContent = `Defined Function ${nthFunc}`;
+  funcHeader.textContent = `Disassembly of function <${func.demangled_name}>:`;
+  funcHeader.title = func.name;
   funcElem.appendChild(funcHeader);
 
   const bodyElem = document.createElement("pre");
@@ -216,7 +216,6 @@ for (const func of state.asm.functions) {
   funcElem.appendChild(bodyElem);
 
   asmElem.appendChild(funcElem);
-  nthFunc++;
 }
 
 // Render the WAT.

--- a/crates/explorer/src/index.js
+++ b/crates/explorer/src/index.js
@@ -195,8 +195,11 @@ for (const func of state.asm.functions) {
   const funcElem = document.createElement("div");
 
   const funcHeader = document.createElement("h3");
-  funcHeader.textContent = `Disassembly of function <${func.demangled_name}>:`;
-  funcHeader.title = func.name;
+  let func_name = func.name === null ? `function[${func.index}]` : func.name;
+  let demangled_name =
+    func.demangled_name === null ? func.demangled_name : func_name;
+  funcHeader.textContent = `Disassembly of function <${demangled_name}>:`;
+  funcHeader.title = `Function ${func.index}: ${func_name}`;
   funcElem.appendChild(funcHeader);
 
   const bodyElem = document.createElement("pre");

--- a/crates/explorer/src/index.js
+++ b/crates/explorer/src/index.js
@@ -195,11 +195,12 @@ for (const func of state.asm.functions) {
   const funcElem = document.createElement("div");
 
   const funcHeader = document.createElement("h3");
-  let func_name = func.name === null ? `function[${func.index}]` : func.name;
+  let func_name =
+    func.name === null ? `function[${func.func_index}]` : func.name;
   let demangled_name =
-    func.demangled_name === null ? func.demangled_name : func_name;
+    func.demangled_name !== null ? func.demangled_name : func_name;
   funcHeader.textContent = `Disassembly of function <${demangled_name}>:`;
-  funcHeader.title = `Function ${func.index}: ${func_name}`;
+  funcHeader.title = `Function ${func.func_index}: ${func_name}`;
   funcElem.appendChild(funcHeader);
 
   const bodyElem = document.createElement("pre");

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use capstone::arch::BuildsCapstone;
 use serde_derive::Serialize;
 use std::{io::Write, str::FromStr};
+use wasmtime_environ::demangle_function_name;
 
 pub fn generate(
     config: &wasmtime::Config,
@@ -83,6 +84,8 @@ struct AnnotatedAsm {
 
 #[derive(Serialize, Debug)]
 struct AnnotatedFunction {
+    name: String,
+    demangled_name: String,
     instructions: Vec<AnnotatedInstruction>,
 }
 
@@ -129,9 +132,8 @@ fn annotate_asm(
     };
 
     let functions = module
-        .function_locations()
-        .into_iter()
-        .map(|(start, len)| {
+        .function_locations_with_names()
+        .map(|(name, start, len)| {
             let body = &text[start..][..len];
 
             let mut cs = match target.architecture {
@@ -181,7 +183,21 @@ fn annotate_asm(
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
-            Ok(AnnotatedFunction { instructions })
+
+            let demangled_name = match name.splitn(2, "::").nth(1) {
+                Some(name) => {
+                    let mut demangled = String::new();
+                    demangle_function_name(&mut demangled, name)
+                        .map_or_else(|_| format!("demangle-error::{}", name), |_| demangled)
+                }
+                None => name.to_string(),
+            };
+
+            Ok(AnnotatedFunction {
+                name,
+                demangled_name,
+                instructions,
+            })
         })
         .collect::<Result<Vec<_>>>()?;
 

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1027,6 +1027,29 @@ impl Module {
         })
     }
 
+    /// Get the locations of functions in this module's `.text` section, with the
+    /// function names.
+    ///
+    /// Each function's location is a (name, `.text` section offset, length) pair.
+    pub fn function_locations_with_names<'a>(
+        &'a self,
+    ) -> impl ExactSizeIterator<Item = (String, usize, usize)> + 'a {
+        let module = self.compiled_module();
+        self.function_locations().map(|(offset, len)| {
+            let (idx, _) = module.func_by_text_offset(offset).unwrap();
+            let idx = module.module().func_index(idx);
+            if let Some(name) = module.func_name(idx) {
+                (
+                    format!("function[{}]::{}", idx.as_u32(), name.to_string()),
+                    offset,
+                    len,
+                )
+            } else {
+                (format!("function[{}]", idx.as_u32()), offset, len)
+            }
+        })
+    }
+
     pub(crate) fn id(&self) -> CompiledModuleId {
         self.inner.module.unique_id()
     }

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1035,19 +1035,17 @@ impl Module {
         &'a self,
     ) -> impl ExactSizeIterator<Item = (String, usize, usize)> + 'a {
         let module = self.compiled_module();
-        self.function_locations().map(|(offset, len)| {
-            let (idx, _) = module.func_by_text_offset(offset).unwrap();
-            let idx = module.module().func_index(idx);
-            if let Some(name) = module.func_name(idx) {
-                (
-                    format!("function[{}]::{}", idx.as_u32(), name.to_string()),
-                    offset,
-                    len,
-                )
-            } else {
-                (format!("function[{}]", idx.as_u32()), offset, len)
-            }
-        })
+        self.function_locations()
+            .enumerate()
+            .map(|(idx, (offset, len))| {
+                let idx = DefinedFuncIndex::from_u32(u32::try_from(idx).unwrap());
+                let idx = module.module().func_index(idx);
+                if let Some(name) = module.func_name(idx) {
+                    (format!("function[{}]::{}", idx.as_u32(), name), offset, len)
+                } else {
+                    (format!("function[{}]", idx.as_u32()), offset, len)
+                }
+            })
     }
 
     pub(crate) fn id(&self) -> CompiledModuleId {


### PR DESCRIPTION
Another one in the "let's make debugging a bit easier": show function names in the "explore" tool.  (There's a bit of code repetition here to clean up the names, but it's slightly different when we're considering HTML output, so I think that's OK.)

Here's how it works on my machine:
<img width="1023" alt="image" src="https://github.com/bytecodealliance/wasmtime/assets/15001/9bb4b160-1bb9-44d3-a59f-615694f24a99">


