### PR TITLE
Fix some typos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -725,7 +725,7 @@ jobs:
     - run: rustup target add wasm32-wasi wasm32-unknown-unknown
     - run: |
         sudo apt-get update && sudo apt-get install -y gdb lldb-15 llvm
-        # woraround for https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/1972855
+        # workaround for https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/1972855
         sudo mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb
         sudo ln -s /usr/lib/llvm-15/lib/python3.10/dist-packages/lldb/* /usr/lib/python3/dist-packages/lldb/
         cargo test test_debug_dwarf -- --ignored --test-threads 1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2815,7 +2815,7 @@ Released 2022-03-07.
   [#3837](https://github.com/bytecodealliance/wasmtime/pull/3837)
 
 * The native stack size allowed for WebAssembly has been decreased from 1 MiB to
-  512 KiB on all platforms to better accomodate running wasm on the main thread
+  512 KiB on all platforms to better accommodate running wasm on the main thread
   on Windows.
   [#3861](https://github.com/bytecodealliance/wasmtime/pull/3861)
 
@@ -3300,7 +3300,7 @@ Released 2021-05-21.
 
 ### Added
 
-* Support for IBM z/Archiecture (`s390x`) machines in Cranelift and Wasmtime:
+* Support for IBM z/Architecture (`s390x`) machines in Cranelift and Wasmtime:
   [#2836](https://github.com/bytecodealliance/wasmtime/pull/2836),
   [#2837](https://github.com/bytecodealliance/wasmtime/pull/2837),
   [#2838](https://github.com/bytecodealliance/wasmtime/pull/2838),
@@ -3849,7 +3849,7 @@ is now enabled by default.
 
   [#1667](https://github.com/bytecodealliance/wasmtime/pull/1667)
 
-The Rust API does not require a store provided during `Module::new` operation. The `Module` can be send accross threads and instantiate for a specific store. The `Instance::new` now requires the store.
+The Rust API does not require a store provided during `Module::new` operation. The `Module` can be send across threads and instantiate for a specific store. The `Instance::new` now requires the store.
 
   [#1761](https://github.com/bytecodealliance/wasmtime/pull/1761)
 

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -151,9 +151,9 @@ async function getWorkspaceMembers() {
 /// buckets across that config.
 ///
 /// This is essentially a `flat_map` where each config that logically tests all
-/// crates int he workspace is mapped to N sharded configs that each test only a
+/// crates in the workspace is mapped to N sharded configs that each test only a
 /// subset of crates in the workspace. Each sharded config's subset of crates to
-/// test are disjoint from all its siblings, and the union of all thes siblings'
+/// test are disjoint from all its siblings, and the union of all these siblings'
 /// crates to test is the full workspace members set.
 ///
 /// With some poetic license around a `crates_to_test` key that doesn't actually

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -38,7 +38,7 @@ rustc-hash  = { workspace = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be
-# accomodated in `tests`.
+# accommodated in `tests`.
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/cranelift/codegen/meta/src/cdsl/types.rs
+++ b/cranelift/codegen/meta/src/cdsl/types.rs
@@ -185,7 +185,7 @@ impl LaneType {
             32 => shared_types::Int::I32,
             64 => shared_types::Int::I64,
             128 => shared_types::Int::I128,
-            _ => unreachable!("unxpected num bits for int"),
+            _ => unreachable!("unexpected num bits for int"),
         })
     }
 
@@ -193,7 +193,7 @@ impl LaneType {
         LaneType::Float(match num_bits {
             32 => shared_types::Float::F32,
             64 => shared_types::Float::F64,
-            _ => unreachable!("unxpected num bits for float"),
+            _ => unreachable!("unexpected num bits for float"),
         })
     }
 

--- a/cranelift/codegen/meta/src/isa/riscv64.rs
+++ b/cranelift/codegen/meta/src/isa/riscv64.rs
@@ -141,7 +141,7 @@ pub(crate) fn define() -> TargetIsa {
     );
 
     // Zvl*: Minimum Vector Length Standard Extensions
-    // These extension specifiy the minimum number of bits in a vector register.
+    // These extension specify the minimum number of bits in a vector register.
     // Since it is a minimum, Zvl64b implies Zvl32b, Zvl128b implies Zvl64b, etc.
     // The V extension supports a maximum of 64K bits in a single register.
     //

--- a/cranelift/codegen/shared/src/constants.rs
+++ b/cranelift/codegen/shared/src/constants.rs
@@ -13,7 +13,7 @@
 // Vector types are encoded with the lane type in the low 4 bits and log2(lanes)
 // in the next highest 4 bits, giving a range of 2-256 lanes.
 
-// Dynamic vector types are encoded similarily.
+// Dynamic vector types are encoded similarly.
 
 /// Start of the lane types.
 pub const LANE_BASE: u16 = 0x70;

--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -656,7 +656,7 @@ fn encode_narrow_field(x: u32, bits: u8) -> u32 {
         debug_assert!(
             x < max,
             "{x} does not fit into {bits} bits (must be less than {max} to \
-             allow for a 0xffffffff sentinal)"
+             allow for a 0xffffffff sentinel)"
         );
         x
     }

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -754,7 +754,7 @@ impl Ieee32 {
     }
 
     /// Create an `Ieee32` number representing the greatest negative value
-    /// not convertable from f32 to a signed integer with width n.
+    /// not convertible from f32 to a signed integer with width n.
     pub fn fcvt_to_sint_negative_overflow<I: Into<i32>>(n: I) -> Self {
         let n = n.into();
         debug_assert!(n < 32);
@@ -971,7 +971,7 @@ impl Ieee64 {
     }
 
     /// Create an `Ieee64` number representing the greatest negative value
-    /// not convertable from f64 to a signed integer with width n.
+    /// not convertible from f64 to a signed integer with width n.
     pub fn fcvt_to_sint_negative_overflow<I: Into<i64>>(n: I) -> Self {
         let n = n.into();
         debug_assert!(n < 64);

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -215,7 +215,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             //
             // See AArch64 ABI (https://github.com/ARM-software/abi-aa/blob/2021Q1/aapcs64/aapcs64.rst#642parameter-passing-rules), (Section 6.4.2 Stage C).
             //
-            // For arguments with alignment of 16 we round up the the register number
+            // For arguments with alignment of 16 we round up the register number
             // to the next even value. So we can never allocate for example an i128
             // to X1 and X2, we have to skip one register and do X2, X3
             // (Stage C.8)

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -185,7 +185,7 @@
         (size OperandSize))
 
        ;; A MOVK with a 16-bit immediate. Modifies its register; we
-       ;; model this with a seprate input `rn` and output `rd` virtual
+       ;; model this with a separate input `rn` and output `rd` virtual
        ;; register, with a regalloc constraint to tie them together.
        (MovK
         (rd WritableReg)
@@ -1700,7 +1700,7 @@
 (decl use_lse () Inst)
 (extern extractor use_lse use_lse)
 
-;; Extractor helpers for various immmediate constants ;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Extractor helpers for various immediate constants ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl pure partial move_wide_const_from_u64 (Type u64) MoveWideConst)
 (extern constructor move_wide_const_from_u64 move_wide_const_from_u64)

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -14,7 +14,7 @@ pub enum ShiftOp {
     LSL = 0b00,
     /// Logical shift right.
     LSR = 0b01,
-    /// Arithmentic shift right.
+    /// Arithmetic shift right.
     ASR = 0b10,
     /// Rotate right.
     ROR = 0b11,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -1061,7 +1061,7 @@ impl MachInstEmit for Inst {
                             &Inst::FpuLoad128 { .. } => {
                                 sink.put4(enc_ldst_imm19(0b10011100, offset, rd));
                             }
-                            _ => panic!("Unspported size for LDR from constant pool!"),
+                            _ => panic!("Unsupported size for LDR from constant pool!"),
                         }
                     }
                     &AMode::SPPreIndexed { simm9 } => {

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -178,7 +178,7 @@ impl FPURightShiftImm {
         // | 32                | 01xxxxx  |
         // | 64                | 1xxxxxx  |
         //
-        // The shift amount is negated such that a shift ammount
+        // The shift amount is negated such that a shift amount
         // of 1 (in 64-bit) is encoded as 0b111111 and a shift
         // amount of 64 is encoded as 0b000000,
         // in the bottom 6 bits.

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -158,7 +158,7 @@ fn inst_size_test() {
 }
 
 impl Inst {
-    /// Create an instruction that loads a constant, using one of serveral options (MOVZ, MOVN,
+    /// Create an instruction that loads a constant, using one of several options (MOVZ, MOVN,
     /// logical immediate, or constant pool).
     pub fn load_constant<F: FnMut(Type) -> Writable<Reg>>(
         rd: Writable<Reg>,

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -726,7 +726,7 @@
   (CSexth)
 ))
 
-;; This is a mix of all Zcb memory adressing instructions
+;; This is a mix of all Zcb memory addressing instructions
 ;;
 ;; Technically they are split across 4 different formats.
 ;; But they are all very similar, so we just group them all together.
@@ -1130,7 +1130,7 @@
 (rule (rv_xor rs1 rs2)
   (alu_rrr (AluOPRRR.Xor) rs1 rs2))
 
-;; Helper for emitting the `xori` ("Exlusive Or Immediate") instruction.
+;; Helper for emitting the `xori` ("Exclusive Or Immediate") instruction.
 ;; rd ← rs1 ⊕ uext(imm)
 (decl rv_xori (XReg Imm12) XReg)
 (rule (rv_xori rs1 imm)
@@ -1172,13 +1172,13 @@
 (rule (rv_snez rs1)
   (rv_sltu (zero_reg) rs1))
 
-;; Helper for emiting the `slti` ("Set Less Than Immediate") instruction.
+;; Helper for emitting the `slti` ("Set Less Than Immediate") instruction.
 ;; rd ← rs1 < imm
 (decl rv_slti (XReg Imm12) XReg)
 (rule (rv_slti rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Slti) rs1 imm))
 
-;; Helper for emiting the `sltiu` ("Set Less Than Immediate Unsigned") instruction.
+;; Helper for emitting the `sltiu` ("Set Less Than Immediate Unsigned") instruction.
 ;; rd ← rs1 < imm
 (decl rv_sltiu (XReg Imm12) XReg)
 (rule (rv_sltiu rs1 imm)
@@ -2092,7 +2092,7 @@
         dst))
 
 ;; some instruction use imm12 as funct12.
-;; so we don't need the imm12 paramter.
+;; so we don't need the imm12 parameter.
 (decl alu_rr_funct12 (AluOPRRI Reg) Reg)
 (rule (alu_rr_funct12 op src)
       (let ((dst WritableXReg (temp_writable_xreg))
@@ -2630,7 +2630,7 @@
         dst))
 
 ;;; some float binary operation
-;;; 1. need move into x reister.
+;;; 1. need move into x register.
 ;;; 2. do the operation.
 ;;; 3. move back.
 (decl lower_float_binary (AluOPRRR FReg FReg Type) FReg)
@@ -2863,7 +2863,7 @@
   (i128_sub (value_regs_zero) val))
 
 
-;; Builds an instruction sequence that traps if the comparision succeeds.
+;; Builds an instruction sequence that traps if the comparison succeeds.
 (decl gen_trapif (IntCC XReg XReg TrapCode) InstOutput)
 (rule (gen_trapif cc a b trap_code)
   (side_effect (SideEffectNoResult.Inst (MInst.TrapIf a b cc trap_code))))

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -855,7 +855,7 @@ impl Inst {
                 // Right now we only put a u32 or u64 in this instruction.
                 // It is not very long, no need to check if need `emit_island`.
                 // If data is very long , this is a bug because RawData is typecial
-                // use to load some data and rely on some positon in the code stream.
+                // use to load some data and rely on some position in the code stream.
                 // and we may exceed `Inst::worst_case_size`.
                 // for more information see https://github.com/bytecodealliance/wasmtime/pull/5612.
                 sink.put_data(&data[..]);
@@ -1867,7 +1867,7 @@ impl Inst {
                     //   auipc rd, 0              # R_RISCV_GOT_HI20 (symbol_name)
                     //   ld    rd, rd, 0          # R_RISCV_PCREL_LO12_I (label)
 
-                    // Create the lable that is going to be published to the final binary object.
+                    // Create the label that is going to be published to the final binary object.
                     let auipc_label = sink.get_label();
                     sink.bind_label(auipc_label, &mut state.ctrl_plane);
 
@@ -1938,7 +1938,7 @@ impl Inst {
                 //
                 // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#global-dynamic
 
-                // Create the lable that is going to be published to the final binary object.
+                // Create the label that is going to be published to the final binary object.
                 let auipc_label = sink.get_label();
                 sink.bind_label(auipc_label, &mut state.ctrl_plane);
 

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -415,7 +415,7 @@ pub fn encode_ci_sp_load(op: CiOp, rd: WritableReg, imm: Uimm6) -> u16 {
     // LDSP:  [5|4:3|8:6]
     // FLDSP: [5|4:3|8:6]
     //
-    // We don't recieve the entire offset in `imm`, just a multiple of the load-size.
+    // We don't receive the entire offset in `imm`, just a multiple of the load-size.
 
     // Number of bits in the lowest position of imm. 3 for lwsp, 2 for {f,}ldsp.
     let low_bits = match op {
@@ -509,7 +509,7 @@ pub fn encode_css_type(op: CssOp, src: Reg, imm: Uimm6) -> u16 {
     // c.sdsp:  [5:3|8:6]
     // c.fsdsp: [5:3|8:6]
     //
-    // We don't recieve the entire offset in `imm`, just a multiple of the load-size.
+    // We don't receive the entire offset in `imm`, just a multiple of the load-size.
 
     // Number of bits in the lowest position of imm. 4 for c.swsp, 3 for c.{f,}sdsp.
     let low_bits = match op {

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -62,7 +62,7 @@ impl Display for Imm12 {
     }
 }
 
-// singed
+// signed
 #[derive(Clone, Copy, Default)]
 pub struct Imm20 {
     /// 32-bit container where the low 20 bits are the data payload.

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -1017,7 +1017,7 @@
 (rule (rv_vfabs_v vs mask vstate) (rv_vfsgnjx_vv vs vs mask vstate))
 
 ;; Helper for emitting the `vfsqrt.v` instruction.
-;; This instruction splats the F regsiter into all elements of the destination vector.
+;; This instruction splats the F register into all elements of the destination vector.
 (decl rv_vfsqrt_v (VReg VecOpMasking VState) VReg)
 (rule (rv_vfsqrt_v vs mask vstate)
   (vec_alu_rr (VecAluOpRR.VfsqrtV) vs mask vstate))
@@ -1097,41 +1097,41 @@
 
 ;; Helper for emitting the `vmv.x.s` instruction.
 ;; This instruction copies the first element of the source vector to the destination X register.
-;; Masked versions of this instuction are not supported.
+;; Masked versions of this instruction are not supported.
 (decl rv_vmv_xs (VReg VState) XReg)
 (rule (rv_vmv_xs vs vstate)
   (vec_alu_rr (VecAluOpRR.VmvXS) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vfmv.f.s` instruction.
 ;; This instruction copies the first element of the source vector to the destination F register.
-;; Masked versions of this instuction are not supported.
+;; Masked versions of this instruction are not supported.
 (decl rv_vfmv_fs (VReg VState) FReg)
 (rule (rv_vfmv_fs vs vstate)
   (vec_alu_rr (VecAluOpRR.VfmvFS) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vmv.s.x` instruction.
 ;; This instruction copies the source X register into first element of the source vector.
-;; Masked versions of this instuction are not supported.
+;; Masked versions of this instruction are not supported.
 (decl rv_vmv_sx (XReg VState) VReg)
 (rule (rv_vmv_sx vs vstate)
   (vec_alu_rr (VecAluOpRR.VmvSX) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vfmv.s.f` instruction.
 ;; This instruction copies the source F register into first element of the source vector.
-;; Masked versions of this instuction are not supported.
+;; Masked versions of this instruction are not supported.
 (decl rv_vfmv_sf (FReg VState) VReg)
 (rule (rv_vfmv_sf vs vstate)
   (vec_alu_rr (VecAluOpRR.VfmvSF) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vmv.v.x` instruction.
-;; This instruction splats the X regsiter into all elements of the destination vector.
+;; This instruction splats the X register into all elements of the destination vector.
 ;; Masked versions of this instruction are called `vmerge`
 (decl rv_vmv_vx (XReg VState) VReg)
 (rule (rv_vmv_vx vs vstate)
   (vec_alu_rr (VecAluOpRR.VmvVX) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vfmv.v.f` instruction.
-;; This instruction splats the F regsiter into all elements of the destination vector.
+;; This instruction splats the F register into all elements of the destination vector.
 ;; Masked versions of this instruction are called `vmerge`
 (decl rv_vfmv_vf (FReg VState) VReg)
 (rule (rv_vfmv_vf vs vstate)
@@ -1862,7 +1862,7 @@
     res))
 
 
-;; Retruns the maximum value integer value that can be represented by a float
+;; Returns the maximum value integer value that can be represented by a float
 (decl float_int_max (Type) u64)
 (rule (float_int_max $F32) 0x4B000000)
 (rule (float_int_max $F64) 0x4330000000000000)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -78,7 +78,7 @@
 ;; !!! Important !!!
 ;; These rules only work for (ishl (uextend _) _) and not for (uextend (ishl _ _))!
 ;; Getting this wrong means a potential misscalculation of the shift amount.
-;; Additionaly we can only ensure that this is correct if the uextend is 32 to 64 bits.
+;; Additionally we can only ensure that this is correct if the uextend is 32 to 64 bits.
 (decl pure partial match_shnadd_uw (Imm64) AluOPRRR)
 (rule (match_shnadd_uw (u64_from_imm64 1)) (AluOPRRR.Sh1adduw))
 (rule (match_shnadd_uw (u64_from_imm64 2)) (AluOPRRR.Sh2adduw))
@@ -1520,7 +1520,7 @@
 ;; The vector instructions also have two variants each. `.vv` and `.vf`, where `.vv` variants
 ;; take two vector operands and the `.vf` variants take a vector operand and a scalar operand.
 ;;
-;; Due to this, variation they recieve the arguments in a different order. So we need to swap
+;; Due to this, variation they receive the arguments in a different order. So we need to swap
 ;; the arguments below.
 ;;
 ;; vfmacc:  vd[i] = +(vs1[i] * vs2[i]) + vd[i]
@@ -1850,7 +1850,7 @@
 ;; For vectors, we also do the same operation.
 ;; We can technically use any type in the bitwise operations, but prefer
 ;; using the type of the inputs so that we avoid emitting unnecessary
-;; `vsetvl` instructions. it's likeley that the vector unit is already
+;; `vsetvl` instructions. it's likely that the vector unit is already
 ;; configured for that type.
 (rule 1 (lower (has_type (ty_vec_fits_in_register ty) (bitselect c x y)))
   (let ((tmp_x VReg (rv_vand_vv c x (unmasked) ty))
@@ -2787,7 +2787,7 @@
 ;; elements. Using vcompress we can extract the elements and group them together.
 ;;
 ;; This is likely not the optimal way of doing this. LLVM does this using a bunch
-;; of vrgathers (See: https://godbolt.org/z/jq8Wj8WG4), that doesen't seem to be
+;; of vrgathers (See: https://godbolt.org/z/jq8Wj8WG4), that doesn't seem to be
 ;; too much better than this.
 ;;
 ;; However V8 does something better. They use 2 vcompresses using LMUL2, that means
@@ -2821,7 +2821,7 @@
 ;; we use a special rounding mode in the right shift instruction.
 ;;
 ;; For the right shift instruction we use `vssrl` which is a Scaling Shift
-;; Right Logical instruction using the `vxrm` fixed-point rouding mode. The
+;; Right Logical instruction using the `vxrm` fixed-point rounding mode. The
 ;; default rounding mode is `rnu` (round-to-nearest-up (add +0.5 LSB)).
 ;; Which is coincidentally the rounding mode we want for `avg_round`.
 (rule (lower (has_type (ty_vec_fits_in_register ty) (avg_round x y)))

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -180,7 +180,7 @@ impl TargetIsa for Riscv64Backend {
         let mut cs = cs_builder.build()?;
 
         // Similar to AArch64, RISC-V uses inline constants rather than a separate
-        // constant pool. We want to skip dissasembly over inline constants instead
+        // constant pool. We want to skip disassembly over inline constants instead
         // of stopping on invalid bytes.
         cs.set_skipdata(true)?;
         Ok(cs)

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1517,7 +1517,7 @@
 (extern extractor vr128_ty vr128_ty)
 
 
-;; Helpers for various immmediate constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helpers for various immediate constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Special integer types and their constructors
 
@@ -1768,7 +1768,7 @@
 (decl memarg_got () MemArg)
 (extern constructor memarg_got memarg_got)
 
-;; Create a MemArg refering to a stack address formed by
+;; Create a MemArg referring to a stack address formed by
 ;; adding a base (relative to SP) and an offset.
 (decl memarg_stack_off (i64 i64) MemArg)
 (extern constructor memarg_stack_off memarg_stack_off)
@@ -3455,7 +3455,7 @@
 ;; Push an instruction sequence to rotate a value loaded from memory
 ;; to the well-defined location: the high bytes in case of a big-endian
 ;; memory operation, and the low bytes in the little-endian case.
-;; (This is somewhat arbitary but chosen to allow the most efficient
+;; (This is somewhat arbitrary but chosen to allow the most efficient
 ;; sequences to compute the various atomic operations.)
 ;; Note that $I8 accesses always use the big-endian case.
 (decl casloop_rotate_in (VecMInstBuilder Type MemFlags Reg Reg) Reg)

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -609,7 +609,7 @@
 ;;
 ;; We never rely on the divide instruction itself to trap; while that trap
 ;; would indeed happen, we have no way of signalling two different trap
-;; conditions from the same instruction.  By explicity checking for the
+;; conditions from the same instruction.  By explicitly checking for the
 ;; integer-overflow case ahead of time, any hardware trap in the divide
 ;; instruction is guaranteed to indicate divison-by-zero.
 ;;
@@ -3841,7 +3841,7 @@
 ;; a condition mask of 2 | 1.
 ;;
 ;; As this does not match any of the encodings used with a normal integer
-;; comparsion, this cannot be represented by any IntCC value.  We need to
+;; comparison, this cannot be represented by any IntCC value.  We need to
 ;; remap the IntCC::UnsignedGreaterThan value that we have here as result
 ;; of the unsigned_add_overflow_condition call to the correct mask.
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -177,7 +177,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 );
             }
 
-            // Windows fastcall dictates that `__m128i` paramters to a function
+            // Windows fastcall dictates that `__m128i` parameters to a function
             // are passed indirectly as pointers, so handle that as a special
             // case before the loop below.
             if param.value_type.is_vector()
@@ -337,7 +337,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         }
 
         // Fastcall's indirect 128+ bit vector arguments are all located on the
-        // stack, and stack space is reserved after all paramters are passed,
+        // stack, and stack space is reserved after all parameters are passed,
         // so allocate from the space now.
         if args_or_rets == ArgsOrRets::Args && is_fastcall {
             for arg in args.args_mut() {

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -205,7 +205,7 @@
                (kind ShiftKind)
                (src Gpr)
                ;; shift count: `Imm8Gpr::Imm8(0 .. #bits-in-type - 1)` or
-               ;; `Imm8Reg::Gpr(r)` where `r` get's move mitosis'd into `%cl`.
+               ;; `Imm8Reg::Gpr(r)` where `r` gets move mitosis'd into `%cl`.
                (num_bits Imm8Gpr)
                (dst WritableGpr))
 
@@ -303,7 +303,7 @@
                      (dst WritableXmm)
                      (imm u8))
 
-       ;; XMM instruction for `vpinsr{b,w,d,q}` which is separte from
+       ;; XMM instruction for `vpinsr{b,w,d,q}` which is separate from
        ;; `XmmRmRImmVex` because `src2` is a gpr, not xmm register.
        (XmmVexPinsr (op AvxOpcode)
                    (src1 Xmm)
@@ -1836,7 +1836,7 @@
 ;;
 ;; These helpers are intended to assist in emitting instructions by taking
 ;; source operands and automatically creating output operands which are then
-;; returned. These are additionally deisgned to assist with SSA-like
+;; returned. These are additionally designed to assist with SSA-like
 ;; construction where the writable version of a register is only present in
 ;; an `MInst` and every other reference to it is a readonly version.
 
@@ -2229,7 +2229,7 @@
 ;; done for integers. This is because we're comparing a fresh register to itself
 ;; and we don't know the previous contents of the register. If a floating-point
 ;; comparison is used then it runs the risk of comparing NaN against NaN and not
-;; actually producing an all-ones mask. By using integer comparision operations
+;; actually producing an all-ones mask. By using integer comparison operations
 ;; we're guaranteeed that everything is equal to itself.
 (decl vector_all_ones () Xmm)
 (rule (vector_all_ones)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -14,7 +14,7 @@ use std::string::String;
 
 pub use crate::isa::x64::lower::isle::generated_code::DivSignedness;
 
-/// An extenstion trait for converting `Writable{Xmm,Gpr}` to `Writable<Reg>`.
+/// An extension trait for converting `Writable{Xmm,Gpr}` to `Writable<Reg>`.
 pub trait ToWritableReg {
     /// Convert `Writable{Xmm,Gpr}` to `Writable<Reg>`.
     fn to_writable_reg(&self) -> Writable<Reg>;
@@ -2150,7 +2150,7 @@ impl From<FloatCC> for FcmpImm {
 /// (i.e. the rounding mode) which only take up the first two bits when encoded.
 /// However the rounding immediate which this field helps make up, also includes
 /// bits 3 and 4 which define the rounding select and precision mask respectively.
-/// These two bits are not defined here and are implictly set to zero when encoded.
+/// These two bits are not defined here and are implicitly set to zero when encoded.
 #[derive(Clone, Copy)]
 pub enum RoundImm {
     /// Round to nearest mode.

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3603,7 +3603,7 @@
 ;; Step 7 - Prep the converted second set by zeroing out negative lanes (these have already been
 ;;          converted correctly with the first set) and by setting overflow lanes to 0x7FFFFFFF
 ;;          as this will allow us to properly saturate overflow lanes when adding to 0x80000000
-;; Step 8 - Add the orginal converted src and the converted tmp1 where float values originally less
+;; Step 8 - Add the original converted src and the converted tmp1 where float values originally less
 ;;          than and equal to INT_MAX will be unchanged, float values originally between INT_MAX+1 and
 ;;          UINT_MAX will add together (INT_MAX) + (SRC - INT_MAX), and float values originally
 ;;          greater than UINT_MAX will be saturated to UINT_MAX (0xFFFFFFFF) after adding (0x8000000 + 0x7FFFFFFF).
@@ -3632,7 +3632,7 @@
 
             ;; Set tmp2 to INT_MAX+1. It is important to note here that after it looks
             ;; like we are only converting INT_MAX (0x7FFFFFFF) but in fact because
-            ;; single precision IEEE-754 floats can only accurately represent contingous
+            ;; single precision IEEE-754 floats can only accurately represent contiguous
             ;; integers up to 2^23 and outside of this range it rounds to the closest
             ;; integer that it can represent. In the case of INT_MAX, this value gets
             ;; represented as 0x4f000000 which is the integer value (INT_MAX+1).

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2407,10 +2407,10 @@ impl<M: ABIMachineSpec> CallSite<M> {
         let tmp = ctx.alloc_tmp(word_type).only_reg().unwrap();
 
         // Any adjustment to SP to account for required outgoing arguments/stack return values must
-        // be done inside of the the call pseudo-op, to ensure that SP is always in a consistent
+        // be done inside of the call pseudo-op, to ensure that SP is always in a consistent
         // state for all other instructions. For example, if a tail-call abi function is called
         // here, the reclamation of the outgoing argument area must be done inside of the call
-        // pseudo-op's emission to ensure that SP is consisten at all other points in the lowered
+        // pseudo-op's emission to ensure that SP is consistent at all other points in the lowered
         // function. (Except the prologue and epilogue, but those are fairly special parts of the
         // function that establish the SP invariants that are relied on elsewhere and are generated
         // after the register allocator has run and thus cannot have register allocator-inserted

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -199,7 +199,7 @@ impl BlockLoweringOrder {
                 let range = block_succ_range[block].clone();
 
                 // If chaos-mode is enabled in the control plane, iterate over
-                // the successors in an arbtirary order, which should have no
+                // the successors in an arbitrary order, which should have no
                 // impact on correctness. The order of the blocks is generally
                 // relevant: Uses must be seen before defs for dead-code
                 // elimination.

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -379,7 +379,7 @@ pub struct MachLabel(u32);
 entity_impl!(MachLabel);
 
 impl MachLabel {
-    /// Get a label for a block. (The first N MachLabels are always reseved for
+    /// Get a label for a block. (The first N MachLabels are always reserved for
     /// the N blocks in the vcode.)
     pub fn from_block(bindex: BlockIndex) -> MachLabel {
         MachLabel(bindex.index() as u32)
@@ -742,7 +742,7 @@ impl<I: VCodeInst> MachBuffer<I> {
     }
 
     /// Inform the buffer of an unconditional branch at the given offset,
-    /// targetting the given label. May be used to optimize branches.
+    /// targeting the given label. May be used to optimize branches.
     /// The last added label-use must correspond to this branch.
     /// This must be called when the current offset is equal to `start`; i.e.,
     /// before actually emitting the branch. This implies that for a branch that
@@ -779,7 +779,7 @@ impl<I: VCodeInst> MachBuffer<I> {
     }
 
     /// Inform the buffer of a conditional branch at the given offset,
-    /// targetting the given label. May be used to optimize branches.
+    /// targeting the given label. May be used to optimize branches.
     /// The last added label-use must correspond to this branch.
     ///
     /// Additional requirement: no labels may be bound between `start` and `end`
@@ -968,7 +968,7 @@ impl<I: VCodeInst> MachBuffer<I> {
 
             // For any branch, conditional or unconditional:
             // - If the target is a label at the current offset, then remove
-            //   the conditional branch, and reset all labels that targetted
+            //   the conditional branch, and reset all labels that targeted
             //   the current offset (end of branch) to the truncated
             //   end-of-code.
             //

--- a/cranelift/codegen/src/machinst/valueregs.rs
+++ b/cranelift/codegen/src/machinst/valueregs.rs
@@ -17,7 +17,7 @@ const VALUE_REGS_PARTS: usize = 2;
 /// By convention, the register parts are kept in machine-endian order here.
 ///
 /// N.B.: we cap the capacity of this at four (when any 32-bit target is
-/// enabled) or two (otherwise), and we use special in-band sentinal `Reg`
+/// enabled) or two (otherwise), and we use special in-band sentinel `Reg`
 /// values (`Reg::invalid()`) to avoid the need to carry a separate length. This
 /// allows the struct to be `Copy` (no heap or drop overhead) and be only 16 or
 /// 8 bytes, which is important for compiler performance.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -224,7 +224,7 @@ pub struct VCodeBuilder<I: VCodeInst> {
     /// In-progress VCode.
     pub(crate) vcode: VCode<I>,
 
-    /// In what direction is the build occuring?
+    /// In what direction is the build occurring?
     direction: VCodeBuildDirection,
 
     /// Debug-value label in-progress map, keyed by label. For each

--- a/cranelift/codegen/src/opts/shifts.isle
+++ b/cranelift/codegen/src/opts/shifts.isle
@@ -176,7 +176,7 @@
       (if-let $true (u64_lt shift_amt (ty_bits_u64 (lane_type ty))))
       (sshr ty x (iconst_u kty shift_amt)))
 
-;; Simliarly, if the shift amount overflows the type, then we can turn
+;; Similarly, if the shift amount overflows the type, then we can turn
 ;; it into a 0
 ;;
 ;; (ishl (ishl x k1) k2) == 0 if shift_mask(k1) + shift_mask(k2) >= ty_bits

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -152,7 +152,7 @@
 ;; the shift amount to the bit width of the value being shifted, and so the high
 ;; half of the `i128` won't ever be used.
 ;;
-;; As a side efect, this marks that value as used.
+;; As a side effect, this marks that value as used.
 (decl lo_reg (Value) Reg)
 (rule (lo_reg val)
       (let ((regs ValueRegs (put_in_regs val)))

--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -70,7 +70,7 @@ where
     }
 
     /// Returns the cardinality of the set. More precisely, it returns the number of calls to
-    /// `insert` with different key values, that have happened since the the set was most recently
+    /// `insert` with different key values, that have happened since the set was most recently
     /// `clear`ed or created with `new`.
     pub fn cardinality(&self) -> usize {
         self.elems[..(self.len + (BITS - 1)) / BITS]

--- a/cranelift/filetests/filetests/parser/tiny.clif
+++ b/cranelift/filetests/filetests/parser/tiny.clif
@@ -111,7 +111,7 @@ block0(v90: f32, v91: f32):
 ; nextln: }
 
 ; The bitcast instruction has two type variables: The controlling type variable
-; controls the outout type, and the input type is a free variable.
+; controls the output type, and the input type is a free variable.
 function %bitcast(i32, f32) {
 block0(v90: i32, v91: f32):
     v0 = bitcast.i8x4 v90

--- a/cranelift/filetests/filetests/runtests/arithmetic-extends.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic-extends.clif
@@ -113,7 +113,7 @@ block0(v0: i32):
 
 
 ;; These tests ensure that we don't merge the `uextend` and `ishl` instructions
-;; in a way that doesen't respect the `ishl` semantics of cutting off the high bits.
+;; in a way that doesn't respect the `ishl` semantics of cutting off the high bits.
 
 function %add_uext_ishl_1(i64, i32) -> i64 {
 block0(v0: i64, v1: i32):

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -53,7 +53,7 @@ impl SubTest for TestCompile {
         let params = func.params.clone();
         let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
-        // With `MachBackend`s, we need to explicitly request dissassembly results.
+        // With `MachBackend`s, we need to explicitly request disassembly results.
         comp_ctx.set_disasm(true);
 
         let compiled_code = comp_ctx.compile(isa, &mut Default::default());

--- a/cranelift/filetests/src/test_domtree.rs
+++ b/cranelift/filetests/src/test_domtree.rs
@@ -105,7 +105,7 @@ impl SubTest for TestDomtree {
             if let Some(got_inst) = domtree.idom(block) {
                 anyhow::bail!(
                     "mismatching idoms for renumbered {}:\n\
-                     want: unrechable, got: {}",
+                     want: unreachable, got: {}",
                     block,
                     got_inst
                 );

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -246,7 +246,7 @@ impl fmt::Display for DefVariableError {
             DefVariableError::DefinedBeforeDeclared(variable) => {
                 write!(
                     f,
-                    "the value of variabe {} was declared before it was defined",
+                    "the value of variable {} was declared before it was defined",
                     variable.index()
                 )?;
             }

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -134,7 +134,7 @@ fn insert_stack_load(
     let type_size = typevar.bytes();
     let (slot, slot_size, category) = fgen.stack_slot_with_size(type_size)?;
 
-    // `stack_load` doesen't support setting MemFlags, and it does not set any
+    // `stack_load` doesn't support setting MemFlags, and it does not set any
     // alias analysis bits, so we can only emit it for `Other` slots.
     if category != AACategory::Other {
         return Err(arbitrary::Error::IncorrectFormat.into());
@@ -161,7 +161,7 @@ fn insert_stack_store(
 
     let (slot, slot_size, category) = fgen.stack_slot_with_size(type_size)?;
 
-    // `stack_store` doesen't support setting MemFlags, and it does not set any
+    // `stack_store` doesn't support setting MemFlags, and it does not set any
     // alias analysis bits, so we can only emit it for `Other` slots.
     if category != AACategory::Other {
         return Err(arbitrary::Error::IncorrectFormat.into());
@@ -822,7 +822,7 @@ static OPCODE_SIGNATURES: Lazy<Vec<OpcodeSignature>> = Lazy::new(|| {
                 // Constants are generated outside of `generate_instructions`
                 Opcode::Iconst => false,
 
-                // TODO: extract_vector raises exceptions during return type generation becuase it
+                // TODO: extract_vector raises exceptions during return type generation because it
                 // uses dynamic vectors.
                 Opcode::ExtractVector => false,
 

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -289,7 +289,7 @@ where
             IsaFlagGen::Host => builder_with_options(true)
                 .expect("Unable to build a TargetIsa for the current host"),
         };
-        // Cranelift has a somwhat weird API for this, but we need to build the final `TargetIsa` to be able
+        // Cranelift has a somewhat weird API for this, but we need to build the final `TargetIsa` to be able
         // to extract the values for the ISA flags. We need that to use the `string_value()` that formats
         // the values so that we can pass it into the builder again.
         let max_isa = max_builder.finish(Flags::new(settings::builder()))?;

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -568,7 +568,7 @@ functions).
 
 The universe of types is very simple: there are *primitives*, which
 can be integers or symbolic constants (imported from the Rust
-embedding), and *enums*, which correspond direclty to Rust enums with
+embedding), and *enums*, which correspond directly to Rust enums with
 variants that have named fields. There is no subtyping. Some examples
 of type definitions are:
 

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -9,7 +9,7 @@
 //! unification or anything like that.
 //!
 //! The term environment is constructed from both the AST and type
-//! envionment. It is sort of a typed and reorganized AST that more directly
+//! environment. It is sort of a typed and reorganized AST that more directly
 //! reflects ISLE semantics than the input ISLE source code (where as the AST is
 //! the opposite).
 

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -203,7 +203,7 @@ impl JITModule {
     ///
     /// # Safety
     ///
-    /// Because this function invalidates any pointers retrived from the
+    /// Because this function invalidates any pointers retrieved from the
     /// corresponding module, it should only be used when none of the functions
     /// from that module are currently executing and none of the `fn` pointers
     /// are called afterwards.

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -22,7 +22,7 @@ pub fn builder() -> Result<isa::Builder, &'static str> {
 /// in the current configuration.
 ///
 /// Selects the given backend variant specifically; this is
-/// useful when more than oen backend exists for a given target
+/// useful when more than one backend exists for a given target
 /// (e.g., on x86-64).
 pub fn builder_with_options(infer_native_flags: bool) -> Result<isa::Builder, &'static str> {
     let mut isa_builder = isa::lookup(Triple::host()).map_err(|err| match err {
@@ -40,7 +40,7 @@ pub fn builder_with_options(infer_native_flags: bool) -> Result<isa::Builder, &'
 /// in the current configuration.
 ///
 /// Selects the given backend variant specifically; this is
-/// useful when more than oen backend exists for a given target
+/// useful when more than one backend exists for a given target
 /// (e.g., on x86-64).
 pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'static str> {
     #[cfg(target_arch = "x86_64")]

--- a/cranelift/native/src/riscv.rs
+++ b/cranelift/native/src/riscv.rs
@@ -50,7 +50,7 @@ pub fn hwcap_detect(isa_builder: &mut dyn Configurable) -> Result<(), &'static s
 /// Read the /proc/cpuinfo file and detect the extensions.
 ///
 /// We are looking for the isa line string, which contains the extensions.
-/// The format for this string is specifid in the linux user space ABI for RISC-V:
+/// The format for this string is specified in the linux user space ABI for RISC-V:
 /// https://github.com/torvalds/linux/blob/09a9639e56c01c7a00d6c0ca63f4c7c41abe075d/Documentation/riscv/uabi.rst
 ///
 /// The format is fairly similar to the one specified in the RISC-V ISA manual, but

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -3806,7 +3806,7 @@ mod tests {
             "print: %default()"
         );
 
-        // Demonstrate some unparseable cases.
+        // Demonstrate some unparsable cases.
         assert!(parse("print", &sig(&[I32], &[I32])).is_err());
         assert!(parse("print:", &sig(&[], &[])).is_err());
         assert!(parse("run: ", &sig(&[], &[])).is_err());

--- a/cranelift/src/souper_harvest.rs
+++ b/cranelift/src/souper_harvest.rs
@@ -140,7 +140,7 @@ fn parse_input(path: PathBuf) -> Result<Vec<Function>> {
     Ok(funcs)
 }
 
-/// A convenience functon for a quick usize hash
+/// A convenience function for a quick usize hash
 #[inline]
 pub fn hash<T: std::hash::Hash + ?Sized>(v: &T) -> usize {
     let mut state = rustc_hash::FxHasher::default();

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2777,7 +2777,7 @@ where
     //   legalization of `heap_addr`, eliding the bounds check entirely.
     //
     // * For wasm64 offsets <=2gb will generate a single `heap_addr`
-    //   instruction, but at this time all heaps are "dyanmic" which means that
+    //   instruction, but at this time all heaps are "dynamic" which means that
     //   a single bounds check is forced. Ideally we'd do better here, but
     //   that's the current state of affairs.
     //

--- a/cranelift/wasm/src/state.rs
+++ b/cranelift/wasm/src/state.rs
@@ -194,7 +194,7 @@ impl ControlStackFrame {
         // (see also `FuncTranslationState::push_if`).
         // Yet, the original_stack_size member accounts for them only once, so that the else
         // block can see the same number of parameters as the consequent block. As a matter of
-        // fact, we need to substract an extra number of parameter values for if blocks.
+        // fact, we need to subtract an extra number of parameter values for if blocks.
         let num_duplicated_params = match self {
             &ControlStackFrame::If {
                 num_param_values, ..
@@ -329,7 +329,7 @@ impl FuncTranslationState {
         (v1, v2, v3)
     }
 
-    /// Helper to ensure the the stack size is at least as big as `n`; note that due to
+    /// Helper to ensure the stack size is at least as big as `n`; note that due to
     /// `debug_assert` this will not execute in non-optimized builds.
     #[inline]
     fn ensure_length_is_at_least(&self, n: usize) {

--- a/crates/c-api/include/wasmtime/async.h
+++ b/crates/c-api/include/wasmtime/async.h
@@ -7,13 +7,13 @@
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.async_support
  *
  * All WebAssembly executes synchronously, but an async support enables the Wasm
- * code be executed on a seperate stack, so it can be paused and resumed. There
+ * code be executed on a separate stack, so it can be paused and resumed. There
  * are three mechanisms for yielding control from wasm to the caller: fuel,
  * epochs, and async host functions.
  *
  * When WebAssembly is executed, a #wasmtime_call_future_t is returned. This
  * struct represents the state of the execution and each call to
- * #wasmtime_call_future_poll will execute the WebAssembly code on a seperate
+ * #wasmtime_call_future_poll will execute the WebAssembly code on a separate
  * stack until the function returns or yields control back to the caller.
  *
  * It's expected these futures are pulled in a loop until completed, at which

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -269,7 +269,7 @@ WASM_API_EXTERN bool wasmtime_linker_get(const wasmtime_linker_t *linker,
                                          wasmtime_extern_t *item);
 
 /**
- * \brief Preform all the checks for instantiating `module` with the linker,
+ * \brief Perform all the checks for instantiating `module` with the linker,
  *        except that instantiation doesn't actually finish.
  *
  * \param linker the linker used to instantiate the provided module.

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -43,7 +43,7 @@ typedef struct wasmtime_store wasmtime_store_t;
  * \brief An interior pointer into a #wasmtime_store_t which is used as
  * "context" for many functions.
  *
- * This context pointer is used pervasively throught Wasmtime's API. This can be
+ * This context pointer is used pervasively throughout Wasmtime's API. This can be
  * acquired from #wasmtime_store_context or #wasmtime_caller_context. The
  * context pointer for a store is the same for the entire lifetime of a store,
  * so it can safely be stored adjacent to a #wasmtime_store_t itself.

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -43,8 +43,8 @@ typedef struct wasmtime_store wasmtime_store_t;
  * \brief An interior pointer into a #wasmtime_store_t which is used as
  * "context" for many functions.
  *
- * This context pointer is used pervasively throughout Wasmtime's API. This can be
- * acquired from #wasmtime_store_context or #wasmtime_caller_context. The
+ * This context pointer is used pervasively throughout Wasmtime's API. This can
+ * be acquired from #wasmtime_store_context or #wasmtime_caller_context. The
  * context pointer for a store is the same for the entire lifetime of a store,
  * so it can safely be stored adjacent to a #wasmtime_store_t itself.
  *

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -153,7 +153,7 @@ const ZSTD_COMPRESSION_LEVELS: std::ops::RangeInclusive<i32> = 0..=21;
 // Default settings, you're welcome to tune them!
 // TODO: what do we want to warn users about?
 
-// At the moment of writing, the modules couldn't depend on anothers,
+// At the moment of writing, the modules couldn't depend on another,
 // so we have at most one module per wasmtime instance
 // if changed, update cli-cache.md
 const DEFAULT_WORKER_EVENT_QUEUE_SIZE: u64 = 0x10;

--- a/crates/cache/src/tests.rs
+++ b/crates/cache/src/tests.rs
@@ -1,7 +1,7 @@
 use super::config::tests::test_prolog;
 use super::*;
 
-// Since cache system is a global thing, each test needs to be run in seperate process.
+// Since cache system is a global thing, each test needs to be run in separate process.
 // So, init() tests are run as integration tests.
 // However, caching is a private thing, an implementation detail, and needs to be tested
 // from the inside of the module.

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -259,7 +259,7 @@ impl WorkerThread {
     }
 
     /// Increases the usage counter and recompresses the file
-    /// if the usage counter reached configurable treshold.
+    /// if the usage counter reached configurable threshold.
     fn handle_on_cache_get(&self, path: PathBuf) {
         trace!("handle_on_cache_get() for path: {}", path.display());
 
@@ -847,7 +847,7 @@ fn acquire_task_fs_lock(
 
 // we have either both, or just path; dir entry is desirable since on some platforms we can get
 // metadata without extra syscalls
-// futhermore: it's better to get a path if we have it instead of allocating a new one from the dir entry
+// furthermore: it's better to get a path if we have it instead of allocating a new one from the dir entry
 fn is_fs_lock_expired(
     entry: Option<&fs::DirEntry>,
     path: &PathBuf,

--- a/crates/cache/src/worker/tests.rs
+++ b/crates/cache/src/worker/tests.rs
@@ -605,12 +605,12 @@ fn test_on_update_cleanup_future_files() {
     let worker_lock_file = cache_dir.join(format!(".cleanup.wip-{}", process::id()));
 
     let scenarios: [&[_]; 5] = [
-        // NOT cleaning up, everythings ok
+        // NOT cleaning up, everything is ok
         &[
             (Duration::from_secs(0), None, true),
             (Duration::from_secs(24 * 60 * 60), None, true),
         ],
-        // NOT cleaning up, everythings ok
+        // NOT cleaning up, everything is ok
         &[
             (Duration::from_secs(0), None, true),
             (Duration::from_secs(24 * 60 * 60 + 1), None, true),

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -1001,7 +1001,7 @@ impl Compiler {
     ///
     /// This can be used to load arguments out of the array if the trampoline we
     /// are building exposes the array calling convention, or it can be used to
-    /// laod results out of the array if the trampoline we are building calls a
+    /// load results out of the array if the trampoline we are building calls a
     /// function that uses the array calling convention.
     fn load_values_from_array(
         &self,

--- a/crates/cranelift/src/debug/transform/address_transform.rs
+++ b/crates/cranelift/src/debug/transform/address_transform.rs
@@ -383,7 +383,7 @@ impl<'a> Iterator for TransformRangeIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             // Merge TransformRangeStartIter and TransformRangeEndIter data using
-            // FuncLookup index's field propery to be sorted by RangeIndex.
+            // FuncLookup index's field property to be sorted by RangeIndex.
             let (start, end, range_index): (
                 Option<GeneratedAddress>,
                 Option<GeneratedAddress>,

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -200,7 +200,7 @@ fn generate_vars(
 ) -> Result<(), Error> {
     let vmctx_label = get_vmctx_value_label();
 
-    // Normalize order of ValueLabelsRanges keys to have reproducable results.
+    // Normalize order of ValueLabelsRanges keys to have reproducible results.
     let mut vars = frame_info.value_ranges.keys().collect::<Vec<_>>();
     vars.sort_by(|a, b| a.index().cmp(&b.index()));
 

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -366,7 +366,7 @@ where
         // If `skip_at_depth` is `Some` then we previously decided to skip over
         // a node and all it's children. Let A be the last node processed, B be
         // the first node skipped, C be previous node, and D the current node.
-        // Then `cached` is the difference from A to B, `depth` is the diffence
+        // Then `cached` is the difference from A to B, `depth` is the difference
         // from B to C, and `depth_delta` is the differenc from C to D.
         let depth_delta = if let Some((depth, cached)) = skip_at_depth {
             // `new_depth` = B to D

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -60,7 +60,7 @@ pub(crate) fn add_internal_types(
         gimli::DW_AT_type = write::AttributeValue::UnitRef(memory_byte_die_id)
     });
 
-    // Create artificial VMContext type and its reference for convinience viewing
+    // Create artificial VMContext type and its reference for convenience viewing
     // its fields (such as memory ref) in a debugger. Build DW_TAG_structure_type:
     //   .. DW_AT_name = "WasmtimeVMContext"
     let vmctx_die_id = comp_unit.add(root_id, gimli::DW_TAG_structure_type);
@@ -93,7 +93,7 @@ pub(crate) fn add_internal_types(
             });
         }
         ModuleMemoryOffset::Imported(_) => {
-            // TODO implement convinience pointer to and additional types for VMMemoryImport.
+            // TODO implement convenience pointer to and additional types for VMMemoryImport.
         }
         ModuleMemoryOffset::None => (),
     }

--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -414,7 +414,7 @@ impl GcCompiler for DrcCompiler {
             .ins()
             .brif(bump_region_is_full, gc_block, &[], no_gc_block, &[]);
 
-        // Block for the the bump region is not full. We should:
+        // Block for when the bump region is not full. We should:
         //
         // * increment this reference's ref count,
         // * store the reference into the bump table at `*next`,

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -30,7 +30,7 @@ use wasmtime_environ::Compiler;
 
 const TEXT_SECTION_NAME: &[u8] = b".text";
 
-/// A helper structure used to assemble the final text section of an exectuable,
+/// A helper structure used to assemble the final text section of an executable,
 /// plus unwinding information and other related details.
 ///
 /// This builder relies on Cranelift-specific internals but assembles into a

--- a/crates/environ/src/compile/address_map.rs
+++ b/crates/environ/src/compile/address_map.rs
@@ -21,7 +21,7 @@ pub struct AddressMapSection {
 
 impl AddressMapSection {
     /// Pushes a new set of instruction mapping information for a function added
-    /// in the exectuable.
+    /// in the executable.
     ///
     /// The `func` argument here is the range of the function, relative to the
     /// start of the text section in the executable. The `instrs` provided are

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -31,13 +31,13 @@ pub use self::trap_encoding::*;
 /// An error while compiling WebAssembly to machine code.
 #[derive(Debug)]
 pub enum CompileError {
-    /// A wasm translation error occured.
+    /// A wasm translation error occurred.
     Wasm(WasmError),
 
-    /// A compilation error occured.
+    /// A compilation error occurred.
     Codegen(String),
 
-    /// A compilation error occured.
+    /// A compilation error occurred.
     DebugInfoNotSupported,
 }
 

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -9,7 +9,7 @@
 //
 // * This representation of a `Component` avoids the need to create a
 //   `PrimaryMap` of some form for each of the index spaces within a component.
-//   This is less so an issue about allocations and moreso that this information
+//   This is less so an issue about allocations and more so that this information
 //   generally just isn't needed any time after instantiation. Avoiding creating
 //   these altogether helps components be lighter weight at runtime and
 //   additionally accelerates instantiation.

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -101,13 +101,13 @@
 //! algorithm is a one-pass approach to partitioning everything into adapter
 //! modules.
 //!
-//! Adapters were indentified in-order as part of the inlining phase of
+//! Adapters were identified in-order as part of the inlining phase of
 //! translation where we're guaranteed that once an adapter is identified
 //! it can't depend on anything identified later. The pass implemented here is
 //! to visit all transitive dependencies of an adapter. If one of the
 //! dependencies of an adapter is an adapter in the current adapter module
 //! being built then the current module is finished and a new adapter module is
-//! started. This should quickly parition adapters into contiugous chunks of
+//! started. This should quickly partition adapters into contiugous chunks of
 //! their index space which can be in adapter modules together.
 //!
 //! There's probably more general algorithms for this but for now this should be
@@ -170,7 +170,7 @@ impl<'data> Translator<'_, 'data> {
     /// metadata for adapter modules.
     pub(super) fn partition_adapter_modules(&mut self, component: &mut dfg::ComponentDfg) {
         // Visit each adapter, in order of its original definition, during the
-        // paritioning. This allows for the guarantee that dependencies are
+        // partitioning. This allows for the guarantee that dependencies are
         // visited in a topological fashion ideally.
         let mut state = PartitionAdapterModules::default();
         for (id, adapter) in component.adapters.iter() {

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -1017,8 +1017,8 @@ impl FlatTypes<'_> {
 }
 
 // Note that this is intentionally duplicated here to keep the size to 1 byte
-// irregardless to changes in the core wasm type system since this will only
-// ever use integers/floats for the forseeable future.
+// regardless to changes in the core wasm type system since this will only
+// ever use integers/floats for the foreseeable future.
 #[derive(PartialEq, Eq, Copy, Clone)]
 #[allow(missing_docs)]
 pub enum FlatType {

--- a/crates/environ/src/component/types_builder/resources.rs
+++ b/crates/environ/src/component/types_builder/resources.rs
@@ -57,7 +57,7 @@
 //! conversion in general. The "leaves" of a type may be resources but there are
 //! other structures in a type such as lists, records, variants, etc. This means
 //! that the `ResourcesBuilder` below is embedded within a
-//! `ComponentTypesBuilder`. This also means that it's unfortuantely not easy to
+//! `ComponentTypesBuilder`. This also means that it's unfortunately not easy to
 //! disentangle pieces and have one nice standalone file that handles everything
 //! related to type information about resources. Instead this one file was
 //! chosen as the place for this doc comment but the file itself is deceptively

--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -1,7 +1,7 @@
 //! Wasmtime's Fused Adapter Compiler of Trampolines (FACT)
 //!
 //! This module contains a compiler which emits trampolines to implement fused
-//! adatpers for the component model. A fused adapter is when a core wasm
+//! adapters for the component model. A fused adapter is when a core wasm
 //! function is lifted from one component instance and then lowered into another
 //! component instance. This communication between components is well-defined by
 //! the spec and ends up creating what's called a "fused adapter".
@@ -14,7 +14,7 @@
 //!
 //! Note that identification of precisely what goes into an adapter module is
 //! not handled in this file, instead that's all done in `translate/adapt.rs`.
-//! Otherwise this module is only reponsible for taking a set of adapters and
+//! Otherwise this module is only responsible for taking a set of adapters and
 //! their imports and then generating a core wasm module to implement all of
 //! that.
 
@@ -605,7 +605,7 @@ cranelift_entity::entity_impl!(FunctionId);
 
 /// A generated function to be added to an adapter module.
 ///
-/// At least one function is created per-adapter and dependeing on the type
+/// At least one function is created per-adapter and depending on the type
 /// hierarchy multiple functions may be generated per-adapter.
 struct Function {
     /// Whether or not the `body` has been finished.
@@ -629,7 +629,7 @@ struct Function {
     /// The contents of the function.
     ///
     /// See `Body` for more information, and the `Vec` here represents the
-    /// concatentation of all the `Body` fragments.
+    /// concatenation of all the `Body` fragments.
     body: Vec<Body>,
 }
 

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -521,7 +521,7 @@ impl Compiler<'_, '_> {
         // The general goal is to avoid creating an exponentially sized function
         // for a linearly sized input (the type section). By outlining helper
         // functions there will ideally be a constant set of helper functions
-        // per type (to accomodate in-memory or on-stack transfers as well as
+        // per type (to accommodate in-memory or on-stack transfers as well as
         // src/dst options) which means that each function is at most a certain
         // size and we have a linear number of functions which should guarantee
         // an overall linear size of the output.
@@ -1229,7 +1229,7 @@ impl Compiler<'_, '_> {
         self.validate_string_length(src, src_enc);
 
         // Optimistically assume that the code unit length of the source is
-        // all that's needed in the destination. Perform that allocaiton
+        // all that's needed in the destination. Perform that allocation
         // here and proceed to transcoding below.
         self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst_opts.ptr());
         let dst_len = self.local_tee_new_tmp(dst_opts.ptr());
@@ -1735,7 +1735,7 @@ impl Compiler<'_, '_> {
         self.instruction(Block(BlockType::Empty));
 
         // Calculate the full byte size of memory with `memory.size`. Note that
-        // arithmetic here is done always in 64-bits to accomodate 4G memories.
+        // arithmetic here is done always in 64-bits to accommodate 4G memories.
         // Additionally it's assumed that 64-bit memories never fill up
         // entirely.
         self.instruction(MemorySize(opts.memory.unwrap().as_u32()));

--- a/crates/environ/src/fact/transcode.rs
+++ b/crates/environ/src/fact/transcode.rs
@@ -67,7 +67,7 @@ impl Transcoder {
             }
 
             // The initial step of transcoding from a fixed format to a compact
-            // format. Takes the ptr/len of the source the the destination
+            // format. Takes the ptr/len of the source the destination
             // pointer. The destination length is implicitly the same. Returns
             // how many code units were consumed in the source, which is also
             // how many bytes were written to the destination.

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -291,7 +291,7 @@ impl MemoryInitialization {
 /// The various callbacks provided here are used to drive the smaller bits of
 /// memory initialization.
 pub trait InitMemory {
-    /// Returns the size, in wasm pages, of the the memory specified. For
+    /// Returns the size, in wasm pages, of the memory specified. For
     /// compile-time purposes this would be the memory type's minimum size.
     fn memory_size_in_pages(&mut self, memory_index: MemoryIndex) -> u64;
 

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -6,7 +6,7 @@ use wasmtime_types::{ModuleInternedRecGroupIndex, ModuleInternedTypeIndex, WasmS
 
 /// All types used in a core wasm module.
 ///
-/// Note that accesing this type is primarily done through the `Index`
+/// Note that accessing this type is primarily done through the `Index`
 /// implementations for this type.
 #[derive(Default, Serialize, Deserialize)]
 pub struct ModuleTypes {

--- a/crates/environ/src/ref_bits.rs
+++ b/crates/environ/src/ref_bits.rs
@@ -25,7 +25,7 @@
 /// bit every time we load.
 ///
 /// Note that we take care to set this bit and mask it off when
-/// accessing tables direclty in fastpaths in generated code as well.
+/// accessing tables directly in fastpaths in generated code as well.
 pub const FUNCREF_INIT_BIT: usize = 1;
 
 /// The mask we apply to all refs loaded from funcref tables.

--- a/crates/fuzzing/src/generators/component_types.rs
+++ b/crates/fuzzing/src/generators/component_types.rs
@@ -3,7 +3,7 @@
 //!
 //! Each case includes a list of arbitrary interface types to use as parameters, plus another one to use as a
 //! result, and a component which exports a function and imports a function.  The exported function forwards its
-//! parameters to the imported one and forwards the result back to the caller.  This serves to excercise Wasmtime's
+//! parameters to the imported one and forwards the result back to the caller.  This serves to exercise Wasmtime's
 //! lifting and lowering code and verify the values remain intact during both processes.
 
 use arbitrary::{Arbitrary, Unstructured};

--- a/crates/fuzzing/src/generators/stacks.rs
+++ b/crates/fuzzing/src/generators/stacks.rs
@@ -1,7 +1,7 @@
 //! Generate a Wasm program that keeps track of its current stack frames.
 //!
 //! We can then compare the stack trace we observe in Wasmtime to what the Wasm
-//! program believes its stack should be. Any discrepencies between the two
+//! program believes its stack should be. Any discrepancies between the two
 //! points to a bug in either this test case generator or Wasmtime's stack
 //! walker.
 
@@ -89,7 +89,7 @@ impl Stacks {
     ///
     /// * `host.check_stack: [] -> []`: The host can check the Wasm's
     ///   understanding of its own stack against the host's understanding of the
-    ///   Wasm stack to find discrepency bugs.
+    ///   Wasm stack to find discrepancy bugs.
     ///
     /// * `host.call_func: [funcref] -> []`: The host should call the given
     ///   `funcref`, creating a call stack with multiple sequences of contiguous

--- a/crates/jit-debug/src/gdb_jit_int.rs
+++ b/crates/jit-debug/src/gdb_jit_int.rs
@@ -42,7 +42,7 @@ extern "C" {
 /// access to the __jit_debug_descriptor within this process.
 static GDB_REGISTRATION: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(Default::default()));
 
-/// Registeration for JIT image
+/// Registration for JIT image
 pub struct GdbJitImageRegistration {
     entry: Pin<Box<JITCodeEntry>>,
     file: Pin<Box<[u8]>>,

--- a/crates/jit-debug/src/perf_jitdump.rs
+++ b/crates/jit-debug/src/perf_jitdump.rs
@@ -84,7 +84,7 @@ pub struct DebugEntry {
 }
 
 /// Describes debug information for a jitted function. An array of debug entries are
-/// appended to this record during writting. Note, this record must preceed the code
+/// appended to this record during writing. Note, this record must precede the code
 /// load record that describes the same jitted function.
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
@@ -139,7 +139,7 @@ pub struct JitDumpFile {
 }
 
 impl JitDumpFile {
-    /// Intialize a JitDumpAgent and write out the header
+    /// Initialize a JitDumpAgent and write out the header
     pub fn new(filename: impl AsRef<Path>, e_machine: u32) -> io::Result<Self> {
         let jitdump_file = OpenOptions::new()
             .read(true)

--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! Each case includes a list of arbitrary interface types to use as parameters, plus another one to use as a
 //! result, and a component which exports a function and imports a function.  The exported function forwards its
-//! parameters to the imported one and forwards the result back to the caller.  This serves to excercise Wasmtime's
+//! parameters to the imported one and forwards the result back to the caller.  This serves to exercise Wasmtime's
 //! lifting and lowering code and verify the values remain intact during both processes.
 
 use arbitrary::{Arbitrary, Unstructured};
@@ -877,7 +877,7 @@ impl Declarations {
 pub struct TestCase<'a> {
     /// The types of parameters to pass to the function
     pub params: Vec<&'a Type>,
-    /// The result types of the the function
+    /// The result types of the function
     pub results: Vec<&'a Type>,
     /// String encoding to use from host-to-component.
     pub encoding1: StringEncoding,

--- a/crates/slab/src/lib.rs
+++ b/crates/slab/src/lib.rs
@@ -16,7 +16,7 @@
 //! let gza = slab.alloc("Gary Grice");
 //! let bill = slab.alloc("Bill Gates");
 //!
-//! // Alloced elements can be accessed infallibly via indexing (and missing and
+//! // Allocated elements can be accessed infallibly via indexing (and missing and
 //! // deallocated entries will panic).
 //! assert_eq!(slab[rza], "Robert Fitzgerald Diggs");
 //!

--- a/crates/test-programs/src/bin/piped_multiple.rs
+++ b/crates/test-programs/src/bin/piped_multiple.rs
@@ -25,7 +25,7 @@ fn consumer() {
     let stdin_pollable1 = stdin.subscribe();
     let stdin_pollable2 = stdin.subscribe();
 
-    // The two pollables are subscribed to the same resource, and must report the same readyness
+    // The two pollables are subscribed to the same resource, and must report the same readiness
     stdin_pollable1.block();
     assert!(stdin_pollable1.ready() && stdin_pollable2.ready());
 

--- a/crates/test-programs/src/bin/preview1_dir_fd_op_failures.rs
+++ b/crates/test-programs/src/bin/preview1_dir_fd_op_failures.rs
@@ -55,7 +55,7 @@ unsafe fn test_fd_dir_ops(dir_fd: wasi::Fd) {
     let r = wasi::fd_seek(dir_fd, 0, wasi::WHENCE_END);
     assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_seek WHENCE_END error");
 
-    // Tell isnt in posix, its basically lseek with WHENCE_CUR above
+    // Tell isn't in posix, its basically lseek with WHENCE_CUR above
     let r = wasi::fd_tell(dir_fd);
     assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_tell error");
 

--- a/crates/test-programs/src/bin/preview1_fd_advise.rs
+++ b/crates/test-programs/src/bin/preview1_fd_advise.rs
@@ -31,7 +31,7 @@ unsafe fn test_fd_advise(dir_fd: wasi::Fd) {
     // Advise the kernel
     wasi::fd_advise(file_fd, 10, 50, wasi::ADVICE_NORMAL).expect("failed advise");
 
-    // Advise shouldnt change size
+    // Advise shouldn't change size
     let stat = wasi::fd_filestat_get(file_fd).expect("failed to fdstat 3");
     assert_eq!(stat.size, 100, "file size should be 100");
 

--- a/crates/test-programs/src/bin/preview1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_read_write.rs
@@ -31,8 +31,8 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
         buf_len: write_buffer.len(),
     };
     // PERM is only the failure on windows under wasmtime-wasi. wasi-common
-    // fails on windows with BADF, so we cant use the `windows =>` syntax
-    // because that doesnt support alternatives like the agnostic syntax does.
+    // fails on windows with BADF, so we can't use the `windows =>` syntax
+    // because that doesn't support alternatives like the agnostic syntax does.
     assert_errno!(
         wasi::fd_write(f_readonly, &[ciovec])
             .err()

--- a/crates/test-programs/src/bin/preview2_tcp_sample_application.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_sample_application.rs
@@ -32,7 +32,7 @@ fn test_tcp_sample_application(family: IpAddressFamily, bind_address: IpSocketAd
 
         let data = input.blocking_read(first_message.len() as u64).unwrap();
 
-        // Check that we sent and recieved our message!
+        // Check that we sent and received our message!
         assert_eq!(data, first_message); // Not guaranteed to work but should work in practice.
     }
 
@@ -48,7 +48,7 @@ fn test_tcp_sample_application(family: IpAddressFamily, bind_address: IpSocketAd
         let (_accepted, input, _output) = listener.blocking_accept().unwrap();
         let data = input.blocking_read(second_message.len() as u64).unwrap();
 
-        // Check that we sent and recieved our message!
+        // Check that we sent and received our message!
         assert_eq!(data, second_message); // Not guaranteed to work but should work in practice.
     }
 }

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -614,7 +614,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
             buf.as_array(dirent_copy_len)
                 .copy_from_slice(&dirent_raw[..dirent_copy_len as usize])?;
 
-            // If the dirent struct wasnt compied entirely, return that we filled the buffer, which
+            // If the dirent struct wasn't compiled entirely, return that we filled the buffer, which
             // tells libc that we're not at EOF.
             if dirent_copy_len < dirent_len {
                 return Ok(buf_len);

--- a/crates/wasi-common/src/sync/sched/windows.rs
+++ b/crates/wasi-common/src/sync/sched/windows.rs
@@ -207,7 +207,7 @@ impl StdinPoll {
             // Wait for data to appear in stdin. If fill_buf returns any slice, it means
             // that either:
             // (a) there is some data in stdin, if non-empty,
-            // (b) EOF was recieved, if its empty
+            // (b) EOF was received, if its empty
             // Linux returns `POLLIN` in both cases, so we imitate this behavior.
             let resp = match std::io::stdin().lock().fill_buf() {
                 Ok(_) => PollState::Ready,

--- a/crates/wasi-common/src/tokio/file.rs
+++ b/crates/wasi-common/src/tokio/file.rs
@@ -189,7 +189,7 @@ macro_rules! wasi_file_impl {
                         Ok(())
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-                        // if e is EPERM, this file isnt supported by epoll because it is immediately
+                        // if e is EPERM, this file isn't supported by epoll because it is immediately
                         // available for reading:
                         Ok(())
                     }
@@ -213,7 +213,7 @@ macro_rules! wasi_file_impl {
                         Ok(())
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-                        // if e is EPERM, this file isnt supported by epoll because it is immediately
+                        // if e is EPERM, this file isn't supported by epoll because it is immediately
                         // available for writing:
                         Ok(())
                     }

--- a/crates/wasi-nn/examples/classification-component-onnx/src/bindings.rs
+++ b/crates/wasi-nn/examples/classification-component-onnx/src/bindings.rs
@@ -859,7 +859,7 @@ pub mod wasi {
           /// WASI. At this time, it should be interpreted as a request, and not a
           /// requirement.
           const DATA_INTEGRITY_SYNC = 1 << 3;
-          /// Requests that reads be performed at the same level of integrety
+          /// Requests that reads be performed at the same level of integrity
           /// requested for writes. This is similar to `O_RSYNC` in POSIX.
           /// 
           /// The precise semantics of this operation have not yet been defined for
@@ -4378,7 +4378,7 @@ pub mod wasi {
             #[allow(unused_unsafe, clippy::all)]
             /// Read from one stream and write to another.
             /// 
-            /// The behavior of splice is equivelant to:
+            /// The behavior of splice is equivalent to:
             /// 1. calling `check-write` on the `output-stream`
             /// 2. calling `read` on the `input-stream` with the smaller of the
             /// `check-write` permitted length and the `len` provided to `splice`

--- a/crates/wasi-nn/examples/classification-component-onnx/src/bindings.rs
+++ b/crates/wasi-nn/examples/classification-component-onnx/src/bindings.rs
@@ -600,7 +600,7 @@ pub mod wasi {
       }
       #[allow(unused_unsafe, clippy::all)]
       /// Create a `pollable` which will resolve once the specified instant
-      /// occured.
+      /// occurred.
       pub fn subscribe_instant(when: Instant,) -> Pollable{
         
         #[allow(unused_imports)]
@@ -623,7 +623,7 @@ pub mod wasi {
       #[allow(unused_unsafe, clippy::all)]
       /// Create a `pollable` which will resolve once the given duration has
       /// elapsed, starting at the time at which this function was called.
-      /// occured.
+      /// occurred.
       pub fn subscribe_duration(when: Duration,) -> Pollable{
         
         #[allow(unused_imports)]
@@ -4205,7 +4205,7 @@ pub mod wasi {
         impl OutputStream {
           #[allow(unused_unsafe, clippy::all)]
           /// Create a `pollable` which will resolve once the output-stream
-          /// is ready for more writing, or an error has occured. When this
+          /// is ready for more writing, or an error has occurred. When this
           /// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
           /// error.
           /// 

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -298,7 +298,7 @@ impl Descriptors {
                     Descriptor::Closed(next) => *next,
                     _ => unreachable!("impossible: freelist points to a closed descriptor"),
                 };
-                // Write descriptor to the entry at the nead of the list
+                // Write descriptor to the entry at the head of the list
                 *freelist_desc = d;
                 // Point closed to the following item
                 self.closed = next_closed;

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -1976,7 +1976,7 @@ pub unsafe extern "C" fn poll_oneoff(
                 .trapping_unwrap()
     );
     // Store the pollable handles at the beginning, and the bool results at the
-    // end, so that we don't clobber the bool results when writting the events.
+    // end, so that we don't clobber the bool results when writing the events.
     let pollables = out as *mut c_void as *mut Pollable;
     let results = out.add(nsubscriptions).cast::<u32>().sub(nsubscriptions);
 

--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -108,7 +108,7 @@ impl WasiCtxBuilder {
     /// Provides a custom implementation of stdin to use.
     ///
     /// By default stdin is closed but an example of using the host's native
-    /// stdin loos like:
+    /// stdin looks like:
     ///
     /// ```
     /// use wasmtime_wasi::{stdin, WasiCtxBuilder};

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -90,7 +90,7 @@ pub struct File {
     pub perms: FilePerms,
     /// The mode the file was opened under: bits for reading, and writing.
     /// Required to correctly report the DescriptorFlags, because cap-std
-    /// doesn't presently provide a cross-platform equivelant of reading the
+    /// doesn't presently provide a cross-platform equivalent of reading the
     /// oflags back out using fcntl.
     pub open_mode: OpenMode,
 
@@ -193,7 +193,7 @@ pub struct Dir {
     pub file_perms: FilePerms,
     /// The mode the directory was opened under: bits for reading, and writing.
     /// Required to correctly report the DescriptorFlags, because cap-std
-    /// doesn't presently provide a cross-platform equivelant of reading the
+    /// doesn't presently provide a cross-platform equivalent of reading the
     /// oflags back out using fcntl.
     pub open_mode: OpenMode,
 

--- a/crates/wasi/src/pipe.rs
+++ b/crates/wasi/src/pipe.rs
@@ -459,7 +459,7 @@ mod test {
     // suitable design for all applications, and we will probably make a knob or change the
     // behavior at some point, but this test shows the behavior as it is implemented:
     async fn backpressure_read_stream() {
-        let (r, mut w) = simplex(16 * 1024); // Make sure this buffer isnt a bottleneck
+        let (r, mut w) = simplex(16 * 1024); // Make sure this buffer isn't a bottleneck
         let mut reader = AsyncReadStream::new(r);
 
         let writer_task = tokio::task::spawn(async move {
@@ -590,7 +590,7 @@ mod test {
                     "expected a LastOperationFailed before we see Closed. {write_ready_res:?}"
                 );
             }
-            // Also possible the worker hasnt processed write yet:
+            // Also possible the worker hasn't processed write yet:
             Ok(()) => {}
             Err(e) => panic!("unexpected flush error: {e:?} {write_ready_res:?}"),
         }
@@ -724,7 +724,7 @@ mod test {
         // back-pressure because now both buffers (simplex and worker) are full.
         writer.write(chunk.clone()).expect("write does not trap");
 
-        // Try shoving even more down there, and it shouldnt accept more input:
+        // Try shoving even more down there, and it shouldn't accept more input:
         writer
             .write(chunk.clone())
             .err()
@@ -789,7 +789,7 @@ mod test {
         // Writes should be refused until this flush succeeds.
         writer.flush().expect("flush succeeds");
 
-        // Try shoving even more down there, and it shouldnt accept more input:
+        // Try shoving even more down there, and it shouldn't accept more input:
         writer
             .write(chunk.clone())
             .err()

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -2421,8 +2421,8 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
                                 || now.seconds == seconds
                                     && u64::from(now.nanoseconds) < nanoseconds
                             {
-                                // `now` is less than `timeout`, which is expressable as u64,
-                                // substract the nanosecond counts directly
+                                // `now` is less than `timeout`, which is expressible as u64,
+                                // subtract the nanosecond counts directly
                                 now.seconds * 1_000_000_000 + u64::from(now.nanoseconds) - timeout
                             } else {
                                 0

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -672,7 +672,7 @@ impl Config {
     /// space consumed by a host function is counted towards this limit. The
     /// host functions are not prevented from consuming more than this limit.
     /// However, if the host function that used more than this limit and called
-    /// back into wasm, then the execution will trap immediatelly because of
+    /// back into wasm, then the execution will trap immediately because of
     /// stack overflow.
     ///
     /// When the `async` feature is enabled, this value cannot exceed the
@@ -1573,7 +1573,7 @@ impl Config {
         Ok(self)
     }
 
-    /// Configure wether wasmtime should compile a module using multiple
+    /// Configure whether wasmtime should compile a module using multiple
     /// threads.
     ///
     /// Disabling this will result in a single thread being used to compile

--- a/crates/wasmtime/src/profiling_agent/jitdump.rs
+++ b/crates/wasmtime/src/profiling_agent/jitdump.rs
@@ -29,7 +29,7 @@ struct JitDumpAgent {
 /// Process-wide JIT dump file. Perf only accepts a unique file per process, in the injection step.
 static JITDUMP_FILE: Mutex<Option<JitDumpFile>> = Mutex::new(None);
 
-/// Intialize a JitDumpAgent and write out the header.
+/// Initialize a JitDumpAgent and write out the header.
 pub fn new() -> Result<Box<dyn ProfilingAgent>> {
     let mut jitdump_file = JITDUMP_FILE.lock().unwrap();
 

--- a/crates/wasmtime/src/profiling_agent/perfmap.rs
+++ b/crates/wasmtime/src/profiling_agent/perfmap.rs
@@ -11,7 +11,7 @@ static PERFMAP_FILE: Mutex<Option<BufWriter<File>>> = Mutex::new(None);
 /// Interface for driving the creation of jitdump files
 struct PerfMapAgent;
 
-/// Intialize a JitDumpAgent and write out the header.
+/// Initialize a JitDumpAgent and write out the header.
 pub fn new() -> Result<Box<dyn ProfilingAgent>> {
     let mut file = PERFMAP_FILE.lock().unwrap();
     if file.is_none() {

--- a/crates/wasmtime/src/runtime/code.rs
+++ b/crates/wasmtime/src/runtime/code.rs
@@ -25,7 +25,7 @@ pub struct CodeObject {
     ///
     /// Note that this type has a significant destructor which unregisters
     /// signatures within the `Engine` it was originally tied to, and this ends
-    /// up corresponding to the liftime of a `Component` or `Module`.
+    /// up corresponding to the lifetime of a `Component` or `Module`.
     signatures: TypeCollection,
 
     /// Type information for the loaded object.

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -322,7 +322,7 @@ impl Func {
     ///
     /// # Panics
     ///
-    /// Panics if this is called on a function in an asyncronous store. This
+    /// Panics if this is called on a function in an asynchronous store. This
     /// only works with functions defined within a synchronous store. Also
     /// panics if `store` does not own this function.
     pub fn call(
@@ -470,7 +470,7 @@ impl Func {
 
         let space = &mut MaybeUninit::<ParamsAndResults<LowerParams, LowerReturn>>::uninit();
 
-        // Double-check the size/alignemnt of `space`, just in case.
+        // Double-check the size/alignment of `space`, just in case.
         //
         // Note that this alone is not enough to guarantee the validity of the
         // `unsafe` block below, but it's definitely required. In any case LLVM

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -1476,7 +1476,7 @@ where
 //
 // Even then though this didn't correctly vectorized for `Vec<u8>`. It's not
 // entirely clear why but it appeared that it's related to reloading the base
-// pointer fo memory (I guess from `MemoryMut` itself?). Overall I'm not really
+// pointer to memory (I guess from `MemoryMut` itself?). Overall I'm not really
 // clear on what's happening there, but this is surely going to be a performance
 // bottleneck in the future.
 fn lower_list<T, U>(
@@ -2069,7 +2069,7 @@ where
 ///
 /// * `payload` - the flat storage space for the entire payload of the variant
 /// * `typed_payload` - projection from the payload storage space to the
-///   individaul storage space for this variant.
+///   individual storage space for this variant.
 /// * `lower` - lowering operation used to initialize the `typed_payload` return
 ///   value.
 ///

--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -205,7 +205,7 @@ impl<'a> InstanceType<'a> {
 /// Small helper method to downcast an `Arc` borrow into a borrow of a concrete
 /// type within the `Arc`.
 ///
-/// Note that this is differnet than `downcast_ref` which projects out `&T`
+/// Note that this is different than `downcast_ref` which projects out `&T`
 /// where here we want `&Arc<T>`.
 fn downcast_arc_ref<T: 'static>(arc: &Arc<dyn Any + Send + Sync>) -> &Arc<T> {
     // First assert that the payload of the `Any` is indeed a `T`

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -514,7 +514,7 @@ pub(crate) use self::store::ComponentStoreData;
 ///         "wasi:filesystem/types/descriptor": MyDescriptorType,
 ///     },
 ///
-///     // Addtional derive attributes to include on generated types (structs or enums).
+///     // Additional derive attributes to include on generated types (structs or enums).
 ///     //
 ///     // These are deduplicated and attached in a deterministic order.
 ///     additional_derives: [

--- a/crates/wasmtime/src/runtime/component/resource_table.rs
+++ b/crates/wasmtime/src/runtime/component/resource_table.rs
@@ -76,7 +76,7 @@ struct TableEntry {
     entry: Box<dyn Any + Send>,
     /// The index of the parent of this entry, if it has one.
     parent: Option<u32>,
-    /// The indicies of any children of this entry.
+    /// The indices of any children of this entry.
     children: BTreeSet<u32>,
 }
 
@@ -275,7 +275,7 @@ impl ResourceTable {
         let e = self.free_entry(key as usize);
         if let Some(parent) = e.parent {
             // Remove deleted resource from parent's child list.
-            // Parent must still be present because it cant be deleted while still having
+            // Parent must still be present because it can't be deleted while still having
             // children:
             self.occupied_mut(parent)
                 .expect("missing parent")

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -263,7 +263,7 @@ impl List {
         List(Handle::new(index, ty))
     }
 
-    /// Retreive the element type of this `list`.
+    /// Retrieve the element type of this `list`.
     pub fn ty(&self) -> Type {
         Type::from(&self.0.types[self.0.index].element, &self.0.instance())
     }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1592,7 +1592,7 @@ pub(crate) fn invoke_wasm_and_catch_traps<T>(
 ///   allocated by WebAssembly code and it's relative to the initial stack
 ///   pointer that called into wasm.
 ///
-/// This function may fail if the the stack limit can't be set because an
+/// This function may fail if the stack limit can't be set because an
 /// interrupt already happened.
 fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Option<usize> {
     // If this is a recursive call, e.g. our stack limit is already set, then
@@ -2561,7 +2561,7 @@ mod rooted {
         /// value past the lifetime of the provided `func`.
         ///
         /// Similarly, callers must ensure that the given `func_ref` is valid
-        /// for the liftime of the return value.
+        /// for the lifetime of the return value.
         pub(crate) unsafe fn new(
             func: &Arc<HostFunc>,
             func_ref: Option<NonNull<VMFuncRef>>,

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -41,7 +41,7 @@ pub(crate) struct InstanceData {
     /// `InstanceHandle`.
     id: InstanceId,
     /// A lazily-populated list of exports of this instance. The order of
-    /// exports here matches the order of the exports in the the original
+    /// exports here matches the order of the exports in the original
     /// module.
     exports: Vec<Option<Extern>>,
 }
@@ -300,7 +300,7 @@ impl Instance {
         // we immediately insert it into the store to keep it alive.
         //
         // Note that we `clone` the instance handle just to make easier
-        // working the the borrow checker here easier. Technically the `&mut
+        // working the borrow checker here easier. Technically the `&mut
         // instance` has somewhat of a borrow on `store` (which
         // conflicts with the borrow on `store.engine`) but this doesn't
         // matter in practice since initialization isn't even running any

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -67,7 +67,7 @@ use log::warn;
 /// [`Linker`] value at program start up and use that continuously for each
 /// [`Store`] created over the lifetime of the program.
 ///
-/// Note that once [`Store`]-owned items, such as [`Global`], are defined witin
+/// Note that once [`Store`]-owned items, such as [`Global`], are defined within
 /// a [`Linker`] then it is no longer compatible with any [`Store`]. At that
 /// point only the [`Store`] that owns the [`Global`] can be used to instantiate
 /// modules.

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -428,7 +428,7 @@ impl Module {
     /// entire lifetime of the [`Module`] returned. Any changes to the file on
     /// disk may change future instantiations of the module to be incorrect.
     /// This is because the file is mapped into memory and lazily loaded pages
-    /// reflect the current state of the file, not necessarily the origianl
+    /// reflect the current state of the file, not necessarily the original
     /// state of the file.
     #[cfg(feature = "std")]
     pub unsafe fn deserialize_file(engine: &Engine, path: impl AsRef<Path>) -> Result<Module> {
@@ -437,7 +437,7 @@ impl Module {
     }
 
     /// Entrypoint for creating a `Module` for all above functions, both
-    /// of the AOT and jit-compiled cateogries.
+    /// of the AOT and jit-compiled categories.
     ///
     /// In all cases the compilation artifact, `code_memory`, is provided here.
     /// The `info_and_types` argument is `None` when a module is being

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -229,7 +229,7 @@ impl Val {
     /// # Unsafety
     ///
     /// This method is unsafe for the reasons that [`ExternRef::from_raw`] and
-    /// [`Func::from_raw`] are unsafe. Additionaly there's no guarantee
+    /// [`Func::from_raw`] are unsafe. Additionally there's no guarantee
     /// otherwise that `raw` should have the type `ty` specified.
     pub unsafe fn from_raw(store: impl AsContextMut, raw: ValRaw, ty: ValType) -> Val {
         match ty {
@@ -529,7 +529,7 @@ impl From<V128> for Val {
 /// example, by claiming that the integer `0xbad1bad2` is actually a reference.
 #[derive(Debug, Clone)]
 pub enum Ref {
-    // NB: We have a variant for each of the type heirarchies defined in Wasm,
+    // NB: We have a variant for each of the type hierarchies defined in Wasm,
     // and push the `Option` that provides nullability into each variant. This
     // allows us to get the most-precise type of any reference value, whether it
     // is null or not, without any additional metadata.

--- a/crates/wasmtime/src/runtime/vm/component/resources.rs
+++ b/crates/wasmtime/src/runtime/vm/component/resources.rs
@@ -20,7 +20,7 @@
 //!
 //! Individual operations are exposed through methods on `ResourceTables` for
 //! lifting/lowering/etc. This does mean though that some other fiddly bits
-//! about ABI details can be found in lifting/lowering thoughout Wasmtime,
+//! about ABI details can be found in lifting/lowering throughout Wasmtime,
 //! namely in the `Resource<T>` and `ResourceAny` types.
 
 use crate::prelude::*;
@@ -62,7 +62,7 @@ pub struct ResourceTables<'a> {
     /// This is the single table used by the host stored within `Store<T>`. Host
     /// resources will point into this and effectively have the same semantics
     /// as-if they're in-component resources. The major distinction though is
-    /// that this is a heterogenous table instead of only containing a single
+    /// that this is a heterogeneous table instead of only containing a single
     /// type.
     pub host_table: Option<&'a mut ResourceTable>,
 

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -48,7 +48,7 @@ pub struct ExportTable {
     pub definition: *mut VMTableDefinition,
     /// Pointer to the containing `VMContext`.
     pub vmctx: *mut VMContext,
-    /// The table declaration, used for compatibilty checking.
+    /// The table declaration, used for compatibility checking.
     pub table: TablePlan,
 }
 
@@ -93,7 +93,7 @@ pub struct ExportGlobal {
     /// Pointer to the containing `VMContext`. May be null for host-created
     /// globals.
     pub vmctx: *mut VMContext,
-    /// The global declaration, used for compatibilty checking.
+    /// The global declaration, used for compatibility checking.
     pub global: Global,
 }
 

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -261,7 +261,7 @@ impl VMGcRef {
         }
     }
 
-    /// Get this GC refererence as a raw u32 value, regardless whether it is
+    /// Get this GC reference as a raw u32 value, regardless whether it is
     /// actually a reference to a GC object or is an `i31ref`.
     pub fn as_raw_u32(&self) -> u32 {
         self.0.get()

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/decommit_queue.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/decommit_queue.rs
@@ -6,7 +6,7 @@
 //!
 //! Even when batching is "disabled" we still use this queue. Batching is
 //! disabled by specifying a batch size of one, in which case, this queue will
-//! immediately get flushed everytime we push onto it.
+//! immediately get flushed every time we push onto it.
 
 use super::PoolingInstanceAllocator;
 use crate::vm::{MemoryAllocationIndex, MemoryImageSlot, Table, TableAllocationIndex};

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -201,7 +201,7 @@ impl TablePool {
         let size_to_memset = size.min(self.keep_resident);
         std::ptr::write_bytes(base, 0, size_to_memset);
 
-        // And decommit the the rest of it.
+        // And decommit the rest of it.
         decommit(base.add(size_to_memset), size - size_to_memset)
     }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
@@ -139,7 +139,7 @@ extern "C" {
     /// Attempts to create a new in-memory image of the `ptr`/`len` combo which
     /// can be mapped to virtual addresses in the future.
     ///
-    /// On successed the returned `wasmtime_memory_image` pointer is stored into `ret`.
+    /// On success the returned `wasmtime_memory_image` pointer is stored into `ret`.
     /// This value stored can be `NULL` to indicate that an image cannot be
     /// created but no failure occurred. The structure otherwise will later be
     /// deallocated with `wasmtime_memory_image_free` and

--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -138,7 +138,7 @@ unsafe extern "C" fn trap_handler(
         // Note that if we use `longjmp` instead of `siglongjmp` then
         // the problem is fixed. The problem with that, however, is that
         // `setjmp` is much slower than `sigsetjmp` due to the
-        // preservation of the proceses signal mask. The reason
+        // preservation of the process's signal mask. The reason
         // `longjmp` appears to work is that it seems to call a function
         // (according to published macOS sources) called
         // `_sigunaltstack` which updates the kernel to say the

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -439,7 +439,7 @@ impl CallThreadState {
     /// * 1 as a pointer - the trap was handled by a custom trap handler on an
     ///   instance, and the trap handler should quickly return.
     /// * a different pointer - a jmp_buf buffer to longjmp to, meaning that
-    ///   the wasm trap was succesfully handled.
+    ///   the wasm trap was successfully handled.
     #[cfg_attr(miri, allow(dead_code))] // miri doesn't handle traps yet
     pub(crate) fn test_if_trap(
         &self,

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -663,7 +663,7 @@ pub struct VMFuncRef {
     /// Wasm-to-native trampoline for the function. In this case, we leave
     /// `wasm_call` empty until the function is passed as an import to Wasm (or
     /// otherwise exposed to Wasm via tables/globals). At this point, we look up
-    /// a Wasm-to-native trampoline for the function in the the Wasm's compiled
+    /// a Wasm-to-native trampoline for the function in the Wasm's compiled
     /// module and use that fill in `VMFunctionImport::wasm_call`. **However**
     /// there is no guarantee that the Wasm module has a trampoline for this
     /// function's signature. The Wasm module only has trampolines for its
@@ -829,7 +829,7 @@ pub struct VMRuntimeLimits {
     /// to the host.
     ///
     /// When a host function is wrapped into a `wasmtime::Func`, and is then
-    /// called from the host, then this member has the sentinal value of `-1 as
+    /// called from the host, then this member has the sentinel value of `-1 as
     /// usize`, meaning that this contiguous sequence of Wasm frames is the
     /// empty sequence, and it is not safe to dereference the
     /// `last_wasm_exit_fp`.

--- a/crates/wiggle/src/borrow.rs
+++ b/crates/wiggle/src/borrow.rs
@@ -105,7 +105,7 @@ mod test {
         assert!(!b.can_read(region()));
         assert!(!b.can_write(region()));
 
-        // releasing the mutable borrows allows raeding/writing again
+        // releasing the mutable borrows allows reading/writing again
         b.mut_unborrow(h1);
         assert!(b.can_read(region()));
         assert!(b.can_write(region()));

--- a/crates/wiggle/src/guest_type.rs
+++ b/crates/wiggle/src/guest_type.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{
 /// A trait for types which are used to report errors. Each type used in the
 /// first result position of an interface function is used, by convention, to
 /// indicate whether the function was successful and subsequent results are valid,
-/// or whether an error occured. This trait allows wiggle to return the correct
+/// or whether an error occurred. This trait allows wiggle to return the correct
 /// value when the interface function's idiomatic Rust method returns
 /// `Ok(<rest of return values>)`.
 pub trait GuestErrorType {

--- a/crates/wiggle/test-helpers/src/lib.rs
+++ b/crates/wiggle/test-helpers/src/lib.rs
@@ -148,7 +148,7 @@ pub struct MemArea {
 }
 
 impl MemArea {
-    // This code is a whole lot like the Region::overlaps func thats at the core of the code under
+    // This code is a whole lot like the Region::overlaps func that's at the core of the code under
     // test.
     // So, I implemented this one with std::ops::Range so it is less likely I wrote the same bug in two
     // places.

--- a/crates/wiggle/tests/records.rs
+++ b/crates/wiggle/tests/records.rs
@@ -21,7 +21,7 @@ impl<'a> records::Records for WasiCtx<'a> {
         let second = an_pair
             .second
             .read()
-            .expect("dereferncing GuestPtr should succeed");
+            .expect("dereferencing GuestPtr should succeed");
         Ok(first as i64 + second as i64)
     }
 

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1445,7 +1445,7 @@ impl<'a> InterfaceGenerator<'a> {
         self.src.push_str("wasmtime::component::flags!(\n");
         self.src.push_str(&format!("{rust_name} {{\n"));
         for flag in flags.flags.iter() {
-            // TODO wasmtime-component-macro doesnt support docs for flags rn
+            // TODO wasmtime-component-macro doesn't support docs for flags rn
             uwrite!(
                 self.src,
                 "#[component(name=\"{}\")] const {};\n",
@@ -2242,7 +2242,7 @@ impl<'a> InterfaceGenerator<'a> {
         {
             // Functions which have a single result `result<ok,err>` get special
             // cased to use the host_wasmtime_rust::Error<err>, making it possible
-            // for them to trap or use `?` to propogate their errors
+            // for them to trap or use `?` to propagate their errors
             self.push_str("Result<");
             if let Some(ok) = r.ok {
                 self.print_ty(&ok, TypeMode::Owned);

--- a/docs/security.md
+++ b/docs/security.md
@@ -80,7 +80,7 @@ correct execution of WebAssembly but can help mitigate issues if bugs are found:
   of the security guarantees of WebAssembly are still upheld.
 
 * Wasmtime is in the [process of implementing control-flow-integrity
-  mechanisms][cfi-rfc] to leverage hardware state for futher guaranteeing that
+  mechanisms][cfi-rfc] to leverage hardware state for further guaranteeing that
   WebAssembly stays within its sandbox. In the event of a bug in Cranelift this
   can help mitigate the impact of where control flow can go to.
 

--- a/examples/async.cpp
+++ b/examples/async.cpp
@@ -165,7 +165,7 @@ int main() {
   // A thread that will async perform host function calls.
   std::thread printer_thread([]() {
     int32_t value_to_print = printer_state.get_value_to_print();
-    std::cout << "recieved value to print!" << std::endl;
+    std::cout << "received value to print!" << std::endl;
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     std::cout << "printing: " << value_to_print << std::endl;
     std::this_thread::sleep_for(std::chrono::milliseconds(500));

--- a/examples/component/main.rs
+++ b/examples/component/main.rs
@@ -11,7 +11,7 @@ bindgen!("convert" in "./examples/component/convert.wit");
 
 struct HostComponent;
 
-// Implmentation of the host interface defined in the wit file.
+// Implementation of the host interface defined in the wit file.
 impl host::Host for HostComponent {
     fn multiply(&mut self, a: f32, b: f32) -> f32 {
         a * b
@@ -24,7 +24,7 @@ struct MyState {
 
 /// This function is only needed until rust can natively output a component.
 ///
-/// Generally embeddings should not be expected to do this programatically, but instead
+/// Generally embeddings should not be expected to do this programmatically, but instead
 /// language specific tooling should be used, for example in Rust `cargo component`
 /// is a good way of doing that: https://github.com/bytecodealliance/cargo-component
 ///

--- a/examples/min-platform/embedding/wasmtime-platform.h
+++ b/examples/min-platform/embedding/wasmtime-platform.h
@@ -188,7 +188,7 @@ extern int32_t wasmtime_init_traps(wasmtime_trap_handler_t handler);
  * Attempts to create a new in-memory image of the `ptr`/`len` combo which
  * can be mapped to virtual addresses in the future.
  *
- * On successed the returned `wasmtime_memory_image` pointer is stored into `ret`.
+ * On success the returned `wasmtime_memory_image` pointer is stored into `ret`.
  * This value stored can be `NULL` to indicate that an image cannot be
  * created but no failure occurred. The structure otherwise will later be
  * deallocated with `wasmtime_memory_image_free` and

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -123,5 +123,5 @@ Running `FUZZGEN_ALLOWED_OPS=ineg,ishl cargo fuzz run cranelift-fuzzgen` will ru
 
 ### `cranelift-icache`
 
-The icache target also uses the fuzzgen library, thus also supports the `FUZZGEN_ALLOWED_OPS` enviornment variable as described in the `cranelift-fuzzgen` section above.
+The icache target also uses the fuzzgen library, thus also supports the `FUZZGEN_ALLOWED_OPS` environment variable as described in the `cranelift-fuzzgen` section above.
 

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -273,7 +273,7 @@ warning: this CLI invocation of Wasmtime is going to break in the future -- for
             // error message then now's probably as good a time as any to nudge
             // them towards the new CLI. Any preexisting scripts which parsed
             // the old CLI should not hit this case which means that all old
-            // succesful parses will not go through here.
+            // successful parses will not go through here.
             //
             // In any case, display the error for the new CLI, including new
             // help text.

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -77,7 +77,7 @@ impl ServeCommand {
     pub fn execute(mut self) -> Result<()> {
         self.run.common.init_logging()?;
 
-        // We force cli errors before starting to listen for connections so tha we don't
+        // We force cli errors before starting to listen for connections so then we don't
         // accidentally delay them to the first request.
         if self.run.common.wasi.nn == Some(true) {
             #[cfg(not(feature = "wasi-nn"))]

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -446,7 +446,7 @@ fn trapping() -> Result<(), Error> {
             }
 
             // recur so that we can trigger a next call.
-            // propogate its trap, if it traps!
+            // propagate its trap, if it traps!
             if recur > 0 {
                 let _ = caller
                     .get_export("export")
@@ -523,7 +523,7 @@ fn trapping() -> Result<(), Error> {
     assert_eq!(s.calls_into_wasm, 1);
     assert_eq!(s.returns_from_wasm, 1);
 
-    // trap in next call to wasm. No calls after the bit is set, so this trap shouldnt happen:
+    // trap in next call to wasm. No calls after the bit is set, so this trap shouldn't happen:
     let (s, e) = run(TRAP_NEXT_CALL_WASM, false);
     assert!(e.is_none());
     assert_eq!(s.calls_into_host, 1);

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1656,7 +1656,7 @@ fn same_module_multiple_stores() -> Result<()> {
     ];
     eprintln!("expected = {expected_stacks:#?}");
     let actual_stacks = stacks.lock().unwrap();
-    eprintln!("actaul = {actual_stacks:#?}");
+    eprintln!("actual = {actual_stacks:#?}");
 
     assert_eq!(actual_stacks.len(), expected_stacks.len());
     for (expected_stack, actual_stack) in expected_stacks.into_iter().zip(actual_stacks.iter()) {

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -466,7 +466,7 @@ impl ABIResults {
 pub(crate) struct ABIParams {
     /// The param operands.
     operands: ABIOperands,
-    /// Whether [`ABIParams`] contains an extra paramter for the stack
+    /// Whether [`ABIParams`] contains an extra parameter for the stack
     /// result area.
     has_retptr: bool,
 }
@@ -623,7 +623,7 @@ impl ABISig {
     }
 
     /// Returns a slice over the signature params, excluding the results
-    /// base paramter, if any.
+    /// base parameter, if any.
     pub fn params_without_retptr(&self) -> &[ABIOperand] {
         if self.params.has_retptr() {
             &self.params()[0..(self.params.len() - 1)]

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -176,7 +176,7 @@ pub(crate) struct StackState {
     /// The base stack pointer offset.
     /// This offset is set when entering the block, after saving any live
     /// registers and locals.
-    /// It is calcuated by substracting the size, in bytes, of any block params
+    /// It is calcuated by subtracting the size, in bytes, of any block params
     /// to the current stack pointer offset.
     pub base_offset: SPOffset,
     /// The target stack pointer offset.
@@ -192,7 +192,7 @@ pub(crate) struct StackState {
     pub target_len: usize,
 }
 
-/// Holds the all the metdata to support the emission
+/// Holds the all the metadata to support the emission
 /// of control flow instructions.
 #[derive(Debug)]
 pub(crate) enum ControlStackFrame {
@@ -227,7 +227,7 @@ pub(crate) enum ControlStackFrame {
         stack_state: StackState,
         /// Exit state of the block.
         ///
-        /// This flag is used to dertermine if a block is a branch
+        /// This flag is used to determine if a block is a branch
         /// target. By default, this is false, and it's updated when
         /// emitting a `br` or `br_if`.
         is_branch_target: bool,
@@ -378,7 +378,7 @@ impl ControlStackFrame {
     /// unreachable state. This function is intended to be called when handling
     /// an unreachable else or end.
     //
-    /// This function will truncate the value stack to the the base length of
+    /// This function will truncate the value stack to the base length of
     /// the control frame and will also set the stack pointer offset to reflect
     /// the offset expected by the target branch.
     ///
@@ -390,7 +390,7 @@ impl ControlStackFrame {
         context: &mut CodeGenContext,
     ) {
         let state = self.stack_state();
-        // This assumes that at jump sites, the machine stack poiter will be
+        // This assumes that at jump sites, the machine stack pointer will be
         // adjusted to match the expectations of the target branch (e.g.
         // `target_offset`); after performing the jump, the MacroAssembler
         // implementation will soft-reset the stack pointer offset to its

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -126,7 +126,7 @@ where
             .into();
 
         self.masm.start_source_loc(Default::default());
-        // We need to use the vmctx paramter before pinning it for stack checking.
+        // We need to use the vmctx parameter before pinning it for stack checking.
         self.masm.prologue(vmctx);
         // Pin the `VMContext` pointer.
         self.masm
@@ -213,7 +213,7 @@ where
                     let addr = self.masm.local_address(results_base_slot);
                     self.masm.store((*reg).into(), addr, (*ty).into());
                 }
-                // The result base parameter is a stack paramter, addressed
+                // The result base parameter is a stack parameter, addressed
                 // from FP.
                 _ => {}
             }
@@ -238,7 +238,7 @@ where
                     fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
                         self.0.$visit($($($arg.clone()),*)?)?;
                         // Only visit operators if the compiler is in a reachable code state. If
-                        // the compiler is in an unrechable code state, most of the operators are
+                        // the compiler is in an unreachable code state, most of the operators are
                         // ignored except for If, Block, Loop, Else and End. These operators need
                         // to be observed in order to keep the control stack frames balanced and to
                         // determine if reachability should be restored.
@@ -377,9 +377,9 @@ where
                 |results, _, _| results.ret_area().copied(),
             );
         } else {
-            // If we reach the end of the function in a unreachable code state,
-            // simly truncate to the the expected values.
-            // The compiler could enter in this state through an infinite loop.
+            // If we reach the end of the function in an unreachable code state,
+            // simply truncate to the expected values.
+            // The compiler could enter this state through an infinite loop.
             self.context.truncate_stack_to(0);
             self.masm.reset_stack_pointer(base);
         }
@@ -545,7 +545,7 @@ where
     /// of doing the least amount of work possible at compile time. For static
     /// heaps, Winch does a bit more of work, given that some of the cases that
     /// are checked against, can benefit compilation times, like for example,
-    /// detecting an out of bouds access at compile time.
+    /// detecting an out of bounds access at compile time.
     pub fn emit_compute_heap_address(
         &mut self,
         memarg: &MemArg,
@@ -646,7 +646,7 @@ where
             //
             //      index <= u32::MAX
             //
-            // Therfore if any 32-bit index access occurs in the region
+            // Therefore if any 32-bit index access occurs in the region
             // represented by
             //
             //      bound + guard_size - (offset + access_size)
@@ -780,7 +780,7 @@ where
         self.masm
             .trapif(IntCmpKind::GeU, TrapCode::TableOutOfBounds);
 
-        // Move the index into the scratch register to calcualte the table
+        // Move the index into the scratch register to calculate the table
         // element address.
         // Moving the value of the index register to the scratch register
         // also avoids overwriting the context of the index register.

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -187,7 +187,7 @@ impl Frame {
     /// Returns the address of the local at the given index.
     ///
     /// # Panics
-    /// This function panics if the the index is not associated to a local.
+    /// This function panics if the index is not associated to a local.
     pub fn get_local_address<M: MacroAssembler>(
         &self,
         index: u32,

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -210,7 +210,7 @@ impl Assembler {
         }
     }
 
-    /// Substract with three registers.
+    /// Subtract with three registers.
     pub fn sub_rrr(&mut self, rm: Reg, rn: Reg, rd: Reg, size: OperandSize) {
         self.emit_alu_rrr_extend(ALUOp::Sub, rm, rn, rd, size);
     }

--- a/winch/codegen/src/isa/aarch64/regs.rs
+++ b/winch/codegen/src/isa/aarch64/regs.rs
@@ -97,7 +97,7 @@ pub(crate) const fn sp() -> Reg {
 /// [MacroAssembler::move_sp_to_shadow_sp] function.
 ///
 /// This approach, requires copying the real stack pointer value into
-/// x28 everytime the real stack pointer moves, which involves
+/// x28 every time the real stack pointer moves, which involves
 /// emitting one more instruction. For example, this is generally how
 /// the real stack pointer and x28 will look like during a function:
 ///

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1186,7 +1186,7 @@ impl Assembler {
         });
     }
 
-    /// Mininum for src and dst XMM registers with results put in dst.
+    /// Minimum for src and dst XMM registers with results put in dst.
     pub fn xmm_min_seq(&mut self, src: Reg, dst: Reg, size: OperandSize) {
         self.emit(Inst::XmmMinMaxSeq {
             size: size.into(),

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -757,7 +757,7 @@ impl Masm for MacroAssembler {
 
         match &(lhs, rhs) {
             (rlhs, RegImm::Reg(rrhs)) => {
-                // If the comparision kind is zero or not zero and both operands
+                // If the comparison kind is zero or not zero and both operands
                 // are the same register, emit a test instruction. Else we emit
                 // a normal comparison.
                 if (kind == Eq || kind == Ne) && (rlhs == rrhs) {
@@ -1037,7 +1037,7 @@ impl MacroAssembler {
         }
     }
 
-    /// A common implemenation for zero-extend stack loads.
+    /// A common implementation for zero-extend stack loads.
     fn load_impl<M>(&mut self, src: Address, dst: Reg, size: OperandSize, flags: MemFlags)
     where
         M: Masm,
@@ -1058,7 +1058,7 @@ impl MacroAssembler {
         }
     }
 
-    /// A common implemenation for stack stores.
+    /// A common implementation for stack stores.
     fn store_impl(&mut self, src: RegImm, dst: Address, size: OperandSize, flags: MemFlags) {
         let scratch = <Self as Masm>::ABI::scratch_reg();
         let float_scratch = <Self as Masm>::ABI::float_scratch_reg();

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -707,7 +707,7 @@ pub(crate) trait MacroAssembler {
     /// expectations regarding the location of the instruction
     /// arguments and regarding the location of the quotient /
     /// remainder. To free the caller from having to deal with the
-    /// architecure specific contraints we give this function access
+    /// architecture specific constraints we give this function access
     /// to the code generation context, allowing each implementation
     /// to decide the lowering path.  For cases in which division is a
     /// unconstrained binary operation, the caller can decide to use

--- a/winch/codegen/src/regalloc.rs
+++ b/winch/codegen/src/regalloc.rs
@@ -12,7 +12,7 @@ use crate::{
 /// If a particular register is not available upon request
 /// the register allocation will perform a "spill", essentially
 /// moving Local and Register values in the stack to memory.
-/// This processs ensures that whenever a register is requested,
+/// This process ensures that whenever a register is requested,
 /// it is going to be available.
 pub(crate) struct RegAlloc {
     /// The register set.
@@ -54,7 +54,7 @@ impl RegAlloc {
             spill(self);
             self.regset
                 .reg(named)
-                .unwrap_or_else(|| panic!("Exepected register {:?} to be available", named))
+                .unwrap_or_else(|| panic!("Expected register {:?} to be available", named))
         })
     }
 

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -163,7 +163,7 @@ impl Val {
         }
     }
 
-    /// Check wheter the value is a memory offset.
+    /// Check whether the value is a memory offset.
     pub fn is_mem(&self) -> bool {
         match *self {
             Self::Memory(_) => true,

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1715,9 +1715,9 @@ where
                 &mut self.context,
                 self.masm,
                 |results, context, masm| {
-                    // In the case of `br_if` theres a possibility that we'll
-                    // exit early from the block or falltrough, for
-                    // a falltrough, we cannot rely on the pre-computed return area;
+                    // In the case of `br_if` there's a possibility that we'll
+                    // exit early from the block or fallthrough, for
+                    // a fallthrough, we cannot rely on the pre-computed return area;
                     // it must be recalculated so that any values that are
                     // generated are correctly placed near the current stack
                     // pointer.
@@ -1891,7 +1891,7 @@ where
         let val1 = self.context.pop_to_reg(self.masm, None);
         self.masm
             .cmp(cond.reg.into(), RegImm::i32(0), OperandSize::S32);
-        // Conditionally move val1 to val2 if the the comparision is
+        // Conditionally move val1 to val2 if the comparison is
         // not zero.
         self.masm
             .cmov(val1.into(), val2.into(), IntCmpKind::Ne, val1.ty.into());
@@ -2135,7 +2135,7 @@ impl From<WasmValType> for OperandSize {
             WasmValType::I64 | WasmValType::F64 => OperandSize::S64,
             WasmValType::Ref(rt) => {
                 match rt.heap_type {
-                    // TODO: Harcoded size, assuming 64-bit support only. Once
+                    // TODO: Hardcoded size, assuming 64-bit support only. Once
                     // Wasmtime supports 32-bit architectures, this will need
                     // to be updated in such a way that the calculation of the
                     // OperandSize will depend on the target's  pointer size.


### PR DESCRIPTION
Corrected typos from various parts of the crate.

The commits are broken down into different parts in case there are different owners who would take on reviewing.

Most are in comments. A few are in asserts and error messages.

Before anyone gets too annoyed with me, consider the time saved for all who will be reading this code in the years to come. :pray:
