### PR TITLE
Add wasmtime-platform.h to release artifacts

### DIFF
--- a/ci/merge-artifacts.sh
+++ b/ci/merge-artifacts.sh
@@ -14,6 +14,7 @@ set -ex
 rm -rf dist
 mkdir dist
 mv -t dist bins-*/*.{msi,wasm}
+mv wasmtime-platform-header/* dist
 
 # Merge tarballs and zips by searching for `*-min` builds, unpacking the
 # min/normal builds, into the same destination, and then repacking into a


### PR DESCRIPTION
This fixes a bug from #8555 where the header was uploaded to CI but didn't make its way to the release itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
