### PR TITLE
Un-gate `Func::new` on compiler features

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -446,7 +446,6 @@ impl Func {
     ///
     /// Panics if the given function type is not associated with this store's
     /// engine.
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn new<T>(
         store: impl AsContextMut<Data = T>,
         ty: FuncType,
@@ -489,7 +488,6 @@ impl Func {
     ///
     /// Panics if the given function type is not associated with this store's
     /// engine.
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub unsafe fn new_unchecked<T>(
         mut store: impl AsContextMut<Data = T>,
         ty: FuncType,
@@ -2199,7 +2197,6 @@ impl HostFunc {
     ///
     /// Panics if the given function type is not associated with the given
     /// engine.
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn new<T>(
         engine: &Engine,
         ty: FuncType,
@@ -2220,7 +2217,6 @@ impl HostFunc {
     ///
     /// Panics if the given function type is not associated with the given
     /// engine.
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub unsafe fn new_unchecked<T>(
         engine: &Engine,
         ty: FuncType,

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -275,7 +275,6 @@ impl<T> Linker<T> {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn define_unknown_imports_as_traps(&mut self, module: &Module) -> anyhow::Result<()> {
         for import in module.imports() {
             if let Err(import_err) = self._get_by_import(&import) {
@@ -310,7 +309,6 @@ impl<T> Linker<T> {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn define_unknown_imports_as_default_values(
         &mut self,
         module: &Module,
@@ -428,7 +426,6 @@ impl<T> Linker<T> {
     ///
     /// Panics if the given function type is not associated with the same engine
     /// as this linker.
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn func_new(
         &mut self,
         module: &str,
@@ -451,7 +448,6 @@ impl<T> Linker<T> {
     ///
     /// Panics if the given function type is not associated with the same engine
     /// as this linker.
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub unsafe fn func_new_unchecked(
         &mut self,
         module: &str,
@@ -781,7 +777,6 @@ impl<T> Linker<T> {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn module(
         &mut self,
         mut store: impl AsContextMut<Data = T>,

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -1,11 +1,13 @@
 //! Support for a calling of an imported function.
 
+use crate::prelude::*;
 use crate::runtime::vm::{
     StoreBox, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMOpaqueContext,
 };
 use crate::type_registry::RegisteredType;
 use crate::{FuncType, ValRaw};
 use anyhow::Result;
+use core::ptr;
 
 struct TrampolineState<F> {
     func: F,
@@ -67,7 +69,6 @@ unsafe extern "C" fn array_call_shim<F>(
     }
 }
 
-#[cfg(any(feature = "cranelift", feature = "winch"))]
 pub fn create_array_call_function<F>(
     ft: &FuncType,
     func: F,
@@ -75,9 +76,6 @@ pub fn create_array_call_function<F>(
 where
     F: Fn(*mut VMContext, &mut [ValRaw]) -> Result<()> + Send + Sync + 'static,
 {
-    use crate::prelude::*;
-    use std::ptr;
-
     let array_call = array_call_shim::<F>;
 
     let sig = ft.clone().into_registered_type();


### PR DESCRIPTION
This commit enables the `Func::new` constructor and related other functions when `cranelift` and `winch` features are both disabled, meaning this is now available in compiler-less builds. This builds on the support of #8629.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
