### PR TITLE
Update docs to match new logging env var

### DIFF
--- a/docs/cli-logging.md
+++ b/docs/cli-logging.md
@@ -4,18 +4,18 @@ Wasmtime's libraries use Rust's [`log`] crate to log diagnostic
 information, and the `wasmtime` CLI executable uses [`pretty_env_logger`]
 by default for logging this information to the console.
 
-Basic logging is controlled by the `RUST_LOG` environment variable. For example,
+Basic logging is controlled by the `WASMTIME_LOG` environment variable. For example,
 To enable logging of WASI system calls, similar to the `strace` command on Linux,
-set `RUST_LOG=wasi_common=trace`.
+set `WASMTIME_LOG=wasmtime_wasi=trace`.
 
 ```sh
-$ RUST_LOG=wasi_common=trace wasmtime hello.wasm
+$ WASMTIME_LOG=wasmtime_wasi=trace hello.wasm
 [...]
- TRACE wasi_common::hostcalls_impl::fs                       > fd_write(fd=1, iovs_ptr=0x10408, iovs_len=1, nwritten=0x10404)
+TRACE wiggle abi{module="wasi_snapshot_preview1" function="fd_write"} wasmtime_wasi::preview1::wasi_snapshot_preview1                     > fd=Fd(1) iovs=*guest 0x14/1
 Hello, world!
- TRACE wasi_common::hostcalls_impl::fs                       >      | *nwritten=14
- TRACE wasi_common::hostcalls                                >      | errno=ESUCCESS (No error occurred. System call completed successfully.)
- TRACE wasi_common::hostcalls_impl::misc                     > proc_exit(rval=1)
+TRACE wiggle abi{module="wasi_snapshot_preview1" function="fd_write"}: wasmtime_wasi::preview1::wasi_snapshot_preview1: result=Ok(14)
+TRACE wiggle abi{module="wasi_snapshot_preview1" function="proc_exit"}: wasmtime_wasi::preview1::wasi_snapshot_preview1: rval=1
+TRACE wiggle abi{module="wasi_snapshot_preview1" function="proc_exit"}: wasmtime_wasi::preview1::wasi_snapshot_preview1: result=Exited with i32 exit status 1
 ```
 
 Wasmtime can also redirect the log messages into log files, with the


### PR DESCRIPTION
 - Update the environment variable to be `WASMTIME_LOG` rather than `RUST_LOG` (#7239).
 - Update the name used for WASI method calls, and the resulting log output (#8066).
