### PR TITLE
Enable Winch by default in builds and artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,6 +341,7 @@ default = [
   "component-model",
   "threads",
   "gc",
+  "winch",
 
   # Enable some nice features of clap by default, but they come at a binary size
   # cost, so allow disabling this through disabling of our own `default`


### PR DESCRIPTION
This commit adds the `winch` feature to the default feature set of the `wasmtime-cli` package meaning that the `wasmtime` CLI will, by default, have support for the Winch compiler.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
