### PR TITLE
c-api: Fix enabling parallel compilation by default

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -22,6 +22,7 @@ option(WASMTIME_DISABLE_ALL_FEATURES
 
 macro(feature rust_name default)
   string(TOUPPER "wasmtime_feature_${rust_name}" cmake_name)
+  string(REPLACE "-" "_" cmake_name ${cmake_name})
   if(${default})
     if(${WASMTIME_DISABLE_ALL_FEATURES})
       set(feature_default OFF)


### PR DESCRIPTION
This commit fixes a mistake in #8642 where a late-minute refactor accidentally ended up disabling parallel compilation by default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
