### PR TITLE
cranelift: Always consider sret arguments used

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -509,7 +509,9 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         let mut value_ir_uses = SecondaryMap::with_default(ValueUseState::Unused);
 
         if let Some(sret_param) = sret_param {
-            value_ir_uses[sret_param] = ValueUseState::Once;
+            // There's an implicit use of the struct-return parameter in each
+            // copy of the function epilogue, which we count here.
+            value_ir_uses[sret_param] = ValueUseState::Multiple;
         }
 
         // Stack of iterators over Values as we do DFS to mark

--- a/cranelift/filetests/filetests/isa/aarch64/issue-8659.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/issue-8659.clif
@@ -1,0 +1,16 @@
+test compile precise-output
+target aarch64
+
+function u0:11(i64 sret) system_v {
+block0(v0: i64):
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/issue-8659.clif
+++ b/cranelift/filetests/filetests/isa/x64/issue-8659.clif
@@ -1,0 +1,27 @@
+test compile precise-output
+target x86_64
+
+function u0:11(i64 sret) system_v {
+block0(v0: i64):
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+


### PR DESCRIPTION
In #8438 we stopped emitting register bindings for unused arguments, based on the use-counts from `compute_use_states`. However, that doesn't count the use of the struct-return argument that's automatically added after lowering when the `rets` instruction is generated in the epilogue. As a result, using a struct-return argument caused register allocation to panic due to the VReg not being defined anywhere.

This commit adds a use to the struct-return argument so that it's always available in the epilogue.

Fixes #8659