### PR TITLE
Release Wasmtime 21.0.0 (for real this time)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -212,6 +212,11 @@ Released 2024-04-22
   mutably borrow disjoint regions of memory.
   [#8277](https://github.com/bytecodealliance/wasmtime/issues/8277)
 
+* Generated bindings with `component::bindgen!` now have a "lower level"
+  function using a generated `GetHost` trait to more flexibly add host
+  implementations into linkers.
+  [#8448](https://github.com/bytecodealliance/wasmtime/issues/8448)
+
 ### Fixed
 
 * Connection timeouts with `wasi-http` have been fixed.


### PR DESCRIPTION
This commit is a re-landing of the automated PR created in https://github.com/bytecodealliance/wasmtime/pull/8655. I cancelled the CI after that PR merged to halt the release at the time, so Wasmtime 21.0.0 doesn't exist anywhere yet. This PR is a manual intervention now that https://github.com/bytecodealliance/wasmtime/issues/8659 is fixed on both `main` and the release branch.

This PR needs to have a non-empty change so I added a brief note to the release notes for a backported PR, which I'll forward-port to main as well after this.

The automated release process will be triggered by the string in the commit for this PR, and it'll be as-if the previous release PR never merged and this is the actual auto-release PR.