### PR TITLE
Add release binaries for x86_64-musl

### DIFF
--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -59,6 +59,11 @@ const array = [
     "os": "ubuntu-latest",
     "target": "x86_64-linux-android",
   },
+  {
+    "build": "x86_64-musl",
+    "os": "ubuntu-latest",
+    "target": "x86_64-unknown-linux-musl",
+  },
 ];
 
 const builds = [];

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -25,7 +25,7 @@ if [[ "$build" = *-min ]]; then
   # Configure a whole bunch of compile-time options which help reduce the size
   # of the binary artifact produced.
   export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
-  export RUSTFLAGS=-Zlocation-detail=none
+  export RUSTFLAGS="-Zlocation-detail=none $RUSTFLAGS"
   export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
   export CARGO_PROFILE_RELEASE_LTO=true
   build_std=-Zbuild-std=std,panic_abort

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -1,0 +1,17 @@
+# Rust binaries need `libgcc_s.so` but ubuntu's musl toolchain does not have it.
+# Get it from alpine instead.
+FROM alpine:3.16 as libgcc_s_src
+RUN apk add libgcc
+
+# Use something glibc-based for the actual compile because the Rust toolchain
+# we're using is glibc-based in CI.
+FROM ubuntu:24.04
+RUN apt-get update -y && apt-get install -y cmake musl-tools
+COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
+
+ENV PATH=$PATH:/rust/bin
+
+# Note that `-crt-feature` is passed here to specifically disable static linking
+# with musl. We want a `*.so` to pop out so static linking isn't what we want.
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -13,5 +13,5 @@ ENV PATH=$PATH:/rust/bin
 
 # Note that `-crt-feature` is passed here to specifically disable static linking
 # with musl. We want a `*.so` to pop out so static linking isn't what we want.
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV RUSTFLAGS=-Ctarget-feature=-crt-static
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -35,4 +35,8 @@ fn build_c_helpers() {
     println!("cargo:rerun-if-changed=src/runtime/vm/helpers.c");
     build.file("src/runtime/vm/helpers.c");
     build.compile("wasmtime-helpers");
+
+    if os == "linux" {
+        println!("cargo:rustc-link-lib=m");
+    }
 }

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -91,6 +91,7 @@ For explanations of what each tier means see below.
 | Target               | `wasm32-wasi` [^3]                | Supported but not tested    |
 | Target               | `aarch64-linux-android`           | CI testing, full-time maintainer |
 | Target               | `x86_64-linux-android`            | CI testing, full-time maintainer |
+| Target               | `x86_64-unknown-linux-musl` [^4]  | CI testing, full-time maintainer |
 | Compiler Backend     | Winch on aarch64                  | finished implementation     |
 | WebAssembly Proposal | [`gc`]                            | Complete implementation     |
 | WASI Proposal        | [`wasi-nn`]                       | More expansive CI testing   |
@@ -118,6 +119,11 @@ as well.
 [^3]: Wasmtime's `cranelift` and `winch` features can be compiled to WebAssembly
 but not the `runtime` feature at this time. This means that
 Wasmtime-compiled-to-wasm can itself compile wasm but cannot execute wasm.
+
+[^4]: Binary artifacts for MUSL are dynamically linked, not statically
+linked, meaning that they are not suitable for "run on any linux distribution"
+style use cases. Wasmtime does not have static binary artifacts at this time and
+that will require building from source.
 
 #### Unsupported features and platforms
 


### PR DESCRIPTION
This was requested in bytecodealliance/wasmtime-py#237 and shouldn't cost us too much in terms of CI resources and maintenance overhead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
