### PR TITLE
corrections to the WASMTIME_LOG docs

### DIFF
--- a/docs/cli-logging.md
+++ b/docs/cli-logging.md
@@ -1,15 +1,16 @@
 # Logging in the `wasmtime` CLI
 
 Wasmtime's libraries use Rust's [`log`] crate to log diagnostic
-information, and the `wasmtime` CLI executable uses [`pretty_env_logger`]
-by default for logging this information to the console.
+information, and the `wasmtime` CLI executable uses [`tracing-subscriber`]
+for displaying this information on the console.
 
 Basic logging is controlled by the `WASMTIME_LOG` environment variable. For example,
 To enable logging of WASI system calls, similar to the `strace` command on Linux,
-set `WASMTIME_LOG=wasmtime_wasi=trace`.
+set `WASMTIME_LOG=wasmtime_wasi=trace`. For more information on specifying
+filters, see [tracing-subscriber's EnvFilter docs].
 
 ```sh
-$ WASMTIME_LOG=wasmtime_wasi=trace hello.wasm
+$ WASMTIME_LOG=wasmtime_wasi=trace wasmtime hello.wasm
 [...]
 TRACE wiggle abi{module="wasi_snapshot_preview1" function="fd_write"} wasmtime_wasi::preview1::wasi_snapshot_preview1                     > fd=Fd(1) iovs=*guest 0x14/1
 Hello, world!
@@ -23,4 +24,5 @@ Wasmtime can also redirect the log messages into log files, with the
 the files named `wasmtime.dbg.*`.
 
 [`log`]: https://crates.io/crates/log
-[`pretty_env_logger`]: https://crates.io/crates/pretty_env_logger
+[`tracing-subscriber`]: https://crates.io/crates/tracing-subscriber
+[tracing-subscriber's EnvFilter docs]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives


### PR DESCRIPTION
Follow-up to #8656

* its tracing-subscriber now, not pretty_env_logger
* point to tracing-subscribers docs on filter directives
* correct invocation of wasmtime in the example

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
