### PR TITLE
wasi-http: add the port to authority when opening a TCP connection

### DIFF
--- a/crates/test-programs/src/bin/api_proxy_forward_request.rs
+++ b/crates/test-programs/src/bin/api_proxy_forward_request.rs
@@ -1,0 +1,42 @@
+use test_programs::wasi::http::types::{
+    Headers, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+};
+
+struct T;
+
+test_programs::proxy::export!(T);
+
+impl test_programs::proxy::exports::wasi::http::incoming_handler::Guest for T {
+    fn handle(request: IncomingRequest, outparam: ResponseOutparam) {
+        let res = test_programs::http::request(
+            request.method(),
+            request.scheme().unwrap(),
+            request.authority().unwrap().as_str(),
+            request.path_with_query().unwrap().as_str(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let hdrs = Headers::from_list(&res.headers).unwrap();
+        let resp = OutgoingResponse::new(hdrs);
+        resp.set_status_code(res.status).expect("status code");
+        let body = resp.body().expect("outgoing response");
+
+        ResponseOutparam::set(outparam, Ok(resp));
+
+        let out = body.write().expect("outgoing stream");
+        out.blocking_write_and_flush(res.body.as_ref())
+            .expect("writing response");
+
+        drop(out);
+        OutgoingBody::finish(body, None).expect("outgoing-body.finish");
+    }
+}
+
+// Technically this should not be here for a proxy, but given the current
+// framework for tests it's required since this file is built as a `bin`
+fn main() {}

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -527,6 +527,25 @@ async fn do_wasi_http_echo(uri: &str, url_header: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+#[test_log::test(tokio::test)]
+async fn wasi_http_without_port() -> Result<()> {
+    let req = hyper::Request::builder()
+        .method(http::Method::GET)
+        .uri("https://httpbin.org/get");
+
+    let response = run_wasi_http(
+        test_programs_artifacts::API_PROXY_FORWARD_REQUEST_COMPONENT,
+        req.body(body::empty())?,
+        None,
+        None,
+    )
+    .await??;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    Ok(())
+}
+
 mod body {
     use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
     use hyper::body::Bytes;

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -528,6 +528,8 @@ async fn do_wasi_http_echo(uri: &str, url_header: Option<&str>) -> Result<()> {
 }
 
 #[test_log::test(tokio::test)]
+// test uses TLS but riscv/s390x don't support that yet
+#[cfg_attr(any(target_arch = "riscv64", target_arch = "s390x"), ignore)]
 async fn wasi_http_without_port() -> Result<()> {
     let req = hyper::Request::builder()
         .method(http::Method::GET)

--- a/crates/wasi/tests/all/api.rs
+++ b/crates/wasi/tests/all/api.rs
@@ -120,6 +120,11 @@ fn api_proxy() {}
 #[allow(dead_code)]
 fn api_proxy_streaming() {}
 
+// This is tested in the wasi-http crate, but need to satisfy the `foreach_api!`
+// macro above.
+#[allow(dead_code)]
+fn api_proxy_forward_request() {}
+
 wasmtime::component::bindgen!({
     world: "test-reactor",
     async: true,


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

#8563 removes the port from the authority, it makes the target address cannot be correctly resolved when opening a TCP connection. This results in that if we want to send an HTTP request in the wasi component, an error `ErrorCode::ConnectionRefused` will be reported directly. The underlying error is `invalid socket address`:

<img width="521" alt="Screenshot 2024-05-21 at 17 21 56" src="https://github.com/bytecodealliance/wasmtime/assets/9134003/6473efef-4306-45c7-8ca4-e5101d14f071">

/cc @alexcrichton @elliottt 