### PR TITLE
x64: Improve lowerings for `ctz`/`clz` instructions

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2129,21 +2129,14 @@
 
 ;; Rules for `clz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; If available, we can use a plain lzcnt instruction here. Note no
-;; special handling is required for zero inputs, because the machine
-;; instruction does what the CLIF expects for zero, i.e. it returns
-;; zero.
-(rule 3 (lower (has_type (ty_32_or_64 ty) (clz src)))
-      (if-let $true (use_lzcnt))
-      (x64_lzcnt ty src))
-
 (rule 2 (lower (has_type (ty_32_or_64 ty) (clz src)))
       (do_clz ty ty src))
 
-(rule 1 (lower
-       (has_type (ty_8_or_16 ty)
-                 (clz src)))
-      (do_clz $I32 ty (extend_to_gpr src $I32 (ExtendKind.Zero))))
+(rule 1 (lower (has_type (ty_8_or_16 ty) (clz src)))
+      (let ((extended Gpr (extend_to_gpr src $I64 (ExtendKind.Zero)))
+            (clz Gpr (do_clz $I64 $I64 extended)))
+        (x64_sub $I64 clz (RegMemImm.Imm (u32_sub 64 (ty_bits ty))))))
+
 
 (rule 0 (lower
        (has_type $I128
@@ -2160,27 +2153,29 @@
 
 ;; Implementation helper for clz; operates on 32 or 64-bit units.
 (decl do_clz (Type Type Gpr) Gpr)
-(rule (do_clz ty orig_ty src)
+
+;; If available, we can use a plain lzcnt instruction here. Note no
+;; special handling is required for zero inputs, because the machine
+;; instruction does what the CLIF expects for zero, i.e. it returns
+;; zero.
+(rule 1 (do_clz ty orig_ty src)
+      (if-let $true (use_lzcnt))
+      (x64_lzcnt ty src))
+
+(rule 0 (do_clz ty orig_ty src)
       (let ((highest_bit_index Reg (bsr_or_else ty src (imm_i64 $I64 -1)))
             (bits_minus_1 Reg (imm ty (u64_sub (ty_bits_u64 orig_ty) 1))))
         (x64_sub ty bits_minus_1 highest_bit_index)))
 
 ;; Rules for `ctz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Analogous to `clz` cases above, but using mirror instructions
-;; (tzcnt vs lzcnt, bsf vs bsr).
-
-(rule 3 (lower (has_type (ty_32_or_64 ty) (ctz src)))
-      (if-let $true (use_bmi1))
-      (x64_tzcnt ty src))
-
 (rule 2 (lower (has_type (ty_32_or_64 ty) (ctz src)))
       (do_ctz ty ty src))
 
-(rule 1 (lower
-       (has_type (ty_8_or_16 ty)
-                 (ctz src)))
-      (do_ctz $I32 ty (extend_to_gpr src $I32 (ExtendKind.Zero))))
+(rule 1 (lower (has_type (ty_8_or_16 ty) (ctz src)))
+      (let ((extended Gpr (extend_to_gpr src $I32 (ExtendKind.Zero)))
+            (stopbit Gpr (x64_or $I32 extended (RegMemImm.Imm (u32_shl 1 (ty_bits ty))))))
+        (do_ctz $I32 ty stopbit)))
 
 (rule 0 (lower
        (has_type $I128
@@ -2196,7 +2191,14 @@
         (value_regs result_lo (imm $I64 0))))
 
 (decl do_ctz (Type Type Gpr) Gpr)
-(rule (do_ctz ty orig_ty src)
+
+;; Analogous to `clz` cases above, but using mirror instructions
+;; (tzcnt vs lzcnt, bsf vs bsr).
+(rule 1 (do_ctz ty orig_ty src)
+      (if-let $true (use_bmi1))
+      (x64_tzcnt ty src))
+
+(rule 0 (do_ctz ty orig_ty src)
       (bsf_or_else ty src (imm $I64 (ty_bits_u64 orig_ty))))
 
 ;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -684,6 +684,11 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn u32_shl(&mut self, x: u32, y: u32) -> u32 {
+            x << y
+        }
+
+        #[inline]
         fn s32_add_fallible(&mut self, a: i32, b: i32) -> Option<i32> {
             a.checked_add(b)
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -133,6 +133,9 @@
 (decl pure u32_and (u32 u32) u32)
 (extern constructor u32_and u32_and)
 
+(decl pure u32_shl (u32 u32) u32)
+(extern constructor u32_shl u32_shl)
+
 ;; Pure/fallible constructor that tries to add two `u32`s, interpreted
 ;; as signed values, and fails to match on overflow.
 (decl pure partial s32_add_fallible (i32 i32) i32)

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -13,20 +13,11 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r8
-;   movabsq $-1, %rcx
-;   bsrq    %rsi, %r9
-;   cmovzq  %rcx, %r9, %r9
-;   movl    $63, %edi
-;   subq    %rdi, %r9, %rdi
-;   movabsq $-1, %rdx
-;   bsrq    %r8, %r10
-;   cmovzq  %rdx, %r10, %r10
-;   movl    $63, %eax
-;   subq    %rax, %r10, %rax
+;   lzcntq  %rsi, %rcx
+;   lzcntq  %rdi, %rax
 ;   addq    %rax, $64, %rax
-;   cmpq    $64, %rdi
-;   cmovnzq %rdi, %rax, %rax
+;   cmpq    $64, %rcx
+;   cmovnzq %rcx, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -37,20 +28,11 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %r8
-;   movq $18446744073709551615, %rcx
-;   bsrq %rsi, %r9
-;   cmoveq %rcx, %r9
-;   movl $0x3f, %edi
-;   subq %r9, %rdi
-;   movq $18446744073709551615, %rdx
-;   bsrq %r8, %r10
-;   cmoveq %rdx, %r10
-;   movl $0x3f, %eax
-;   subq %r10, %rax
+;   lzcntq %rsi, %rcx
+;   lzcntq %rdi, %rax
 ;   addq $0x40, %rax
-;   cmpq $0x40, %rdi
-;   cmovneq %rdi, %rax
+;   cmpq $0x40, %rcx
+;   cmovneq %rcx, %rax
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -116,12 +98,9 @@ block0(v0: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzwl  %di, %eax
-;   movabsq $-1, %rdx
-;   bsrl    %eax, %r10d
-;   cmovzl  %edx, %r10d, %r10d
-;   movl    $15, %eax
-;   subl    %eax, %r10d, %eax
+;   movzwq  %di, %rax
+;   lzcntq  %rax, %rax
+;   subq    %rax, $48, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -131,12 +110,9 @@ block0(v0: i16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzwl %di, %eax
-;   movq $18446744073709551615, %rdx
-;   bsrl %eax, %r10d
-;   cmovel %edx, %r10d
-;   movl $0xf, %eax
-;   subl %r10d, %eax
+;   movzwq %di, %rax
+;   lzcntq %rax, %rax
+;   subq $0x30, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -151,12 +127,9 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbl  %dil, %eax
-;   movabsq $-1, %rdx
-;   bsrl    %eax, %r10d
-;   cmovzl  %edx, %r10d, %r10d
-;   movl    $7, %eax
-;   subl    %eax, %r10d, %eax
+;   movzbq  %dil, %rax
+;   lzcntq  %rax, %rax
+;   subq    %rax, $56, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -166,12 +139,9 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzbl %dil, %eax
-;   movq $18446744073709551615, %rdx
-;   bsrl %eax, %r10d
-;   cmovel %edx, %r10d
-;   movl $7, %eax
-;   subl %r10d, %eax
+;   movzbq %dil, %rax
+;   lzcntq %rax, %rax
+;   subq $0x38, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/clz.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz.clif
@@ -132,12 +132,13 @@ block0(v0: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzwl  %di, %eax
+;   movzwq  %di, %rax
 ;   movabsq $-1, %rdx
-;   bsrl    %eax, %r10d
-;   cmovzl  %edx, %r10d, %r10d
-;   movl    $15, %eax
-;   subl    %eax, %r10d, %eax
+;   bsrq    %rax, %r10
+;   cmovzq  %rdx, %r10, %r10
+;   movl    $63, %eax
+;   subq    %rax, %r10, %rax
+;   subq    %rax, $48, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -147,12 +148,13 @@ block0(v0: i16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzwl %di, %eax
+;   movzwq %di, %rax
 ;   movq $18446744073709551615, %rdx
-;   bsrl %eax, %r10d
-;   cmovel %edx, %r10d
-;   movl $0xf, %eax
-;   subl %r10d, %eax
+;   bsrq %rax, %r10
+;   cmoveq %rdx, %r10
+;   movl $0x3f, %eax
+;   subq %r10, %rax
+;   subq $0x30, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -167,12 +169,13 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbl  %dil, %eax
+;   movzbq  %dil, %rax
 ;   movabsq $-1, %rdx
-;   bsrl    %eax, %r10d
-;   cmovzl  %edx, %r10d, %r10d
-;   movl    $7, %eax
-;   subl    %eax, %r10d, %eax
+;   bsrq    %rax, %r10
+;   cmovzq  %rdx, %r10, %r10
+;   movl    $63, %eax
+;   subq    %rax, %r10, %rax
+;   subq    %rax, $56, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -182,12 +185,13 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzbl %dil, %eax
+;   movzbq %dil, %rax
 ;   movq $18446744073709551615, %rdx
-;   bsrl %eax, %r10d
-;   cmovel %edx, %r10d
-;   movl $7, %eax
-;   subl %r10d, %eax
+;   bsrq %rax, %r10
+;   cmoveq %rdx, %r10
+;   movl $0x3f, %eax
+;   subq %r10, %rax
+;   subq $0x38, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/clz.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_llvm_abi_extensions=true
-target x86_64 has_lzcnt
+target x86_64
 
 
 function %clz(i128) -> i128 {
@@ -66,7 +66,11 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lzcntq  %rdi, %rax
+;   movabsq $-1, %rax
+;   bsrq    %rdi, %r8
+;   cmovzq  %rax, %r8, %r8
+;   movl    $63, %eax
+;   subq    %rax, %r8, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -76,7 +80,11 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   lzcntq %rdi, %rax
+;   movq $18446744073709551615, %rax
+;   bsrq %rdi, %r8
+;   cmoveq %rax, %r8
+;   movl $0x3f, %eax
+;   subq %r8, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -91,7 +99,11 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lzcntl  %edi, %eax
+;   movabsq $-1, %rax
+;   bsrl    %edi, %r8d
+;   cmovzl  %eax, %r8d, %r8d
+;   movl    $31, %eax
+;   subl    %eax, %r8d, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -101,7 +113,11 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   lzcntl %edi, %eax
+;   movq $18446744073709551615, %rax
+;   bsrl %edi, %r8d
+;   cmovel %eax, %r8d
+;   movl $0x1f, %eax
+;   subl %r8d, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -13,15 +13,11 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $64, %ecx
-;   bsfq    %rdi, %rax
-;   cmovzq  %rcx, %rax, %rax
-;   movl    $64, %edi
-;   bsfq    %rsi, %rdx
-;   cmovzq  %rdi, %rdx, %rdx
-;   addq    %rdx, $64, %rdx
+;   tzcntq  %rdi, %rax
+;   tzcntq  %rsi, %r9
+;   addq    %r9, $64, %r9
 ;   cmpq    $64, %rax
-;   cmovzq  %rdx, %rax, %rax
+;   cmovzq  %r9, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -32,15 +28,11 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movl $0x40, %ecx
-;   bsfq %rdi, %rax
-;   cmoveq %rcx, %rax
-;   movl $0x40, %edi
-;   bsfq %rsi, %rdx
-;   cmoveq %rdi, %rdx
-;   addq $0x40, %rdx
+;   tzcntq %rdi, %rax
+;   tzcntq %rsi, %r9
+;   addq $0x40, %r9
 ;   cmpq $0x40, %rax
-;   cmoveq %rdx, %rax
+;   cmoveq %r9, %rax
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -106,10 +98,9 @@ block0(v0: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzwl  %di, %eax
-;   movl    $16, %edx
-;   bsfl    %eax, %eax
-;   cmovzl  %edx, %eax, %eax
+;   movzwl  %di, %ecx
+;   orl     %ecx, $65536, %ecx
+;   tzcntl  %ecx, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -119,10 +110,9 @@ block0(v0: i16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzwl %di, %eax
-;   movl $0x10, %edx
-;   bsfl %eax, %eax
-;   cmovel %edx, %eax
+;   movzwl %di, %ecx
+;   orl $0x10000, %ecx
+;   tzcntl %ecx, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -137,10 +127,9 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbl  %dil, %eax
-;   movl    $8, %edx
-;   bsfl    %eax, %eax
-;   cmovzl  %edx, %eax, %eax
+;   movzbl  %dil, %ecx
+;   orl     %ecx, $256, %ecx
+;   tzcntl  %ecx, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -150,10 +139,10 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzbl %dil, %eax
-;   movl $8, %edx
-;   bsfl %eax, %eax
-;   cmovel %edx, %eax
+;   movzbl %dil, %ecx
+;   orl $0x100, %ecx
+;   tzcntl %ecx, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/ctz.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_llvm_abi_extensions=true
-target x86_64 has_bmi1
+target x86_64
 
 
 function %ctz(i128) -> i128 {
@@ -56,7 +56,9 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   tzcntq  %rdi, %rax
+;   movl    $64, %ecx
+;   bsfq    %rdi, %rax
+;   cmovzq  %rcx, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -66,7 +68,9 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   tzcntq %rdi, %rax
+;   movl $0x40, %ecx
+;   bsfq %rdi, %rax
+;   cmoveq %rcx, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -81,7 +85,9 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   tzcntl  %edi, %eax
+;   movl    $32, %ecx
+;   bsfl    %edi, %eax
+;   cmovzl  %ecx, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -91,7 +97,9 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   tzcntl %edi, %eax
+;   movl $0x20, %ecx
+;   bsfl %edi, %eax
+;   cmovel %ecx, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/ctz.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz.clif
@@ -114,10 +114,11 @@ block0(v0: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzwl  %di, %eax
-;   movl    $16, %edx
-;   bsfl    %eax, %eax
-;   cmovzl  %edx, %eax, %eax
+;   movzwl  %di, %ecx
+;   orl     %ecx, $65536, %ecx
+;   movl    $16, %r9d
+;   bsfl    %ecx, %eax
+;   cmovzl  %r9d, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -127,10 +128,11 @@ block0(v0: i16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzwl %di, %eax
-;   movl $0x10, %edx
-;   bsfl %eax, %eax
-;   cmovel %edx, %eax
+;   movzwl %di, %ecx
+;   orl $0x10000, %ecx
+;   movl $0x10, %r9d
+;   bsfl %ecx, %eax
+;   cmovel %r9d, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -145,10 +147,11 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbl  %dil, %eax
-;   movl    $8, %edx
-;   bsfl    %eax, %eax
-;   cmovzl  %edx, %eax, %eax
+;   movzbl  %dil, %ecx
+;   orl     %ecx, $256, %ecx
+;   movl    $8, %r9d
+;   bsfl    %ecx, %eax
+;   cmovzl  %r9d, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -158,10 +161,12 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzbl %dil, %eax
-;   movl $8, %edx
-;   bsfl %eax, %eax
-;   cmovel %edx, %eax
+;   movzbl %dil, %ecx
+;   orl $0x100, %ecx
+;   movl $8, %r9d
+;   bsfl %ecx, %eax
+;   cmovel %r9d, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+

--- a/cranelift/filetests/filetests/runtests/i128-bitops-count.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitops-count.clif
@@ -3,6 +3,9 @@ set enable_llvm_abi_extensions=true
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_lzcnt
+target x86_64 has_bmi1
+target x86_64 has_popcnt has_sse42
 target riscv64
 target riscv64 has_zbb
 target riscv64 has_zbb has_zbs

--- a/cranelift/filetests/filetests/runtests/popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/popcnt.clif
@@ -3,7 +3,7 @@ test run
 target aarch64
 target s390x
 target x86_64
-target x86_64 has_popcnt
+target x86_64 has_popcnt has_sse42
 target riscv64
 target riscv64 has_c has_zcb
 


### PR DESCRIPTION
👋 Hey,

This PR slightly improves the lowerings for `clz` and `ctz` for some types (`i8`/`i16`/`i128`)  by emitting the native `{l,t}zcount` instructions for these. Previously we would never emit them even if available.

The first commit just expands our compile tests for these new cases, and the second commit contains the actual lowering changes.

Additionally I've also added the `use_sse42` flag to the `popcnt` runtests since it is required to emit the popcnt instruction.