### PR TITLE
Use BuildHasher::hash_one

### DIFF
--- a/cranelift/src/souper_harvest.rs
+++ b/cranelift/src/souper_harvest.rs
@@ -7,6 +7,7 @@ use cranelift_codegen::Context;
 use cranelift_reader::parse_sets_and_triple;
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use std::collections::HashSet;
+use std::hash::{BuildHasher, BuildHasherDefault};
 use std::io::Write;
 use std::path::PathBuf;
 use std::{fs, io};
@@ -143,7 +144,5 @@ fn parse_input(path: PathBuf) -> Result<Vec<Function>> {
 /// A convenience function for a quick usize hash
 #[inline]
 pub fn hash<T: std::hash::Hash + ?Sized>(v: &T) -> usize {
-    let mut state = rustc_hash::FxHasher::default();
-    v.hash(&mut state);
-    std::hash::Hasher::finish(&state) as usize
+    BuildHasherDefault::<rustc_hash::FxHasher>::default().hash_one(v) as usize
 }


### PR DESCRIPTION
I noticed that a bit of #8498 could use the relatively-new `hash_one` helper, so here's a PR.

Up to you whether you want the change; it does exactly the same thing.