### PR TITLE
Fix tail calls being turned on by default

### DIFF
--- a/tests/disas/arith.wat
+++ b/tests/disas/arith.wat
@@ -14,7 +14,7 @@
   (data (i32.const 0) "abcdefgh")
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -9,7 +9,7 @@
     i32.load
     i32.add))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -31,7 +31,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -67,7 +67,7 @@
 ;; @002e                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -103,7 +103,7 @@
 ;; @0044                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -127,7 +127,7 @@
 ;; @0054                               return v2
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64) -> i32 fast {
+;; function u0:3(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/byteswap.wat
+++ b/tests/disas/byteswap.wat
@@ -71,7 +71,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -85,7 +85,7 @@
 ;; @0057                               return v19
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i64 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/call-simd.wat
+++ b/tests/disas/call-simd.wat
@@ -15,11 +15,11 @@
   (start $main)
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     sig0 = (i64 vmctx, i64, i8x16, i8x16) -> i8x16 fast
+;;     sig0 = (i64 vmctx, i64, i8x16, i8x16) -> i8x16 tail
 ;;     fn0 = colocated u0:1 sig0
 ;;     const0 = 0x00000004000000030000000200000001
 ;;     stack_limit = gv2
@@ -34,7 +34,7 @@
 ;; @0048                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i8x16, i8x16) -> i8x16 fast {
+;; function u0:1(i64 vmctx, i64, i8x16, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/call.wat
+++ b/tests/disas/call.wat
@@ -11,11 +11,11 @@
   (start $main)
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     fn0 = colocated u0:1 sig0
 ;;     stack_limit = gv2
 ;;
@@ -29,7 +29,7 @@
 ;; @0028                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -21,7 +21,7 @@
     return
     i32.const 42)
 )
-;; function u0:0(i64 vmctx, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @002f                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) fast {
+;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -59,7 +59,7 @@
 ;; @0036                               jump block2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) fast {
+;; function u0:2(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -72,7 +72,7 @@
 ;; @003f                               return
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -22,7 +22,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @005f                               return v12, v12
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -17,7 +17,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -36,7 +36,7 @@
 ;; @005f                               return v8, v8
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -35,7 +35,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -86,7 +86,7 @@
 ;; @0056                               return v11, v19, v29
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) fast {
+;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -31,7 +31,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -66,7 +66,7 @@
 ;; @0056                               return v13, v23, v35
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) fast {
+;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -6,7 +6,7 @@
     local.get 0
     f32.load))
 
-;; function u0:0(i64 vmctx, i64, i32) -> f32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -9,7 +9,7 @@
     local.get 1
     f32.store))
 
-;; function u0:0(i64 vmctx, i64, i32, f32) fast {
+;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -8,7 +8,7 @@
     local.get 0
     f64.load))
 
-;; function u0:0(i64 vmctx, i64, i32) -> f64 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> f64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -9,7 +9,7 @@
     local.get 1
     f64.store))
 
-;; function u0:0(i64 vmctx, i64, i32, f64) fast {
+;; function u0:0(i64 vmctx, i64, i32, f64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -20,7 +20,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -33,7 +33,7 @@
 ;; @0040                               return v3, v4
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64, i64) -> i64, i64, i64 fast {
+;; function u0:1(i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,12 +46,12 @@
 ;; @0049                               return v4, v5, v6
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64, i64) -> i64 fast {
+;; function u0:2(i64 vmctx, i64, i64) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     sig0 = (i64 vmctx, i64, i64, i64) -> i64, i64, i64 fast
-;;     sig1 = (i64 vmctx, i64, i64) -> i64, i64 fast
+;;     sig0 = (i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail
+;;     sig1 = (i64 vmctx, i64, i64) -> i64, i64 tail
 ;;     fn0 = colocated u0:1 sig0
 ;;     fn1 = colocated u0:0 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -23,7 +23,7 @@
   (data (i32.const 0) "0000")
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -20,7 +20,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -9,7 +9,7 @@
   (start $main)
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -8,7 +8,7 @@
     local.get 0
     i32.load))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -8,7 +8,7 @@
     local.get 0
     i32.load16_s))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -8,7 +8,7 @@
     local.get 0
     i32.load16_u))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -8,7 +8,7 @@
     local.get 0
     i32.load8_s))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -8,7 +8,7 @@
     local.get 0
     i32.load8_u))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -9,7 +9,7 @@
     local.get 1
     i32.store))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -9,7 +9,7 @@
     local.get 1
     i32.store16))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -9,7 +9,7 @@
     local.get 1
     i32.store8))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -8,7 +8,7 @@
     local.get 0
     i64.load))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -8,7 +8,7 @@
     local.get 0
     i64.load16_s))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -8,7 +8,7 @@
     local.get 0
     i64.load16_u))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -8,7 +8,7 @@
     local.get 0
     i64.load8_s))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -8,7 +8,7 @@
     local.get 0
     i64.load8_u))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -9,7 +9,7 @@
     local.get 1
     i64.store))
 
-;; function u0:0(i64 vmctx, i64, i32, i64) fast {
+;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -9,7 +9,7 @@
     local.get 1
     i64.store16))
 
-;; function u0:0(i64 vmctx, i64, i32, i64) fast {
+;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -9,7 +9,7 @@
     local.get 1
     i64.store32))
 
-;; function u0:0(i64 vmctx, i64, i32, i64) fast {
+;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -9,7 +9,7 @@
     local.get 1
     i64.store8))
 
-;; function u0:0(i64 vmctx, i64, i32, i64) fast {
+;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -22,13 +22,13 @@
         end)
 )
 
-;; function u0:0(i64 vmctx, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
@@ -75,13 +75,13 @@
 ;; @002e                               jump block2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) fast {
+;; function u0:1(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -8,13 +8,13 @@
   (table (;0;) 23 23 funcref)
 )
 
-;; function u0:0(i64 vmctx, i64, i32, i8x16) -> i8x16 fast {
+;; function u0:0(i64 vmctx, i64, i32, i8x16) -> i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 fast
+;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -8,13 +8,13 @@
   (table (;0;) 23 23 funcref)
 )
 
-;; function u0:0(i64 vmctx, i64, i32, f32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, f32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, f32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/if-reachability-translation-0.wat
+++ b/tests/disas/if-reachability-translation-0.wat
@@ -13,7 +13,7 @@
     end
     i32.const 0))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-reachability-translation-1.wat
+++ b/tests/disas/if-reachability-translation-1.wat
@@ -13,7 +13,7 @@
     end
     i32.const 0))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -13,7 +13,7 @@
     end
     i32.const 0))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -13,7 +13,7 @@
     end
     i32.const 0))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-reachability-translation-4.wat
+++ b/tests/disas/if-reachability-translation-4.wat
@@ -13,7 +13,7 @@
     end
     i32.const 0))
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -15,7 +15,7 @@
     end
     i32.const 0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -15,7 +15,7 @@
     end
     i32.const 0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -19,7 +19,7 @@
   (export "main" (func $main))
   (export "memory" (memory 0)))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -42,7 +42,7 @@
   (export "main" (func $main))
   (export "memory" (memory 0)))
 
-;; function u0:0(i64 vmctx, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/indirect-call-caching-exclude-0-index.wat
+++ b/tests/disas/indirect-call-caching-exclude-0-index.wat
@@ -18,7 +18,7 @@
   call_indirect (result i32))
 
  (elem (i32.const 0) func $f1 $f2 $f3))
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -32,7 +32,7 @@
 ;; @0041                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @0046                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -60,13 +60,13 @@
 ;; @004b                               return v2
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/indirect-call-caching-exclude-table-export.wat
+++ b/tests/disas/indirect-call-caching-exclude-table-export.wat
@@ -17,7 +17,7 @@
   call_indirect (result i32))
 
  (elem (i32.const 1) func $f1 $f2 $f3))
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -31,7 +31,7 @@
 ;; @0045                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @004a                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -59,13 +59,13 @@
 ;; @004f                               return v2
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/indirect-call-caching-exclude-table-writes.wat
+++ b/tests/disas/indirect-call-caching-exclude-table-writes.wat
@@ -22,7 +22,7 @@
   table.set)
 
  (elem (i32.const 1) func $f1 $f2 $f3))
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -36,7 +36,7 @@
 ;; @0054                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -50,7 +50,7 @@
 ;; @0059                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -64,13 +64,13 @@
 ;; @005e                               return v2
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
@@ -110,7 +110,7 @@
 ;; @0066                               return v3
 ;; }
 ;;
-;; function u0:4(i64 vmctx, i64) fast {
+;; function u0:4(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/indirect-call-caching-slot-limit-1.wat
+++ b/tests/disas/indirect-call-caching-slot-limit-1.wat
@@ -20,13 +20,13 @@
   call_indirect (result i32)
   call_indirect (result i32)))
   
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/indirect-call-caching-slot-limit-2.wat
+++ b/tests/disas/indirect-call-caching-slot-limit-2.wat
@@ -25,13 +25,13 @@
   local.get 0
   call_indirect (result i32)))
   
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
@@ -133,13 +133,13 @@
 ;; @0046                               return v3
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/indirect-call-caching.wat
+++ b/tests/disas/indirect-call-caching.wat
@@ -19,7 +19,7 @@
   call_indirect (result i32))
 
  (elem (i32.const 1) func $f1 $f2 $f3))
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -33,7 +33,7 @@
 ;; @0041                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -47,7 +47,7 @@
 ;; @0046                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -61,13 +61,13 @@
 ;; @004b                               return v2
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -20,7 +20,7 @@
   call_indirect (result i32))
 
  (elem (i32.const 1) func $f1 $f2 $f3))
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -34,7 +34,7 @@
 ;; @0041                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -48,7 +48,7 @@
 ;; @0046                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -62,13 +62,13 @@
 ;; @004b                               return v2
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) -> i32 fast
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/issue-5696.wat
+++ b/tests/disas/issue-5696.wat
@@ -9,7 +9,7 @@
     ;; call 0
   )
 )
-;; function u0:0(i64 vmctx, i64, i64) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i64) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       mov     w8, w2
+;;       ldr     x7, [x2, #0x68]
+;;       mov     w8, w4
 ;;       sub     x7, x7, #4
 ;;       cmp     x8, x7
 ;;       b.hi    #0x2c
-;;   1c: ldr     x9, [x0, #0x60]
-;;       str     w3, [x9, w2, uxtw]
+;;   1c: ldr     x9, [x2, #0x60]
+;;       str     w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       mov     w8, w2
+;;       ldr     x7, [x2, #0x68]
+;;       mov     w8, w4
 ;;       sub     x7, x7, #4
 ;;       cmp     x8, x7
 ;;       b.hi    #0x6c
-;;   5c: ldr     x9, [x0, #0x60]
-;;       ldr     w0, [x9, w2, uxtw]
+;;   5c: ldr     x9, [x2, #0x60]
+;;       ldr     w2, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       mov     w10, w2
+;;       ldr     x9, [x2, #0x68]
+;;       mov     w10, w4
 ;;       mov     x11, #0x1004
 ;;       sub     x9, x9, x11
 ;;       cmp     x10, x9
 ;;       b.hi    #0x34
-;;   20: ldr     x11, [x0, #0x60]
+;;   20: ldr     x11, [x2, #0x60]
 ;;       add     x11, x11, #1, lsl #12
-;;       str     w3, [x11, w2, uxtw]
+;;       str     w5, [x11, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -37,15 +37,15 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       mov     w10, w2
+;;       ldr     x9, [x2, #0x68]
+;;       mov     w10, w4
 ;;       mov     x11, #0x1004
 ;;       sub     x9, x9, x11
 ;;       cmp     x10, x9
 ;;       b.hi    #0x74
-;;   60: ldr     x11, [x0, #0x60]
+;;   60: ldr     x11, [x2, #0x60]
 ;;       add     x10, x11, #1, lsl #12
-;;       ldr     w0, [x10, w2, uxtw]
+;;       ldr     w2, [x10, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,17 +21,17 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     w11, #-0xfffc
 ;;       adds    x10, x10, x11
 ;;       b.hs    #0x40
-;;   18: ldr     x11, [x0, #0x68]
+;;   18: ldr     x11, [x2, #0x68]
 ;;       cmp     x10, x11
 ;;       b.hi    #0x3c
-;;   24: ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;   24: ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
-;;       str     w3, [x13, x14]
+;;       str     w5, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -40,17 +40,17 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     w11, #-0xfffc
 ;;       adds    x10, x10, x11
 ;;       b.hs    #0xa0
-;;   78: ldr     x11, [x0, #0x68]
+;;   78: ldr     x11, [x2, #0x68]
 ;;       cmp     x10, x11
 ;;       b.hi    #0x9c
-;;   84: ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;   84: ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
-;;       ldr     w0, [x13, x14]
+;;       ldr     w2, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       mov     w7, w2
+;;       ldr     x6, [x2, #0x68]
+;;       mov     w7, w4
 ;;       cmp     x7, x6
 ;;       b.hs    #0x28
-;;   18: ldr     x8, [x0, #0x60]
-;;       strb    w3, [x8, w2, uxtw]
+;;   18: ldr     x8, [x2, #0x60]
+;;       strb    w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,12 +34,12 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       mov     w7, w2
+;;       ldr     x6, [x2, #0x68]
+;;       mov     w7, w4
 ;;       cmp     x7, x6
 ;;       b.hs    #0x68
-;;   58: ldr     x8, [x0, #0x60]
-;;       ldrb    w0, [x8, w2, uxtw]
+;;   58: ldr     x8, [x2, #0x60]
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       mov     w10, w2
+;;       ldr     x9, [x2, #0x68]
+;;       mov     w10, w4
 ;;       mov     x11, #0x1001
 ;;       sub     x9, x9, x11
 ;;       cmp     x10, x9
 ;;       b.hi    #0x34
-;;   20: ldr     x11, [x0, #0x60]
+;;   20: ldr     x11, [x2, #0x60]
 ;;       add     x11, x11, #1, lsl #12
-;;       strb    w3, [x11, w2, uxtw]
+;;       strb    w5, [x11, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -37,15 +37,15 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       mov     w10, w2
+;;       ldr     x9, [x2, #0x68]
+;;       mov     w10, w4
 ;;       mov     x11, #0x1001
 ;;       sub     x9, x9, x11
 ;;       cmp     x10, x9
 ;;       b.hi    #0x74
-;;   60: ldr     x11, [x0, #0x60]
+;;   60: ldr     x11, [x2, #0x60]
 ;;       add     x10, x11, #1, lsl #12
-;;       ldrb    w0, [x10, w2, uxtw]
+;;       ldrb    w2, [x10, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,17 +21,17 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     w11, #-0xffff
 ;;       adds    x10, x10, x11
 ;;       b.hs    #0x40
-;;   18: ldr     x11, [x0, #0x68]
+;;   18: ldr     x11, [x2, #0x68]
 ;;       cmp     x10, x11
 ;;       b.hi    #0x3c
-;;   24: ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;   24: ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
-;;       strb    w3, [x13, x14]
+;;       strb    w5, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -40,17 +40,17 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     w11, #-0xffff
 ;;       adds    x10, x10, x11
 ;;       b.hs    #0xa0
-;;   78: ldr     x11, [x0, #0x68]
+;;   78: ldr     x11, [x2, #0x68]
 ;;       cmp     x10, x11
 ;;       b.hi    #0x9c
-;;   84: ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;   84: ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
-;;       ldrb    w0, [x13, x14]
+;;       ldrb    w2, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,31 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x12, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x12, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       sub     x12, x12, #4
 ;;       mov     x13, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x12
 ;;       csel    x11, x13, x10, hi
 ;;       csdb
-;;       str     w3, [x11]
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x12, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x12, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       sub     x12, x12, #4
 ;;       mov     x13, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x12
 ;;       csel    x11, x13, x10, hi
 ;;       csdb
-;;       ldr     w0, [x11]
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,35 +21,35 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x14, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x14, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x15, #0x1004
 ;;       sub     x14, x14, x15
 ;;       mov     x15, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x12, x14
 ;;       csel    x13, x15, x13, hi
 ;;       csdb
-;;       str     w3, [x13]
+;;       str     w5, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x14, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x14, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x15, #0x1004
 ;;       sub     x14, x14, x15
 ;;       mov     x15, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x12, x14
 ;;       csel    x13, x15, x13, hi
 ;;       csdb
-;;       ldr     w0, [x13]
+;;       ldr     w2, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,20 +21,20 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w13, w2
+;;       mov     w13, w4
 ;;       mov     w14, #-0xfffc
 ;;       adds    x13, x13, x14
 ;;       b.hs    #0x48
-;;   18: ldr     x14, [x0, #0x68]
-;;       ldr     x0, [x0, #0x60]
+;;   18: ldr     x14, [x2, #0x68]
+;;       ldr     x0, [x2, #0x60]
 ;;       mov     x15, #0
-;;       add     x0, x0, w2, uxtw
+;;       add     x0, x0, w4, uxtw
 ;;       mov     x1, #0xffff0000
 ;;       add     x0, x0, x1
 ;;       cmp     x13, x14
 ;;       csel    x15, x15, x0, hi
 ;;       csdb
-;;       str     w3, [x15]
+;;       str     w5, [x15]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   48: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -42,20 +42,20 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w13, w2
+;;       mov     w13, w4
 ;;       mov     w14, #-0xfffc
 ;;       adds    x13, x13, x14
 ;;       b.hs    #0xa8
-;;   78: ldr     x14, [x0, #0x68]
-;;       ldr     x0, [x0, #0x60]
+;;   78: ldr     x14, [x2, #0x68]
+;;       ldr     x0, [x2, #0x60]
 ;;       mov     x15, #0
-;;       add     x0, x0, w2, uxtw
+;;       add     x0, x0, w4, uxtw
 ;;       mov     x1, #0xffff0000
 ;;       add     x0, x0, x1
 ;;       cmp     x13, x14
 ;;       csel    x15, x15, x0, hi
 ;;       csdb
-;;       ldr     w0, [x15]
+;;       ldr     w2, [x15]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   a8: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x9
 ;;       csel    x10, x12, x10, hs
 ;;       csdb
-;;       strb    w3, [x10]
+;;       strb    w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x9
 ;;       csel    x10, x12, x10, hs
 ;;       csdb
-;;       ldrb    w0, [x10]
+;;       ldrb    w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,35 +21,35 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x14, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x14, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x15, #0x1001
 ;;       sub     x14, x14, x15
 ;;       mov     x15, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x12, x14
 ;;       csel    x13, x15, x13, hi
 ;;       csdb
-;;       strb    w3, [x13]
+;;       strb    w5, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x14, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x14, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x15, #0x1001
 ;;       sub     x14, x14, x15
 ;;       mov     x15, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x12, x14
 ;;       csel    x13, x15, x13, hi
 ;;       csdb
-;;       ldrb    w0, [x13]
+;;       ldrb    w2, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,20 +21,20 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w13, w2
+;;       mov     w13, w4
 ;;       mov     w14, #-0xffff
 ;;       adds    x13, x13, x14
 ;;       b.hs    #0x48
-;;   18: ldr     x14, [x0, #0x68]
-;;       ldr     x0, [x0, #0x60]
+;;   18: ldr     x14, [x2, #0x68]
+;;       ldr     x0, [x2, #0x60]
 ;;       mov     x15, #0
-;;       add     x0, x0, w2, uxtw
+;;       add     x0, x0, w4, uxtw
 ;;       mov     x1, #0xffff0000
 ;;       add     x0, x0, x1
 ;;       cmp     x13, x14
 ;;       csel    x15, x15, x0, hi
 ;;       csdb
-;;       strb    w3, [x15]
+;;       strb    w5, [x15]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   48: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -42,20 +42,20 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w13, w2
+;;       mov     w13, w4
 ;;       mov     w14, #-0xffff
 ;;       adds    x13, x13, x14
 ;;       b.hs    #0xa8
-;;   78: ldr     x14, [x0, #0x68]
-;;       ldr     x0, [x0, #0x60]
+;;   78: ldr     x14, [x2, #0x68]
+;;       ldr     x0, [x2, #0x60]
 ;;       mov     x15, #0
-;;       add     x0, x0, w2, uxtw
+;;       add     x0, x0, w4, uxtw
 ;;       mov     x1, #0xffff0000
 ;;       add     x0, x0, x1
 ;;       cmp     x13, x14
 ;;       csel    x15, x15, x0, hi
 ;;       csdb
-;;       ldrb    w0, [x15]
+;;       ldrb    w2, [x15]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   a8: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       mov     w7, w2
+;;       ldr     x6, [x2, #0x68]
+;;       mov     w7, w4
 ;;       cmp     x7, x6
 ;;       b.hi    #0x28
-;;   18: ldr     x8, [x0, #0x60]
-;;       str     w3, [x8, w2, uxtw]
+;;   18: ldr     x8, [x2, #0x60]
+;;       str     w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,12 +34,12 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       mov     w7, w2
+;;       ldr     x6, [x2, #0x68]
+;;       mov     w7, w4
 ;;       cmp     x7, x6
 ;;       b.hi    #0x68
-;;   58: ldr     x8, [x0, #0x60]
-;;       ldr     w0, [x8, w2, uxtw]
+;;   58: ldr     x8, [x2, #0x60]
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       mov     w8, w2
+;;       ldr     x7, [x2, #0x68]
+;;       mov     w8, w4
 ;;       cmp     x8, x7
 ;;       b.hi    #0x2c
-;;   18: ldr     x9, [x0, #0x60]
+;;   18: ldr     x9, [x2, #0x60]
 ;;       add     x9, x9, #1, lsl #12
-;;       str     w3, [x9, w2, uxtw]
+;;       str     w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       mov     w8, w2
+;;       ldr     x7, [x2, #0x68]
+;;       mov     w8, w4
 ;;       cmp     x8, x7
 ;;       b.hi    #0x6c
-;;   58: ldr     x9, [x0, #0x60]
+;;   58: ldr     x9, [x2, #0x60]
 ;;       add     x8, x9, #1, lsl #12
-;;       ldr     w0, [x8, w2, uxtw]
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       mov     w9, w2
+;;       ldr     x8, [x2, #0x68]
+;;       mov     w9, w4
 ;;       cmp     x9, x8
 ;;       b.hi    #0x30
-;;   18: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   18: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       str     w3, [x10, x11]
+;;       str     w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       mov     w9, w2
+;;       ldr     x8, [x2, #0x68]
+;;       mov     w9, w4
 ;;       cmp     x9, x8
 ;;       b.hi    #0x70
-;;   58: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   58: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       ldr     w0, [x10, x11]
+;;       ldr     w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       mov     w7, w2
+;;       ldr     x6, [x2, #0x68]
+;;       mov     w7, w4
 ;;       cmp     x7, x6
 ;;       b.hs    #0x28
-;;   18: ldr     x8, [x0, #0x60]
-;;       strb    w3, [x8, w2, uxtw]
+;;   18: ldr     x8, [x2, #0x60]
+;;       strb    w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,12 +34,12 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       mov     w7, w2
+;;       ldr     x6, [x2, #0x68]
+;;       mov     w7, w4
 ;;       cmp     x7, x6
 ;;       b.hs    #0x68
-;;   58: ldr     x8, [x0, #0x60]
-;;       ldrb    w0, [x8, w2, uxtw]
+;;   58: ldr     x8, [x2, #0x60]
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       mov     w8, w2
+;;       ldr     x7, [x2, #0x68]
+;;       mov     w8, w4
 ;;       cmp     x8, x7
 ;;       b.hi    #0x2c
-;;   18: ldr     x9, [x0, #0x60]
+;;   18: ldr     x9, [x2, #0x60]
 ;;       add     x9, x9, #1, lsl #12
-;;       strb    w3, [x9, w2, uxtw]
+;;       strb    w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       mov     w8, w2
+;;       ldr     x7, [x2, #0x68]
+;;       mov     w8, w4
 ;;       cmp     x8, x7
 ;;       b.hi    #0x6c
-;;   58: ldr     x9, [x0, #0x60]
+;;   58: ldr     x9, [x2, #0x60]
 ;;       add     x8, x9, #1, lsl #12
-;;       ldrb    w0, [x8, w2, uxtw]
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       mov     w9, w2
+;;       ldr     x8, [x2, #0x68]
+;;       mov     w9, w4
 ;;       cmp     x9, x8
 ;;       b.hi    #0x30
-;;   18: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   18: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       strb    w3, [x10, x11]
+;;       strb    w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       mov     w9, w2
+;;       ldr     x8, [x2, #0x68]
+;;       mov     w9, w4
 ;;       cmp     x9, x8
 ;;       b.hi    #0x70
-;;   58: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   58: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       ldrb    w0, [x10, x11]
+;;       ldrb    w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x9
 ;;       csel    x10, x12, x10, hi
 ;;       csdb
-;;       str     w3, [x10]
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x9
 ;;       csel    x10, x12, x10, hi
 ;;       csdb
-;;       ldr     w0, [x10]
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,31 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x11, x10
 ;;       csel    x11, x12, x13, hi
 ;;       csdb
-;;       str     w3, [x11]
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x11, x10
 ;;       csel    x11, x12, x13, hi
 ;;       csdb
-;;       ldr     w0, [x11]
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,33 +21,33 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x0, #0x68]
-;;       ldr     x14, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x11, [x2, #0x68]
+;;       ldr     x14, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x13, #0
-;;       add     x14, x14, w2, uxtw
+;;       add     x14, x14, w4, uxtw
 ;;       mov     x15, #0xffff0000
 ;;       add     x14, x14, x15
 ;;       cmp     x12, x11
 ;;       csel    x12, x13, x14, hi
 ;;       csdb
-;;       str     w3, [x12]
+;;       str     w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x0, #0x68]
-;;       ldr     x14, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x11, [x2, #0x68]
+;;       ldr     x14, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x13, #0
-;;       add     x14, x14, w2, uxtw
+;;       add     x14, x14, w4, uxtw
 ;;       mov     x15, #0xffff0000
 ;;       add     x14, x14, x15
 ;;       cmp     x12, x11
 ;;       csel    x12, x13, x14, hi
 ;;       csdb
-;;       ldr     w0, [x12]
+;;       ldr     w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x9
 ;;       csel    x10, x12, x10, hs
 ;;       csdb
-;;       strb    w3, [x10]
+;;       strb    w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x10, x10, w2, uxtw
+;;       add     x10, x10, w4, uxtw
 ;;       cmp     x11, x9
 ;;       csel    x10, x12, x10, hs
 ;;       csdb
-;;       ldrb    w0, [x10]
+;;       ldrb    w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,31 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x11, x10
 ;;       csel    x11, x12, x13, hi
 ;;       csdb
-;;       strb    w3, [x11]
+;;       strb    w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x13, [x0, #0x60]
-;;       mov     w11, w2
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x13, [x2, #0x60]
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       add     x13, x13, w2, uxtw
+;;       add     x13, x13, w4, uxtw
 ;;       add     x13, x13, #1, lsl #12
 ;;       cmp     x11, x10
 ;;       csel    x11, x12, x13, hi
 ;;       csdb
-;;       ldrb    w0, [x11]
+;;       ldrb    w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,33 +21,33 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x0, #0x68]
-;;       ldr     x14, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x11, [x2, #0x68]
+;;       ldr     x14, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x13, #0
-;;       add     x14, x14, w2, uxtw
+;;       add     x14, x14, w4, uxtw
 ;;       mov     x15, #0xffff0000
 ;;       add     x14, x14, x15
 ;;       cmp     x12, x11
 ;;       csel    x12, x13, x14, hi
 ;;       csdb
-;;       strb    w3, [x12]
+;;       strb    w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x0, #0x68]
-;;       ldr     x14, [x0, #0x60]
-;;       mov     w12, w2
+;;       ldr     x11, [x2, #0x68]
+;;       ldr     x14, [x2, #0x60]
+;;       mov     w12, w4
 ;;       mov     x13, #0
-;;       add     x14, x14, w2, uxtw
+;;       add     x14, x14, w4, uxtw
 ;;       mov     x15, #0xffff0000
 ;;       add     x14, x14, x15
 ;;       cmp     x12, x11
 ;;       csel    x12, x13, x14, hi
 ;;       csdb
-;;       ldrb    w0, [x12]
+;;       ldrb    w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
+;;       ldr     x6, [x2, #0x68]
 ;;       sub     x6, x6, #4
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x28
-;;   18: ldr     x8, [x0, #0x60]
-;;       str     w3, [x8, x2]
+;;   18: ldr     x8, [x2, #0x60]
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,12 +34,12 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
+;;       ldr     x6, [x2, #0x68]
 ;;       sub     x6, x6, #4
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x68
-;;   58: ldr     x8, [x0, #0x60]
-;;       ldr     w0, [x8, x2]
+;;   58: ldr     x8, [x2, #0x60]
+;;       ldr     w2, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
+;;       ldr     x8, [x2, #0x68]
 ;;       mov     x9, #0x1004
 ;;       sub     x8, x8, x9
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       b.hi    #0x30
-;;   1c: ldr     x10, [x0, #0x60]
+;;   1c: ldr     x10, [x2, #0x60]
 ;;       add     x10, x10, #1, lsl #12
-;;       str     w3, [x10, x2]
+;;       str     w5, [x10, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
+;;       ldr     x8, [x2, #0x68]
 ;;       mov     x9, #0x1004
 ;;       sub     x8, x8, x9
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       b.hi    #0x70
-;;   5c: ldr     x10, [x0, #0x60]
+;;   5c: ldr     x10, [x2, #0x60]
 ;;       add     x9, x10, #1, lsl #12
-;;       ldr     w0, [x9, x2]
+;;       ldr     w2, [x9, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w9, #-0xfffc
-;;       adds    x9, x2, x9
+;;       adds    x9, x4, x9
 ;;       b.hs    #0x3c
-;;   14: ldr     x10, [x0, #0x68]
+;;   14: ldr     x10, [x2, #0x68]
 ;;       cmp     x9, x10
 ;;       b.hi    #0x38
-;;   20: ldr     x12, [x0, #0x60]
-;;       add     x12, x12, x2
+;;   20: ldr     x12, [x2, #0x60]
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
-;;       str     w3, [x12, x13]
+;;       str     w5, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -40,15 +40,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w9, #-0xfffc
-;;       adds    x9, x2, x9
+;;       adds    x9, x4, x9
 ;;       b.hs    #0x7c
-;;   54: ldr     x10, [x0, #0x68]
+;;   54: ldr     x10, [x2, #0x68]
 ;;       cmp     x9, x10
 ;;       b.hi    #0x78
-;;   60: ldr     x12, [x0, #0x60]
-;;       add     x12, x12, x2
+;;   60: ldr     x12, [x2, #0x60]
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
-;;       ldr     w0, [x12, x13]
+;;       ldr     w2, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,11 +21,11 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x68]
-;;       cmp     x2, x5
+;;       ldr     x6, [x2, #0x68]
+;;       cmp     x4, x6
 ;;       b.hs    #0x24
-;;   14: ldr     x7, [x0, #0x60]
-;;       strb    w3, [x7, x2]
+;;   14: ldr     x7, [x2, #0x60]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -33,11 +33,11 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x68]
-;;       cmp     x2, x5
+;;       ldr     x5, [x2, #0x68]
+;;       cmp     x4, x5
 ;;       b.hs    #0x64
-;;   54: ldr     x7, [x0, #0x60]
-;;       ldrb    w0, [x7, x2]
+;;   54: ldr     x7, [x2, #0x60]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
+;;       ldr     x8, [x2, #0x68]
 ;;       mov     x9, #0x1001
 ;;       sub     x8, x8, x9
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       b.hi    #0x30
-;;   1c: ldr     x10, [x0, #0x60]
+;;   1c: ldr     x10, [x2, #0x60]
 ;;       add     x10, x10, #1, lsl #12
-;;       strb    w3, [x10, x2]
+;;       strb    w5, [x10, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
+;;       ldr     x8, [x2, #0x68]
 ;;       mov     x9, #0x1001
 ;;       sub     x8, x8, x9
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       b.hi    #0x70
-;;   5c: ldr     x10, [x0, #0x60]
+;;   5c: ldr     x10, [x2, #0x60]
 ;;       add     x9, x10, #1, lsl #12
-;;       ldrb    w0, [x9, x2]
+;;       ldrb    w2, [x9, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w9, #-0xffff
-;;       adds    x9, x2, x9
+;;       adds    x9, x4, x9
 ;;       b.hs    #0x3c
-;;   14: ldr     x10, [x0, #0x68]
+;;   14: ldr     x10, [x2, #0x68]
 ;;       cmp     x9, x10
 ;;       b.hi    #0x38
-;;   20: ldr     x12, [x0, #0x60]
-;;       add     x12, x12, x2
+;;   20: ldr     x12, [x2, #0x60]
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
-;;       strb    w3, [x12, x13]
+;;       strb    w5, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -40,15 +40,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w9, #-0xffff
-;;       adds    x9, x2, x9
+;;       adds    x9, x4, x9
 ;;       b.hs    #0x7c
-;;   54: ldr     x10, [x0, #0x68]
+;;   54: ldr     x10, [x2, #0x68]
 ;;       cmp     x9, x10
 ;;       b.hi    #0x78
-;;   60: ldr     x12, [x0, #0x60]
-;;       add     x12, x12, x2
+;;   60: ldr     x12, [x2, #0x60]
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
-;;       ldrb    w0, [x12, x13]
+;;       ldrb    w2, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x9, [x0, #0x60]
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x9, [x2, #0x60]
 ;;       sub     x10, x10, #4
 ;;       mov     x11, #0
-;;       add     x9, x9, x2
-;;       cmp     x2, x10
+;;       add     x9, x9, x4
+;;       cmp     x4, x10
 ;;       csel    x10, x11, x9, hi
 ;;       csdb
-;;       str     w3, [x10]
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x9, [x0, #0x60]
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x9, [x2, #0x60]
 ;;       sub     x10, x10, #4
 ;;       mov     x11, #0
-;;       add     x9, x9, x2
-;;       cmp     x2, x10
+;;       add     x9, x9, x4
+;;       cmp     x4, x10
 ;;       csel    x10, x11, x9, hi
 ;;       csdb
-;;       ldr     w0, [x10]
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,33 +21,33 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x12, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x12, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x13, #0x1004
 ;;       sub     x12, x12, x13
 ;;       mov     x13, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x12
+;;       cmp     x4, x12
 ;;       csel    x12, x13, x11, hi
 ;;       csdb
-;;       str     w3, [x12]
+;;       str     w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x12, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x12, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x13, #0x1004
 ;;       sub     x12, x12, x13
 ;;       mov     x13, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x12
+;;       cmp     x4, x12
 ;;       csel    x12, x13, x11, hi
 ;;       csdb
-;;       ldr     w0, [x12]
+;;       ldr     w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -22,18 +22,18 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w12, #-0xfffc
-;;       adds    x12, x2, x12
+;;       adds    x12, x4, x12
 ;;       b.hs    #0x44
-;;   14: ldr     x13, [x0, #0x68]
-;;       ldr     x15, [x0, #0x60]
+;;   14: ldr     x13, [x2, #0x68]
+;;       ldr     x15, [x2, #0x60]
 ;;       mov     x14, #0
-;;       add     x15, x15, x2
+;;       add     x15, x15, x4
 ;;       mov     x0, #0xffff0000
 ;;       add     x15, x15, x0
 ;;       cmp     x12, x13
 ;;       csel    x14, x14, x15, hi
 ;;       csdb
-;;       str     w3, [x14]
+;;       str     w5, [x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   44: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -42,18 +42,18 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w12, #-0xfffc
-;;       adds    x12, x2, x12
+;;       adds    x12, x4, x12
 ;;       b.hs    #0xa4
-;;   74: ldr     x13, [x0, #0x68]
-;;       ldr     x15, [x0, #0x60]
+;;   74: ldr     x13, [x2, #0x68]
+;;       ldr     x15, [x2, #0x60]
 ;;       mov     x14, #0
-;;       add     x15, x15, x2
+;;       add     x15, x15, x4
 ;;       mov     x0, #0xffff0000
 ;;       add     x15, x15, x0
 ;;       cmp     x12, x13
 ;;       csel    x14, x14, x15, hi
 ;;       csdb
-;;       ldr     w0, [x14]
+;;       ldr     w2, [x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   a4: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,27 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
+;;       ldr     x8, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
 ;;       mov     x9, #0
-;;       add     x10, x10, x2
-;;       cmp     x2, x8
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
 ;;       csel    x9, x9, x10, hs
 ;;       csdb
-;;       strb    w3, [x9]
+;;       strb    w5, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
+;;       ldr     x8, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
 ;;       mov     x9, #0
-;;       add     x10, x10, x2
-;;       cmp     x2, x8
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
 ;;       csel    x9, x9, x10, hs
 ;;       csdb
-;;       ldrb    w0, [x9]
+;;       ldrb    w2, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,33 +21,33 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x12, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x12, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x13, #0x1001
 ;;       sub     x12, x12, x13
 ;;       mov     x13, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x12
+;;       cmp     x4, x12
 ;;       csel    x12, x13, x11, hi
 ;;       csdb
-;;       strb    w3, [x12]
+;;       strb    w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x12, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x12, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x13, #0x1001
 ;;       sub     x12, x12, x13
 ;;       mov     x13, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x12
+;;       cmp     x4, x12
 ;;       csel    x12, x13, x11, hi
 ;;       csdb
-;;       ldrb    w0, [x12]
+;;       ldrb    w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -22,18 +22,18 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w12, #-0xffff
-;;       adds    x12, x2, x12
+;;       adds    x12, x4, x12
 ;;       b.hs    #0x44
-;;   14: ldr     x13, [x0, #0x68]
-;;       ldr     x15, [x0, #0x60]
+;;   14: ldr     x13, [x2, #0x68]
+;;       ldr     x15, [x2, #0x60]
 ;;       mov     x14, #0
-;;       add     x15, x15, x2
+;;       add     x15, x15, x4
 ;;       mov     x0, #0xffff0000
 ;;       add     x15, x15, x0
 ;;       cmp     x12, x13
 ;;       csel    x14, x14, x15, hi
 ;;       csdb
-;;       strb    w3, [x14]
+;;       strb    w5, [x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   44: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -42,18 +42,18 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w12, #-0xffff
-;;       adds    x12, x2, x12
+;;       adds    x12, x4, x12
 ;;       b.hs    #0xa4
-;;   74: ldr     x13, [x0, #0x68]
-;;       ldr     x15, [x0, #0x60]
+;;   74: ldr     x13, [x2, #0x68]
+;;       ldr     x15, [x2, #0x60]
 ;;       mov     x14, #0
-;;       add     x15, x15, x2
+;;       add     x15, x15, x4
 ;;       mov     x0, #0xffff0000
 ;;       add     x15, x15, x0
 ;;       cmp     x12, x13
 ;;       csel    x14, x14, x15, hi
 ;;       csdb
-;;       ldrb    w0, [x14]
+;;       ldrb    w2, [x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   a4: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,11 +21,11 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x68]
-;;       cmp     x2, x5
+;;       ldr     x6, [x2, #0x68]
+;;       cmp     x4, x6
 ;;       b.hi    #0x24
-;;   14: ldr     x7, [x0, #0x60]
-;;       str     w3, [x7, x2]
+;;   14: ldr     x7, [x2, #0x60]
+;;       str     w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -33,11 +33,11 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x68]
-;;       cmp     x2, x5
+;;       ldr     x5, [x2, #0x68]
+;;       cmp     x4, x5
 ;;       b.hi    #0x64
-;;   54: ldr     x7, [x0, #0x60]
-;;       ldr     w0, [x7, x2]
+;;   54: ldr     x7, [x2, #0x60]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       cmp     x2, x6
+;;       ldr     x6, [x2, #0x68]
+;;       cmp     x4, x6
 ;;       b.hi    #0x28
-;;   14: ldr     x8, [x0, #0x60]
+;;   14: ldr     x8, [x2, #0x60]
 ;;       add     x8, x8, #1, lsl #12
-;;       str     w3, [x8, x2]
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,12 +34,12 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       cmp     x2, x6
+;;       ldr     x6, [x2, #0x68]
+;;       cmp     x4, x6
 ;;       b.hi    #0x68
-;;   54: ldr     x8, [x0, #0x60]
+;;   54: ldr     x8, [x2, #0x60]
 ;;       add     x7, x8, #1, lsl #12
-;;       ldr     w0, [x7, x2]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       cmp     x2, x7
+;;       ldr     x7, [x2, #0x68]
+;;       cmp     x4, x7
 ;;       b.hi    #0x2c
-;;   14: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   14: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       str     w3, [x9, x10]
+;;       str     w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       cmp     x2, x7
+;;       ldr     x7, [x2, #0x68]
+;;       cmp     x4, x7
 ;;       b.hi    #0x6c
-;;   54: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   54: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       ldr     w0, [x9, x10]
+;;       ldr     w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,11 +21,11 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x68]
-;;       cmp     x2, x5
+;;       ldr     x6, [x2, #0x68]
+;;       cmp     x4, x6
 ;;       b.hs    #0x24
-;;   14: ldr     x7, [x0, #0x60]
-;;       strb    w3, [x7, x2]
+;;   14: ldr     x7, [x2, #0x60]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -33,11 +33,11 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x68]
-;;       cmp     x2, x5
+;;       ldr     x5, [x2, #0x68]
+;;       cmp     x4, x5
 ;;       b.hs    #0x64
-;;   54: ldr     x7, [x0, #0x60]
-;;       ldrb    w0, [x7, x2]
+;;   54: ldr     x7, [x2, #0x60]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       cmp     x2, x6
+;;       ldr     x6, [x2, #0x68]
+;;       cmp     x4, x6
 ;;       b.hi    #0x28
-;;   14: ldr     x8, [x0, #0x60]
+;;   14: ldr     x8, [x2, #0x60]
 ;;       add     x8, x8, #1, lsl #12
-;;       strb    w3, [x8, x2]
+;;       strb    w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,12 +34,12 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x68]
-;;       cmp     x2, x6
+;;       ldr     x6, [x2, #0x68]
+;;       cmp     x4, x6
 ;;       b.hi    #0x68
-;;   54: ldr     x8, [x0, #0x60]
+;;   54: ldr     x8, [x2, #0x60]
 ;;       add     x7, x8, #1, lsl #12
-;;       ldrb    w0, [x7, x2]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       cmp     x2, x7
+;;       ldr     x7, [x2, #0x68]
+;;       cmp     x4, x7
 ;;       b.hi    #0x2c
-;;   14: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   14: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       strb    w3, [x9, x10]
+;;       strb    w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x0, #0x68]
-;;       cmp     x2, x7
+;;       ldr     x7, [x2, #0x68]
+;;       cmp     x4, x7
 ;;       b.hi    #0x6c
-;;   54: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   54: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       ldrb    w0, [x9, x10]
+;;       ldrb    w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,27 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
+;;       ldr     x8, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
 ;;       mov     x9, #0
-;;       add     x10, x10, x2
-;;       cmp     x2, x8
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
 ;;       csel    x9, x9, x10, hi
 ;;       csdb
-;;       str     w3, [x9]
+;;       str     w5, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
+;;       ldr     x8, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
 ;;       mov     x9, #0
-;;       add     x10, x10, x2
-;;       cmp     x2, x8
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
 ;;       csel    x9, x9, x10, hi
 ;;       csdb
-;;       ldr     w0, [x9]
+;;       ldr     w2, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x10, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x10, x10, x11, hi
 ;;       csdb
-;;       str     w3, [x10]
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x10, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x10, x10, x11, hi
 ;;       csdb
-;;       ldr     w0, [x10]
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,31 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x12, [x0, #0x60]
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x12, [x2, #0x60]
 ;;       mov     x11, #0
-;;       add     x12, x12, x2
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
 ;;       add     x12, x12, x13
-;;       cmp     x2, x10
+;;       cmp     x4, x10
 ;;       csel    x11, x11, x12, hi
 ;;       csdb
-;;       str     w3, [x11]
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x12, [x0, #0x60]
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x12, [x2, #0x60]
 ;;       mov     x11, #0
-;;       add     x12, x12, x2
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
 ;;       add     x12, x12, x13
-;;       cmp     x2, x10
+;;       cmp     x4, x10
 ;;       csel    x11, x11, x12, hi
 ;;       csdb
-;;       ldr     w0, [x11]
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,27 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
+;;       ldr     x8, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
 ;;       mov     x9, #0
-;;       add     x10, x10, x2
-;;       cmp     x2, x8
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
 ;;       csel    x9, x9, x10, hs
 ;;       csdb
-;;       strb    w3, [x9]
+;;       strb    w5, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x0, #0x68]
-;;       ldr     x10, [x0, #0x60]
+;;       ldr     x8, [x2, #0x68]
+;;       ldr     x10, [x2, #0x60]
 ;;       mov     x9, #0
-;;       add     x10, x10, x2
-;;       cmp     x2, x8
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
 ;;       csel    x9, x9, x10, hs
 ;;       csdb
-;;       ldrb    w0, [x9]
+;;       ldrb    w2, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x10, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x10, x10, x11, hi
 ;;       csdb
-;;       strb    w3, [x10]
+;;       strb    w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x0, #0x68]
-;;       ldr     x11, [x0, #0x60]
+;;       ldr     x9, [x2, #0x68]
+;;       ldr     x11, [x2, #0x60]
 ;;       mov     x10, #0
-;;       add     x11, x11, x2
+;;       add     x11, x11, x4
 ;;       add     x11, x11, #1, lsl #12
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x10, x10, x11, hi
 ;;       csdb
-;;       ldrb    w0, [x10]
+;;       ldrb    w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,31 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x12, [x0, #0x60]
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x12, [x2, #0x60]
 ;;       mov     x11, #0
-;;       add     x12, x12, x2
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
 ;;       add     x12, x12, x13
-;;       cmp     x2, x10
+;;       cmp     x4, x10
 ;;       csel    x11, x11, x12, hi
 ;;       csdb
-;;       strb    w3, [x11]
+;;       strb    w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x0, #0x68]
-;;       ldr     x12, [x0, #0x60]
+;;       ldr     x10, [x2, #0x68]
+;;       ldr     x12, [x2, #0x60]
 ;;       mov     x11, #0
-;;       add     x12, x12, x2
+;;       add     x12, x12, x4
 ;;       mov     x13, #0xffff0000
 ;;       add     x12, x12, x13
-;;       cmp     x2, x10
+;;       cmp     x4, x10
 ;;       csel    x11, x11, x12, hi
 ;;       csdb
-;;       ldrb    w0, [x11]
+;;       ldrb    w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w6, w2
+;;       mov     w6, w4
 ;;       orr     x7, xzr, #0xfffffffc
 ;;       cmp     x6, x7
 ;;       b.hi    #0x28
-;;   18: ldr     x8, [x0, #0x60]
-;;       str     w3, [x8, w2, uxtw]
+;;   18: ldr     x8, [x2, #0x60]
+;;       str     w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,12 +34,12 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w6, w2
+;;       mov     w6, w4
 ;;       orr     x7, xzr, #0xfffffffc
 ;;       cmp     x6, x7
 ;;       b.hi    #0x68
-;;   58: ldr     x8, [x0, #0x60]
-;;       ldr     w0, [x8, w2, uxtw]
+;;   58: ldr     x8, [x2, #0x60]
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, w2
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1004
 ;;       cmp     x7, x8
 ;;       b.hi    #0x2c
-;;   18: ldr     x9, [x0, #0x60]
+;;   18: ldr     x9, [x2, #0x60]
 ;;       add     x9, x9, #1, lsl #12
-;;       str     w3, [x9, w2, uxtw]
+;;       str     w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, w2
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1004
 ;;       cmp     x7, x8
 ;;       b.hi    #0x6c
-;;   58: ldr     x9, [x0, #0x60]
+;;   58: ldr     x9, [x2, #0x60]
 ;;       add     x8, x9, #1, lsl #12
-;;       ldr     w0, [x8, w2, uxtw]
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w8, w2
+;;       mov     w8, w4
 ;;       mov     x9, #0xfffc
 ;;       cmp     x8, x9
 ;;       b.hi    #0x30
-;;   18: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   18: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       str     w3, [x10, x11]
+;;       str     w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w8, w2
+;;       mov     w8, w4
 ;;       mov     x9, #0xfffc
 ;;       cmp     x8, x9
 ;;       b.hi    #0x70
-;;   58: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   58: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       ldr     w0, [x10, x11]
+;;       ldr     w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       strb    w3, [x4, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       strb    w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       ldrb    w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       ldrb    w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, w2
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1001
 ;;       cmp     x7, x8
 ;;       b.hi    #0x2c
-;;   18: ldr     x9, [x0, #0x60]
+;;   18: ldr     x9, [x2, #0x60]
 ;;       add     x9, x9, #1, lsl #12
-;;       strb    w3, [x9, w2, uxtw]
+;;       strb    w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, w2
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1001
 ;;       cmp     x7, x8
 ;;       b.hi    #0x6c
-;;   58: ldr     x9, [x0, #0x60]
+;;   58: ldr     x9, [x2, #0x60]
 ;;       add     x8, x9, #1, lsl #12
-;;       ldrb    w0, [x8, w2, uxtw]
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w8, w2
+;;       mov     w8, w4
 ;;       mov     x9, #0xffff
 ;;       cmp     x8, x9
 ;;       b.hi    #0x30
-;;   18: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   18: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       strb    w3, [x10, x11]
+;;       strb    w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w8, w2
+;;       mov     w8, w4
 ;;       mov     x9, #0xffff
 ;;       cmp     x8, x9
 ;;       b.hi    #0x70
-;;   58: ldr     x10, [x0, #0x60]
-;;       add     x10, x10, w2, uxtw
+;;   58: ldr     x10, [x2, #0x60]
+;;       add     x10, x10, w4, uxtw
 ;;       mov     x11, #0xffff0000
-;;       ldrb    w0, [x10, x11]
+;;       ldrb    w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w9, w2
+;;       mov     w9, w4
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, w2, uxtw
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, w4, uxtw
 ;;       orr     x8, xzr, #0xfffffffc
 ;;       cmp     x9, x8
 ;;       csel    x11, x10, x11, hi
 ;;       csdb
-;;       str     w3, [x11]
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w9, w2
+;;       mov     w9, w4
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, w2, uxtw
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, w4, uxtw
 ;;       orr     x8, xzr, #0xfffffffc
 ;;       cmp     x9, x8
 ;;       csel    x11, x10, x11, hi
 ;;       csdb
-;;       ldr     w0, [x11]
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,31 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     x11, #0
-;;       ldr     x12, [x0, #0x60]
-;;       add     x12, x12, w2, uxtw
+;;       ldr     x12, [x2, #0x60]
+;;       add     x12, x12, w4, uxtw
 ;;       add     x12, x12, #1, lsl #12
 ;;       mov     w9, #-0x1004
 ;;       cmp     x10, x9
 ;;       csel    x12, x11, x12, hi
 ;;       csdb
-;;       str     w3, [x12]
+;;       str     w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     x11, #0
-;;       ldr     x12, [x0, #0x60]
-;;       add     x12, x12, w2, uxtw
+;;       ldr     x12, [x2, #0x60]
+;;       add     x12, x12, w4, uxtw
 ;;       add     x12, x12, #1, lsl #12
 ;;       mov     w9, #-0x1004
 ;;       cmp     x10, x9
 ;;       csel    x12, x11, x12, hi
 ;;       csdb
-;;       ldr     w0, [x12]
+;;       ldr     w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,33 +21,33 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, w2
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;       ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
 ;;       add     x13, x13, x14
 ;;       mov     x10, #0xfffc
 ;;       cmp     x11, x10
 ;;       csel    x13, x12, x13, hi
 ;;       csdb
-;;       str     w3, [x13]
+;;       str     w5, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, w2
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;       ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
 ;;       add     x13, x13, x14
 ;;       mov     x10, #0xfffc
 ;;       cmp     x11, x10
 ;;       csel    x13, x12, x13, hi
 ;;       csdb
-;;       ldr     w0, [x13]
+;;       ldr     w2, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       strb    w3, [x4, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       strb    w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       ldrb    w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       ldrb    w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,31 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     x11, #0
-;;       ldr     x12, [x0, #0x60]
-;;       add     x12, x12, w2, uxtw
+;;       ldr     x12, [x2, #0x60]
+;;       add     x12, x12, w4, uxtw
 ;;       add     x12, x12, #1, lsl #12
 ;;       mov     w9, #-0x1001
 ;;       cmp     x10, x9
 ;;       csel    x12, x11, x12, hi
 ;;       csdb
-;;       strb    w3, [x12]
+;;       strb    w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w2
+;;       mov     w10, w4
 ;;       mov     x11, #0
-;;       ldr     x12, [x0, #0x60]
-;;       add     x12, x12, w2, uxtw
+;;       ldr     x12, [x2, #0x60]
+;;       add     x12, x12, w4, uxtw
 ;;       add     x12, x12, #1, lsl #12
 ;;       mov     w9, #-0x1001
 ;;       cmp     x10, x9
 ;;       csel    x12, x11, x12, hi
 ;;       csdb
-;;       ldrb    w0, [x12]
+;;       ldrb    w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,33 +21,33 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, w2
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;       ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
 ;;       add     x13, x13, x14
 ;;       mov     x10, #0xffff
 ;;       cmp     x11, x10
 ;;       csel    x13, x12, x13, hi
 ;;       csdb
-;;       strb    w3, [x13]
+;;       strb    w5, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, w2
+;;       mov     w11, w4
 ;;       mov     x12, #0
-;;       ldr     x13, [x0, #0x60]
-;;       add     x13, x13, w2, uxtw
+;;       ldr     x13, [x2, #0x60]
+;;       add     x13, x13, w4, uxtw
 ;;       mov     x14, #0xffff0000
 ;;       add     x13, x13, x14
 ;;       mov     x10, #0xffff
 ;;       cmp     x11, x10
 ;;       csel    x13, x12, x13, hi
 ;;       csdb
-;;       ldrb    w0, [x13]
+;;       ldrb    w2, [x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       str     w3, [x4, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       str     w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       ldr     w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       ldr     w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,17 +21,17 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x5, x5, #1, lsl #12
-;;       str     w3, [x5, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, #1, lsl #12
+;;       str     w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x4, x5, #1, lsl #12
-;;       ldr     w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       add     x5, x5, #1, lsl #12
+;;       ldr     w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,19 +21,19 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       str     w3, [x6, x7]
+;;       str     w5, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       ldr     w0, [x6, x7]
+;;       ldr     w2, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       strb    w3, [x4, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       strb    w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       ldrb    w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       ldrb    w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,17 +21,17 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x5, x5, #1, lsl #12
-;;       strb    w3, [x5, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, #1, lsl #12
+;;       strb    w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x4, x5, #1, lsl #12
-;;       ldrb    w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       add     x5, x5, #1, lsl #12
+;;       ldrb    w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,19 +21,19 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       strb    w3, [x6, x7]
+;;       strb    w5, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       ldrb    w0, [x6, x7]
+;;       ldrb    w2, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       str     w3, [x4, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       str     w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       ldr     w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       ldr     w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,17 +21,17 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x5, x5, #1, lsl #12
-;;       str     w3, [x5, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, #1, lsl #12
+;;       str     w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x4, x5, #1, lsl #12
-;;       ldr     w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       add     x5, x5, #1, lsl #12
+;;       ldr     w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,19 +21,19 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       str     w3, [x6, x7]
+;;       str     w5, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       ldr     w0, [x6, x7]
+;;       ldr     w2, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       strb    w3, [x4, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       strb    w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x4, [x0, #0x60]
-;;       ldrb    w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       ldrb    w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,17 +21,17 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x5, x5, #1, lsl #12
-;;       strb    w3, [x5, w2, uxtw]
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, #1, lsl #12
+;;       strb    w5, [x6, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x5, [x0, #0x60]
-;;       add     x4, x5, #1, lsl #12
-;;       ldrb    w0, [x4, w2, uxtw]
+;;       ldr     x5, [x2, #0x60]
+;;       add     x5, x5, #1, lsl #12
+;;       ldrb    w2, [x5, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,19 +21,19 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       strb    w3, [x6, x7]
+;;       strb    w5, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x6, [x0, #0x60]
-;;       add     x6, x6, w2, uxtw
+;;       ldr     x6, [x2, #0x60]
+;;       add     x6, x6, w4, uxtw
 ;;       mov     x7, #0xffff0000
-;;       ldrb    w0, [x6, x7]
+;;       ldrb    w2, [x6, x7]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,11 +21,11 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x5, xzr, #0xfffffffc
-;;       cmp     x2, x5
+;;       orr     x6, xzr, #0xfffffffc
+;;       cmp     x4, x6
 ;;       b.hi    #0x24
-;;   14: ldr     x7, [x0, #0x60]
-;;       str     w3, [x7, x2]
+;;   14: ldr     x7, [x2, #0x60]
+;;       str     w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,10 +34,10 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       orr     x5, xzr, #0xfffffffc
-;;       cmp     x2, x5
+;;       cmp     x4, x5
 ;;       b.hi    #0x64
-;;   54: ldr     x7, [x0, #0x60]
-;;       ldr     w0, [x7, x2]
+;;   54: ldr     x7, [x2, #0x60]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -22,11 +22,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1004
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x28
-;;   14: ldr     x8, [x0, #0x60]
+;;   14: ldr     x8, [x2, #0x60]
 ;;       add     x8, x8, #1, lsl #12
-;;       str     w3, [x8, x2]
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,11 +35,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1004
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x68
-;;   54: ldr     x8, [x0, #0x60]
+;;   54: ldr     x8, [x2, #0x60]
 ;;       add     x7, x8, #1, lsl #12
-;;       ldr     w0, [x7, x2]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -22,12 +22,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xfffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x2c
-;;   14: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   14: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       str     w3, [x9, x10]
+;;       str     w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xfffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x6c
-;;   54: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   54: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       ldr     w0, [x9, x10]
+;;       ldr     w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,11 +21,11 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x5, xzr, #0xffffffff
-;;       cmp     x2, x5
+;;       orr     x6, xzr, #0xffffffff
+;;       cmp     x4, x6
 ;;       b.hi    #0x24
-;;   14: ldr     x7, [x0, #0x60]
-;;       strb    w3, [x7, x2]
+;;   14: ldr     x7, [x2, #0x60]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,10 +34,10 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       orr     x5, xzr, #0xffffffff
-;;       cmp     x2, x5
+;;       cmp     x4, x5
 ;;       b.hi    #0x64
-;;   54: ldr     x7, [x0, #0x60]
-;;       ldrb    w0, [x7, x2]
+;;   54: ldr     x7, [x2, #0x60]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -22,11 +22,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1001
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x28
-;;   14: ldr     x8, [x0, #0x60]
+;;   14: ldr     x8, [x2, #0x60]
 ;;       add     x8, x8, #1, lsl #12
-;;       strb    w3, [x8, x2]
+;;       strb    w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,11 +35,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1001
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x68
-;;   54: ldr     x8, [x0, #0x60]
+;;   54: ldr     x8, [x2, #0x60]
 ;;       add     x7, x8, #1, lsl #12
-;;       ldrb    w0, [x7, x2]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -22,12 +22,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x2c
-;;   14: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   14: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       strb    w3, [x9, x10]
+;;       strb    w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x6c
-;;   54: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   54: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       ldrb    w0, [x9, x10]
+;;       ldrb    w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -22,13 +22,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       str     w3, [x10]
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       ldr     w0, [x10]
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -22,14 +22,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1004
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       str     w3, [x11]
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -37,13 +37,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1004
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       ldr     w0, [x11]
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xfffc
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       str     w3, [x12]
+;;       str     w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -38,14 +38,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xfffc
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       ldr     w0, [x12]
+;;       ldr     w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -22,13 +22,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       strb    w3, [x10]
+;;       strb    w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       ldrb    w0, [x10]
+;;       ldrb    w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -22,14 +22,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1001
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       strb    w3, [x11]
+;;       strb    w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -37,13 +37,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1001
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       ldrb    w0, [x11]
+;;       ldrb    w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xffff
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       strb    w3, [x12]
+;;       strb    w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -38,14 +38,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xffff
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       ldrb    w0, [x12]
+;;       ldrb    w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,11 +21,11 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x5, xzr, #0xfffffffc
-;;       cmp     x2, x5
+;;       orr     x6, xzr, #0xfffffffc
+;;       cmp     x4, x6
 ;;       b.hi    #0x24
-;;   14: ldr     x7, [x0, #0x60]
-;;       str     w3, [x7, x2]
+;;   14: ldr     x7, [x2, #0x60]
+;;       str     w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,10 +34,10 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       orr     x5, xzr, #0xfffffffc
-;;       cmp     x2, x5
+;;       cmp     x4, x5
 ;;       b.hi    #0x64
-;;   54: ldr     x7, [x0, #0x60]
-;;       ldr     w0, [x7, x2]
+;;   54: ldr     x7, [x2, #0x60]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -22,11 +22,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1004
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x28
-;;   14: ldr     x8, [x0, #0x60]
+;;   14: ldr     x8, [x2, #0x60]
 ;;       add     x8, x8, #1, lsl #12
-;;       str     w3, [x8, x2]
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,11 +35,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1004
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x68
-;;   54: ldr     x8, [x0, #0x60]
+;;   54: ldr     x8, [x2, #0x60]
 ;;       add     x7, x8, #1, lsl #12
-;;       ldr     w0, [x7, x2]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -22,12 +22,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xfffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x2c
-;;   14: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   14: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       str     w3, [x9, x10]
+;;       str     w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xfffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x6c
-;;   54: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   54: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       ldr     w0, [x9, x10]
+;;       ldr     w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,11 +21,11 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x5, xzr, #0xffffffff
-;;       cmp     x2, x5
+;;       orr     x6, xzr, #0xffffffff
+;;       cmp     x4, x6
 ;;       b.hi    #0x24
-;;   14: ldr     x7, [x0, #0x60]
-;;       strb    w3, [x7, x2]
+;;   14: ldr     x7, [x2, #0x60]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -34,10 +34,10 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       orr     x5, xzr, #0xffffffff
-;;       cmp     x2, x5
+;;       cmp     x4, x5
 ;;       b.hi    #0x64
-;;   54: ldr     x7, [x0, #0x60]
-;;       ldrb    w0, [x7, x2]
+;;   54: ldr     x7, [x2, #0x60]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -22,11 +22,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1001
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x28
-;;   14: ldr     x8, [x0, #0x60]
+;;   14: ldr     x8, [x2, #0x60]
 ;;       add     x8, x8, #1, lsl #12
-;;       strb    w3, [x8, x2]
+;;       strb    w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -35,11 +35,11 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w6, #-0x1001
-;;       cmp     x2, x6
+;;       cmp     x4, x6
 ;;       b.hi    #0x68
-;;   54: ldr     x8, [x0, #0x60]
+;;   54: ldr     x8, [x2, #0x60]
 ;;       add     x7, x8, #1, lsl #12
-;;       ldrb    w0, [x7, x2]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -22,12 +22,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x2c
-;;   14: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   14: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       strb    w3, [x9, x10]
+;;       strb    w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x7, #0xffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       b.hi    #0x6c
-;;   54: ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;   54: ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       mov     x10, #0xffff0000
-;;       ldrb    w0, [x9, x10]
+;;       ldrb    w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -22,13 +22,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       str     w3, [x10]
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       ldr     w0, [x10]
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -22,14 +22,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1004
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       str     w3, [x11]
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -37,13 +37,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1004
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       ldr     w0, [x11]
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xfffc
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       str     w3, [x12]
+;;       str     w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -38,14 +38,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xfffc
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       ldr     w0, [x12]
+;;       ldr     w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -22,13 +22,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       strb    w3, [x10]
+;;       strb    w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x8, #0
-;;       ldr     x9, [x0, #0x60]
-;;       add     x9, x9, x2
+;;       ldr     x9, [x2, #0x60]
+;;       add     x9, x9, x4
 ;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x2, x7
+;;       cmp     x4, x7
 ;;       csel    x10, x8, x9, hi
 ;;       csdb
-;;       ldrb    w0, [x10]
+;;       ldrb    w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -22,14 +22,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1001
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       strb    w3, [x11]
+;;       strb    w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -37,13 +37,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x9, #0
-;;       ldr     x10, [x0, #0x60]
-;;       add     x10, x10, x2
+;;       ldr     x10, [x2, #0x60]
+;;       add     x10, x10, x4
 ;;       add     x10, x10, #1, lsl #12
 ;;       mov     w8, #-0x1001
-;;       cmp     x2, x8
+;;       cmp     x4, x8
 ;;       csel    x11, x9, x10, hi
 ;;       csdb
-;;       ldrb    w0, [x11]
+;;       ldrb    w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xffff
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       strb    w3, [x12]
+;;       strb    w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -38,14 +38,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x10, #0
-;;       ldr     x11, [x0, #0x60]
-;;       add     x11, x11, x2
+;;       ldr     x11, [x2, #0x60]
+;;       add     x11, x11, x4
 ;;       mov     x12, #0xffff0000
 ;;       add     x11, x11, x12
 ;;       mov     x9, #0xffff
-;;       cmp     x2, x9
+;;       cmp     x4, x9
 ;;       csel    x12, x10, x11, hi
 ;;       csdb
-;;       ldrb    w0, [x12]
+;;       ldrb    w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -44,7 +44,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -37,7 +37,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -37,7 +37,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -37,7 +37,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -37,7 +37,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -37,7 +37,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -37,7 +37,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -39,7 +39,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -41,7 +41,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -40,7 +40,7 @@
 ;; @0043                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0x1000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -18,7 +18,7 @@
     local.get 0
     i32.load8_u offset=0xffff0000))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -42,7 +42,7 @@
 ;; @0047                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -12,7 +12,7 @@
   (data (i32.const 0) "0000")
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-0.wat
+++ b/tests/disas/multi-0.wat
@@ -4,7 +4,7 @@
   (func (export "i64.dup") (param i64) (result i64 i64)
     (local.get 0) (local.get 0)))
 
-;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -7,7 +7,7 @@
     (block (param i32 i64) (result i32 i64 f64)
       (f64.const 1234.5))))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) -> i32, i64, f64 fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) -> i32, i64, f64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -11,7 +11,7 @@
       (else
         (i64.const -2)))))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -8,7 +8,7 @@
       i64.const 42
       return)))
 
-;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-12.wat
+++ b/tests/disas/multi-12.wat
@@ -10,7 +10,7 @@
       drop
       return)))
 
-;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -11,7 +11,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -11,7 +11,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-15.wat
+++ b/tests/disas/multi-15.wat
@@ -23,7 +23,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32, i64, f32, f32, i32, f64, f32, i32, i32, i32, f32, f64, f64, f64, i32, i32, f32) -> f64, f32, i32, i32, i32, i64, f32, i32, i32, f32, f64, f64, i32, f32, i32, f64 fast {
+;; function u0:0(i64 vmctx, i64, i32, i64, f32, f32, i32, f64, f32, i32, i32, i32, f32, f64, f64, f64, i32, i32, f32) -> f64, f32, i32, i32, i32, i64, f32, i32, i32, f32, f64, f64, i32, f32, i32, f64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -10,7 +10,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -27,11 +27,11 @@
   )
   (export "main" (func $main)))
 
-;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     sig0 = (i64 vmctx, i64, i32, i32, i32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/multi-2.wat
+++ b/tests/disas/multi-2.wat
@@ -7,7 +7,7 @@
     (loop (param i64 i64) (result i64 i64)
        return)))
 
-;; function u0:0(i64 vmctx, i64, i64, i64) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i64, i64) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -14,7 +14,7 @@
         (i64.const 0)
         (i64.const 0)))))
 
-;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -14,7 +14,7 @@
         i64.sub
         i64.const 2))))
 
-;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 fast {
+;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-5.wat
+++ b/tests/disas/multi-5.wat
@@ -12,7 +12,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-6.wat
+++ b/tests/disas/multi-6.wat
@@ -12,7 +12,7 @@
   )
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-7.wat
+++ b/tests/disas/multi-7.wat
@@ -10,7 +10,7 @@
         (drop)
         (i64.const -1)))))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -13,7 +13,7 @@
         (drop)
         (i64.const -2)))))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -16,7 +16,7 @@
         (drop)
         (i64.const -2)))))
 
-;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 fast {
+;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -20,7 +20,7 @@
     local.get 0
     i32.load8_u offset=0))
 
-;; function u0:0(i64 vmctx, i64, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -43,7 +43,7 @@
 ;; @0044                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -12,7 +12,7 @@
 	)
 )
 
-;; function u0:0(i64 vmctx, i64) -> r64 fast {
+;; function u0:0(i64 vmctx, i64) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -26,7 +26,7 @@
 ;; @001b                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> r64 fast {
+;; function u0:1(i64 vmctx, i64) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -13,7 +13,7 @@
   (func (export "drop")
     data.drop $passive))
 
-;; function u0:0(i64 vmctx, i64, i32, i32, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -35,7 +35,7 @@
 ;; @0041                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) fast {
+;; function u0:1(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -16,7 +16,7 @@
       v128.store)
 )
 
-;; function u0:0(i64 vmctx, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/pr2559.wat
+++ b/tests/disas/pr2559.wat
@@ -52,11 +52,11 @@
   (export "main2" (func $main2))
 )
 
-;; function u0:0(i64 vmctx, i64) -> i8x16, i8x16, i8x16 fast {
+;; function u0:0(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 fast
+;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail
 ;;     fn0 = colocated u0:0 sig0
 ;;     stack_limit = gv2
 ;;
@@ -92,11 +92,11 @@
 ;; @0055                               return v2, v3, v4
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i8x16, i8x16, i8x16 fast {
+;; function u0:1(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
-;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 fast
+;;     sig0 = (i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail
 ;;     fn0 = colocated u0:1 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -18,7 +18,7 @@
   (elem $fnptrs (i32.const 1) func $callee)
 )
 
-;; function u0:0(i64 vmctx, i64) fast {
+;; function u0:0(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -31,13 +31,13 @@
 ;; @002c                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) fast {
+;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) fast
+;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -13,7 +13,7 @@
   (global (export "funcref-imported") funcref (ref.func $imported))
   (global (export "funcref-local") funcref (ref.func $local)))
 
-;; function u0:1(i64 vmctx, i64) -> r64, r64, i64, i64 fast {
+;; function u0:1(i64 vmctx, i64) -> r64, r64, i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -20,7 +20,7 @@
     select (result externref))
 )
 
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -37,7 +37,7 @@
 ;; @002a                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> r64 fast {
+;; function u0:1(i64 vmctx, i64) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -54,7 +54,7 @@
 ;; @0036                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64, r64) -> r64 fast {
+;; function u0:2(i64 vmctx, i64, r64) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -84,7 +84,7 @@
   (memory 0)
 )
 
-;; function u0:0(i64 vmctx, i64, i8x16) fast {
+;; function u0:0(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -105,7 +105,7 @@
 ;; @004b                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i8x16) fast {
+;; function u0:1(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -128,7 +128,7 @@
 ;; @005a                               return
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64, i8x16) fast {
+;; function u0:2(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -151,7 +151,7 @@
 ;; @0069                               return
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i8x16) fast {
+;; function u0:3(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -174,7 +174,7 @@
 ;; @0079                               return
 ;; }
 ;;
-;; function u0:4(i64 vmctx, i64, i8x16) fast {
+;; function u0:4(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -195,7 +195,7 @@
 ;; @0088                               return
 ;; }
 ;;
-;; function u0:5(i64 vmctx, i64, i8x16) fast {
+;; function u0:5(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -218,7 +218,7 @@
 ;; @0097                               return
 ;; }
 ;;
-;; function u0:6(i64 vmctx, i64, i8x16) fast {
+;; function u0:6(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -241,7 +241,7 @@
 ;; @00a6                               return
 ;; }
 ;;
-;; function u0:7(i64 vmctx, i64, i8x16) fast {
+;; function u0:7(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -264,7 +264,7 @@
 ;; @00b6                               return
 ;; }
 ;;
-;; function u0:8(i64 vmctx, i64, i8x16) fast {
+;; function u0:8(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -285,7 +285,7 @@
 ;; @00c5                               return
 ;; }
 ;;
-;; function u0:9(i64 vmctx, i64, i8x16) fast {
+;; function u0:9(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -308,7 +308,7 @@
 ;; @00d4                               return
 ;; }
 ;;
-;; function u0:10(i64 vmctx, i64, i8x16) fast {
+;; function u0:10(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -331,7 +331,7 @@
 ;; @00e3                               return
 ;; }
 ;;
-;; function u0:11(i64 vmctx, i64, i8x16) fast {
+;; function u0:11(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -354,7 +354,7 @@
 ;; @00f3                               return
 ;; }
 ;;
-;; function u0:12(i64 vmctx, i64, i8x16) fast {
+;; function u0:12(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -375,7 +375,7 @@
 ;; @0102                               return
 ;; }
 ;;
-;; function u0:13(i64 vmctx, i64, i8x16) fast {
+;; function u0:13(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -398,7 +398,7 @@
 ;; @0111                               return
 ;; }
 ;;
-;; function u0:14(i64 vmctx, i64, i8x16) fast {
+;; function u0:14(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -421,7 +421,7 @@
 ;; @0120                               return
 ;; }
 ;;
-;; function u0:15(i64 vmctx, i64, i8x16) fast {
+;; function u0:15(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -442,7 +442,7 @@
 ;; @012f                               return
 ;; }
 ;;
-;; function u0:16(i64 vmctx, i64, i8x16) fast {
+;; function u0:16(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -465,7 +465,7 @@
 ;; @013e                               return
 ;; }
 ;;
-;; function u0:17(i64 vmctx, i64, i8x16) fast {
+;; function u0:17(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -488,7 +488,7 @@
 ;; @014d                               return
 ;; }
 ;;
-;; function u0:18(i64 vmctx, i64, i8x16) fast {
+;; function u0:18(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -511,7 +511,7 @@
 ;; @015d                               return
 ;; }
 ;;
-;; function u0:19(i64 vmctx, i64, i8x16) fast {
+;; function u0:19(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -532,7 +532,7 @@
 ;; @016c                               return
 ;; }
 ;;
-;; function u0:20(i64 vmctx, i64, i8x16) fast {
+;; function u0:20(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -555,7 +555,7 @@
 ;; @017b                               return
 ;; }
 ;;
-;; function u0:21(i64 vmctx, i64, i8x16) fast {
+;; function u0:21(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -578,7 +578,7 @@
 ;; @018a                               return
 ;; }
 ;;
-;; function u0:22(i64 vmctx, i64, i8x16) fast {
+;; function u0:22(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -601,7 +601,7 @@
 ;; @0199                               return
 ;; }
 ;;
-;; function u0:23(i64 vmctx, i64, i8x16) fast {
+;; function u0:23(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -624,7 +624,7 @@
 ;; @01a8                               return
 ;; }
 ;;
-;; function u0:24(i64 vmctx, i64, i8x16) fast {
+;; function u0:24(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -647,7 +647,7 @@
 ;; @01b7                               return
 ;; }
 ;;
-;; function u0:25(i64 vmctx, i64, i8x16) fast {
+;; function u0:25(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -670,7 +670,7 @@
 ;; @01c6                               return
 ;; }
 ;;
-;; function u0:26(i64 vmctx, i64, i8x16) fast {
+;; function u0:26(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -693,7 +693,7 @@
 ;; @01d5                               return
 ;; }
 ;;
-;; function u0:27(i64 vmctx, i64, i8x16) fast {
+;; function u0:27(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -716,7 +716,7 @@
 ;; @01e4                               return
 ;; }
 ;;
-;; function u0:28(i64 vmctx, i64, i8x16) fast {
+;; function u0:28(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -739,7 +739,7 @@
 ;; @01f3                               return
 ;; }
 ;;
-;; function u0:29(i64 vmctx, i64, i8x16) fast {
+;; function u0:29(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -762,7 +762,7 @@
 ;; @0202                               return
 ;; }
 ;;
-;; function u0:30(i64 vmctx, i64, i8x16) fast {
+;; function u0:30(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -785,7 +785,7 @@
 ;; @0211                               return
 ;; }
 ;;
-;; function u0:31(i64 vmctx, i64, i8x16) fast {
+;; function u0:31(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -808,7 +808,7 @@
 ;; @0220                               return
 ;; }
 ;;
-;; function u0:32(i64 vmctx, i64, i8x16) fast {
+;; function u0:32(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -831,7 +831,7 @@
 ;; @022f                               return
 ;; }
 ;;
-;; function u0:33(i64 vmctx, i64, i8x16) fast {
+;; function u0:33(i64 vmctx, i64, i8x16) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/simd.wat
+++ b/tests/disas/simd.wat
@@ -30,7 +30,7 @@
   (export "test_const" (func $test_const))
 )
 
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -46,7 +46,7 @@
 ;; @0055                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -65,7 +65,7 @@
 ;; @0073                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -82,7 +82,7 @@
 ;; @008b                               return v2
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64) fast {
+;; function u0:3(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -18,7 +18,7 @@
         )
     )
 )
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -33,7 +33,7 @@
 ;; @0024                               return v3
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -45,7 +45,7 @@
 ;; @002c                               return v5
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -23,7 +23,7 @@
     local.get 3
     table.copy $u $t))
 
-;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -36,7 +36,7 @@
 ;; @007b                               return v8
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -49,7 +49,7 @@
 ;; @0080                               return v8
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 fast {
+;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -62,7 +62,7 @@
 ;; @0085                               return v8
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -82,7 +82,7 @@
 ;; @0094                               return v6
 ;; }
 ;;
-;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -15,7 +15,7 @@
     local.get 0
     table.get 0))
 
-;; function u0:0(i64 vmctx, i64) -> r64 fast {
+;; function u0:0(i64 vmctx, i64) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -101,7 +101,7 @@
 ;; @0056                               return v14
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> r64 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -14,7 +14,7 @@
     local.get 0
     table.get 0))
 
-;; function u0:0(i64 vmctx, i64) -> r64 fast {
+;; function u0:0(i64 vmctx, i64) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -101,7 +101,7 @@
 ;; @0055                               return v14
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> r64 fast {
+;; function u0:1(i64 vmctx, i64, i32) -> r64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -16,7 +16,7 @@
     local.get 0
     local.get 1
     table.set 0))
-;; function u0:0(i64 vmctx, i64, r64) fast {
+;; function u0:0(i64 vmctx, i64, r64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -141,7 +141,7 @@
 ;; @0058                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, r64) fast {
+;; function u0:1(i64 vmctx, i64, i32, r64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -16,7 +16,7 @@
     local.get 1
     table.set 0))
 
-;; function u0:0(i64 vmctx, i64, r64) fast {
+;; function u0:0(i64 vmctx, i64, r64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -142,7 +142,7 @@
 ;; @0057                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, r64) fast {
+;; function u0:1(i64 vmctx, i64, i32, r64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -113,7 +113,7 @@
         local.get $sum)
 )
 
-;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -126,13 +126,13 @@
 ;; @0039                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -156,13 +156,13 @@
 ;; @0066                               return v35
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -186,12 +186,12 @@
 ;; @0091                               return v35
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -113,7 +113,7 @@
         local.get $sum)
 )
 
-;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -126,14 +126,14 @@
 ;; @0039                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
-;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:9 sig0
 ;;     stack_limit = gv2
 ;;
@@ -180,13 +180,13 @@
 ;; @0066                               return v51
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
@@ -234,12 +234,12 @@
 ;; @0091                               return v51
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -78,7 +78,7 @@
   (elem (i32.const 0))
 )
 
-;; function u0:0(i64 vmctx, i64) -> i32 fast {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -88,7 +88,7 @@
 ;; @0043                               trap unreachable
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 fast {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -101,7 +101,7 @@
 ;; @004e                               trap unreachable
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64) -> i32 fast {
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -133,7 +133,7 @@
 ;; @008c                               trap unreachable
 ;; }
 ;;
-;; function u0:3(i64 vmctx, i64) fast {
+;; function u0:3(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -29,13 +29,13 @@
 )
 
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 fast {
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i32) -> i32 fast
+;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -1,4 +1,5 @@
 ;;! target="x86_64"
+;;! test = "winch"
 
 (module
   (type $over-i32 (func (param i32) (result i32)))
@@ -8,7 +9,7 @@
       $fib-i32
     )
   )
-  
+
   (func $fib-i32 (export "fib-i32") (type $over-i32)
     (if (result i32) (i32.le_u (local.get 0) (i32.const 1))
       (then (i32.const 1))
@@ -29,96 +30,136 @@
 )
 
 
-;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
-;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
-;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
-;;     fn0 = colocated u1:9 sig1
-;;     stack_limit = gv2
-;;
-;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0038                               v4 = iconst.i32 1
-;; @003a                               v5 = icmp ule v2, v4  ; v4 = 1
-;; @003a                               v6 = uextend.i32 v5
-;; @003b                               brif v6, block2, block4
-;;
-;;                                 block2:
-;; @003d                               v8 = iconst.i32 1
-;; @003f                               jump block3(v8)  ; v8 = 1
-;;
-;;                                 block4:
-;; @0042                               v9 = iconst.i32 2
-;; @0044                               v10 = isub.i32 v2, v9  ; v9 = 2
-;; @0045                               v11 = iconst.i32 0
-;; @0047                               v12 = iconst.i32 1
-;; @0047                               v13 = icmp uge v11, v12  ; v11 = 0, v12 = 1
-;; @0047                               v14 = uextend.i64 v11  ; v11 = 0
-;; @0047                               v15 = global_value.i64 gv4
-;; @0047                               v16 = ishl_imm v14, 3
-;; @0047                               v17 = iadd v15, v16
-;; @0047                               v18 = iconst.i64 0
-;; @0047                               v19 = select_spectre_guard v13, v18, v17  ; v18 = 0
-;; @0047                               v20 = load.i64 table_oob aligned table v19
-;; @0047                               v21 = band_imm v20, -2
-;; @0047                               brif v20, block6(v21), block5
-;;
-;;                                 block5 cold:
-;; @0047                               v23 = iconst.i32 0
-;; @0047                               v24 = global_value.i64 gv3
-;; @0047                               v25 = call fn0(v24, v23, v11)  ; v23 = 0, v11 = 0
-;; @0047                               jump block6(v25)
-;;
-;;                                 block6(v22: i64):
-;; @0047                               v26 = global_value.i64 gv3
-;; @0047                               v27 = load.i64 notrap aligned readonly v26+80
-;; @0047                               v28 = load.i32 notrap aligned readonly v27
-;; @0047                               v29 = load.i32 icall_null aligned readonly v22+16
-;; @0047                               v30 = icmp eq v29, v28
-;; @0047                               trapz v30, bad_sig
-;; @0047                               v31 = load.i64 notrap aligned readonly v22+8
-;; @0047                               v32 = load.i64 notrap aligned readonly v22+24
-;; @0047                               v33 = call_indirect sig0, v31(v32, v0, v10)
-;; @004c                               v35 = iconst.i32 1
-;; @004e                               v36 = isub.i32 v2, v35  ; v35 = 1
-;; @004f                               v37 = iconst.i32 0
-;; @0051                               v38 = iconst.i32 1
-;; @0051                               v39 = icmp uge v37, v38  ; v37 = 0, v38 = 1
-;; @0051                               v40 = uextend.i64 v37  ; v37 = 0
-;; @0051                               v41 = global_value.i64 gv4
-;; @0051                               v42 = ishl_imm v40, 3
-;; @0051                               v43 = iadd v41, v42
-;; @0051                               v44 = iconst.i64 0
-;; @0051                               v45 = select_spectre_guard v39, v44, v43  ; v44 = 0
-;; @0051                               v46 = load.i64 table_oob aligned table v45
-;; @0051                               v47 = band_imm v46, -2
-;; @0051                               brif v46, block8(v47), block7
-;;
-;;                                 block7 cold:
-;; @0051                               v49 = iconst.i32 0
-;; @0051                               v50 = global_value.i64 gv3
-;; @0051                               v51 = call fn0(v50, v49, v37)  ; v49 = 0, v37 = 0
-;; @0051                               jump block8(v51)
-;;
-;;                                 block8(v48: i64):
-;; @0051                               v52 = global_value.i64 gv3
-;; @0051                               v53 = load.i64 notrap aligned readonly v52+80
-;; @0051                               v54 = load.i32 notrap aligned readonly v53
-;; @0051                               v55 = load.i32 icall_null aligned readonly v48+16
-;; @0051                               v56 = icmp eq v55, v54
-;; @0051                               trapz v56, bad_sig
-;; @0051                               v57 = load.i64 notrap aligned readonly v48+8
-;; @0051                               v58 = load.i64 notrap aligned readonly v48+24
-;; @0051                               v59 = call_indirect sig0, v57(v58, v0, v36)
-;; @0054                               v60 = iadd.i32 v33, v59
-;; @0055                               jump block3(v60)
-;;
-;;                                 block3(v7: i32):
-;; @0056                               jump block1(v7)
-;;
-;;                                 block1(v3: i32):
-;; @0056                               return v3
-;; }
+;; wasm[0]::function[0]::fib-i32:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    (%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x1c8
+;;   1b: movq    %rdi, %r14
+;;       subq    $0x18, %rsp
+;;       movq    %rdi, 0x10(%rsp)
+;;       movq    %rsi, 8(%rsp)
+;;       movl    %edx, 4(%rsp)
+;;       movl    4(%rsp), %eax
+;;       cmpl    $1, %eax
+;;       movl    $0, %eax
+;;       setbe   %al
+;;       testl   %eax, %eax
+;;       je      0x52
+;;   48: movl    $1, %eax
+;;       jmp     0x1c2
+;;   52: movl    4(%rsp), %eax
+;;       subl    $2, %eax
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    $0, %ecx
+;;       movq    %r14, %rdx
+;;       movl    0x60(%rdx), %ebx
+;;       cmpl    %ebx, %ecx
+;;       jae     0x1ca
+;;   73: movl    %ecx, %r11d
+;;       imulq   $8, %r11, %r11
+;;       movq    0x58(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpl    %ebx, %ecx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0xbb
+;;   96: subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       movl    (%rsp), %edx
+;;       callq   0x2dd
+;;       addq    $4, %rsp
+;;       movq    0x14(%rsp), %r14
+;;       jmp     0xbf
+;;   bb: andq    $0xfffffffffffffffe, %rax
+;;       testq   %rax, %rax
+;;       je      0x1cc
+;;   c8: movq    0x50(%r14), %r11
+;;       movl    (%r11), %ecx
+;;       movl    0x10(%rax), %edx
+;;       cmpl    %edx, %ecx
+;;       jne     0x1ce
+;;   da: pushq   %rax
+;;       popq    %rcx
+;;       movq    0x18(%rcx), %r8
+;;       movq    8(%rcx), %rbx
+;;       subq    $4, %rsp
+;;       movq    %r8, %rdi
+;;       movq    %r14, %rsi
+;;       movl    4(%rsp), %edx
+;;       callq   *%rbx
+;;       addq    $4, %rsp
+;;       addq    $4, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       movl    4(%rsp), %ecx
+;;       subl    $1, %ecx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       movl    $0, %ecx
+;;       movq    %r14, %rdx
+;;       movl    0x60(%rdx), %ebx
+;;       cmpl    %ebx, %ecx
+;;       jae     0x1d0
+;;  129: movl    %ecx, %r11d
+;;       imulq   $8, %r11, %r11
+;;       movq    0x58(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpl    %ebx, %ecx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0x17a
+;;  14c: subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       movl    0xc(%rsp), %edx
+;;       callq   0x2dd
+;;       addq    $0xc, %rsp
+;;       addq    $4, %rsp
+;;       movq    0x18(%rsp), %r14
+;;       jmp     0x17e
+;;  17a: andq    $0xfffffffffffffffe, %rax
+;;       testq   %rax, %rax
+;;       je      0x1d2
+;;  187: movq    0x50(%r14), %r11
+;;       movl    (%r11), %ecx
+;;       movl    0x10(%rax), %edx
+;;       cmpl    %edx, %ecx
+;;       jne     0x1d4
+;;  199: pushq   %rax
+;;       popq    %rcx
+;;       movq    0x18(%rcx), %r8
+;;       movq    8(%rcx), %rbx
+;;       movq    %r8, %rdi
+;;       movq    %r14, %rsi
+;;       movl    (%rsp), %edx
+;;       callq   *%rbx
+;;       addq    $4, %rsp
+;;       movq    0x14(%rsp), %r14
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       addl    %eax, %ecx
+;;       movl    %ecx, %eax
+;;       addq    $0x18, %rsp
+;;       popq    %rbp
+;;       retq
+;;  1c8: ud2
+;;  1ca: ud2
+;;  1cc: ud2
+;;  1ce: ud2
+;;  1d0: ud2
+;;  1d2: ud2
+;;  1d4: ud2

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -16,7 +16,7 @@
     )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) fast {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
@@ -29,13 +29,13 @@
 ;; @0032                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) fast {
+;; function u0:1(i64 vmctx, i64) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i32) fast
+;;     sig0 = (i64 vmctx, i64, i32) tail
 ;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -1,4 +1,5 @@
 ;;! target="x86_64"
+;;! test = "winch"
 
 (module
     (type $param-i32 (func (param i32)))
@@ -16,63 +17,86 @@
     )
 )
 
-;; function u0:0(i64 vmctx, i64, i32) tail {
-;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
-;;     gv2 = load.i64 notrap aligned gv1
-;;     stack_limit = gv2
+;; wasm[0]::function[0]::param-i32:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    (%r11), %r11
+;;       addq    $0x18, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x36
+;;   1b: movq    %rdi, %r14
+;;       subq    $0x18, %rsp
+;;       movq    %rdi, 0x10(%rsp)
+;;       movq    %rsi, 8(%rsp)
+;;       movl    %edx, 4(%rsp)
+;;       addq    $0x18, %rsp
+;;       popq    %rbp
+;;       retq
+;;   36: ud2
 ;;
-;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0032                               jump block1
-;;
-;;                                 block1:
-;; @0032                               return
-;; }
-;;
-;; function u0:1(i64 vmctx, i64) tail {
-;;     gv0 = vmctx
-;;     gv1 = load.i64 notrap aligned readonly gv0+8
-;;     gv2 = load.i64 notrap aligned gv1
-;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64, i32) tail
-;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
-;;     fn0 = colocated u1:9 sig1
-;;     stack_limit = gv2
-;;
-;;                                 block0(v0: i64, v1: i64):
-;; @0035                               v2 = iconst.i32 0
-;; @0039                               v3 = iconst.i32 0
-;; @003b                               v4 = iconst.i32 1
-;; @003b                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 1
-;; @003b                               v6 = uextend.i64 v3  ; v3 = 0
-;; @003b                               v7 = global_value.i64 gv4
-;; @003b                               v8 = ishl_imm v6, 3
-;; @003b                               v9 = iadd v7, v8
-;; @003b                               v10 = iconst.i64 0
-;; @003b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @003b                               v12 = load.i64 table_oob aligned table v11
-;; @003b                               v13 = band_imm v12, -2
-;; @003b                               brif v12, block3(v13), block2
-;;
-;;                                 block2 cold:
-;; @003b                               v15 = iconst.i32 0
-;; @003b                               v16 = global_value.i64 gv3
-;; @003b                               v17 = call fn0(v16, v15, v3)  ; v15 = 0, v3 = 0
-;; @003b                               jump block3(v17)
-;;
-;;                                 block3(v14: i64):
-;; @003b                               v18 = global_value.i64 gv3
-;; @003b                               v19 = load.i64 notrap aligned readonly v18+80
-;; @003b                               v20 = load.i32 notrap aligned readonly v19
-;; @003b                               v21 = load.i32 icall_null aligned readonly v14+16
-;; @003b                               v22 = icmp eq v21, v20
-;; @003b                               trapz v22, bad_sig
-;; @003b                               v23 = load.i64 notrap aligned readonly v14+8
-;; @003b                               v24 = load.i64 notrap aligned readonly v14+24
-;; @003b                               call_indirect sig0, v23(v24, v0, v2)  ; v2 = 0
-;; @003e                               jump block1
-;;
-;;                                 block1:
-;; @003e                               return
-;; }
+;; wasm[0]::function[1]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    (%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x126
+;;   5b: movq    %rdi, %r14
+;;       subq    $0x18, %rsp
+;;       movq    %rdi, 0x10(%rsp)
+;;       movq    %rsi, 8(%rsp)
+;;       movq    $0, (%rsp)
+;;       movl    4(%rsp), %r11d
+;;       subq    $4, %rsp
+;;       movl    %r11d, (%rsp)
+;;       movl    $0, %ecx
+;;       movq    %r14, %rdx
+;;       movl    0x60(%rdx), %ebx
+;;       cmpl    %ebx, %ecx
+;;       jae     0x128
+;;   94: movl    %ecx, %r11d
+;;       imulq   $8, %r11, %r11
+;;       movq    0x58(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpl    %ebx, %ecx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0xdc
+;;   b7: subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       movl    (%rsp), %edx
+;;       callq   0x303
+;;       addq    $4, %rsp
+;;       movq    0x14(%rsp), %r14
+;;       jmp     0xe0
+;;   dc: andq    $0xfffffffffffffffe, %rax
+;;       testq   %rax, %rax
+;;       je      0x12a
+;;   e9: movq    0x50(%r14), %r11
+;;       movl    (%r11), %ecx
+;;       movl    0x10(%rax), %edx
+;;       cmpl    %edx, %ecx
+;;       jne     0x12c
+;;   fb: movq    0x18(%rax), %rbx
+;;       movq    8(%rax), %rcx
+;;       subq    $4, %rsp
+;;       movq    %rbx, %rdi
+;;       movq    %r14, %rsi
+;;       movl    4(%rsp), %edx
+;;       callq   *%rcx
+;;       addq    $4, %rsp
+;;       addq    $4, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       addq    $0x18, %rsp
+;;       popq    %rbp
+;;       retq
+;;  126: ud2
+;;  128: ud2
+;;  12a: ud2
+;;  12c: ud2


### PR DESCRIPTION
Logic in `Config` to conditionally enable tail calls wasn't handling the case where the configured compiler strategy was `Strategy::Auto` meaning that by default tail calls weren't actually enabled. This commit refactors handling of `Strategy` to avoid storing `Strategy::Auto` in `CompilerConfig` so tests against it can use either cranelift or winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
