### PR TITLE
winch: Ensure the right return type for f64 comparisons

### DIFF
--- a/tests/misc_testsuite/winch/float-comparison.wast
+++ b/tests/misc_testsuite/winch/float-comparison.wast
@@ -1,0 +1,13 @@
+(module
+  (func (result i32 i32 i32)
+    i32.const 1
+    i32.eqz
+    f64.const 0
+    f64.const 1
+    f64.ne
+    i32.const 1111
+  )
+  (export "d" (func 0))
+)
+
+(assert_return (invoke "d") (i32.const 0) (i32.const 1) (i32.const 1111))

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -261,8 +261,10 @@ impl<'a> CodeGenContext<'a> {
         self.free_reg(src2);
 
         let dst = match size {
-            OperandSize::S32 => TypedReg::i32(dst),
-            OperandSize::S64 => TypedReg::i64(dst),
+            // Float comparison operators are defined as
+            // [f64 f64] -> i32
+            // https://webassembly.github.io/spec/core/appendix/index-instructions.html
+            OperandSize::S32 | OperandSize::S64 => TypedReg::i32(dst),
             OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => unreachable!(),
         };
         self.stack.push(dst.into());

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -608,7 +608,7 @@ impl ControlStackFrame {
         }
     }
 
-    /// Orchestrates how blocks results are handled.
+    /// Orchestrates how block results are handled.
     /// Results are handled in reverse order, starting from register results
     /// continuing to memory values. This guarantees that the stack ordering
     /// invariant is maintained. See [ABIResults] for more details.


### PR DESCRIPTION
Fixes: https://github.com/bytecodealliance/wasmtime/issues/8632

This commit fixes the handling of f64 comparison operations in Winch. f64 comparison operations are defined as

	[f64 f64] -> [i32]

according to https://webassembly.github.io/spec/core/appendix/index-instructions.html

The previous implementation was widening the result to `[i64]`  which caused issues with stack shuffling in multi-value returns.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
