### PR TITLE
Use `[su]extend_maybe` in the `iconst_[su]` extractors

### DIFF
--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -74,7 +74,7 @@
 ;; When constructing, the rule will fail if the value cannot be represented in
 ;; the target type.  If it fits, it'll be masked accordingly in the constant.
 (decl iconst_s (Type i64) Value)
-(extractor (iconst_s ty c) (inst_data_tupled (iconst_sextend_etor ty c)))
+(extractor (iconst_s ty c) (sextend_maybe ty (inst_data_tupled (iconst_sextend_etor _inner_ty c))))
 (rule 0 (iconst_s ty c)
 	(if-let c_masked (u64_and (i64_as_u64 c) (ty_umax ty)))
 	(if-let c_reextended (i64_sextend_u64 ty c_masked))
@@ -89,7 +89,7 @@
 ;; When constructing, the rule will fail if the value cannot be represented in
 ;; the target type.
 (decl iconst_u (Type u64) Value)
-(extractor (iconst_u ty c) (iconst ty (u64_from_imm64 c)))
+(extractor (iconst_u ty c) (uextend_maybe ty (iconst _inner_ty (u64_from_imm64 c))))
 (rule 0 (iconst_u ty c)
 	(if-let $true (u64_le c (ty_umax ty)))
     (iconst ty (imm64 c)))

--- a/cranelift/filetests/filetests/egraph/i128-opts.clif
+++ b/cranelift/filetests/filetests/egraph/i128-opts.clif
@@ -135,3 +135,23 @@ block0:
     ; check: v4 = iadd v1, v3
     ; check: return v4
 }
+
+function %mul_2u_i128(i128) -> i128 {
+block0(v0: i128):
+    v1 = iconst.i16 2
+    v2 = uextend.i128 v1
+    v3 = imul v0, v2
+    return v3
+    ; check: v4 = iadd v0, v0
+    ; check: return v4
+}
+
+function %mul_neg1_i128(i128) -> i128 {
+block0(v0: i128):
+    v1 = iconst.i16 -1
+    v2 = sextend.i128 v1
+    v3 = imul v0, v2
+    return v3
+    ; check: v4 = ineg v0
+    ; check: return v4
+}


### PR DESCRIPTION
This enables various things -- like `x * 2` → `x + x` and `x * -1` → `-x` -- for 128-bit numbers as well.

Thanks to @jameysharp over in https://github.com/bytecodealliance/wasmtime/pull/8653#issuecomment-2125435660 for noticing that these extractors weren't ever going to match 128-bit numbers as-written, even though the rules could produce 128-bit values.