### PR TITLE
Add basic support for DWARF processing with components

### DIFF
--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -1,5 +1,14 @@
 //! Debug utils for WebAssembly using Cranelift.
 
+use crate::CompiledFunctionMetadata;
+use cranelift_codegen::isa::TargetIsa;
+use object::write::SymbolId;
+use std::collections::HashMap;
+use wasmtime_environ::{
+    DefinedFuncIndex, EntityRef, MemoryIndex, ModuleTranslation, OwnedMemoryIndex, PrimaryMap,
+    PtrSize, StaticModuleIndex, Tunables, VMOffsets,
+};
+
 /// Memory definition offset in the VMContext structure.
 #[derive(Debug, Clone)]
 pub enum ModuleMemoryOffset {
@@ -16,6 +25,154 @@ pub enum ModuleMemoryOffset {
         /// lies.
         offset_to_memory_base: u32,
     },
+}
+
+type Reader<'input> = gimli::EndianSlice<'input, gimli::LittleEndian>;
+
+/// "Package structure" to collect together various artifacts/results of a
+/// compilation.
+///
+/// This structure is threaded through a number of top-level functions of DWARF
+/// processing within in this submodule to pass along all the bits-and-pieces of
+/// the compilation context.
+pub struct Compilation<'a> {
+    /// All module translations which were present in this compilation.
+    ///
+    /// This map has one entry for core wasm modules and may have multiple (or
+    /// zero) for components.
+    translations: &'a PrimaryMap<StaticModuleIndex, ModuleTranslation<'a>>,
+
+    /// Accessor of a particular compiled function for a module.
+    ///
+    /// This returns the `object`-based-symbol for the function as well as the
+    /// `&CompiledFunction`.
+    get_func:
+        &'a dyn Fn(StaticModuleIndex, DefinedFuncIndex) -> (SymbolId, &'a CompiledFunctionMetadata),
+
+    /// Optionally-specified `*.dwp` file, currently only supported for core
+    /// wasm modules.
+    dwarf_package_bytes: Option<&'a [u8]>,
+
+    /// Compilation settings used when producing functions.
+    tunables: &'a Tunables,
+
+    /// Translation between `SymbolId` and a `usize`-based symbol which gimli
+    /// uses.
+    symbol_index_to_id: Vec<SymbolId>,
+    symbol_id_to_index: HashMap<SymbolId, (usize, StaticModuleIndex, DefinedFuncIndex)>,
+
+    /// The `ModuleMemoryOffset` for each module within `translations`.
+    ///
+    /// Note that this doesn't support multi-memory at this time.
+    module_memory_offsets: PrimaryMap<StaticModuleIndex, ModuleMemoryOffset>,
+}
+
+impl<'a> Compilation<'a> {
+    pub fn new(
+        isa: &dyn TargetIsa,
+        translations: &'a PrimaryMap<StaticModuleIndex, ModuleTranslation<'a>>,
+        get_func: &'a dyn Fn(
+            StaticModuleIndex,
+            DefinedFuncIndex,
+        ) -> (SymbolId, &'a CompiledFunctionMetadata),
+        dwarf_package_bytes: Option<&'a [u8]>,
+        tunables: &'a Tunables,
+    ) -> Compilation<'a> {
+        // Build the `module_memory_offsets` map based on the modules in
+        // `translations`.
+        let mut module_memory_offsets = PrimaryMap::new();
+        for (i, translation) in translations {
+            let ofs = VMOffsets::new(
+                isa.triple().architecture.pointer_width().unwrap().bytes(),
+                &translation.module,
+            );
+
+            let memory_offset = if ofs.num_imported_memories > 0 {
+                ModuleMemoryOffset::Imported {
+                    offset_to_vm_memory_definition: ofs.vmctx_vmmemory_import(MemoryIndex::new(0))
+                        + u32::from(ofs.vmmemory_import_from()),
+                    offset_to_memory_base: ofs.ptr.vmmemory_definition_base().into(),
+                }
+            } else if ofs.num_defined_memories > 0 {
+                // The addition of shared memory makes the following assumption,
+                // "owned memory index = 0", possibly false. If the first memory
+                // is a shared memory, the base pointer will not be stored in
+                // the `owned_memories` array. The following code should
+                // eventually be fixed to not only handle shared memories but
+                // also multiple memories.
+                assert_eq!(
+                    ofs.num_defined_memories, ofs.num_owned_memories,
+                    "the memory base pointer may be incorrect due to sharing memory"
+                );
+                ModuleMemoryOffset::Defined(
+                    ofs.vmctx_vmmemory_definition_base(OwnedMemoryIndex::new(0)),
+                )
+            } else {
+                ModuleMemoryOffset::None
+            };
+            let j = module_memory_offsets.push(memory_offset);
+            assert_eq!(i, j);
+        }
+
+        // Build the `symbol <=> usize` mappings
+        let mut symbol_index_to_id = Vec::new();
+        let mut symbol_id_to_index = HashMap::new();
+
+        for (module, translation) in translations {
+            for func in translation.module.defined_func_indices() {
+                let (sym, _func) = get_func(module, func);
+                symbol_id_to_index.insert(sym, (symbol_index_to_id.len(), module, func));
+                symbol_index_to_id.push(sym);
+            }
+        }
+
+        Compilation {
+            translations,
+            get_func,
+            dwarf_package_bytes,
+            tunables,
+            symbol_index_to_id,
+            symbol_id_to_index,
+            module_memory_offsets,
+        }
+    }
+
+    /// Returns an iterator over all function indexes present in this
+    /// compilation.
+    ///
+    /// Each function is additionally accompanied with its module index.
+    fn indexes(&self) -> impl Iterator<Item = (StaticModuleIndex, DefinedFuncIndex)> + '_ {
+        self.translations
+            .iter()
+            .flat_map(|(i, t)| t.module.defined_func_indices().map(move |j| (i, j)))
+    }
+
+    /// Returns an iterator of all functions with their module, symbol, and
+    /// function metadata that were produced during compilation.
+    fn functions(
+        &self,
+    ) -> impl Iterator<Item = (StaticModuleIndex, usize, &'a CompiledFunctionMetadata)> + '_ {
+        self.indexes().map(move |(module, func)| {
+            let (sym, func) = self.function(module, func);
+            (module, sym, func)
+        })
+    }
+
+    /// Returns the symbol and metadata associated with a specific function.
+    fn function(
+        &self,
+        module: StaticModuleIndex,
+        func: DefinedFuncIndex,
+    ) -> (usize, &'a CompiledFunctionMetadata) {
+        let (sym, func) = (self.get_func)(module, func);
+        (self.symbol_id_to_index[&sym].0, func)
+    }
+
+    /// Maps a `usize`-based symbol used by gimli to the object-based
+    /// `SymbolId`.
+    pub fn symbol_id(&self, sym: usize) -> SymbolId {
+        self.symbol_index_to_id[sym]
+    }
 }
 
 pub use write_debuginfo::{emit_dwarf, DwarfSectionRelocTarget};

--- a/crates/cranelift/src/debug/gc.rs
+++ b/crates/cranelift/src/debug/gc.rs
@@ -1,8 +1,10 @@
 use crate::debug::transform::AddressTransform;
+use crate::debug::{Compilation, Reader};
 use gimli::constants;
 use gimli::read;
-use gimli::{Reader, UnitSectionOffset};
+use gimli::UnitSectionOffset;
 use std::collections::{HashMap, HashSet};
+use wasmtime_environ::{PrimaryMap, StaticModuleIndex};
 
 #[derive(Debug)]
 pub struct Dependencies {
@@ -65,23 +67,26 @@ impl Dependencies {
     }
 }
 
-pub fn build_dependencies<R: Reader<Offset = usize>>(
-    dwarf: &read::Dwarf<R>,
-    dwp: &Option<read::DwarfPackage<R>>,
-    at: &AddressTransform,
+pub fn build_dependencies(
+    compilation: &mut Compilation<'_>,
+    dwp: &Option<read::DwarfPackage<Reader<'_>>>,
+    at: &PrimaryMap<StaticModuleIndex, AddressTransform>,
 ) -> read::Result<Dependencies> {
     let mut deps = Dependencies::new();
-    let mut units = dwarf.units();
-    while let Some(unit) = units.next()? {
-        build_unit_dependencies(unit, dwarf, dwp, at, &mut deps)?;
+    for (i, translation) in compilation.translations.iter() {
+        let dwarf = &translation.debuginfo.dwarf;
+        let mut units = dwarf.units();
+        while let Some(unit) = units.next()? {
+            build_unit_dependencies(unit, dwarf, dwp, &at[i], &mut deps)?;
+        }
     }
     Ok(deps)
 }
 
-fn build_unit_dependencies<R: Reader<Offset = usize>>(
-    header: read::UnitHeader<R>,
-    dwarf: &read::Dwarf<R>,
-    dwp: &Option<read::DwarfPackage<R>>,
+fn build_unit_dependencies(
+    header: read::UnitHeader<Reader<'_>>,
+    dwarf: &read::Dwarf<Reader<'_>>,
+    dwp: &Option<read::DwarfPackage<Reader<'_>>>,
     at: &AddressTransform,
     deps: &mut Dependencies,
 ) -> read::Result<()> {
@@ -103,7 +108,7 @@ fn build_unit_dependencies<R: Reader<Offset = usize>>(
     Ok(())
 }
 
-fn has_die_back_edge<R: Reader<Offset = usize>>(die: &read::DebuggingInformationEntry<R>) -> bool {
+fn has_die_back_edge(die: &read::DebuggingInformationEntry<Reader<'_>>) -> bool {
     match die.tag() {
         constants::DW_TAG_variable
         | constants::DW_TAG_constant
@@ -123,10 +128,10 @@ fn has_die_back_edge<R: Reader<Offset = usize>>(die: &read::DebuggingInformation
     }
 }
 
-fn has_valid_code_range<R: Reader<Offset = usize>>(
-    die: &read::DebuggingInformationEntry<R>,
-    dwarf: &read::Dwarf<R>,
-    unit: &read::Unit<R>,
+fn has_valid_code_range(
+    die: &read::DebuggingInformationEntry<Reader<'_>>,
+    dwarf: &read::Dwarf<Reader<'_>>,
+    unit: &read::Unit<Reader<'_>>,
     at: &AddressTransform,
 ) -> read::Result<bool> {
     match die.tag() {
@@ -199,10 +204,10 @@ fn has_valid_code_range<R: Reader<Offset = usize>>(
     Ok(false)
 }
 
-fn build_die_dependencies<R: Reader<Offset = usize>>(
-    die: read::EntriesTreeNode<R>,
-    dwarf: &read::Dwarf<R>,
-    unit: &read::Unit<R>,
+fn build_die_dependencies(
+    die: read::EntriesTreeNode<Reader<'_>>,
+    dwarf: &read::Dwarf<Reader<'_>>,
+    unit: &read::Unit<Reader<'_>>,
     at: &AddressTransform,
     deps: &mut Dependencies,
 ) -> read::Result<()> {
@@ -229,11 +234,11 @@ fn build_die_dependencies<R: Reader<Offset = usize>>(
     Ok(())
 }
 
-fn build_attr_dependencies<R: Reader<Offset = usize>>(
-    attr: &read::Attribute<R>,
+fn build_attr_dependencies(
+    attr: &read::Attribute<Reader<'_>>,
     offset: UnitSectionOffset,
-    _dwarf: &read::Dwarf<R>,
-    unit: &read::Unit<R>,
+    _dwarf: &read::Dwarf<Reader<'_>>,
+    unit: &read::Unit<Reader<'_>>,
     _at: &AddressTransform,
     deps: &mut Dependencies,
 ) -> read::Result<()> {

--- a/crates/cranelift/src/debug/transform/line_program.rs
+++ b/crates/cranelift/src/debug/transform/line_program.rs
@@ -6,7 +6,7 @@ use gimli::{
     write, AttributeValue::DebugLineRef, DebugLine, DebugLineOffset, DebugStr,
     DebuggingInformationEntry, LineEncoding, Unit,
 };
-use wasmtime_environ::{DefinedFuncIndex, EntityRef};
+use wasmtime_environ::DefinedFuncIndex;
 
 #[derive(Debug)]
 enum SavedLineProgramRow {
@@ -222,7 +222,7 @@ where
                     continue; // no code generated
                 }
             };
-            let symbol = index.index();
+            let symbol = map.symbol;
             let base_addr = map.offset;
             out_program.begin_sequence(Some(write::Address::Symbol { symbol, addend: 0 }));
             // TODO track and place function declaration line here

--- a/crates/cranelift/src/debug/transform/range_info_builder.rs
+++ b/crates/cranelift/src/debug/transform/range_info_builder.rs
@@ -2,7 +2,7 @@ use super::address_transform::AddressTransform;
 use super::{DebugInputContext, Reader};
 use anyhow::Error;
 use gimli::{write, AttributeValue, DebuggingInformationEntry, RangeListsOffset, Unit};
-use wasmtime_environ::{DefinedFuncIndex, EntityRef};
+use wasmtime_environ::DefinedFuncIndex;
 
 pub(crate) enum RangeInfoBuilder {
     Undefined,
@@ -172,8 +172,8 @@ impl RangeInfoBuilder {
                 }
             }
             RangeInfoBuilder::Function(index) => {
+                let symbol = addr_tr.map()[*index].symbol;
                 let range = addr_tr.func_range(*index);
-                let symbol = index.index();
                 let addr = write::Address::Symbol {
                     symbol,
                     addend: range.0 as i64,

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -1,8 +1,7 @@
 use super::expression::{CompiledExpression, FunctionFrameInfo};
-use super::utils::{add_internal_types, append_vmctx_info, get_function_frame_info};
+use super::utils::{add_internal_types, append_vmctx_info};
 use super::AddressTransform;
-use crate::debug::ModuleMemoryOffset;
-use crate::CompiledFunctionsMetadata;
+use crate::debug::{Compilation, ModuleMemoryOffset};
 use anyhow::{Context, Error};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_wasm::get_vmctx_value_label;
@@ -12,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmtime_environ::{
-    DebugInfoData, DefinedFuncIndex, EntityRef, FuncIndex, FunctionMetadata, WasmFileInfo,
+    DebugInfoData, EntityRef, FunctionMetadata, PrimaryMap, StaticModuleIndex, WasmFileInfo,
     WasmValType,
 };
 
@@ -31,8 +30,8 @@ macro_rules! assert_dwarf_str {
 }
 
 fn generate_line_info(
-    addr_tr: &AddressTransform,
-    translated: &HashSet<DefinedFuncIndex>,
+    addr_tr: &PrimaryMap<StaticModuleIndex, AddressTransform>,
+    translated: &HashSet<usize>,
     out_encoding: gimli::Encoding,
     w: &WasmFileInfo,
     comp_dir_id: write::StringId,
@@ -58,12 +57,17 @@ fn generate_line_info(
         None,
     );
 
-    for (i, map) in addr_tr.map() {
-        let symbol = i.index();
-        if translated.contains(&i) {
-            continue;
-        }
+    let maps = addr_tr.iter().flat_map(|(_, transform)| {
+        transform.map().iter().filter_map(|(_, map)| {
+            if translated.contains(&map.symbol) {
+                None
+            } else {
+                Some((map.symbol, map))
+            }
+        })
+    });
 
+    for (symbol, map) in maps {
         let base_addr = map.offset;
         out_program.begin_sequence(Some(write::Address::Symbol { symbol, addend: 0 }));
         for addr_map in map.addresses.iter() {
@@ -279,26 +283,24 @@ fn check_invalid_chars_in_path(path: PathBuf) -> Option<PathBuf> {
 }
 
 pub fn generate_simulated_dwarf(
-    addr_tr: &AddressTransform,
-    di: &DebugInfoData,
-    memory_offset: &ModuleMemoryOffset,
-    funcs: &CompiledFunctionsMetadata,
-    translated: &HashSet<DefinedFuncIndex>,
+    compilation: &mut Compilation<'_>,
+    addr_tr: &PrimaryMap<StaticModuleIndex, AddressTransform>,
+    translated: &HashSet<usize>,
     out_encoding: gimli::Encoding,
     out_units: &mut write::UnitTable,
     out_strings: &mut write::StringTable,
     isa: &dyn TargetIsa,
 ) -> Result<(), Error> {
-    let path = di
-        .wasm_file
-        .path
-        .to_owned()
-        .and_then(check_invalid_chars_in_path)
-        .unwrap_or_else(|| autogenerate_dwarf_wasm_path(di));
-
-    let func_names = &di.name_section.func_names;
-    let locals_names = &di.name_section.locals_names;
-    let imported_func_count = di.wasm_file.imported_func_count;
+    let (wasm_file, path) = {
+        let di = &compilation.translations.iter().next().unwrap().1.debuginfo;
+        let path = di
+            .wasm_file
+            .path
+            .to_owned()
+            .and_then(check_invalid_chars_in_path)
+            .unwrap_or_else(|| autogenerate_dwarf_wasm_path(di));
+        (&di.wasm_file, path)
+    };
 
     let (unit, root_id, name_id) = {
         let comp_dir_id = out_strings.add(assert_dwarf_str!(path
@@ -317,7 +319,7 @@ pub fn generate_simulated_dwarf(
             addr_tr,
             translated,
             out_encoding,
-            &di.wasm_file,
+            wasm_file,
             comp_dir_id,
             name_id,
             name,
@@ -343,14 +345,21 @@ pub fn generate_simulated_dwarf(
         (unit, root_id, name_id)
     };
 
-    let wasm_types = add_wasm_types(unit, root_id, out_strings, memory_offset);
+    let mut module_wasm_types = PrimaryMap::new();
+    for (module, memory_offset) in compilation.module_memory_offsets.iter() {
+        let wasm_types = add_wasm_types(unit, root_id, out_strings, memory_offset);
+        let i = module_wasm_types.push(wasm_types);
+        assert_eq!(i, module);
+    }
 
-    for (i, map) in addr_tr.map().iter() {
-        let index = i.index();
-        if translated.contains(&i) {
+    for (module, index) in compilation.indexes().collect::<Vec<_>>() {
+        let (symbol, _) = compilation.function(module, index);
+        if translated.contains(&symbol) {
             continue;
         }
 
+        let addr_tr = &addr_tr[module];
+        let map = &addr_tr.map()[index];
         let start = map.offset as u64;
         let end = start + map.len as u64;
         let die_id = unit.add(root_id, gimli::DW_TAG_subprogram);
@@ -358,7 +367,7 @@ pub fn generate_simulated_dwarf(
         die.set(
             gimli::DW_AT_low_pc,
             write::AttributeValue::Address(write::Address::Symbol {
-                symbol: index,
+                symbol,
                 addend: start as i64,
             }),
         );
@@ -367,13 +376,17 @@ pub fn generate_simulated_dwarf(
             write::AttributeValue::Udata(end - start),
         );
 
-        let func_index = imported_func_count + (index as u32);
-        let id = match func_names
-            .get(&FuncIndex::from_u32(func_index))
+        let translation = &compilation.translations[module];
+        let func_index = translation.module.func_index(index);
+        let di = &translation.debuginfo;
+        let id = match di
+            .name_section
+            .func_names
+            .get(&func_index)
             .and_then(|s| check_invalid_chars_in_name(s))
         {
             Some(n) => out_strings.add(assert_dwarf_str!(n)),
-            None => out_strings.add(format!("wasm-function[{}]", func_index)),
+            None => out_strings.add(format!("wasm-function[{}]", func_index.as_u32())),
         };
 
         die.set(gimli::DW_AT_name, write::AttributeValue::StringRef(id));
@@ -390,21 +403,20 @@ pub fn generate_simulated_dwarf(
             write::AttributeValue::Udata(wasm_offset),
         );
 
-        if let Some(frame_info) = get_function_frame_info(memory_offset, funcs, i) {
-            let source_range = addr_tr.func_source_range(i);
-            generate_vars(
-                unit,
-                die_id,
-                addr_tr,
-                &frame_info,
-                &[(source_range.0, source_range.1)],
-                &wasm_types,
-                &di.wasm_file.funcs[index],
-                locals_names.get(&FuncIndex::from_u32(index as u32)),
-                out_strings,
-                isa,
-            )?;
-        }
+        let frame_info = compilation.function_frame_info(module, index);
+        let source_range = addr_tr.func_source_range(index);
+        generate_vars(
+            unit,
+            die_id,
+            addr_tr,
+            &frame_info,
+            &[(source_range.0, source_range.1)],
+            &module_wasm_types[module],
+            &di.wasm_file.funcs[index.as_u32() as usize],
+            di.name_section.locals_names.get(&func_index),
+            out_strings,
+            isa,
+        )?;
     }
 
     Ok(())

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -4,17 +4,16 @@ use super::expression::compile_expression;
 use super::line_program::clone_line_program;
 use super::range_info_builder::RangeInfoBuilder;
 use super::refs::{PendingDebugInfoRefs, PendingUnitRefs, UnitRefsMap};
-use super::utils::{add_internal_types, append_vmctx_info, get_function_frame_info};
-use super::{DebugInputContext, Reader};
-use crate::debug::ModuleMemoryOffset;
-use crate::CompiledFunctionsMetadata;
+use super::utils::{add_internal_types, append_vmctx_info};
+use super::DebugInputContext;
+use crate::debug::{Compilation, Reader};
 use anyhow::{Context, Error};
 use cranelift_codegen::ir::Endianness;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::write;
 use gimli::{AttributeValue, DebuggingInformationEntry, Unit};
 use std::collections::HashSet;
-use wasmtime_environ::DefinedFuncIndex;
+use wasmtime_environ::StaticModuleIndex;
 use wasmtime_versioned_export_macros::versioned_stringify_ident;
 
 struct InheritedAttr<T> {
@@ -45,14 +44,11 @@ impl<T> InheritedAttr<T> {
     }
 }
 
-fn get_base_type_name<R>(
-    type_entry: &DebuggingInformationEntry<R>,
-    unit: &Unit<R, R::Offset>,
-    context: &DebugInputContext<R>,
-) -> Result<String, Error>
-where
-    R: Reader,
-{
+fn get_base_type_name(
+    type_entry: &DebuggingInformationEntry<Reader<'_>>,
+    unit: &Unit<Reader<'_>, usize>,
+    context: &DebugInputContext<Reader<'_>>,
+) -> Result<String, Error> {
     // FIXME remove recursion.
     if let Some(AttributeValue::UnitRef(ref offset)) = type_entry.attr_value(gimli::DW_AT_type)? {
         let mut entries = unit.entries_at_offset(*offset)?;
@@ -107,20 +103,17 @@ enum WebAssemblyPtrKind {
 ///
 /// Notice that "resolve_vmctx_memory_ptr" is external/builtin
 /// subprogram that is not part of Wasm code.
-fn replace_pointer_type<R>(
+fn replace_pointer_type(
     parent_id: write::UnitEntryId,
     kind: WebAssemblyPtrKind,
     comp_unit: &mut write::Unit,
     wp_die_id: write::UnitEntryId,
-    pointer_type_entry: &DebuggingInformationEntry<R>,
-    unit: &Unit<R, R::Offset>,
-    context: &DebugInputContext<R>,
+    pointer_type_entry: &DebuggingInformationEntry<Reader<'_>>,
+    unit: &Unit<Reader<'_>, usize>,
+    context: &DebugInputContext<Reader<'_>>,
     out_strings: &mut write::StringTable,
     pending_die_refs: &mut PendingUnitRefs,
-) -> Result<write::UnitEntryId, Error>
-where
-    R: Reader,
-{
+) -> Result<write::UnitEntryId, Error> {
     const WASM_PTR_LEN: u8 = 4;
 
     macro_rules! add_tag {
@@ -245,7 +238,7 @@ where
     Ok(wrapper_die_id)
 }
 
-fn is_dead_code<R: Reader>(entry: &DebuggingInformationEntry<R>) -> bool {
+fn is_dead_code(entry: &DebuggingInformationEntry<Reader<'_>>) -> bool {
     const TOMBSTONE: u64 = u32::MAX as u64;
 
     match entry.attr_value(gimli::DW_AT_low_pc) {
@@ -254,24 +247,20 @@ fn is_dead_code<R: Reader>(entry: &DebuggingInformationEntry<R>) -> bool {
     }
 }
 
-pub(crate) fn clone_unit<'a, R>(
-    dwarf: &gimli::Dwarf<R>,
-    unit: &Unit<R, R::Offset>,
-    split_unit: Option<&Unit<R, R::Offset>>,
-    split_dwarf: Option<&gimli::Dwarf<R>>,
-    context: &DebugInputContext<R>,
-    addr_tr: &'a AddressTransform,
-    funcs: &'a CompiledFunctionsMetadata,
-    memory_offset: &ModuleMemoryOffset,
+pub(crate) fn clone_unit(
+    compilation: &mut Compilation<'_>,
+    module: StaticModuleIndex,
+    unit: &Unit<Reader<'_>, usize>,
+    split_unit: Option<&Unit<Reader<'_>, usize>>,
+    split_dwarf: Option<&gimli::Dwarf<Reader<'_>>>,
+    context: &DebugInputContext<Reader<'_>>,
+    addr_tr: &AddressTransform,
     out_encoding: gimli::Encoding,
     out_units: &mut write::UnitTable,
     out_strings: &mut write::StringTable,
-    translated: &mut HashSet<DefinedFuncIndex>,
+    translated: &mut HashSet<usize>,
     isa: &dyn TargetIsa,
-) -> Result<Option<(write::UnitId, UnitRefsMap, PendingDebugInfoRefs)>, Error>
-where
-    R: Reader,
-{
+) -> Result<Option<(write::UnitId, UnitRefsMap, PendingDebugInfoRefs)>, Error> {
     let mut die_ref_map = UnitRefsMap::new();
     let mut pending_die_refs = PendingUnitRefs::new();
     let mut pending_di_refs = PendingDebugInfoRefs::new();
@@ -290,6 +279,9 @@ where
             skeleton_die = Some(die_tuple.1);
         }
     }
+
+    let dwarf = &compilation.translations[module].debuginfo.dwarf;
+    let memory_offset = &compilation.module_memory_offsets[module];
 
     // Iterate over all of this compilation unit's entries.
     let mut entries = program_unit.entries();
@@ -403,12 +395,11 @@ where
             let range_builder = RangeInfoBuilder::from_subprogram_die(
                 dwarf, &unit, entry, context, addr_tr, cu_low_pc,
             )?;
-            if let RangeInfoBuilder::Function(func_index) = range_builder {
-                if let Some(frame_info) = get_function_frame_info(memory_offset, funcs, func_index)
-                {
-                    current_value_range.push(new_stack_len, frame_info);
-                }
-                translated.insert(func_index);
+            if let RangeInfoBuilder::Function(func) = range_builder {
+                let frame_info = compilation.function_frame_info(module, func);
+                current_value_range.push(new_stack_len, frame_info);
+                let (symbol, _) = compilation.function(module, func);
+                translated.insert(symbol);
                 current_scope_ranges.push(new_stack_len, range_builder.get_ranges(addr_tr));
                 Some(range_builder)
             } else {

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -1,12 +1,11 @@
 use super::address_transform::AddressTransform;
 use super::expression::{CompiledExpression, FunctionFrameInfo};
 use crate::debug::ModuleMemoryOffset;
-use crate::CompiledFunctionsMetadata;
 use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::write;
-use wasmtime_environ::DefinedFuncIndex;
 use wasmtime_versioned_export_macros::versioned_stringify_ident;
+
 ///Adds internal Wasm utility types DIEs such as WebAssemblyPtr and
 /// WasmtimeVMContext.
 ///
@@ -163,24 +162,4 @@ pub(crate) fn append_vmctx_info(
     var_die.set(gimli::DW_AT_location, loc);
 
     Ok(())
-}
-
-pub(crate) fn get_function_frame_info<'a, 'b, 'c>(
-    memory_offset: &ModuleMemoryOffset,
-    funcs: &'b CompiledFunctionsMetadata,
-    func_index: DefinedFuncIndex,
-) -> Option<FunctionFrameInfo<'a>>
-where
-    'b: 'a,
-    'c: 'a,
-{
-    if let Some(func) = funcs.get(func_index) {
-        let frame_info = FunctionFrameInfo {
-            value_ranges: &func.value_labels_ranges,
-            memory_offset: memory_offset.clone(),
-        };
-        Some(frame_info)
-    } else {
-        None
-    }
 }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -11,9 +11,7 @@ use cranelift_codegen::{
     settings, FinalizedMachReloc, FinalizedRelocTarget, MachTrap,
 };
 use cranelift_entity::PrimaryMap;
-use cranelift_wasm::{
-    DefinedFuncIndex, FuncIndex, WasmFuncType, WasmHeapTopType, WasmHeapType, WasmValType,
-};
+use cranelift_wasm::{FuncIndex, WasmFuncType, WasmHeapTopType, WasmHeapType, WasmValType};
 
 use target_lexicon::Architecture;
 use wasmtime_environ::{
@@ -33,8 +31,6 @@ mod compiler;
 mod debug;
 mod func_environ;
 mod gc;
-
-type CompiledFunctionsMetadata<'a> = PrimaryMap<DefinedFuncIndex, &'a CompiledFunctionMetadata>;
 
 /// Trap code used for debug assertions we emit in our JIT code.
 const DEBUG_ASSERT_TRAP_CODE: u16 = u16::MAX;

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::{obj, Tunables};
 use crate::{
     BuiltinFunctionIndex, DefinedFuncIndex, FlagValue, FuncIndex, FunctionLoc, ObjectKind,
-    PrimaryMap, WasmError, WasmFuncType, WasmFunctionInfo,
+    PrimaryMap, StaticModuleIndex, WasmError, WasmFuncType, WasmFunctionInfo,
 };
 use anyhow::Result;
 use object::write::{Object, SymbolId};
@@ -353,15 +353,20 @@ pub trait Compiler: Send + Sync {
     #[cfg(feature = "component-model")]
     fn component_compiler(&self) -> &dyn crate::component::ComponentCompiler;
 
-    /// Appends generated DWARF sections to the `obj` specified for the compiled
-    /// functions.
-    fn append_dwarf(
+    /// Appends generated DWARF sections to the `obj` specified.
+    ///
+    /// The `translations` track all compiled functions and `get_func` can be
+    /// used to acquire the metadata for a particular function within a module.
+    fn append_dwarf<'a>(
         &self,
         obj: &mut Object<'_>,
-        translation: &ModuleTranslation<'_>,
-        funcs: &PrimaryMap<DefinedFuncIndex, (SymbolId, &(dyn Any + Send))>,
-        dwarf_package_bytes: Option<&[u8]>,
-        tunables: &Tunables,
+        translations: &'a PrimaryMap<StaticModuleIndex, ModuleTranslation<'a>>,
+        get_func: &'a dyn Fn(
+            StaticModuleIndex,
+            DefinedFuncIndex,
+        ) -> (SymbolId, &'a (dyn Any + Send)),
+        dwarf_package_bytes: Option<&'a [u8]>,
+        tunables: &'a Tunables,
     ) -> Result<()>;
 
     /// Creates a new System V Common Information Entry for the ISA.

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -676,6 +676,12 @@ impl Module {
             func_ref: FuncRefIndex::reserved_value(),
         })
     }
+
+    /// Returns an iterator over all of the defined function indices in this
+    /// module.
+    pub fn defined_func_indices(&self) -> impl Iterator<Item = DefinedFuncIndex> {
+        (0..self.functions.len() - self.num_imported_funcs).map(|i| DefinedFuncIndex::new(i))
+    }
 }
 
 /// Type information about functions in a wasm module.

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -9,7 +9,7 @@ use wasmtime_cranelift::{CompiledFunction, ModuleTextBuilder};
 use wasmtime_environ::{
     AddressMapSection, BuiltinFunctionIndex, CompileError, DefinedFuncIndex, FunctionBodyData,
     FunctionLoc, ModuleTranslation, ModuleTypesBuilder, PrimaryMap, RelocationTarget,
-    TrapEncodingBuilder, Tunables, VMOffsets, WasmFunctionInfo,
+    StaticModuleIndex, TrapEncodingBuilder, Tunables, VMOffsets, WasmFunctionInfo,
 };
 use winch_codegen::{BuiltinFunctions, TargetIsa};
 
@@ -208,13 +208,16 @@ impl wasmtime_environ::Compiler for Compiler {
         self.trampolines.component_compiler()
     }
 
-    fn append_dwarf(
+    fn append_dwarf<'a>(
         &self,
         _obj: &mut Object<'_>,
-        _translation: &ModuleTranslation<'_>,
-        _funcs: &PrimaryMap<DefinedFuncIndex, (SymbolId, &(dyn Any + Send))>,
-        _dwarf_package: Option<&[u8]>,
-        _tunables: &wasmtime_environ::Tunables,
+        _translations: &'a PrimaryMap<StaticModuleIndex, ModuleTranslation<'a>>,
+        _get_func: &'a dyn Fn(
+            StaticModuleIndex,
+            DefinedFuncIndex,
+        ) -> (SymbolId, &'a (dyn Any + Send)),
+        _dwarf_package_bytes: Option<&'a [u8]>,
+        _tunables: &'a Tunables,
     ) -> Result<()> {
         todo!()
     }

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -356,7 +356,7 @@ check: exited with status = 0
     #[test]
     #[ignore]
     fn dwarf_simple() -> Result<()> {
-        for wasm in [DWARF_SIMPLE] {
+        for wasm in [DWARF_SIMPLE, DWARF_SIMPLE_COMPONENT] {
             test_dwarf_simple(wasm, &[])?;
         }
         Ok(())


### PR DESCRIPTION
This commit updates the native-DWARF processing (the `-D debug-info` CLI flag) to support components. Previously component support was not implemented and if there was more than one core wasm module within a component then dwarf would be ignored entirely.

This commit contains a number of refactorings to plumb a more full compilation context throughout the dwarf processing pipeline. Previously the data structures used only were able to support a single module. A new `Compilation` structure is used to represent the results of an entire compilation and is plumbed through the various locations. Most of the refactorings in this commit were then to extend loops to loop over more things and handle the case where there is more than one core wasm module.

I'll admit I'm not expert on DWARF but basic examples appear to work locally and most of the additions here seemed relatively straightforward in terms of "add another loop to iterate over more things" but I'm not 100% sure how well this will work. In theory this now supports concatenating DWARF sections across multiple core wasm modules, but that's not super well tested.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
