### PR TITLE
Allow empty block param lists in clif files

### DIFF
--- a/cranelift/filetests/filetests/parser/tiny.clif
+++ b/cranelift/filetests/filetests/parser/tiny.clif
@@ -10,6 +10,16 @@ block0:
 ; nextln:     trap user0
 ; nextln: }
 
+; The same small function, but with empty parens on the first block.
+function %minimal_empty_parens() {
+block0():
+    trap user0
+}
+; sameln: function %minimal_empty_parens() fast {
+; nextln: block0:
+; nextln:     trap user0
+; nextln: }
+
 ; Create and use values.
 ; Polymorphic instructions with type suffix.
 function %ivalues() {

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2043,13 +2043,18 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    // Parse parenthesized list of block parameters. Returns a vector of (u32, Type) pairs with the
-    // value numbers of the defined values and the defined types.
+    // Parse parenthesized list of block parameters.
     //
-    // block-params ::= * "(" block-param { "," block-param } ")"
+    // block-params ::= * "(" ( block-param { "," block-param } )? ")"
     fn parse_block_params(&mut self, ctx: &mut Context, block: Block) -> ParseResult<()> {
-        // block-params ::= * "(" block-param { "," block-param } ")"
+        // block-params ::= * "(" ( block-param { "," block-param } )? ")"
         self.match_token(Token::LPar, "expected '(' before block parameters")?;
+
+        // block-params ::= "(" * ")"
+        if self.token() == Some(Token::RPar) {
+            self.consume();
+            return Ok(());
+        }
 
         // block-params ::= "(" * block-param { "," block-param } ")"
         self.parse_block_param(ctx, block)?;


### PR DESCRIPTION
Allow block definitions to be parsed with empty parens, rather than requiring that there be a non-empty list of arguments if they're present.

```
function %f() {
block0():
    trap ud0
}
```

This is a pretty superficial change, but when iterating on clif files, it is nice to have to make fewer changes to get to a file that can make it through the pipeline.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
