### PR TITLE
Remove the last references to boolean types

### DIFF
--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -158,8 +158,6 @@ impl Type {
 
     /// Get a type with the same number of lanes as this type, but with the lanes replaced by
     /// integers of the same size.
-    ///
-    /// Scalar types follow this same rule, but `b1` is converted into `i8`
     pub fn as_int(self) -> Self {
         self.replace_lanes(match self.lane_type() {
             I8 => I8,

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -218,7 +218,7 @@ fn write_arg(w: &mut dyn Write, func: &Function, arg: Value) -> fmt::Result {
 ///
 ///    block1:
 ///    block1(v1: i32):
-///    block10(v4: f64, v5: b1):
+///    block10(v4: f64, v5: i8):
 ///
 pub fn write_block_header(
     w: &mut dyn Write,

--- a/cranelift/docs/compare-llvm.md
+++ b/cranelift/docs/compare-llvm.md
@@ -155,9 +155,9 @@ can hold.
 - Cranelift has no aggregate types. LLVM has named and anonymous struct types as
   well as array types.
 
-Cranelift has multiple boolean types, whereas LLVM simply uses `i1`. The sized
-Cranelift boolean types are used to represent SIMD vector masks like `b32x4`
-where each lane is either all 0 or all 1 bits.
+Cranelift uses integer-typed values of `0` or `1` for booleans, whereas LLVM
+simply uses `i1`. The sized Cranelift integer types are used to represent SIMD
+vector masks like `i32x4` where each lane is either all 0 or all 1 bits.
 
 Cranelift instructions and function calls can return multiple result values. LLVM
 instead models this by returning a single value of an aggregate type.

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -32,7 +32,7 @@ pub enum Token<'a> {
     Arrow,                 // '->'
     Float(&'a str),        // Floating point immediate
     Integer(&'a str),      // Integer immediate
-    Type(types::Type),     // i32, f32, b32x4, ...
+    Type(types::Type),     // i32, f32, i32x4, ...
     DynamicType(u32),      // dt5
     Value(Value),          // v12, v7
     Block(Block),          // block3


### PR DESCRIPTION
I grepped through the codebase for any remaining references to boolean types, and found a small handful. I've replaced them with the equivalent integer types, and updated docs as necessary.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
