### PR TITLE
Remove ArgumentPurpose::StackLimit

### DIFF
--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -250,12 +250,6 @@ pub enum ArgumentPurpose {
     /// This is a pointer to a context struct containing details about the current sandbox. It is
     /// used as a base pointer for `vmctx` global values.
     VMContext,
-
-    /// A stack limit pointer.
-    ///
-    /// This is a pointer to a stack limit. It is used to check the current stack pointer
-    /// against. Can only appear once in a signature.
-    StackLimit,
 }
 
 impl fmt::Display for ArgumentPurpose {
@@ -265,7 +259,6 @@ impl fmt::Display for ArgumentPurpose {
             Self::StructArgument(size) => return write!(f, "sarg({})", size),
             Self::StructReturn => "sret",
             Self::VMContext => "vmctx",
-            Self::StackLimit => "stack_limit",
         })
     }
 }
@@ -277,7 +270,6 @@ impl FromStr for ArgumentPurpose {
             "normal" => Ok(Self::Normal),
             "sret" => Ok(Self::StructReturn),
             "vmctx" => Ok(Self::VMContext),
-            "stack_limit" => Ok(Self::StackLimit),
             _ if s.starts_with("sarg(") => {
                 if !s.ends_with(")") {
                     return Err(());
@@ -374,7 +366,6 @@ mod tests {
             (ArgumentPurpose::Normal, "normal"),
             (ArgumentPurpose::StructReturn, "sret"),
             (ArgumentPurpose::VMContext, "vmctx"),
-            (ArgumentPurpose::StackLimit, "stack_limit"),
             (ArgumentPurpose::StructArgument(42), "sarg(42)"),
         ];
         for &(e, n) in &all_purpose {

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -166,9 +166,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
             if matches!(
                 param.purpose,
-                ir::ArgumentPurpose::StructArgument(_)
-                    | ir::ArgumentPurpose::StructReturn
-                    | ir::ArgumentPurpose::StackLimit
+                ir::ArgumentPurpose::StructArgument(_) | ir::ArgumentPurpose::StructReturn
             ) {
                 assert!(
                     call_conv != isa::CallConv::Tail,

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1164,13 +1164,9 @@ impl<M: ABIMachineSpec> Callee<M> {
         // stack limit. This can either be specified as a special-purpose
         // argument or as a global value which often calculates the stack limit
         // from the arguments.
-        let stack_limit =
-            get_special_purpose_param_register(f, sigs, sig, ir::ArgumentPurpose::StackLimit)
-                .map(|reg| (reg, smallvec![]))
-                .or_else(|| {
-                    f.stack_limit
-                        .map(|gv| gen_stack_limit::<M>(f, sigs, sig, gv))
-                });
+        let stack_limit = f
+            .stack_limit
+            .map(|gv| gen_stack_limit::<M>(f, sigs, sig, gv));
 
         let tail_args_size = sigs[sig].sized_stack_arg_space;
 

--- a/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
@@ -15,19 +15,6 @@ block0:
 ; block0: ; offset 0x0
 ;   ret
 
-function %stack_limit_leaf_zero(i64 stack_limit) {
-block0(v0: i64):
-    return
-}
-
-; VCode:
-; block0:
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   ret
-
 function %stack_limit_gv_leaf_zero(i64 vmctx) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0
@@ -44,42 +31,6 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
-
-function %stack_limit_call_zero(i64 stack_limit) {
-    fn0 = %foo()
-block0(v0: i64):
-    call fn0()
-    return
-}
-
-; VCode:
-;   stp fp, lr, [sp, #-16]!
-;   mov fp, sp
-;   add x16, x0, #16
-;   subs xzr, sp, x16, UXTX
-;   b.lo #trap=stk_ovf
-; block0:
-;   load_ext_name x0, TestCase(%foo)+0
-;   blr x0
-;   ldp fp, lr, [sp], #16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   stp x29, x30, [sp, #-0x10]!
-;   mov x29, sp
-;   add x16, x0, #0x10
-;   cmp sp, x16
-;   b.lo #0x30
-; block1: ; offset 0x14
-;   ldr x0, #0x1c
-;   b #0x24
-;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
-;   .byte 0x00, 0x00, 0x00, 0x00
-;   blr x0
-;   ldp x29, x30, [sp], #0x10
-;   ret
-;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
 
 function %stack_limit_gv_call_zero(i64 vmctx) {
     gv0 = vmctx
@@ -123,87 +74,6 @@ block0(v0: i64):
 ;   blr x0
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
-;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
-
-function %stack_limit(i64 stack_limit) {
-    ss0 = explicit_slot 168
-block0(v0: i64):
-    return
-}
-
-; VCode:
-;   stp fp, lr, [sp, #-16]!
-;   mov fp, sp
-;   add x16, x0, #176
-;   subs xzr, sp, x16, UXTX
-;   b.lo #trap=stk_ovf
-;   sub sp, sp, #176
-; block0:
-;   add sp, sp, #176
-;   ldp fp, lr, [sp], #16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   stp x29, x30, [sp, #-0x10]!
-;   mov x29, sp
-;   add x16, x0, #0xb0
-;   cmp sp, x16
-;   b.lo #0x24
-;   sub sp, sp, #0xb0
-; block1: ; offset 0x18
-;   add sp, sp, #0xb0
-;   ldp x29, x30, [sp], #0x10
-;   ret
-;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
-
-function %huge_stack_limit(i64 stack_limit) {
-    ss0 = explicit_slot 400000
-block0(v0: i64):
-    return
-}
-
-; VCode:
-;   stp fp, lr, [sp, #-16]!
-;   mov fp, sp
-;   subs xzr, sp, x0, UXTX
-;   b.lo #trap=stk_ovf
-;   movz w17, #6784
-;   movk w17, w17, #6, LSL #16
-;   add x16, x0, x17, UXTX
-;   subs xzr, sp, x16, UXTX
-;   b.lo #trap=stk_ovf
-;   movz w16, #6784
-;   movk w16, w16, #6, LSL #16
-;   sub sp, sp, x16, UXTX
-; block0:
-;   movz w16, #6784
-;   movk w16, w16, #6, LSL #16
-;   add sp, sp, x16, UXTX
-;   ldp fp, lr, [sp], #16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   stp x29, x30, [sp, #-0x10]!
-;   mov x29, sp
-;   cmp sp, x0
-;   b.lo #0x44
-;   mov w17, #0x1a80
-;   movk w17, #6, lsl #16
-;   add x16, x0, x17, uxtx
-;   cmp sp, x16
-;   b.lo #0x48
-;   mov w16, #0x1a80
-;   movk w16, #6, lsl #16
-;   sub sp, sp, x16
-; block1: ; offset 0x30
-;   mov w16, #0x1a80
-;   movk w16, #6, lsl #16
-;   add sp, sp, x16
-;   ldp x29, x30, [sp], #0x10
-;   ret
-;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
 
 function %limit_preamble(i64 vmctx) {

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -16,19 +16,6 @@ block0:
 ; block0: ; offset 0x0
 ;   ret
 
-function %stack_limit_leaf_zero(i64 stack_limit) {
-block0(v0: i64):
-    return
-}
-
-; VCode:
-; block0:
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   ret
-
 function %stack_limit_gv_leaf_zero(i64 vmctx) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0
@@ -44,49 +31,6 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ret
-
-function %stack_limit_call_zero(i64 stack_limit) {
-    fn0 = %foo()
-block0(v0: i64):
-    call fn0()
-    return
-}
-
-; VCode:
-;   addi sp,sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   addi t6,a0,16
-;   trap_if stk_ovf##(sp ult t6)
-; block0:
-;   load_sym a0,%foo+0
-;   callind a0
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   addi sp,sp,16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   addi t6, a0, 0x10
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-; block1: ; offset 0x1c
-;   auipc a0, 0
-;   ld a0, 0xc(a0)
-;   j 0xc
-;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
-;   .byte 0x00, 0x00, 0x00, 0x00
-;   jalr a0
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
 ;   ret
 
 function %stack_limit_gv_call_zero(i64 vmctx) {
@@ -135,104 +79,6 @@ block0(v0: i64):
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   jalr a0
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
-;   ret
-
-function %stack_limit(i64 stack_limit) {
-    ss0 = explicit_slot 168
-block0(v0: i64):
-    return
-}
-
-; VCode:
-;   addi sp,sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   addi t6,a0,176
-;   trap_if stk_ovf##(sp ult t6)
-;   addi sp,sp,-176
-; block0:
-;   addi sp,sp,176
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   addi sp,sp,16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   addi t6, a0, 0xb0
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-;   addi sp, sp, -0xb0
-; block1: ; offset 0x20
-;   addi sp, sp, 0xb0
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
-;   ret
-
-function %huge_stack_limit(i64 stack_limit) {
-    ss0 = explicit_slot 400000
-block0(v0: i64):
-    return
-}
-
-; VCode:
-;   addi sp,sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   trap_if stk_ovf##(sp ult a0)
-;   lui t5,98
-;   addi t5,t5,-1408
-;   add t6,t5,a0
-;   trap_if stk_ovf##(sp ult t6)
-;   lui a0,98
-;   addi a0,a0,-1408
-;   call %Probestack
-;   lui t6,-98
-;   addi t6,t6,1408
-;   add sp,sp,t6
-; block0:
-;   lui t6,98
-;   addi t6,t6,-1408
-;   add sp,sp,t6
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   addi sp,sp,16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   bgeu sp, a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-;   lui t5, 0x62
-;   addi t5, t5, -0x580
-;   add t6, t5, a0
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-;   lui a0, 0x62
-;   addi a0, a0, -0x580
-;   auipc ra, 0 ; reloc_external RiscvCallPlt %Probestack 0
-;   jalr ra
-;   lui t6, 0xfff9e
-;   addi t6, t6, 0x580
-;   add sp, sp, t6
-; block1: ; offset 0x48
-;   lui t6, 0x62
-;   addi t6, t6, -0x580
-;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
@@ -14,19 +14,6 @@ block0:
 ; block0: ; offset 0x0
 ;   br %r14
 
-function %stack_limit_leaf_zero(i64 stack_limit) {
-block0(v0: i64):
-    return
-}
-
-; VCode:
-; block0:
-;   br %r14
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   br %r14
-
 function %stack_limit_gv_leaf_zero(i64 vmctx) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0
@@ -42,41 +29,6 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   br %r14
-
-function %stack_limit_call_zero(i64 stack_limit) {
-    fn0 = %foo()
-block0(v0: i64):
-    call fn0()
-    return
-}
-
-; VCode:
-;   la %r1, 160(%r2)
-;   clgrtle %r15, %r1
-;   stmg %r14, %r15, 112(%r15)
-;   aghi %r15, -160
-; block0:
-;   bras %r1, 12 ; data %foo + 0 ; lg %r2, 0(%r1)
-;   basr %r14, %r2
-;   lmg %r14, %r15, 272(%r15)
-;   br %r14
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   la %r1, 0xa0(%r2)
-;   clgrtle %r15, %r1 ; trap: stk_ovf
-;   stmg %r14, %r15, 0x70(%r15)
-;   aghi %r15, -0xa0
-; block1: ; offset 0x12
-;   bras %r1, 0x1e
-;   .byte 0x00, 0x00 ; reloc_external Abs8 %foo 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   lg %r2, 0(%r1)
-;   basr %r14, %r2
-;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 
 function %stack_limit_gv_call_zero(i64 vmctx) {
@@ -120,81 +72,6 @@ block0(v0: i64):
 ;   lg %r2, 0(%r1)
 ;   basr %r14, %r2
 ;   lmg %r14, %r15, 0x110(%r15)
-;   br %r14
-
-function %stack_limit(i64 stack_limit) {
-    ss0 = explicit_slot 168
-block0(v0: i64):
-    return
-}
-
-; VCode:
-;   la %r1, 168(%r2)
-;   clgrtle %r15, %r1
-;   aghi %r15, -168
-; block0:
-;   aghi %r15, 168
-;   br %r14
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   la %r1, 0xa8(%r2)
-;   clgrtle %r15, %r1 ; trap: stk_ovf
-;   aghi %r15, -0xa8
-; block1: ; offset 0xc
-;   aghi %r15, 0xa8
-;   br %r14
-
-function %large_stack_limit(i64 stack_limit) {
-    ss0 = explicit_slot 400000
-block0(v0: i64):
-    return
-}
-
-; VCode:
-;   clgrtle %r15, %r2
-;   lay %r1, 400000(%r2)
-;   clgrtle %r15, %r1
-;   agfi %r15, -400000
-; block0:
-;   agfi %r15, 400000
-;   br %r14
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   clgrtle %r15, %r2 ; trap: stk_ovf
-;   lay %r1, 0x61a80(%r2)
-;   clgrtle %r15, %r1 ; trap: stk_ovf
-;   agfi %r15, -0x61a80
-; block1: ; offset 0x14
-;   agfi %r15, 0x61a80
-;   br %r14
-
-function %huge_stack_limit(i64 stack_limit) {
-    ss0 = explicit_slot 4000000
-block0(v0: i64):
-    return
-}
-
-; VCode:
-;   clgrtle %r15, %r2
-;   lgr %r1, %r2
-;   algfi %r1, 4000000
-;   clgrtle %r15, %r1
-;   agfi %r15, -4000000
-; block0:
-;   agfi %r15, 4000000
-;   br %r14
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   clgrtle %r15, %r2 ; trap: stk_ovf
-;   lgr %r1, %r2
-;   algfi %r1, 0x3d0900
-;   clgrtle %r15, %r1 ; trap: stk_ovf
-;   agfi %r15, -0x3d0900
-; block1: ; offset 0x18
-;   agfi %r15, 0x3d0900
 ;   br %r14
 
 function %limit_preamble(i64 vmctx) {

--- a/cranelift/filetests/filetests/parser/call.clif
+++ b/cranelift/filetests/filetests/parser/call.clif
@@ -84,11 +84,11 @@ block0:
 ; check: return
 
 ; Special purpose function arguments
-function %special1(i32 sret, i32 stack_limit) -> i32 vmctx {
-block0(v1: i32, v2: i32):
+function %special1(i32 sret) -> i32 vmctx {
+block0(v1: i32):
     return v1
 }
-; check: function %special1(i32 sret, i32 stack_limit) -> i32 vmctx fast {
-; check: block0(v1: i32, v2: i32):
+; check: function %special1(i32 sret) -> i32 vmctx fast {
+; check: block0(v1: i32):
 ; check:     return v1
 ; check: }


### PR DESCRIPTION
The special `stack_limit` argument annotation is currently unused, so let's remove it. I have grepped through the cg clif source and didn't find anything that obviously relied on this annotation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
