### PR TITLE
riscv64: Special-case `f32const 0` and `f64const 0`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1836,12 +1836,10 @@
 ;; TODO: Load floats using `fld` instead of `ld`
 (decl imm (Type u64) Reg)
 
-;; Special-case 0.0 for floats to use the `(zero_reg)` directly. This
-;; additionally goes ahead and clears out the entire destination register to
-;; avoid any false dependencies from unset bits. See #7162 for
-;; why this doesn't fall out of the rules below.
-(rule 8 (imm (ty_scalar_float ty) 0)
-  (gen_bitcast (zero_reg) $I64 $F64))
+;; Special-case 0.0 for floats to use the `(zero_reg)` directly.
+;; See #7162 for why this doesn't fall out of the rules below.
+(rule 8 (imm $F32 0) (gen_bitcast (zero_reg) $I32 $F32))
+(rule 8 (imm $F64 0) (gen_bitcast (zero_reg) $I64 $F64))
 
 ;; If Zfa is enabled, we can load certain constants with the `fli` instruction.
 (rule 7 (imm (ty_scalar_float ty) imm)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1836,6 +1836,13 @@
 ;; TODO: Load floats using `fld` instead of `ld`
 (decl imm (Type u64) Reg)
 
+;; Special-case 0.0 for floats to use the `(zero_reg)` directly. This
+;; additionally goes ahead and clears out the entire destination register to
+;; avoid any false dependencies from unset bits. See #7162 for
+;; why this doesn't fall out of the rules below.
+(rule 8 (imm (ty_scalar_float ty) 0)
+  (gen_bitcast (zero_reg) $I64 $F64))
+
 ;; If Zfa is enabled, we can load certain constants with the `fli` instruction.
 (rule 7 (imm (ty_scalar_float ty) imm)
   (if-let $true (has_zfa))

--- a/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
@@ -22,7 +22,7 @@ block1(v4: f32):
 ; VCode:
 ; block0:
 ;   li a0,0
-;   fmv.d.x fa1,zero
+;   fmv.w.x fa1,zero
 ;   fmv.x.w a5,fa1
 ;   not a1,a5
 ;   fmv.w.x fa3,a1
@@ -42,7 +42,7 @@ block1(v4: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero
-;   fmv.d.x fa1, zero
+;   fmv.w.x fa1, zero
 ;   fmv.x.w a5, fa1
 ;   not a1, a5
 ;   fmv.w.x fa3, a1

--- a/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
@@ -22,20 +22,19 @@ block1(v4: f32):
 ; VCode:
 ; block0:
 ;   li a0,0
-;   li a1,0
+;   fmv.d.x fa1,zero
+;   fmv.x.w a5,fa1
+;   not a1,a5
 ;   fmv.w.x fa3,a1
+;   fmv.x.w a4,fa3
 ;   fmv.x.w a1,fa3
-;   not a2,a1
-;   fmv.w.x fa4,a2
-;   fmv.x.w a5,fa4
-;   fmv.x.w a1,fa4
-;   or a3,a5,a1
-;   fmv.w.x fa4,a3
-;   br_table a0,[MachLabel(1),MachLabel(2)]##tmp1=a1,tmp2=a2
+;   or a2,a4,a1
+;   fmv.w.x fa2,a2
+;   br_table a0,[MachLabel(1),MachLabel(2)]##tmp1=a2,tmp2=a1
 ; block1:
 ;   j label3
 ; block2:
-;   fmv.d fa4,fa3
+;   fmv.d fa2,fa1
 ;   j label3
 ; block3:
 ;   ret
@@ -43,31 +42,30 @@ block1(v4: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero
-;   mv a1, zero
+;   fmv.d.x fa1, zero
+;   fmv.x.w a5, fa1
+;   not a1, a5
 ;   fmv.w.x fa3, a1
+;   fmv.x.w a4, fa3
 ;   fmv.x.w a1, fa3
-;   not a2, a1
-;   fmv.w.x fa4, a2
-;   fmv.x.w a5, fa4
-;   fmv.x.w a1, fa4
-;   or a3, a5, a1
-;   fmv.w.x fa4, a3
+;   or a2, a4, a1
+;   fmv.w.x fa2, a2
 ;   slli t6, a0, 0x20
 ;   srli t6, t6, 0x20
-;   addi a2, zero, 1
-;   bltu t6, a2, 0xc
-;   auipc a2, 0
-;   jalr zero, a2, 0x28
+;   addi a1, zero, 1
+;   bltu t6, a1, 0xc
 ;   auipc a1, 0
-;   slli a2, t6, 3
-;   add a1, a1, a2
-;   jalr zero, a1, 0x10
+;   jalr zero, a1, 0x28
 ;   auipc a2, 0
-;   jalr zero, a2, 0xc
-; block1: ; offset 0x58
+;   slli a1, t6, 3
+;   add a2, a2, a1
+;   jalr zero, a2, 0x10
+;   auipc a1, 0
+;   jalr zero, a1, 0xc
+; block1: ; offset 0x54
 ;   j 8
-; block2: ; offset 0x5c
-;   fmv.d fa4, fa3
-; block3: ; offset 0x60
+; block2: ; offset 0x58
+;   fmv.d fa2, fa1
+; block3: ; offset 0x5c
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/constants.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/constants.clif
@@ -426,14 +426,12 @@ block0:
 
 ; VCode:
 ; block0:
-;   li a0,0
-;   fmv.d.x fa0,a0
+;   fmv.d.x fa0,zero
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv a0, zero
-;   fmv.d.x fa0, a0
+;   fmv.d.x fa0, zero
 ;   ret
 
 function %f() -> f32 {
@@ -444,14 +442,12 @@ block0:
 
 ; VCode:
 ; block0:
-;   li a0,0
-;   fmv.w.x fa0,a0
+;   fmv.d.x fa0,zero
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv a0, zero
-;   fmv.w.x fa0, a0
+;   fmv.d.x fa0, zero
 ;   ret
 
 function %f() -> f64 {

--- a/cranelift/filetests/filetests/isa/riscv64/constants.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/constants.clif
@@ -442,12 +442,12 @@ block0:
 
 ; VCode:
 ; block0:
-;   fmv.d.x fa0,zero
+;   fmv.w.x fa0,zero
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fmv.d.x fa0, zero
+;   fmv.w.x fa0, zero
 ;   ret
 
 function %f() -> f64 {

--- a/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
@@ -14,10 +14,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   li a1,0
-;   fmv.d.x fa3,a1
-;   fle.d a2,fa3,fa3
-;   beq a2,zero,taken(label1),not_taken(label2)
+;   fmv.d.x fa1,zero
+;   fle.d a1,fa1,fa1
+;   beq a1,zero,taken(label1),not_taken(label2)
 ; block1:
 ;   j label3
 ; block2:
@@ -27,10 +26,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv a1, zero
-;   fmv.d.x fa3, a1
-;   fle.d a2, fa3, fa3
-; block1: ; offset 0xc
+;   fmv.d.x fa1, zero
+;   fle.d a1, fa1, fa1
+; block1: ; offset 0x8
 ;   ret
 
 function %f1() {
@@ -45,10 +43,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   li a1,0
-;   fmv.d.x fa3,a1
-;   fle.d a2,fa3,fa3
-;   beq a2,zero,taken(label1),not_taken(label2)
+;   fmv.d.x fa1,zero
+;   fle.d a1,fa1,fa1
+;   beq a1,zero,taken(label1),not_taken(label2)
 ; block1:
 ;   j label3
 ; block2:
@@ -58,10 +55,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv a1, zero
-;   fmv.d.x fa3, a1
-;   fle.d a2, fa3, fa3
-; block1: ; offset 0xc
+;   fmv.d.x fa1, zero
+;   fle.d a1, fa1, fa1
+; block1: ; offset 0x8
 ;   ret
 
 function %ord(f32, f32) -> i8 {


### PR DESCRIPTION
This commit is inspired by discussion on #8695 which made me remember the discussion around #7162 historically. In lieu of a deeper fix for the issue of "why can't `iconst 0` use `(zero_reg)`" it's still possible to add special-cases to rules throughout the backend so this commit does that for generating zero-value floats.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
