### PR TITLE
Revert "Use `[su]extend_maybe` in the `iconst_[su]` extractors (#8686)"

### DIFF
--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -74,7 +74,7 @@
 ;; When constructing, the rule will fail if the value cannot be represented in
 ;; the target type.  If it fits, it'll be masked accordingly in the constant.
 (decl iconst_s (Type i64) Value)
-(extractor (iconst_s ty c) (sextend_maybe ty (inst_data_tupled (iconst_sextend_etor _inner_ty c))))
+(extractor (iconst_s ty c) (inst_data_tupled (iconst_sextend_etor ty c)))
 (rule 0 (iconst_s ty c)
 	(if-let c_masked (u64_and (i64_as_u64 c) (ty_umax ty)))
 	(if-let c_reextended (i64_sextend_u64 ty c_masked))
@@ -89,7 +89,7 @@
 ;; When constructing, the rule will fail if the value cannot be represented in
 ;; the target type.
 (decl iconst_u (Type u64) Value)
-(extractor (iconst_u ty c) (uextend_maybe ty (iconst _inner_ty (u64_from_imm64 c))))
+(extractor (iconst_u ty c) (iconst ty (u64_from_imm64 c)))
 (rule 0 (iconst_u ty c)
 	(if-let $true (u64_le c (ty_umax ty)))
     (iconst ty (imm64 c)))

--- a/cranelift/filetests/filetests/egraph/i128-opts.clif
+++ b/cranelift/filetests/filetests/egraph/i128-opts.clif
@@ -135,3 +135,23 @@ block0:
     ; check: v4 = iadd v1, v3
     ; check: return v4
 }
+
+function %slt() -> i8 {
+block0:
+    v0 = iconst.i64 0
+    v1 = uextend.i128 v0
+    v2 = icmp slt v1, v1
+    return v2
+    ; check: v3 = iconst.i8 0
+    ; check: return
+}
+
+function %ult() -> i8 {
+block0:
+    v0 = iconst.i64 0
+    v1 = uextend.i128 v0
+    v2 = icmp ult v1, v1
+    return v2
+    ; check: v3 = iconst.i8 0
+    ; check: return
+}

--- a/cranelift/filetests/filetests/egraph/i128-opts.clif
+++ b/cranelift/filetests/filetests/egraph/i128-opts.clif
@@ -135,23 +135,3 @@ block0:
     ; check: v4 = iadd v1, v3
     ; check: return v4
 }
-
-function %mul_2u_i128(i128) -> i128 {
-block0(v0: i128):
-    v1 = iconst.i16 2
-    v2 = uextend.i128 v1
-    v3 = imul v0, v2
-    return v3
-    ; check: v4 = iadd v0, v0
-    ; check: return v4
-}
-
-function %mul_neg1_i128(i128) -> i128 {
-block0(v0: i128):
-    v1 = iconst.i16 -1
-    v2 = sextend.i128 v1
-    v3 = imul v0, v2
-    return v3
-    ; check: v4 = ineg v0
-    ; check: return v4
-}


### PR DESCRIPTION
This reverts commit 66f499f43c793bd0f31e4ce5cc0f98c41e6cf9d9. Additionally this commit adds in tests from #8690 so if #8686 is redone the tests will fail as-is.

Closes #8690