### PR TITLE
Enable all features for docs.rs documentation

### DIFF
--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -13,6 +13,9 @@ edition.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 anyhow = { workspace = true }
 postcard = { workspace = true }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -14,10 +14,7 @@ rust-version.workspace = true
 workspace = true
 
 [package.metadata.docs.rs]
-# Docs.rs will use the `component-model` feature for documentation;
-# so this feature also passed in to the `cargo doc` invocation in CI.
-# See .github/workflows/main.yml
-features = ["component-model"]
+all-features = true
 
 [dependencies]
 wasmtime-asm-macros = { workspace = true, optional = true }


### PR DESCRIPTION
This commit switches to add `all-features = true` for both the `wasmtime` and `wasmtime-environ` crates on docs.rs. I occasionally look at `wasmtime-environ` online as it can be helpful for exploration and otherwise the docs are empty by default. Otherwise using `all-features` for Wasmtime also includes APIs specific to Winch, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
