### PR TITLE
Enable rustc's `unused-lifetimes` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ unused_extern_crates = 'warn'
 trivial_numeric_casts = 'warn'
 unstable_features = 'warn'
 unused_import_braces = 'warn'
+unused-lifetimes = 'warn'
 
 [workspace.lints.clippy]
 # The default set of lints in Clippy is viewed as "too noisy" right now so

--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -20,7 +20,7 @@ fn instantiate(pre: &InstancePre<WasiCtx>, engine: &Engine) -> Result<()> {
     Ok(())
 }
 
-fn benchmark_name<'a>(strategy: &InstanceAllocationStrategy) -> &'static str {
+fn benchmark_name(strategy: &InstanceAllocationStrategy) -> &'static str {
     match strategy {
         InstanceAllocationStrategy::OnDemand => "default",
         InstanceAllocationStrategy::Pooling { .. } => "pooling",

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1087,7 +1087,7 @@ fn checked_round_up(val: u32, mask: u32) -> Option<u32> {
 
 impl<M: ABIMachineSpec> Callee<M> {
     /// Create a new body ABI instance.
-    pub fn new<'a>(
+    pub fn new(
         f: &ir::Function,
         isa: &dyn TargetIsa,
         isa_flags: &M::F,

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -179,7 +179,7 @@ pub fn parse_test<'a>(text: &'a str, options: ParseOptions<'a>) -> ParseResult<T
 ///    or `print`
 ///  - `Ok(Some(command))` if the comment is intended as a `RunCommand` and can be parsed to one
 ///  - `Err` otherwise.
-pub fn parse_run_command<'a>(text: &str, signature: &Signature) -> ParseResult<Option<RunCommand>> {
+pub fn parse_run_command(text: &str, signature: &Signature) -> ParseResult<Option<RunCommand>> {
     let _tt = timing::parse_text();
     // We remove leading spaces and semi-colons for convenience here instead of at the call sites
     // since this function will be attempting to parse a RunCommand from a CLIF comment.

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -27,7 +27,7 @@ struct Sha256Hasher(Sha256);
 
 impl<'config> ModuleCacheEntry<'config> {
     /// Create the cache entry.
-    pub fn new<'data>(compiler_name: &str, cache_config: &'config CacheConfig) -> Self {
+    pub fn new(compiler_name: &str, cache_config: &'config CacheConfig) -> Self {
         if cache_config.enabled() {
             Self(Some(ModuleCacheEntryInner::new(
                 compiler_name,
@@ -108,7 +108,7 @@ impl<'config> ModuleCacheEntry<'config> {
 }
 
 impl<'config> ModuleCacheEntryInner<'config> {
-    fn new<'data>(compiler_name: &str, cache_config: &'config CacheConfig) -> Self {
+    fn new(compiler_name: &str, cache_config: &'config CacheConfig) -> Self {
         // If debug assertions are enabled then assume that we're some sort of
         // local build. We don't want local builds to stomp over caches between
         // builds, so just use a separate cache directory based on the mtime of

--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -132,7 +132,7 @@ fn read_dwarf_package_from_bytes<'data>(
     }
 }
 
-pub fn transform_dwarf<'data>(
+pub fn transform_dwarf(
     isa: &dyn TargetIsa,
     di: &DebugInfoData,
     funcs: &CompiledFunctionsMetadata,

--- a/crates/cranelift/src/debug/write_debuginfo.rs
+++ b/crates/cranelift/src/debug/write_debuginfo.rs
@@ -140,7 +140,7 @@ impl Writer for WriterRelocate {
     }
 }
 
-fn create_frame_table<'a>(
+fn create_frame_table(
     isa: &dyn TargetIsa,
     funcs: &CompiledFunctionsMetadata,
 ) -> Option<FrameTable> {
@@ -174,7 +174,7 @@ fn create_frame_table<'a>(
     Some(table)
 }
 
-pub fn emit_dwarf<'a>(
+pub fn emit_dwarf(
     isa: &dyn TargetIsa,
     debuginfo_data: &DebugInfoData,
     funcs: &CompiledFunctionsMetadata,

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -4,7 +4,7 @@ use anyhow::ensure;
 use wasmtime::*;
 
 /// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_linker<'module, T>(store: &mut Store<T>, module: &Module) -> Result<Linker<T>> {
+pub fn dummy_linker<T>(store: &mut Store<T>, module: &Module) -> Result<Linker<T>> {
     let mut linker = Linker::new(store.engine());
     linker.allow_shadowing(true);
     for import in module.imports() {

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -35,7 +35,7 @@ mod gen {
     }
 
     /// Convert the host errors to their WITX-generated type.
-    impl<'a> types::UserErrorConversion for WasiNnCtx {
+    impl types::UserErrorConversion for WasiNnCtx {
         fn nn_errno_from_wasi_nn_error(
             &mut self,
             e: WasiNnError,
@@ -51,8 +51,8 @@ mod gen {
 }
 
 /// Wire up the WITX-generated trait to the `wasi-nn` host state.
-impl<'a> gen::wasi_ephemeral_nn::WasiEphemeralNn for WasiNnCtx {
-    fn load<'b>(
+impl gen::wasi_ephemeral_nn::WasiEphemeralNn for WasiNnCtx {
+    fn load(
         &mut self,
         builders: &gen::types::GraphBuilderArray<'_>,
         encoding: gen::types::GraphEncoding,
@@ -128,7 +128,7 @@ impl<'a> gen::wasi_ephemeral_nn::WasiEphemeralNn for WasiNnCtx {
         }
     }
 
-    fn get_output<'b>(
+    fn get_output(
         &mut self,
         exec_context_id: gen::types::GraphExecutionContext,
         index: u32,

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -122,7 +122,7 @@ pub(crate) fn build_artifacts<T: FinishedObject>(
 /// The output artifact here is the serialized object file contained within
 /// an owned mmap along with metadata about the compilation itself.
 #[cfg(feature = "component-model")]
-pub(crate) fn build_component_artifacts<'a, T: FinishedObject>(
+pub(crate) fn build_component_artifacts<T: FinishedObject>(
     engine: &Engine,
     binary: &[u8],
     _dwarf_package: Option<&[u8]>,

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -533,7 +533,7 @@ unsafe impl WasmTy for Func {
     }
 
     #[inline]
-    fn compatible_with_store<'a>(&self, store: &StoreOpaque) -> bool {
+    fn compatible_with_store(&self, store: &StoreOpaque) -> bool {
         store.store_data().contains(self.0)
     }
 
@@ -571,7 +571,7 @@ unsafe impl WasmTy for Option<Func> {
     }
 
     #[inline]
-    fn compatible_with_store<'a>(&self, store: &StoreOpaque) -> bool {
+    fn compatible_with_store(&self, store: &StoreOpaque) -> bool {
         if let Some(f) = self {
             store.store_data().contains(f.0)
         } else {

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -227,7 +227,7 @@ pub(crate) enum TrapTest {
 /// returning them as a `Result`.
 ///
 /// Highly unsafe since `closure` won't have any dtors run.
-pub unsafe fn catch_traps<'a, F>(
+pub unsafe fn catch_traps<F>(
     signal_handler: Option<*const SignalHandler<'static>>,
     capture_backtrace: bool,
     capture_coredump: bool,


### PR DESCRIPTION
This is allow-by-default doesn't seem to have any false positives in Wasmtime's codebase so enable it by default to help clean up vestiges of old refactorings.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
