### PR TITLE
Allow graphic ASCII characters in symbol names

### DIFF
--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -413,11 +413,12 @@ impl<'a> CompileInputs<'a> {
         /// Maximum length of symbols generated in objects.
         const MAX_SYMBOL_LEN: usize = 96;
 
-        // Just to be on the safe side, avoid passing user-provided data to tools
-        // like "perf" or "objdump", and filter the name.  Let only characters usually
-        // used for function names, plus some characters that might be used in name
-        // mangling.
-        let bad_char = |c: char| !c.is_ascii_alphanumeric() && !r"<>[]_-:@$".contains(c);
+        // Just to be on the safe side, filter out characters that could
+        // pose issues to tools such as "perf" or "objdump".  To avoid
+        // having to update a list of allowed characters for each different
+        // language that compiles to Wasm, allows only graphic ASCII
+        // characters; replace runs of everything else with a "?".
+        let bad_char = |c: char| !c.is_ascii_graphic();
         if name.chars().any(bad_char) {
             let mut last_char_seen = '\u{0000}';
             Cow::Owned(


### PR DESCRIPTION
The original idea of the filtering here was to avoid passing characters such as the NUL byte, whitespaces, or other things that could cause issues to tools that will consume this data.  Since it's impractical to update the list of allowed characters every time a language that
compiles to Wasm generates symbols slightly differently, allow all graphic ASCII characters instead.

(Tests don't need updating.)