### PR TITLE
Always generate the same output structure with `bindgen!`

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -154,6 +154,7 @@ impl Parse for Config {
                     Opt::Features(f) => {
                         features.extend(f.into_iter().map(|f| f.value()));
                     }
+                    Opt::RequireStoreDataSend(val) => opts.require_store_data_send = val,
                 }
             }
         } else {
@@ -228,6 +229,7 @@ mod kw {
     syn::custom_keyword!(stringify);
     syn::custom_keyword!(skip_mut_forwarding_impls);
     syn::custom_keyword!(features);
+    syn::custom_keyword!(require_store_data_send);
 }
 
 enum Opt {
@@ -245,6 +247,7 @@ enum Opt {
     Stringify(bool),
     SkipMutForwardingImpls(bool),
     Features(Vec<syn::LitStr>),
+    RequireStoreDataSend(bool),
 }
 
 impl Parse for Opt {
@@ -402,6 +405,12 @@ impl Parse for Opt {
             syn::bracketed!(contents in input);
             let list = Punctuated::<_, Token![,]>::parse_terminated(&contents)?;
             Ok(Opt::Features(list.into_iter().collect()))
+        } else if l.peek(kw::require_store_data_send) {
+            input.parse::<kw::require_store_data_send>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::RequireStoreDataSend(
+                input.parse::<syn::LitBool>()?.value,
+            ))
         } else {
             Err(l.error())
         }

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -574,3 +574,78 @@ mod custom_derives {
         }
     }
 }
+
+mod with_and_mixing_async {
+    mod with_async {
+        wasmtime::component::bindgen!({
+            inline: "
+                package my:inline;
+                interface foo {
+                    type t = u32;
+                    foo: func() -> t;
+                }
+                interface bar {
+                    use foo.{t};
+                    bar: func() -> t;
+                }
+                world x {
+                    import bar;
+                }
+            ",
+            async: {
+                only_imports: ["bar"],
+            },
+        });
+    }
+
+    mod without_async {
+        wasmtime::component::bindgen!({
+            inline: "
+                package my:inline;
+                interface foo {
+                    type t = u32;
+                    foo: func() -> t;
+                }
+                interface bar {
+                    use foo.{t};
+                    bar: func() -> t;
+                }
+                world x {
+                    import bar;
+                }
+            ",
+            with: {
+                "my:inline/foo": super::with_async::my::inline::foo,
+            },
+            require_store_data_send: true,
+        });
+    }
+
+    mod third {
+        wasmtime::component::bindgen!({
+            inline: "
+                package my:inline;
+                interface foo {
+                    type t = u32;
+                    foo: func() -> t;
+                }
+                interface bar {
+                    use foo.{t};
+                    bar: func() -> t;
+                }
+                interface baz {
+                    use bar.{t};
+                    baz: func() -> t;
+                }
+                world x {
+                    import baz;
+                }
+            ",
+            with: {
+                "my:inline/foo": super::with_async::my::inline::foo,
+                "my:inline/bar": super::without_async::my::inline::bar,
+            },
+            require_store_data_send: true,
+        });
+    }
+}

--- a/crates/wasi-http/src/proxy.rs
+++ b/crates/wasi-http/src/proxy.rs
@@ -136,9 +136,10 @@ pub mod sync {
             async: false,
             with: {
                 "wasi:http": crate::bindings::http, // http is in this crate
-                "wasi:io": wasmtime_wasi::bindings::sync, // io is sync
+                "wasi:io": wasmtime_wasi::bindings::sync::io, // io is sync
                 "wasi": wasmtime_wasi::bindings, // everything else
             },
+            require_store_data_send: true,
         });
     }
 

--- a/crates/wasi/src/bindings.rs
+++ b/crates/wasi/src/bindings.rs
@@ -34,6 +34,7 @@ pub mod sync {
                 "wasi:io/streams/input-stream": super::super::io::streams::InputStream,
                 "wasi:io/streams/output-stream": super::super::io::streams::OutputStream,
             },
+            require_store_data_send: true,
         });
     }
     pub use self::generated::exports;

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -529,6 +529,12 @@ pub(crate) use self::store::ComponentStoreData;
 ///     //
 ///     // This option defaults to an empty array.
 ///     features: ["foo", "bar", "baz"],
+///
+///     // An niche configuration option to require that the `T` in `Store<T>`
+///     // is always `Send` in the generated bindings. Typically not needed
+///     // but if synchronous bindings depend on asynchronous bindings using
+///     // the `with` key then this may be required.
+///     require_store_data_send: false,
 /// });
 /// ```
 pub use wasmtime_component_macro::bindgen;


### PR DESCRIPTION
Currently with the `bindgen!` macro when the `with` key is used then the generated bindings are different than if the `with` key was not used. Not only for replacement purposes but the generated bindings are missing two key pieces:

* In the generated `add_to_linker` functions bounds and invocations of `with`-overridden interfaces are all missing. This means that the generated `add_to_linker` functions don't actually represent the full world.

* The generated module hierarchy has "holes" for all the modules that are overridden. While it's mostly a minor inconvenience it's also easy enough to generate everything via `pub use` to have everything hooked up correctly.

After this PR it means that each `bindgen!` macro should, in isolation, work for any other `bindgen!` macro invocation. It shouldn't be necessary to weave things together and remember how each macro was invoked along the way. This is primarily to unblock #8715 which is running into a case where tcp/udp are generated as sync but their dependency, `wasi:sockets/network`, is used from an upstream async version. The generated `add_to_linker` does not compile because tcp/udp depend on `wasi:sockets/network` isn't added to the linker. After fixing that it then required more modules to be generated, hence this PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
