### PR TITLE
docs: Fix small typo in externref docs

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -25,7 +25,7 @@ use core::mem::MaybeUninit;
 /// operations that Wasm can perform on them via what functions you allow Wasm
 /// to import.
 ///
-/// Like all WebAssembly references, these are opaque and unforgable to Wasm:
+/// Like all WebAssembly references, these are opaque and unforgeable to Wasm:
 /// they cannot be faked and Wasm cannot, for example, cast the integer
 /// `0x12345678` into a reference, pretend it is a valid `externref`, and trick
 /// the host into dereferencing it and segfaulting or worse.


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
