### PR TITLE
wasi-http: Add Send bound to WasiHttpView

### DIFF
--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -30,7 +30,7 @@ impl WasiHttpCtx {
 }
 
 /// A trait which provides internal WASI HTTP state.
-pub trait WasiHttpView {
+pub trait WasiHttpView: Send {
     /// Returns a mutable reference to the WASI HTTP context.
     fn ctx(&mut self) -> &mut WasiHttpCtx;
 


### PR DESCRIPTION
This is practically always desired and its absence has caused some downstream integration headaches.