### PR TITLE
Make an HTTP test more robust to failure

### DIFF
--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -535,7 +535,7 @@ async fn wasi_http_without_port() -> Result<()> {
         .method(http::Method::GET)
         .uri("https://httpbin.org/get");
 
-    let response = run_wasi_http(
+    let _response: hyper::Response<_> = run_wasi_http(
         test_programs_artifacts::API_PROXY_FORWARD_REQUEST_COMPONENT,
         req.body(body::empty())?,
         None,
@@ -543,7 +543,10 @@ async fn wasi_http_without_port() -> Result<()> {
     )
     .await??;
 
-    assert_eq!(response.status(), StatusCode::OK);
+    // NB: don't test the actual return code of `response`. This is testing a
+    // live http request against a live server and things happen. If we got this
+    // far it's already successful that the request was made and the lack of
+    // port in the URI was handled.
 
     Ok(())
 }


### PR DESCRIPTION
This handles flakiness [seen online] and makes the test more robust. It was known that this test was not "fully robust" when added in #8671 and this is the "work over time" to handle failures we see in the wild.

[seen online]: https://github.com/bytecodealliance/wasmtime/actions/runs/9324271722/job/25669233977

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
