### PR TITLE
README: fix link of "Standards Compliant" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ command may not install the target for the correct copy of Rust.)
 [Secure]: https://docs.wasmtime.dev/security.html
 [Configurable]: https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html
 [WASI]: https://docs.rs/wasmtime-wasi/latest/wasmtime_wasi/
-[Standards Compliant]: https://docs.wasmtime.dev/stability-wasm-proposals-support.html
+[Standards Compliant]: https://docs.wasmtime.dev/stability-tiers.html
 
 ## Language Support
 


### PR DESCRIPTION
to point to https://docs.wasmtime.dev/stability-tiers.html

Closes https://github.com/bytecodealliance/wasmtime/issues/8729

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
