### PR TITLE
Update object to 0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-module",
  "log",
- "object 0.33.0",
+ "object 0.36.0",
  "target-lexicon",
 ]
 
@@ -1862,7 +1862,7 @@ version = "22.0.0"
 dependencies = [
  "anyhow",
  "libloading",
- "object 0.33.0",
+ "object 0.36.0",
  "wasmtime",
 ]
 
@@ -1932,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.3",
@@ -3184,7 +3184,7 @@ version = "22.0.0"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
- "object 0.33.0",
+ "object 0.36.0",
  "wasi",
  "wasm-encoder",
  "wit-bindgen-rust-macro",
@@ -3392,7 +3392,7 @@ dependencies = [
  "mach2",
  "memfd",
  "memoffset",
- "object 0.33.0",
+ "object 0.36.0",
  "once_cell",
  "paste",
  "postcard",
@@ -3537,7 +3537,7 @@ dependencies = [
  "log",
  "memchr",
  "num_cpus",
- "object 0.33.0",
+ "object 0.36.0",
  "once_cell",
  "rayon",
  "rustix",
@@ -3624,7 +3624,7 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "log",
- "object 0.33.0",
+ "object 0.36.0",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -3644,7 +3644,7 @@ dependencies = [
  "gimli",
  "indexmap 2.2.6",
  "log",
- "object 0.33.0",
+ "object 0.36.0",
  "postcard",
  "rustc-demangle",
  "serde",
@@ -3761,7 +3761,7 @@ dependencies = [
 name = "wasmtime-jit-debug"
 version = "22.0.0"
 dependencies = [
- "object 0.33.0",
+ "object 0.36.0",
  "once_cell",
  "rustix",
  "wasmtime-versioned-export-macros",
@@ -3916,7 +3916,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli",
- "object 0.33.0",
+ "object 0.36.0",
  "target-lexicon",
  "wasmparser",
  "wasmtime-cranelift",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ wit-component = "0.209.1"
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
 cc = "1.0"
-object = { version = "0.33", default-features = false, features = ['read_core', 'elf'] }
+object = { version = "0.36", default-features = false, features = ['read_core', 'elf'] }
 gimli = { version = "0.28.0", default-features = false, features = ['read'] }
 addr2line = { version = "0.21.0", default-features = false }
 anyhow = { version = "1.0.22", default-features = false }

--- a/crates/wasmtime/src/runtime/debug.rs
+++ b/crates/wasmtime/src/runtime/debug.rs
@@ -127,7 +127,7 @@ fn convert_object_elf_to_loadable_file<E: Endian>(
     let text_range = match sections.section_by_name(e, b".text") {
         Some((i, text)) => {
             let range = text.file_range(e);
-            let off = header.e_shoff.get(e) as usize + i * header.e_shentsize.get(e) as usize;
+            let off = header.e_shoff.get(e) as usize + i.0 * header.e_shentsize.get(e) as usize;
 
             let section: &mut SectionHeader64<E> =
                 object::from_bytes_mut(&mut bytes[off..]).unwrap().0;

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
 fn main() -> Result<()> {
     use anyhow::{anyhow, Context};
     use libloading::os::unix::{Library, Symbol, RTLD_GLOBAL, RTLD_NOW};
-    use object::{Object, ObjectSymbol, SymbolKind};
+    use object::{Object, ObjectSymbol};
     use std::io::Write;
     use wasmtime::{Config, Engine};
 
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     // running `libembedding.so` in this case requires only minimal
     // dependencies.
     for sym in object.symbols() {
-        if !sym.is_undefined() || sym.is_weak() || sym.kind() == SymbolKind::Null {
+        if !sym.is_undefined() || sym.is_weak() {
             continue;
         }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -405,7 +405,11 @@ version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.object]]
-version = "0.29.0"
+version = "0.32.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.object]]
+version = "0.36.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ocaml-boxroot-sys]]


### PR DESCRIPTION
This fixes handling of empty symbols in cranelift-object for Mach-O, which is needed for https://github.com/rust-lang/rustc_codegen_cranelift/issues/1456 (@bjorn3)
