### PR TITLE
Update `i64_from_iconst` to only match `iconst`

### DIFF
--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -223,7 +223,13 @@ macro_rules! isle_lower_prelude_methods {
         #[inline]
         fn i64_from_iconst(&mut self, val: Value) -> Option<i64> {
             let inst = self.def_inst(val)?;
-            let constant = self.lower_ctx.get_constant(inst)? as i64;
+            let constant = match self.lower_ctx.data(inst) {
+                InstructionData::UnaryImm {
+                    opcode: Opcode::Iconst,
+                    imm,
+                } => imm.bits(),
+                _ => return None,
+            };
             let ty = self.lower_ctx.output_ty(inst, 0);
             let shift_amt = std::cmp::max(0, 64 - self.ty_bits(ty));
             Some((constant << shift_amt) >> shift_amt)


### PR DESCRIPTION
Previously this extractor would additionally match `f32const` and `f64const` which while theoretically not the end of the world can be confusing. Nowadays switch it to instead only matching the `iconst` instruction, as the name implies, and if necessary matching float constants is probably best done through separate ISLE lowering rules.

Closes #8723

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
