### PR TITLE
Handle defined shared memories in dwarf processing

### DIFF
--- a/crates/test-programs/artifacts/build.rs
+++ b/crates/test-programs/artifacts/build.rs
@@ -90,7 +90,7 @@ fn build_and_generate_tests() {
         }
 
         // Generate a component from each test.
-        if kind == "nn" || target == "dwarf_imported_memory" {
+        if kind == "nn" || target == "dwarf_imported_memory" || target == "dwarf_shared_memory" {
             continue;
         }
         let adapter = match target.as_str() {

--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -1,4 +1,6 @@
 fn main() {
     println!("cargo:rustc-link-arg-bin=dwarf_imported_memory=--import-memory");
     println!("cargo:rustc-link-arg-bin=dwarf_imported_memory=--export-memory");
+    println!("cargo:rustc-link-arg-bin=dwarf_shared_memory=--no-check-features");
+    println!("cargo:rustc-link-arg-bin=dwarf_shared_memory=--shared-memory");
 }

--- a/crates/test-programs/src/bin/dwarf_shared_memory.rs
+++ b/crates/test-programs/src/bin/dwarf_shared_memory.rs
@@ -1,0 +1,1 @@
+include!("./dwarf_simple.rs");

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -370,4 +370,10 @@ check: exited with status = 0
             &["--preload=env=./tests/all/debug/satisfy_memory_import.wat"],
         )
     }
+
+    #[test]
+    #[ignore]
+    fn dwarf_shared_memory() -> Result<()> {
+        test_dwarf_simple(DWARF_SHARED_MEMORY, &[])
+    }
 }


### PR DESCRIPTION
This commit resolves an assert in the dwarf generating of core wasm modules when the module has a defined linear memory which is flagged `shared`. This is represented slightly differently in the `VMContext` than owned memories that aren't `shared`, and looks more like an imported memory. With support in #8740 it's now much easier to support this.

Closes #8652

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
