### PR TITLE
Fix meaning of generated `.debug_loc` sections

### DIFF
--- a/crates/test-programs/src/bin/dwarf_multiple_codegen_units.rs
+++ b/crates/test-programs/src/bin/dwarf_multiple_codegen_units.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let a = 3;
+    foo::bar(a);
+}
+
+mod foo {
+    pub fn bar(x: u32) -> u32 {
+        let mut sum = 0;
+        for i in 0..x {
+            sum += i;
+        }
+        sum
+    }
+}


### PR DESCRIPTION
This commit is a fix to Wasmtime's DWARF processing transform to correct the meaning of the `.debug_loc` section. This section's addresses are relative to the `DW_AT_low_pc` entry located in the `DW_TAG_compile_unit` container, but Wasmtime's construction of this section didn't take this into account. Instead all addresses in `.debug_loc` are relative to the start of the compiled object, not to the start of the compile unit itself. This commit fixes this by unconditionally describing `DW_TAG_compile_unit` locations with `DW_AT_ranges` instead of `DW_AT_low_pc`. This ends up fixing debug information for debug information using `.debug_loc` with multiple codegen units.

Closes #8752

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
