### PR TITLE
Fix some aspects of running debug tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,6 +217,8 @@ jobs:
             run_full=true
           elif grep -q 'prtest:full' commits.log; then
             run_full=true
+          elif grep -q 'prtest:debug' commits.log; then
+            echo run-dwarf=true >> $GITHUB_OUTPUT
           fi
           if grep -q crates.c-api names.log; then
             echo test-capi=true >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,6 +196,7 @@ jobs:
       test-nightly: ${{ steps.calculate.outputs.test-nightly }}
       audit: ${{ steps.calculate.outputs.audit }}
       preview1-adapter: ${{ steps.calculate.outputs.preview1-adapter }}
+      run-dwarf: ${{ steps.calculate.outputs.run-dwarf }}
     steps:
     - uses: actions/checkout@v4
     - id: calculate
@@ -235,6 +236,9 @@ jobs:
           if grep -q component-adapter names.log; then
             echo preview1-adapter=true >> $GITHUB_OUTPUT
           fi
+          if grep -q debug names.log; then
+            echo run-dwarf=true >> $GITHUB_OUTPUT
+          fi
         fi
         matrix="$(node ./ci/build-test-matrix.js ./commits.log ./names.log $run_full)"
         echo "test-matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
@@ -249,6 +253,7 @@ jobs:
             echo test-nightly=true >> $GITHUB_OUTPUT
             echo audit=true >> $GITHUB_OUTPUT
             echo preview1-adapter=true >> $GITHUB_OUTPUT
+            echo run-dwarf=true >> $GITHUB_OUTPUT
         fi
 
   # Build all documentation of Wasmtime, including the C API documentation,
@@ -739,7 +744,7 @@ jobs:
   # Test debug (DWARF) related functionality.
   test_debug_dwarf:
     needs: determine
-    if: needs.determine.outputs.run-full
+    if: needs.determine.outputs.run-dwarf
     name: Test DWARF debugging
     runs-on: 'ubuntu-latest'
     steps:
@@ -753,7 +758,7 @@ jobs:
         # workaround for https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/1972855
         sudo mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb
         sudo ln -s /usr/lib/llvm-15/lib/python3.10/dist-packages/lldb/* /usr/lib/python3/dist-packages/lldb/
-        cargo test test_debug_dwarf -- --ignored --test-threads 1
+        cargo test --test all -- --ignored --test-threads 1 debug::
       env:
         RUST_BACKTRACE: 1
         LLDB: lldb-15 # override default version, 14


### PR DESCRIPTION
This commit fixes the filter used to run tests in CI to include all debug with a broader filter to include the whole `debug` module of tests. This fixes a mistake where recent tests added weren't running in CI.

This then additionally adds a `run-dwarf` filter in CI to run these tests on any changes to filenames containing "debug" in the name.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
