### PR TITLE
Recommend `-O opt-level=0` when debugging wasm

### DIFF
--- a/docs/examples-debugging-native-debugger.md
+++ b/docs/examples-debugging-native-debugger.md
@@ -13,7 +13,8 @@ the same time:
 
 2. Run Wasmtime with the debug info enabled; this is `-D debug-info` from the
    CLI and `Config::debug_info(true)` in an embedding (e.g. see [debugging in a
-   Rust embedding](./examples-rust-debugging.md))
+   Rust embedding](./examples-rust-debugging.md)). It's also recommended to use
+   `-O opt-level=0` for better inspection of local variables if desired.
 
 3. Use a supported debugger:
 
@@ -21,7 +22,7 @@ the same time:
     lldb -- wasmtime run -D debug-info foo.wasm
     ```
     ```sh
-    gdb --args wasmtime run -D debug-info foo.wasm
+    gdb --args wasmtime run -D debug-info -O opt-level=0 foo.wasm
     ```
 
 If you run into trouble, the following discussions might help:

--- a/examples/fib-debug/main.c
+++ b/examples/fib-debug/main.c
@@ -16,6 +16,7 @@ int main(int argc, const char *argv[]) {
   // original fib-wasm.c source code and variables.
   wasm_config_t *config = wasm_config_new();
   wasmtime_config_debug_info_set(config, true);
+  wasmtime_config_cranelift_opt_level_set(config, WASMTIME_OPT_LEVEL_NONE);
 
   // Initialize.
   printf("Initializing...\n");

--- a/examples/fib-debug/main.rs
+++ b/examples/fib-debug/main.rs
@@ -14,7 +14,11 @@ fn main() -> Result<()> {
     // Load our previously compiled wasm file (built previously with Cargo) and
     // also ensure that we generate debuginfo so this executable can be
     // debugged in GDB.
-    let engine = Engine::new(Config::new().debug_info(true).opt_level(OptLevel::None))?;
+    let engine = Engine::new(
+        Config::new()
+            .debug_info(true)
+            .cranelift_opt_level(OptLevel::None),
+    )?;
     let mut store = Store::new(&engine, ());
     let module = Module::from_file(&engine, "target/wasm32-unknown-unknown/debug/fib.wasm")?;
     let instance = Instance::new(&mut store, &module, &[])?;

--- a/examples/fib-debug/main.rs
+++ b/examples/fib-debug/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     // Load our previously compiled wasm file (built previously with Cargo) and
     // also ensure that we generate debuginfo so this executable can be
     // debugged in GDB.
-    let engine = Engine::new(Config::new().debug_info(true))?;
+    let engine = Engine::new(Config::new().debug_info(true).opt_level(OptLevel::None))?;
     let mut store = Store::new(&engine, ());
     let module = Module::from_file(&engine, "target/wasm32-unknown-unknown/debug/fib.wasm")?;
     let instance = Instance::new(&mut store, &module, &[])?;


### PR DESCRIPTION
This improves inspection of local variables by avoiding the egraph pass which doesn't have full fidelity in terms of preserving debug information.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
