### PR TITLE
cranelift/isle: add `Binding::MakeSome` for partial constructors

### DIFF
--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -639,8 +639,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                     )?;
                     write!(ctx.out, "{}", &ctx.indent)?;
                     match ret_kind {
-                        ReturnKind::Plain => write!(ctx.out, "return ")?,
-                        ReturnKind::Option => write!(ctx.out, "return Some(")?,
+                        ReturnKind::Plain | ReturnKind::Option => write!(ctx.out, "return ")?,
                         ReturnKind::Iterator => write!(ctx.out, "returns.extend(Some(")?,
                     }
                     self.emit_expr(ctx, result)?;
@@ -648,8 +647,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                         write!(ctx.out, ".clone()")?;
                     }
                     match ret_kind {
-                        ReturnKind::Plain => writeln!(ctx.out, ";")?,
-                        ReturnKind::Option => writeln!(ctx.out, ");")?,
+                        ReturnKind::Plain | ReturnKind::Option => writeln!(ctx.out, ";")?,
                         ReturnKind::Iterator => {
                             writeln!(ctx.out, "));")?;
                             writeln!(
@@ -753,6 +751,11 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                 Ok(())
             }
 
+            &Binding::MakeSome { inner } => {
+                write!(ctx.out, "Some(")?;
+                self.emit_expr(ctx, inner)?;
+                write!(ctx.out, ")")
+            }
             &Binding::MatchSome { source } => {
                 self.emit_expr(ctx, source)?;
                 write!(ctx.out, "?")

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -339,6 +339,17 @@ impl Term {
         matches!(self.kind, TermKind::EnumVariant { .. })
     }
 
+    /// Is this term partial?
+    pub fn is_partial(&self) -> bool {
+        matches!(
+            self.kind,
+            TermKind::Decl {
+                flags: TermFlags { partial: true, .. },
+                ..
+            }
+        )
+    }
+
     /// Does this term have a constructor?
     pub fn has_constructor(&self) -> bool {
         matches!(


### PR DESCRIPTION
When working with ISLE's "trie again" representation there is an awkward detail with partial internal constructors. The result binding of a rule will refer to an expression of type `T`, while the return type of the generated constructor is type `Option<T>`. The wrapping of the return expression in `Some(..)` happens at codegen when the return kind is `ReturnKind::Option`.

This presents an incompatibility when implementing inlining at the trie level. If a constructor binding is selected for inlining then all the bindings for the rule application are imported, and the constructor callsite is replaced with the result binding. Therefore the result of inlining replaces a binding of type `Option<T>` with one of type `T` and the result is invalid. To fix this we just need to figure out where the right place is to insert the `Some(..)` wrapper.

This PR offers one approach to add a `Binding::MakeSome` variant and materialize the `Some(..)` wrapping in the trie. Note we already have `Binding::{Match,Make}Variant` and `Binding::MatchSome` so `Binding::MakeSome` is a natural addition. The rule set builder is expanded to wrap the result binding in MakeSome for partial constructors. With this change the `Some(..)` wrapper in codegen is no longer needed, and the inlining problem mentioned above goes away.