### PR TITLE
Fix riscv64 for no-std

### DIFF
--- a/crates/wasmtime/src/runtime/vm/arch/riscv64.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/riscv64.rs
@@ -12,7 +12,7 @@ pub type V128Abi = u128;
 pub fn get_stack_pointer() -> usize {
     let stack_pointer: usize;
     unsafe {
-        std::arch::asm!(
+        core::arch::asm!(
             "mv {}, sp",
             out(reg) stack_pointer,
             options(nostack,nomem),


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
See issue #8768
