### PR TITLE
Dynamically configure Spectre heap mitigations on/off in fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -261,6 +261,8 @@ impl Config {
                     dynamic_memory_reserved_for_growth: Some(0),
                     guard_before_linear_memory: false,
                     memory_init_cow: true,
+                    // Doesn't matter, only using virtual memory.
+                    cranelift_enable_heap_access_spectre_mitigations: None,
                 })
             } else {
                 self.wasmtime.memory_config.clone()

--- a/crates/fuzzing/src/generators/memory.rs
+++ b/crates/fuzzing/src/generators/memory.rs
@@ -118,6 +118,7 @@ pub struct NormalMemoryConfig {
     pub dynamic_memory_guard_size: Option<u64>,
     pub dynamic_memory_reserved_for_growth: Option<u64>,
     pub guard_before_linear_memory: bool,
+    pub cranelift_enable_heap_access_spectre_mitigations: Option<bool>,
     pub memory_init_cow: bool,
 }
 
@@ -132,6 +133,7 @@ impl<'a> Arbitrary<'a> for NormalMemoryConfig {
             dynamic_memory_reserved_for_growth: <Option<u32> as Arbitrary>::arbitrary(u)?
                 .map(Into::into),
             guard_before_linear_memory: u.arbitrary()?,
+            cranelift_enable_heap_access_spectre_mitigations: u.arbitrary()?,
             memory_init_cow: u.arbitrary()?,
         };
 
@@ -156,6 +158,15 @@ impl NormalMemoryConfig {
             )
             .guard_before_linear_memory(self.guard_before_linear_memory)
             .memory_init_cow(self.memory_init_cow);
+
+        if let Some(enable) = self.cranelift_enable_heap_access_spectre_mitigations {
+            unsafe {
+                config.cranelift_flag_set(
+                    "enable_heap_access_spectre_mitigation",
+                    &enable.to_string(),
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
We have slightly different bounds checks for when Spectre mitigations are enabled or disabled, so add a knob to our fuzzing machinery to exercise all cases.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
