### PR TITLE
Update rustls root certificate handling in default_send_request_handler

### DIFF
--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -303,15 +303,12 @@ pub async fn default_send_request_handler(
 
         #[cfg(not(any(target_arch = "riscv64", target_arch = "s390x")))]
         {
-            use rustls::pki_types::{ServerName, TrustAnchor};
+            use rustls::pki_types::ServerName;
 
-            // derived from https://github.com/tokio-rs/tls/blob/master/tokio-rustls/examples/client/src/main.rs
-            let mut root_cert_store = rustls::RootCertStore::empty();
-            root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| TrustAnchor {
-                name_constraints: ta.name_constraints.to_owned(),
-                subject: ta.subject.to_owned(),
-                subject_public_key_info: ta.subject_public_key_info.to_owned(),
-            }));
+            // derived from https://github.com/rustls/rustls/blob/main/examples/src/bin/simpleclient.rs
+            let root_cert_store = rustls::RootCertStore {
+                roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+            };
             let config = rustls::ClientConfig::builder()
                 .with_root_certificates(root_cert_store)
                 .with_no_client_auth();


### PR DESCRIPTION
While researching #8748, I noticed that the link in the comment results in a 404 error. The link refers to `tokio-rs/tls`. `tokio-rustls` has since moved to `rustls/tokio-rustls`.

I also noticed that the examples in the rustls documentation provide a more elegant method to add `webpki-roots` to the `RootCertStore`.

This PR doesn't change any functionality; it just updates Wasmtime's usage of `webpki-roots` and the `RootCertStore`, improving code readability, while also updating the link to one of the newer examples in the rustls repository.