### PR TITLE
Remove the `ModuleRuntimeInfo` trait

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -247,6 +247,7 @@ pub trait PtrSize {
 }
 
 /// Type representing the size of a pointer for the current compilation host
+#[derive(Clone, Copy)]
 pub struct HostPtr;
 
 impl PtrSize for HostPtr {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1319,7 +1319,7 @@ impl Func {
                     let _ = VMArrayCallHostFuncContext::from_opaque(f.as_ref().vmctx);
 
                     let sig = self.type_index(store.store_data());
-                    module.runtime_info().wasm_to_array_trampoline(sig).expect(
+                    module.wasm_to_array_trampoline(sig).expect(
                         "if the wasm is importing a function of a given type, it must have the \
                          type's trampoline",
                     )

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -1,8 +1,8 @@
 use crate::linker::{Definition, DefinitionType};
 use crate::prelude::*;
 use crate::runtime::vm::{
-    Imports, InstanceAllocationRequest, StorePtr, VMFuncRef, VMFunctionImport, VMGlobalImport,
-    VMMemoryImport, VMOpaqueContext, VMTableImport,
+    Imports, InstanceAllocationRequest, ModuleRuntimeInfo, StorePtr, VMFuncRef, VMFunctionImport,
+    VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTableImport,
 };
 use crate::store::{InstanceId, StoreOpaque, Stored};
 use crate::types::matching;
@@ -284,7 +284,7 @@ impl Instance {
                 .engine()
                 .allocator()
                 .allocate_module(InstanceAllocationRequest {
-                    runtime_info: &module.runtime_info(),
+                    runtime_info: &ModuleRuntimeInfo::Module(module.clone()),
                     imports,
                     host_state: Box::new(Instance(instance_to_be)),
                     store: StorePtr::new(store.traitobj()),
@@ -821,9 +821,7 @@ impl<T> InstancePre<T> {
                         // Wasm-to-native trampoline.
                         debug_assert!(matches!(f.host_ctx(), crate::HostContext::Array(_)));
                         func_refs.push(VMFuncRef {
-                            wasm_call: module
-                                .runtime_info()
-                                .wasm_to_array_trampoline(f.sig_index()),
+                            wasm_call: module.wasm_to_array_trampoline(f.sig_index()),
                             ..*f.func_ref()
                         });
                     }

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1,8 +1,5 @@
 use crate::prelude::*;
-use crate::runtime::vm::{
-    CompiledModuleId, MemoryImage, MmapVec, ModuleMemoryImages, VMArrayCallFunction,
-    VMWasmCallFunction,
-};
+use crate::runtime::vm::{CompiledModuleId, MmapVec, ModuleMemoryImages, VMWasmCallFunction};
 use crate::sync::OnceLock;
 use crate::{
     code::CodeObject,
@@ -16,15 +13,14 @@ use crate::{
 use alloc::sync::Arc;
 use anyhow::{bail, Result};
 use core::fmt;
-use core::mem;
 use core::ops::Range;
 use core::ptr::NonNull;
 #[cfg(feature = "std")]
 use std::path::Path;
 use wasmparser::{Parser, ValidPayload, Validator};
 use wasmtime_environ::{
-    CompiledModuleInfo, DefinedFuncIndex, DefinedMemoryIndex, EntityIndex, HostPtr, ModuleTypes,
-    ObjectKind, TypeTrace, VMOffsets, VMSharedTypeIndex,
+    CompiledModuleInfo, EntityIndex, HostPtr, ModuleTypes, ObjectKind, TypeTrace, VMOffsets,
+    VMSharedTypeIndex,
 };
 mod registry;
 
@@ -584,11 +580,11 @@ impl Module {
         &self.inner.module
     }
 
-    fn code_object(&self) -> &Arc<CodeObject> {
+    pub(crate) fn code_object(&self) -> &Arc<CodeObject> {
         &self.inner.code
     }
 
-    pub(crate) fn env_module(&self) -> &wasmtime_environ::Module {
+    pub(crate) fn env_module(&self) -> &Arc<wasmtime_environ::Module> {
         self.compiled_module().module()
     }
 
@@ -904,14 +900,6 @@ impl Module {
         }
     }
 
-    /// Returns the `ModuleInner` cast as `ModuleRuntimeInfo` for use
-    /// by the runtime.
-    pub(crate) fn runtime_info(&self) -> Arc<dyn crate::runtime::vm::ModuleRuntimeInfo> {
-        // N.B.: this needs to return a clone because we cannot
-        // statically cast the &Arc<ModuleInner> to &Arc<dyn Trait...>.
-        self.inner.clone()
-    }
-
     pub(crate) fn module_info(&self) -> &dyn crate::runtime::vm::ModuleInfo {
         &*self.inner
     }
@@ -952,7 +940,7 @@ impl Module {
     /// as a performance optimization if required but is otherwise handled
     /// automatically.
     pub fn initialize_copy_on_write_image(&self) -> Result<()> {
-        self.inner.memory_images()?;
+        self.memory_images()?;
         Ok(())
     }
 
@@ -1034,6 +1022,56 @@ impl Module {
     pub(crate) fn id(&self) -> CompiledModuleId {
         self.inner.module.unique_id()
     }
+
+    pub(crate) fn offsets(&self) -> &VMOffsets<HostPtr> {
+        &self.inner.offsets
+    }
+
+    /// Return the address, in memory, of the trampoline that allows Wasm to
+    /// call a array function of the given signature.
+    pub(crate) fn wasm_to_array_trampoline(
+        &self,
+        signature: VMSharedTypeIndex,
+    ) -> Option<NonNull<VMWasmCallFunction>> {
+        log::trace!("Looking up trampoline for {signature:?}");
+        let trampoline_shared_ty = self.inner.engine.signatures().trampoline_type(signature);
+        let trampoline_module_ty = self
+            .inner
+            .code
+            .signatures()
+            .trampoline_type(trampoline_shared_ty)?;
+        debug_assert!(self
+            .inner
+            .engine
+            .signatures()
+            .borrow(
+                self.inner
+                    .code
+                    .signatures()
+                    .shared_type(trampoline_module_ty)
+                    .unwrap()
+            )
+            .unwrap()
+            .unwrap_func()
+            .is_trampoline_type());
+
+        let ptr = self
+            .compiled_module()
+            .wasm_to_array_trampoline(trampoline_module_ty)
+            .as_ptr()
+            .cast::<VMWasmCallFunction>()
+            .cast_mut();
+        Some(NonNull::new(ptr).unwrap())
+    }
+
+    pub(crate) fn memory_images(&self) -> Result<Option<&ModuleMemoryImages>> {
+        let images = self
+            .inner
+            .memory_images
+            .get_or_try_init(|| memory_images(&self.inner.engine, &self.inner.module))?
+            .as_ref();
+        Ok(images)
+    }
 }
 
 /// Describes a function for a given module.
@@ -1042,16 +1080,6 @@ pub struct ModuleFunction {
     pub name: Option<String>,
     pub offset: usize,
     pub len: usize,
-}
-
-impl ModuleInner {
-    fn memory_images(&self) -> Result<Option<&ModuleMemoryImages>> {
-        let images = self
-            .memory_images
-            .get_or_try_init(|| memory_images(&self.engine, &self.module))?
-            .as_ref();
-        Ok(images)
-    }
 }
 
 impl Drop for ModuleInner {
@@ -1082,90 +1110,6 @@ fn _assert_send_sync() {
     _assert::<Module>();
 }
 
-impl crate::runtime::vm::ModuleRuntimeInfo for ModuleInner {
-    fn module(&self) -> &Arc<wasmtime_environ::Module> {
-        self.module.module()
-    }
-
-    fn engine_type_index(
-        &self,
-        module_index: wasmtime_environ::ModuleInternedTypeIndex,
-    ) -> VMSharedTypeIndex {
-        self.code
-            .signatures()
-            .shared_type(module_index)
-            .expect("bad module-level interned type index")
-    }
-
-    fn function(&self, index: DefinedFuncIndex) -> NonNull<VMWasmCallFunction> {
-        let ptr = self
-            .module
-            .finished_function(index)
-            .as_ptr()
-            .cast::<VMWasmCallFunction>()
-            .cast_mut();
-        NonNull::new(ptr).unwrap()
-    }
-
-    fn array_to_wasm_trampoline(&self, index: DefinedFuncIndex) -> Option<VMArrayCallFunction> {
-        let ptr = self.module.array_to_wasm_trampoline(index)?.as_ptr();
-        Some(unsafe { mem::transmute::<*const u8, VMArrayCallFunction>(ptr) })
-    }
-
-    fn wasm_to_array_trampoline(
-        &self,
-        signature: VMSharedTypeIndex,
-    ) -> Option<NonNull<VMWasmCallFunction>> {
-        log::trace!("Looking up trampoline for {signature:?}");
-        let trampoline_shared_ty = self.engine.signatures().trampoline_type(signature);
-        let trampoline_module_ty = self
-            .code
-            .signatures()
-            .trampoline_type(trampoline_shared_ty)?;
-        debug_assert!(self
-            .engine
-            .signatures()
-            .borrow(
-                self.code
-                    .signatures()
-                    .shared_type(trampoline_module_ty)
-                    .unwrap()
-            )
-            .unwrap()
-            .unwrap_func()
-            .is_trampoline_type());
-
-        let ptr = self
-            .module
-            .wasm_to_array_trampoline(trampoline_module_ty)
-            .as_ptr()
-            .cast::<VMWasmCallFunction>()
-            .cast_mut();
-        Some(NonNull::new(ptr).unwrap())
-    }
-
-    fn memory_image(&self, memory: DefinedMemoryIndex) -> Result<Option<&Arc<MemoryImage>>> {
-        let images = self.memory_images()?;
-        Ok(images.and_then(|images| images.get_memory_image(memory)))
-    }
-
-    fn unique_id(&self) -> Option<CompiledModuleId> {
-        Some(self.module.unique_id())
-    }
-
-    fn wasm_data(&self) -> &[u8] {
-        self.module.code_memory().wasm_data()
-    }
-
-    fn type_ids(&self) -> &[VMSharedTypeIndex] {
-        self.code.signatures().as_module_map().values().as_slice()
-    }
-
-    fn offsets(&self) -> &VMOffsets<HostPtr> {
-        &self.offsets
-    }
-}
-
 impl crate::runtime::vm::ModuleInfo for ModuleInner {
     fn lookup_stack_map(&self, pc: usize) -> Option<&wasmtime_environ::StackMap> {
         let text_offset = pc - self.module.text().as_ptr() as usize;
@@ -1189,88 +1133,6 @@ impl crate::runtime::vm::ModuleInfo for ModuleInner {
         };
 
         Some(&info.stack_maps[index].stack_map)
-    }
-}
-
-/// A barebones implementation of ModuleRuntimeInfo that is useful for
-/// cases where a purpose-built environ::Module is used and a full
-/// CompiledModule does not exist (for example, for tests or for the
-/// default-callee instance).
-pub(crate) struct BareModuleInfo {
-    module: Arc<wasmtime_environ::Module>,
-    one_signature: Option<VMSharedTypeIndex>,
-    offsets: VMOffsets<HostPtr>,
-}
-
-impl BareModuleInfo {
-    pub(crate) fn empty(module: Arc<wasmtime_environ::Module>) -> Self {
-        BareModuleInfo::maybe_imported_func(module, None)
-    }
-
-    pub(crate) fn maybe_imported_func(
-        module: Arc<wasmtime_environ::Module>,
-        one_signature: Option<VMSharedTypeIndex>,
-    ) -> Self {
-        BareModuleInfo {
-            offsets: VMOffsets::new(HostPtr, &module),
-            module,
-            one_signature,
-        }
-    }
-
-    pub(crate) fn into_traitobj(self) -> Arc<dyn crate::runtime::vm::ModuleRuntimeInfo> {
-        Arc::new(self)
-    }
-}
-
-impl crate::runtime::vm::ModuleRuntimeInfo for BareModuleInfo {
-    fn module(&self) -> &Arc<wasmtime_environ::Module> {
-        &self.module
-    }
-
-    fn engine_type_index(
-        &self,
-        _module_index: wasmtime_environ::ModuleInternedTypeIndex,
-    ) -> VMSharedTypeIndex {
-        unreachable!()
-    }
-
-    fn function(&self, _index: DefinedFuncIndex) -> NonNull<VMWasmCallFunction> {
-        unreachable!()
-    }
-
-    fn array_to_wasm_trampoline(&self, _index: DefinedFuncIndex) -> Option<VMArrayCallFunction> {
-        unreachable!()
-    }
-
-    fn wasm_to_array_trampoline(
-        &self,
-        _signature: VMSharedTypeIndex,
-    ) -> Option<NonNull<VMWasmCallFunction>> {
-        unreachable!()
-    }
-
-    fn memory_image(&self, _memory: DefinedMemoryIndex) -> Result<Option<&Arc<MemoryImage>>> {
-        Ok(None)
-    }
-
-    fn unique_id(&self) -> Option<CompiledModuleId> {
-        None
-    }
-
-    fn wasm_data(&self) -> &[u8] {
-        &[]
-    }
-
-    fn type_ids(&self) -> &[VMSharedTypeIndex] {
-        match &self.one_signature {
-            Some(id) => core::slice::from_ref(id),
-            None => &[],
-        }
-    }
-
-    fn offsets(&self) -> &VMOffsets<HostPtr> {
-        &self.offsets
     }
 }
 

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -190,7 +190,7 @@ impl ModuleRegistry {
         // See also the comment in `ModuleInner::wasm_to_native_trampoline`.
         for (_, code) in self.loaded_code.values() {
             for module in code.modules.values() {
-                if let Some(trampoline) = module.runtime_info().wasm_to_array_trampoline(sig) {
+                if let Some(trampoline) = module.wasm_to_array_trampoline(sig) {
                     return Some(trampoline);
                 }
             }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -78,13 +78,14 @@
 
 use crate::instance::InstanceData;
 use crate::linker::Definition;
-use crate::module::{BareModuleInfo, RegisteredModuleId};
+use crate::module::RegisteredModuleId;
 use crate::prelude::*;
 use crate::runtime::vm::mpk::{self, ProtectionKey, ProtectionMask};
 use crate::runtime::vm::{
     Backtrace, ExportGlobal, GcHeapAllocationIndex, GcRootsList, GcStore,
-    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, OnDemandInstanceAllocator,
-    SignalHandler, StoreBox, StorePtr, VMContext, VMFuncRef, VMGcRef, VMRuntimeLimits, WasmFault,
+    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, ModuleRuntimeInfo,
+    OnDemandInstanceAllocator, SignalHandler, StoreBox, StorePtr, VMContext, VMFuncRef, VMGcRef,
+    VMRuntimeLimits, WasmFault,
 };
 use crate::trampoline::VMHostGlobalContext;
 use crate::RootSet;
@@ -534,7 +535,7 @@ impl<T> Store<T> {
         // is never null.
         inner.default_caller = {
             let module = Arc::new(wasmtime_environ::Module::default());
-            let shim = BareModuleInfo::empty(module).into_traitobj();
+            let shim = ModuleRuntimeInfo::bare(module);
             let allocator = OnDemandInstanceAllocator::default();
             allocator
                 .validate_module(shim.module(), shim.offsets())

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -11,11 +11,10 @@ pub(crate) use memory::MemoryCreatorProxy;
 
 use self::memory::create_memory;
 use self::table::create_table;
-use crate::module::BareModuleInfo;
 use crate::prelude::*;
 use crate::runtime::vm::{
-    Imports, InstanceAllocationRequest, InstanceAllocator, OnDemandInstanceAllocator, SharedMemory,
-    StorePtr, VMFunctionImport,
+    Imports, InstanceAllocationRequest, InstanceAllocator, ModuleRuntimeInfo,
+    OnDemandInstanceAllocator, SharedMemory, StorePtr, VMFunctionImport,
 };
 use crate::store::{InstanceId, StoreOpaque};
 use crate::{MemoryType, TableType};
@@ -40,8 +39,7 @@ fn create_handle(
         // The configured instance allocator should only be used when creating module instances
         // as we don't want host objects to count towards instance limits.
         let module = Arc::new(module);
-        let runtime_info =
-            &BareModuleInfo::maybe_imported_func(module, one_signature).into_traitobj();
+        let runtime_info = &ModuleRuntimeInfo::bare_maybe_imported_func(module, one_signature);
         let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0);
         let handle = allocator.allocate_module(InstanceAllocationRequest {
             imports,

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -1,12 +1,11 @@
 use crate::memory::{LinearMemory, MemoryCreator};
-use crate::module::BareModuleInfo;
 use crate::prelude::*;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::{
     CompiledModuleId, GcHeapAllocationIndex, Imports, InstanceAllocationRequest, InstanceAllocator,
-    InstanceAllocatorImpl, Memory, MemoryAllocationIndex, MemoryImage, OnDemandInstanceAllocator,
-    RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, StorePtr, Table, TableAllocationIndex,
-    VMMemoryDefinition,
+    InstanceAllocatorImpl, Memory, MemoryAllocationIndex, MemoryImage, ModuleRuntimeInfo,
+    OnDemandInstanceAllocator, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, StorePtr,
+    Table, TableAllocationIndex, VMMemoryDefinition,
 };
 use crate::store::{InstanceId, StoreOpaque};
 use crate::MemoryType;
@@ -56,7 +55,7 @@ pub fn create_memory(
     // associated with external objects. The configured instance allocator
     // should only be used when creating module instances as we don't want host
     // objects to count towards instance limits.
-    let runtime_info = &BareModuleInfo::maybe_imported_func(Arc::new(module), None).into_traitobj();
+    let runtime_info = &ModuleRuntimeInfo::bare_maybe_imported_func(Arc::new(module), None);
     let host_state = Box::new(());
     let imports = Imports::default();
     let request = InstanceAllocationRequest {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -3,9 +3,11 @@
 #![deny(missing_docs)]
 #![warn(clippy::cast_sign_loss)]
 
+use crate::prelude::*;
 use alloc::sync::Arc;
 use anyhow::{Error, Result};
 use core::fmt;
+use core::mem;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use wasmtime_environ::{
@@ -182,50 +184,149 @@ pub unsafe trait Store {
 /// the bottom of the dependence DAG though, we don't know or care about
 /// that; we just need some implementor of this trait for each
 /// allocation request.
-pub trait ModuleRuntimeInfo: Send + Sync + 'static {
+#[derive(Clone)]
+pub enum ModuleRuntimeInfo {
+    Module(crate::Module),
+    Bare(Box<BareModuleInfo>),
+}
+
+/// A barebones implementation of ModuleRuntimeInfo that is useful for
+/// cases where a purpose-built environ::Module is used and a full
+/// CompiledModule does not exist (for example, for tests or for the
+/// default-callee instance).
+#[derive(Clone)]
+pub struct BareModuleInfo {
+    module: Arc<wasmtime_environ::Module>,
+    one_signature: Option<VMSharedTypeIndex>,
+    offsets: VMOffsets<HostPtr>,
+}
+
+impl ModuleRuntimeInfo {
+    pub(crate) fn bare(module: Arc<wasmtime_environ::Module>) -> Self {
+        ModuleRuntimeInfo::bare_maybe_imported_func(module, None)
+    }
+
+    pub(crate) fn bare_maybe_imported_func(
+        module: Arc<wasmtime_environ::Module>,
+        one_signature: Option<VMSharedTypeIndex>,
+    ) -> Self {
+        ModuleRuntimeInfo::Bare(Box::new(BareModuleInfo {
+            offsets: VMOffsets::new(HostPtr, &module),
+            module,
+            one_signature,
+        }))
+    }
+
     /// The underlying Module.
-    fn module(&self) -> &Arc<wasmtime_environ::Module>;
+    pub(crate) fn module(&self) -> &Arc<wasmtime_environ::Module> {
+        match self {
+            ModuleRuntimeInfo::Module(m) => m.env_module(),
+            ModuleRuntimeInfo::Bare(b) => &b.module,
+        }
+    }
 
     /// Translate a module-level interned type index into an engine-level
     /// interned type index.
-    fn engine_type_index(&self, module_index: ModuleInternedTypeIndex) -> VMSharedTypeIndex;
+    fn engine_type_index(&self, module_index: ModuleInternedTypeIndex) -> VMSharedTypeIndex {
+        match self {
+            ModuleRuntimeInfo::Module(m) => m
+                .code_object()
+                .signatures()
+                .shared_type(module_index)
+                .expect("bad module-level interned type index"),
+            ModuleRuntimeInfo::Bare(_) => unreachable!(),
+        }
+    }
 
     /// Returns the address, in memory, that the function `index` resides at.
-    fn function(&self, index: DefinedFuncIndex) -> NonNull<VMWasmCallFunction>;
+    fn function(&self, index: DefinedFuncIndex) -> NonNull<VMWasmCallFunction> {
+        let module = match self {
+            ModuleRuntimeInfo::Module(m) => m,
+            ModuleRuntimeInfo::Bare(_) => unreachable!(),
+        };
+        let ptr = module
+            .compiled_module()
+            .finished_function(index)
+            .as_ptr()
+            .cast::<VMWasmCallFunction>()
+            .cast_mut();
+        NonNull::new(ptr).unwrap()
+    }
 
     /// Returns the address, in memory, of the trampoline that allows the given
     /// defined Wasm function to be called by the array calling convention.
     ///
     /// Returns `None` for Wasm functions which do not escape, and therefore are
     /// not callable from outside the Wasm module itself.
-    fn array_to_wasm_trampoline(&self, index: DefinedFuncIndex) -> Option<VMArrayCallFunction>;
-
-    /// Return the address, in memory, of the trampoline that allows Wasm to
-    /// call a array function of the given signature.
-    fn wasm_to_array_trampoline(
-        &self,
-        signature: VMSharedTypeIndex,
-    ) -> Option<NonNull<VMWasmCallFunction>>;
+    fn array_to_wasm_trampoline(&self, index: DefinedFuncIndex) -> Option<VMArrayCallFunction> {
+        let m = match self {
+            ModuleRuntimeInfo::Module(m) => m,
+            ModuleRuntimeInfo::Bare(_) => unreachable!(),
+        };
+        let ptr = m
+            .compiled_module()
+            .array_to_wasm_trampoline(index)?
+            .as_ptr();
+        Some(unsafe { mem::transmute::<*const u8, VMArrayCallFunction>(ptr) })
+    }
 
     /// Returns the `MemoryImage` structure used for copy-on-write
     /// initialization of the memory, if it's applicable.
-    fn memory_image(&self, memory: DefinedMemoryIndex)
-        -> anyhow::Result<Option<&Arc<MemoryImage>>>;
+    fn memory_image(
+        &self,
+        memory: DefinedMemoryIndex,
+    ) -> anyhow::Result<Option<&Arc<MemoryImage>>> {
+        match self {
+            ModuleRuntimeInfo::Module(m) => {
+                let images = m.memory_images()?;
+                Ok(images.and_then(|images| images.get_memory_image(memory)))
+            }
+            ModuleRuntimeInfo::Bare(_) => Ok(None),
+        }
+    }
 
     /// A unique ID for this particular module. This can be used to
     /// allow for fastpaths to optimize a "re-instantiate the same
     /// module again" case.
-    fn unique_id(&self) -> Option<CompiledModuleId>;
+    fn unique_id(&self) -> Option<CompiledModuleId> {
+        match self {
+            ModuleRuntimeInfo::Module(m) => Some(m.id()),
+            ModuleRuntimeInfo::Bare(_) => None,
+        }
+    }
 
     /// A slice pointing to all data that is referenced by this instance.
-    fn wasm_data(&self) -> &[u8];
+    fn wasm_data(&self) -> &[u8] {
+        match self {
+            ModuleRuntimeInfo::Module(m) => m.compiled_module().code_memory().wasm_data(),
+            ModuleRuntimeInfo::Bare(_) => &[],
+        }
+    }
 
     /// Returns an array, indexed by `ModuleInternedTypeIndex` of all
     /// `VMSharedSignatureIndex` entries corresponding to the `SignatureIndex`.
-    fn type_ids(&self) -> &[VMSharedTypeIndex];
+    fn type_ids(&self) -> &[VMSharedTypeIndex] {
+        match self {
+            ModuleRuntimeInfo::Module(m) => m
+                .code_object()
+                .signatures()
+                .as_module_map()
+                .values()
+                .as_slice(),
+            ModuleRuntimeInfo::Bare(b) => match &b.one_signature {
+                Some(s) => core::slice::from_ref(s),
+                None => &[],
+            },
+        }
+    }
 
     /// Offset information for the current host.
-    fn offsets(&self) -> &VMOffsets<HostPtr>;
+    pub(crate) fn offsets(&self) -> &VMOffsets<HostPtr> {
+        match self {
+            ModuleRuntimeInfo::Module(m) => m.offsets(),
+            ModuleRuntimeInfo::Bare(b) => &b.offsets,
+        }
+    }
 }
 
 /// Returns the host OS page size, in bytes.

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -61,7 +61,7 @@ pub struct Instance {
     /// lazy initialization. This provides access to the underlying
     /// Wasm module entities, the compiled JIT code, metadata about
     /// functions, lazy initialization state, etc.
-    runtime_info: Arc<dyn ModuleRuntimeInfo>,
+    runtime_info: ModuleRuntimeInfo,
 
     /// WebAssembly linear memory data.
     ///

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -6,7 +6,6 @@ use crate::runtime::vm::memory::Memory;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::table::Table;
 use crate::runtime::vm::{CompiledModuleId, ModuleRuntimeInfo, Store, VMFuncRef, VMGcRef};
-use alloc::sync::Arc;
 use anyhow::{bail, Result};
 use core::{any::Any, mem, ptr};
 use wasmtime_environ::{
@@ -42,7 +41,7 @@ pub struct InstanceAllocationRequest<'a> {
     /// addresses, precomputed images for lazy memory and table
     /// initialization, and the like. This Arc is cloned and held for
     /// the lifetime of the instance.
-    pub runtime_info: &'a Arc<dyn ModuleRuntimeInfo>,
+    pub runtime_info: &'a ModuleRuntimeInfo,
 
     /// The imports to use for the instantiation.
     pub imports: Imports<'a>,


### PR DESCRIPTION
Replace it with an `enum` of the two possibilities that it can be. This removes the need to have a trait dispatch indirection in the `vm` module. Previously this was required as `wasmtime-runtime` was a separate crate, but now it's no longer required.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
