### PR TITLE
Switch some asserts to debug asserts

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2000,7 +2000,7 @@ impl<T> Caller<'_, T> {
         // And the return value must not borrow from the caller/store.
         R: 'static,
     {
-        assert!(!caller.is_null());
+        debug_assert!(!caller.is_null());
         crate::runtime::vm::Instance::from_vmctx(caller, |instance| {
             let store = StoreContextMut::from_raw(instance.store());
             let gc_lifo_scope = store.0.gc_roots().enter_lifo_scope();

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -233,7 +233,7 @@ impl Instance {
     /// pointers to the same `Instance`.
     #[inline]
     pub unsafe fn from_vmctx<R>(vmctx: *mut VMContext, f: impl FnOnce(&mut Instance) -> R) -> R {
-        assert!(!vmctx.is_null());
+        debug_assert!(!vmctx.is_null());
         let ptr = vmctx
             .byte_sub(mem::size_of::<Instance>())
             .cast::<Instance>();
@@ -458,7 +458,7 @@ impl Instance {
     pub fn store(&self) -> *mut dyn Store {
         let ptr =
             unsafe { *self.vmctx_plus_offset::<*mut dyn Store>(self.offsets().vmctx_store()) };
-        assert!(!ptr.is_null());
+        debug_assert!(!ptr.is_null());
         ptr
     }
 


### PR DESCRIPTION
These are on the critical path of calling from wasm to the host and while minor helps clean up the path.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
