### PR TITLE
Disable `AutoAssertNoGc` when `gc` is disabled

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -403,7 +403,9 @@ pub struct AutoAssertNoGc<'a> {
 impl<'a> AutoAssertNoGc<'a> {
     #[inline]
     pub fn new(store: &'a mut StoreOpaque) -> Self {
-        let entered = if let Some(gc_store) = store.gc_store.as_mut() {
+        let entered = if !cfg!(feature = "gc") {
+            false
+        } else if let Some(gc_store) = store.gc_store.as_mut() {
             gc_store.gc_heap.enter_no_gc_scope();
             true
         } else {


### PR DESCRIPTION
Statically avoids various assertions/checks when this feature is disabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
