### PR TITLE
Statically disable MPK without the pooling allocator

### DIFF
--- a/crates/wasmtime/src/runtime/vm/mpk/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/mod.rs
@@ -30,7 +30,13 @@
 //! the public interface.
 
 cfg_if::cfg_if! {
-    if #[cfg(all(target_arch = "x86_64", target_os = "linux", feature = "std", not(miri)))] {
+    if #[cfg(all(
+        target_arch = "x86_64",
+        target_os = "linux",
+        feature = "pooling-allocator",
+        feature = "std",
+        not(miri),
+    ))] {
         mod enabled;
         mod pkru;
         mod sys;


### PR DESCRIPTION
When the pooling allocator is itself disabled then there's no use for enabling MPK so this commit switches the implementation to all of the disabled versions of the primitives. This notably makes `ProtectionKey` an uninhabited `enum` meaning that `Option<ProtectionKey>` in the `Store` is a zero-sized field and `.is_none()` returns a constant `true`. This is on the hot path of entering/exiting wasm so can help speed up things a bit there.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
