### PR TITLE
Add a compile-time feature for call hooks

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -126,6 +126,7 @@ default = [
   'component-model',
   'threads',
   'std',
+  'call-hook',
 ]
 
 # An on-by-default feature enabling runtime compilation of WebAssembly modules
@@ -261,3 +262,9 @@ std = [
   'object/std',
   'once_cell/std',
 ]
+
+# Enables support for the `Store::call_hook` API which enables injecting custom
+# logic around all entries/exits from WebAssembly. This has a slight performance
+# cost for all host functions so is provided as a compile-time feature if
+# embedders would like to disable it.
+call-hook = []

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -254,6 +254,11 @@
 //! * `threads` - Enabled by default, this enables compile-time support for the
 //!   WebAssembly `threads` proposal, notably shared memories.
 //!
+//! * `call-hook` - Enabled by default, this enables support for the
+//!   [`Store::call_hook`] API. This incurs a small overhead on all
+//!   entries/exits from WebAssembly and may want to be disabled by some
+//!   embedders.
+//!
 //! More crate features can be found in the [manifest] of Wasmtime itself for
 //! seeing what can be enabled and disabled.
 //!

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -49,7 +49,7 @@ pub use linker::*;
 pub use memory::*;
 pub use module::{Module, ModuleExport};
 pub use resources::*;
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", feature = "call-hook"))]
 pub use store::CallHookHandler;
 pub use store::{
     AsContext, AsContextMut, CallHook, Store, StoreContext, StoreContextMut, UpdateDeadline,


### PR DESCRIPTION
This commit moves the `Store::call_hook` API behind a Cargo feature named `call-hook`. This helps speed up the path from wasm into the host by avoiding branches at the start and the end of the execution. In a thread on [Zulip] this is locally leading to significant performance gains in this particular microbenchmark so having an option to disable it at the crate layer seems like a reasonable way to thread this needle for now. This definitely has a downside in that it requires a crate feature at all, but I'm not sure of a better solution as LLVM can't dynamically detect that `Store::call_hook` is never invoked and therefore the branch can be optimized away.

[Zulip]: https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/Performance.20regression.20since.20rust.201.2E65/near/444505571

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
