### PR TITLE
Update MSRV to 1.77.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -23,7 +23,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2024-05-06" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2024-06-13" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.76.0"
+rust-version = "1.77.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -583,27 +583,6 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
-        fn dynamic_int_lane(&mut self, ty: Type) -> Option<u32> {
-            if ty.is_dynamic_vector() && crate::machinst::ty_has_int_representation(ty.lane_type())
-            {
-                Some(ty.lane_bits())
-            } else {
-                None
-            }
-        }
-
-        #[inline]
-        fn dynamic_fp_lane(&mut self, ty: Type) -> Option<u32> {
-            if ty.is_dynamic_vector()
-                && crate::machinst::ty_has_float_or_vec_representation(ty.lane_type())
-            {
-                Some(ty.lane_bits())
-            } else {
-                None
-            }
-        }
-
-        #[inline]
         fn ty_dyn64_int(&mut self, ty: Type) -> Option<Type> {
             if ty.is_dynamic_vector() && ty.min_bits() == 64 && ty.lane_type().is_int() {
                 Some(ty)

--- a/cranelift/codegen/src/machinst/helpers.rs
+++ b/cranelift/codegen/src/machinst/helpers.rs
@@ -8,16 +8,6 @@ pub fn ty_bits(ty: Type) -> usize {
     ty.bits() as usize
 }
 
-/// Is the type represented by an integer (not float) at the machine level?
-pub(crate) fn ty_has_int_representation(ty: Type) -> bool {
-    ty.is_int() || ty.is_ref()
-}
-
-/// Is the type represented by a float or vector value at the machine level?
-pub(crate) fn ty_has_float_or_vec_representation(ty: Type) -> bool {
-    ty.is_vector() || ty.is_float()
-}
-
 /// Align a size up to a power-of-two alignment.
 pub(crate) fn align_to<N>(x: N, alignment: N) -> N
 where

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -581,16 +581,6 @@
 (decl dynamic_lane (u32 u32) Type)
 (extern extractor dynamic_lane dynamic_lane)
 
-;; Match a dynamic-lane integer type, extracting (# bits per lane) from the given
-;; type.
-(decl dynamic_int_lane (u32) Type)
-(extern extractor dynamic_int_lane dynamic_int_lane)
-
-;; Match a dynamic-lane floating point type, extracting (# bits per lane)
-;; from the given type.
-(decl dynamic_fp_lane (u32) Type)
-(extern extractor dynamic_fp_lane dynamic_fp_lane)
-
 ;; An extractor that only matches 64-bit dynamic vector types with integer
 ;; lanes (I8X8XN, I16X4XN, I32X2XN)
 (decl ty_dyn64_int (Type) Type)

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -167,7 +167,7 @@ mod tests {
 
             if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
                 assert_eq!(isa.default_call_conv(), CallConv::AppleAarch64);
-            } else if cfg!(any(unix, target_os = "nebulet")) {
+            } else if cfg!(unix) {
                 assert_eq!(isa.default_call_conv(), CallConv::SystemV);
             } else if cfg!(windows) {
                 assert_eq!(isa.default_call_conv(), CallConv::WindowsFastcall);

--- a/crates/wasi-common/src/tokio/mod.rs
+++ b/crates/wasi-common/src/tokio/mod.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(io_lifetimes_use_std, feature(io_safety))]
-
 mod dir;
 mod file;
 pub mod net;


### PR DESCRIPTION
This accompanies today's release of Rust 1.79.0. This means that CI will now use the latest stable of 1.79.0 for testing primarily. Additionally this updates the pinned nightly commit used for testing to today's nightly and fixes a few warnings that uncovered. I plan on having a follow-up that leverages some new APIs and features in 1.77.0.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
