### PR TITLE
Try migrating to a "more official" github pages provider

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -30,16 +30,13 @@ jobs:
 
     - run: ./ci/merge-artifacts.sh
 
-    # Deploy the `gh-pages.tar.gz` artifact to the `gh-pages` branch.
-    - run: tar xf gh-pages.tar.gz
-      working-directory: gh-pages
-    - name: Deploy to gh-pages
-      uses: JamesIves/github-pages-deploy-action@v4
+    # also prepare to deploy GH pages on main
+    - if: github.ref == 'refs/heads/main'
+      uses: actions/configure-pages@v5
+    - if: github.ref == 'refs/heads/main'
+      uses: actions/upload-pages-artifact@v3
       with:
-        folder: ./gh-pages/gh-pages
-        single-commit: true
-        clean: true
-      if: github.ref == 'refs/heads/main'
+        path: "./gh-pages/gh-pages"
 
     - run: npm install --production
       working-directory: .github/actions/github-release
@@ -49,3 +46,19 @@ jobs:
         files: "dist/*"
         token: ${{ github.token }}
       continue-on-error: true
+
+  # See https://github.com/actions/deploy-pages
+  deploy:
+    name: Deploy gh-pages artifact
+    if: github.ref == 'refs/heads/main'
+    needs: publish
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This commit is an attempt to migrate from
`JamesIves/github-pages-deploy-action`, a third party action, to what appears to be a more official action under the `github.com/actions` organization. This was first pioneered in
bytecodealliance/wasm-tools#1597 and it looked like it would work well over here too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
