### PR TITLE
Fix a typo in the `wasmtime_test` macro

### DIFF
--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -97,7 +97,7 @@ impl TestConfig {
         })?;
 
         if self.wasm_features.len() > 2 {
-            return Err(meta.error("Expected at most 7 strategies"));
+            return Err(meta.error("Expected at most 2 off-by-default wasm features"));
         }
 
         if self.wasm_features_unsupported_by_winch {


### PR DESCRIPTION
Follow-up to: https://github.com/bytecodealliance/wasmtime/pull/8789; fixes the validation error message.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
