### PR TITLE
Add `anyhow` stuff to our internal `wasmtime` crate prelude

### DIFF
--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -24,7 +24,6 @@
 
 use crate::prelude::*;
 use crate::Engine;
-use anyhow::{Context, Result};
 use std::{
     any::Any,
     borrow::Cow,

--- a/crates/wasmtime/src/compile/code_builder.rs
+++ b/crates/wasmtime/src/compile/code_builder.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::Engine;
-use anyhow::{anyhow, bail, Context, Result};
 use std::borrow::Cow;
 use std::path::Path;
 

--- a/crates/wasmtime/src/compile/runtime.rs
+++ b/crates/wasmtime/src/compile/runtime.rs
@@ -1,9 +1,9 @@
 use crate::compile::HashedEngineCompileEnv;
 #[cfg(feature = "component-model")]
 use crate::component::Component;
+use crate::prelude::*;
 use crate::runtime::vm::MmapVec;
 use crate::{CodeBuilder, CodeMemory, Engine, Module};
-use anyhow::{Context, Error, Result};
 use object::write::WritableBuffer;
 use std::sync::Arc;
 use wasmtime_environ::{FinishedObject, ObjectBuilder, ObjectKind};

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use alloc::sync::Arc;
-use anyhow::{bail, ensure, Result};
 use core::fmt;
 use core::str::FromStr;
 use hashbrown::{HashMap, HashSet};

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -6,7 +6,6 @@ use crate::runtime::vm::GcRuntime;
 use crate::sync::OnceLock;
 use crate::Config;
 use alloc::sync::Arc;
-use anyhow::{Context, Result};
 use core::sync::atomic::{AtomicU64, Ordering};
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 use object::write::{Object, StandardSegment};

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -23,7 +23,6 @@
 
 use crate::prelude::*;
 use crate::{Engine, ModuleVersionStrategy, Precompiled};
-use anyhow::{anyhow, bail, ensure, Context, Result};
 use core::str::FromStr;
 use object::endian::NativeEndian;
 #[cfg(any(feature = "cranelift", feature = "winch"))]

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -281,7 +281,11 @@
 extern crate std;
 extern crate alloc;
 
-use wasmtime_environ::prelude;
+pub(crate) mod prelude {
+    pub use crate::{Error, Result};
+    pub use anyhow::{anyhow, bail, ensure, format_err, Context};
+    pub use wasmtime_environ::prelude::*;
+}
 
 /// A helper macro to safely map `MaybeUninit<T>` to `MaybeUninit<U>` where `U`
 /// is a field projection within `T`.
@@ -375,6 +379,7 @@ use sync_nostd as sync;
 ///
 /// This type can be used to interact with `wasmtimes`'s extensive use
 /// of `anyhow::Error` while still not directly depending on `anyhow`.
+///
 /// This type alias is identical to `anyhow::Result`.
 #[doc(no_inline)]
 pub use anyhow::{Error, Result};

--- a/crates/wasmtime/src/profiling_agent.rs
+++ b/crates/wasmtime/src/profiling_agent.rs
@@ -1,6 +1,4 @@
 use crate::prelude::*;
-#[allow(unused)]
-use anyhow::{bail, Result};
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "profiling", target_os = "linux"))] {

--- a/crates/wasmtime/src/profiling_agent/jitdump.rs
+++ b/crates/wasmtime/src/profiling_agent/jitdump.rs
@@ -13,13 +13,11 @@
 
 use crate::prelude::*;
 use crate::profiling_agent::ProfilingAgent;
-use anyhow::Result;
+use object::elf;
 use std::process;
 use std::sync::Mutex;
 use target_lexicon::Architecture;
 use wasmtime_jit_debug::perf_jitdump::*;
-
-use object::elf;
 
 /// Interface for driving the creation of jitdump files
 struct JitDumpAgent {

--- a/crates/wasmtime/src/profiling_agent/perfmap.rs
+++ b/crates/wasmtime/src/profiling_agent/perfmap.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::profiling_agent::ProfilingAgent;
-use anyhow::Result;
 use std::io::{self, BufWriter, Write};
 use std::process;
 use std::{fs::File, sync::Mutex};

--- a/crates/wasmtime/src/profiling_agent/vtune.rs
+++ b/crates/wasmtime/src/profiling_agent/vtune.rs
@@ -14,7 +14,6 @@
 
 use crate::prelude::*;
 use crate::profiling_agent::ProfilingAgent;
-use anyhow::Result;
 use ittapi::jit::MethodLoadBuilder;
 use std::sync::Mutex;
 

--- a/crates/wasmtime/src/runtime/code_memory.rs
+++ b/crates/wasmtime/src/runtime/code_memory.rs
@@ -2,7 +2,6 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::{libcalls, MmapVec, UnwindRegistration};
-use anyhow::{anyhow, bail, Context, Result};
 use core::mem::ManuallyDrop;
 use core::ops::Range;
 use object::endian::NativeEndian;

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use crate::{FuncType, ValType};
 use alloc::sync::Arc;
-use anyhow::Result;
 use core::any::Any;
 use core::mem;
 use core::ops::Range;

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -8,7 +8,6 @@ use crate::runtime::vm::{Export, ExportFunction};
 use crate::store::{StoreOpaque, Stored};
 use crate::{AsContext, AsContextMut, StoreContextMut, ValRaw};
 use alloc::sync::Arc;
-use anyhow::{bail, Context, Result};
 use core::mem::{self, MaybeUninit};
 use core::ptr::NonNull;
 use wasmtime_environ::component::{

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -9,7 +9,6 @@ use crate::runtime::vm::component::{
 use crate::runtime::vm::{VMFuncRef, VMMemoryDefinition, VMOpaqueContext};
 use crate::{AsContextMut, StoreContextMut, ValRaw};
 use alloc::sync::Arc;
-use anyhow::{bail, Context, Result};
 use core::any::Any;
 use core::mem::{self, MaybeUninit};
 use core::ptr::NonNull;

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -9,7 +9,6 @@ use crate::runtime::vm::{VMFuncRef, VMMemoryDefinition};
 use crate::store::{StoreId, StoreOpaque};
 use crate::{FuncType, StoreContextMut};
 use alloc::sync::Arc;
-use anyhow::{bail, Result};
 use core::ptr::NonNull;
 use wasmtime_environ::component::{ComponentTypes, StringEncoding, TypeResourceTableIndex};
 

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -7,7 +7,6 @@ use crate::runtime::vm::SendSyncPtr;
 use crate::{AsContextMut, StoreContext, StoreContextMut, ValRaw};
 use alloc::borrow::Cow;
 use alloc::sync::Arc;
-use anyhow::{anyhow, bail, Context, Result};
 use core::fmt;
 use core::marker;
 use core::mem::{self, MaybeUninit};

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -9,7 +9,6 @@ use crate::runtime::vm::VMFuncRef;
 use crate::store::{StoreOpaque, Stored};
 use crate::{AsContextMut, Module, StoreContextMut};
 use alloc::sync::Arc;
-use anyhow::{anyhow, Context, Result};
 use core::marker;
 use core::ptr::{self, NonNull};
 use wasmtime_environ::{component::*, EngineOrModuleTypeIndex};

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -8,7 +8,6 @@ use crate::component::{
 use crate::prelude::*;
 use crate::{AsContextMut, Engine, Module, StoreContextMut};
 use alloc::sync::Arc;
-use anyhow::{bail, Context, Result};
 use core::future::Future;
 use core::marker;
 use core::pin::Pin;

--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -6,7 +6,6 @@ use crate::runtime::vm::component::ComponentInstance;
 use crate::types::matching;
 use crate::Module;
 use alloc::sync::Arc;
-use anyhow::{anyhow, bail, Context, Result};
 use core::any::Any;
 use wasmtime_environ::component::{
     ComponentTypes, ResourceIndex, TypeComponentInstance, TypeDef, TypeFuncIndex, TypeModule,

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -655,3 +655,9 @@ pub use wasmtime_component_macro::flags;
 
 #[cfg(any(docsrs, test, doctest))]
 pub mod bindgen_examples;
+
+// NB: needed for the links in the docs above to work in all `cargo doc`
+// configurations and avoid errors.
+#[cfg(not(any(docsrs, test, doctest)))]
+#[doc(hidden)]
+pub mod bindgen_examples {}

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -6,7 +6,6 @@ use crate::runtime::vm::component::{ComponentInstance, InstanceFlags, ResourceTa
 use crate::runtime::vm::{SendSyncPtr, VMFuncRef, ValRaw};
 use crate::store::{StoreId, StoreOpaque};
 use crate::{AsContextMut, StoreContextMut, Trap};
-use anyhow::{bail, ensure, Result};
 use core::any::TypeId;
 use core::fmt;
 use core::marker;

--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -2,7 +2,6 @@ use crate::component::func::{desc, Lift, LiftContext, Lower, LowerContext};
 use crate::component::ResourceAny;
 use crate::prelude::*;
 use crate::ValRaw;
-use anyhow::{anyhow, bail, Result};
 use core::mem::MaybeUninit;
 use core::slice::{Iter, IterMut};
 use wasmtime_component_util::{DiscriminantSize, FlagsSize};

--- a/crates/wasmtime/src/runtime/debug.rs
+++ b/crates/wasmtime/src/runtime/debug.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use anyhow::{anyhow, bail, ensure, Error};
 use core::mem::size_of;
 use object::elf::*;
 use object::endian::{BigEndian, Endian, Endianness, LittleEndian};

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use crate::runtime::vm::{GcRootsList, SendSyncPtr};
 use crate::{
     store::{AutoAssertNoGc, StoreData, StoreOpaque, Stored},
@@ -5,7 +6,6 @@ use crate::{
     AnyRef, AsContext, AsContextMut, ExternRef, Func, GlobalType, HeapType, Mutability, Ref,
     RootedGcRefImpl, Val, ValType,
 };
-use anyhow::{bail, Context, Result};
 use core::ptr;
 use core::ptr::NonNull;
 use wasmtime_environ::TypeTrace;

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -3,7 +3,6 @@ use crate::runtime::vm::{self as runtime};
 use crate::store::{AutoAssertNoGc, StoreData, StoreOpaque, Stored};
 use crate::trampoline::generate_table_export;
 use crate::{AnyRef, AsContext, AsContextMut, ExternRef, Func, HeapType, Ref, TableType};
-use anyhow::{anyhow, bail, Context, Result};
 use core::iter;
 use core::ptr::NonNull;
 use runtime::{GcRootsList, SendSyncPtr};

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -11,7 +11,6 @@ use crate::{
     StoreContext, StoreContextMut, Val, ValRaw, ValType,
 };
 use alloc::sync::Arc;
-use anyhow::{bail, Context as _, Error, Result};
 use core::ffi::c_void;
 use core::future::Future;
 use core::mem::{self, MaybeUninit};

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -1,11 +1,11 @@
 use super::invoke_wasm_and_catch_traps;
+use crate::prelude::*;
 use crate::runtime::vm::{VMFuncRef, VMOpaqueContext};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{
     AsContext, AsContextMut, Engine, Func, FuncType, HeapType, NoFunc, RefType, StoreContextMut,
     ValRaw, ValType,
 };
-use anyhow::{bail, Context, Result};
 use core::ffi::c_void;
 use core::marker;
 use core::mem::{self, MaybeUninit};

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -7,7 +7,6 @@ use crate::{
     AsContextMut, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType, ManuallyRooted, RefType,
     Result, RootSet, Rooted, StoreContext, StoreContextMut, ValRaw, ValType, WasmTy,
 };
-use anyhow::Context;
 use core::any::Any;
 use core::mem;
 use core::mem::MaybeUninit;

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -108,7 +108,6 @@ use crate::{
     store::{AutoAssertNoGc, StoreId, StoreOpaque},
     AsContext, AsContextMut, GcRef, Result, RootedGcRef,
 };
-use anyhow::anyhow;
 use core::any;
 use core::marker;
 use core::mem;

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -11,7 +11,6 @@ use crate::{
     StoreContext, StoreContextMut, Table, TypedFunc,
 };
 use alloc::sync::Arc;
-use anyhow::{anyhow, bail, Context, Result};
 use core::ptr::NonNull;
 use wasmparser::WasmFeatures;
 use wasmtime_environ::{

--- a/crates/wasmtime/src/runtime/instantiate.rs
+++ b/crates/wasmtime/src/runtime/instantiate.rs
@@ -7,7 +7,6 @@ use crate::prelude::*;
 use crate::runtime::vm::{CompiledModuleId, MmapVec};
 use crate::{code_memory::CodeMemory, profiling_agent::ProfilingAgent};
 use alloc::sync::Arc;
-use anyhow::Result;
 use core::str;
 use wasmtime_environ::{
     CompiledFunctionInfo, CompiledModuleInfo, DefinedFuncIndex, FuncIndex, FunctionLoc,
@@ -70,8 +69,6 @@ impl CompiledModule {
     fn register_debug_and_profiling(&mut self, profiler: &dyn ProfilingAgent) -> Result<()> {
         #[cfg(feature = "debug-builtins")]
         if self.meta.native_debug_info_present {
-            use anyhow::Context;
-
             let text = self.text();
             let bytes = crate::debug::create_gdbjit_image(
                 self.mmap().to_vec(),
@@ -263,7 +260,6 @@ impl CompiledModule {
     /// what filename and line number a wasm pc comes from.
     #[cfg(feature = "addr2line")]
     pub fn symbolize_context(&self) -> Result<Option<SymbolizeContext<'_>>> {
-        use anyhow::Context;
         use gimli::EndianSlice;
         if !self.meta.has_wasm_debuginfo {
             return Ok(None);

--- a/crates/wasmtime/src/runtime/limits.rs
+++ b/crates/wasmtime/src/runtime/limits.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use anyhow::{bail, Result};
 
 /// Value returned by [`ResourceLimiter::instances`] default method
 pub const DEFAULT_INSTANCE_LIMIT: usize = 10000;

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -7,7 +7,6 @@ use crate::{
     Instance, Module, StoreContextMut, Val, ValRaw, ValType, WasmTyList,
 };
 use alloc::sync::Arc;
-use anyhow::{bail, Context, Result};
 use core::fmt;
 #[cfg(feature = "async")]
 use core::future::Future;

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -4,7 +4,6 @@ use crate::store::{StoreData, StoreOpaque, Stored};
 use crate::trampoline::generate_memory_export;
 use crate::Trap;
 use crate::{AsContext, AsContextMut, Engine, MemoryType, StoreContext, StoreContextMut};
-use anyhow::{bail, Result};
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::ops::Range;

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -11,7 +11,6 @@ use crate::{
     Engine,
 };
 use alloc::sync::Arc;
-use anyhow::{bail, Result};
 use core::fmt;
 use core::ops::Range;
 use core::ptr::NonNull;

--- a/crates/wasmtime/src/runtime/profiling.rs
+++ b/crates/wasmtime/src/runtime/profiling.rs
@@ -1,9 +1,6 @@
 use crate::prelude::*;
 use crate::runtime::vm::Backtrace;
 use crate::{instantiate::CompiledModule, AsContext, Module};
-#[allow(unused_imports)]
-use anyhow::bail;
-use anyhow::Result;
 use fxprof_processed_profile::{
     debugid::DebugId, CategoryHandle, Frame, FrameFlags, FrameInfo, LibraryInfo, Profile,
     ReferenceTimestamp, Symbol, SymbolTable, Timestamp,

--- a/crates/wasmtime/src/runtime/stack.rs
+++ b/crates/wasmtime/src/runtime/stack.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use anyhow::Error;
 use std::{ops::Range, sync::Arc};
 use wasmtime_fiber::{RuntimeFiberStack, RuntimeFiberStackCreator};
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -92,7 +92,6 @@ use crate::RootSet;
 use crate::{module::ModuleRegistry, Engine, Module, Trap, Val, ValRaw};
 use crate::{Global, Instance, Memory, RootScope, Table, Uninhabited};
 use alloc::sync::Arc;
-use anyhow::{anyhow, bail, Result};
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::future::Future;

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -19,7 +19,6 @@ use crate::runtime::vm::{
 use crate::store::{InstanceId, StoreOpaque};
 use crate::{MemoryType, TableType};
 use alloc::sync::Arc;
-use anyhow::Result;
 use core::any::Any;
 use wasmtime_environ::{MemoryIndex, Module, TableIndex, VMSharedTypeIndex};
 

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -6,7 +6,6 @@ use crate::runtime::vm::{
 };
 use crate::type_registry::RegisteredType;
 use crate::{FuncType, ValRaw};
-use anyhow::Result;
 use core::ptr;
 
 struct TrampolineState<F> {

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -10,7 +10,6 @@ use crate::runtime::vm::{
 use crate::store::{InstanceId, StoreOpaque};
 use crate::MemoryType;
 use alloc::sync::Arc;
-use anyhow::{anyhow, Result};
 use core::ops::Range;
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, EntityIndex, HostPtr, MemoryPlan, MemoryStyle, Module,

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::TableType;
-use anyhow::Result;
 use wasmtime_environ::{EntityIndex, Module, TypeTrace};
 
 pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<InstanceId> {

--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -19,11 +19,12 @@ use wasmtime_environ::{
 ///
 /// # Errors in Wasmtime
 ///
-/// Error-handling in Wasmtime is primarily done through the [`anyhow`] crate
-/// where most results are a [`Result<T>`](anyhow::Result) which is an alias for
-/// [`Result<T, anyhow::Error>`](std::result::Result). Errors in Wasmtime are
-/// represented with [`anyhow::Error`] which acts as a container for any type of
-/// error in addition to optional context for this error. The "base" error or
+/// Error-handling in Wasmtime is primarily done through the
+/// [`anyhow`][mod@anyhow] crate where most results are a
+/// [`Result<T>`](anyhow::Result) which is an alias for [`Result<T,
+/// anyhow::Error>`](std::result::Result). Errors in Wasmtime are represented
+/// with [`anyhow::Error`] which acts as a container for any type of error in
+/// addition to optional context for this error. The "base" error or
 /// [`anyhow::Error::root_cause`] is a [`Trap`] whenever WebAssembly hits a
 /// trap, or otherwise it's whatever the host created the error with when
 /// returning an error for a host call.

--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -3,7 +3,6 @@ use super::coredump::WasmCoreDump;
 use crate::prelude::*;
 use crate::store::StoreOpaque;
 use crate::{AsContext, Module};
-use anyhow::Error;
 use core::fmt;
 use wasmtime_environ::{
     demangle_function_name, demangle_function_name_or_index, EntityRef, FilePos,

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use anyhow::{bail, ensure, Context, Result};
 use core::fmt::{self, Display, Write};
 use wasmtime_environ::{
     EngineOrModuleTypeIndex, EntityType, Global, Memory, ModuleTypes, Table, TypeTrace,

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::{linker::DefinitionType, Engine, FuncType};
-use anyhow::{anyhow, bail, Result};
 use wasmtime_environ::{
     EntityType, Global, Memory, ModuleTypes, Table, TypeTrace, VMSharedTypeIndex,
     WasmCompositeType, WasmFieldType, WasmHeapType, WasmRefType, WasmSubType, WasmValType,

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -1,10 +1,10 @@
+use crate::prelude::*;
 use crate::runtime::vm::{TableElement, VMGcRef};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{
     AnyRef, AsContext, AsContextMut, ExternRef, Func, HeapType, RefType, Rooted, RootedGcRefImpl,
     ValType, V128,
 };
-use anyhow::{bail, Context, Result};
 use core::ptr;
 
 pub use crate::runtime::vm::ValRaw;

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -5,7 +5,6 @@
 
 use crate::prelude::*;
 use alloc::sync::Arc;
-use anyhow::{anyhow, Error, Result};
 use core::fmt;
 use core::mem;
 use core::ptr::NonNull;

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -6,13 +6,13 @@
 //! Eventually it's intended that module-to-module calls, which would be
 //! cranelift-compiled adapters, will use this `VMComponentContext` as well.
 
+use crate::prelude::*;
 use crate::runtime::vm::{
     SendSyncPtr, Store, VMArrayCallFunction, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition,
     VMOpaqueContext, VMWasmCallFunction, ValRaw,
 };
 use alloc::alloc::Layout;
 use alloc::sync::Arc;
-use anyhow::Result;
 use core::any::Any;
 use core::marker;
 use core::mem;

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -1,7 +1,7 @@
 //! Implementation of string transcoding required by the component model.
 
+use crate::prelude::*;
 use crate::runtime::vm::component::{ComponentInstance, VMComponentContext};
-use anyhow::{anyhow, Result};
 use core::cell::Cell;
 use core::slice;
 use wasmtime_environ::component::TypeResourceTableIndex;

--- a/crates/wasmtime/src/runtime/vm/component/resources.rs
+++ b/crates/wasmtime/src/runtime/vm/component/resources.rs
@@ -24,7 +24,6 @@
 //! namely in the `Resource<T>` and `ResourceAny` types.
 
 use crate::prelude::*;
-use anyhow::{bail, Result};
 use core::mem;
 use wasmtime_environ::component::TypeResourceTableIndex;
 use wasmtime_environ::PrimaryMap;

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -1,7 +1,7 @@
 //! Evaluating const expressions.
 
+use crate::prelude::*;
 use crate::runtime::vm::{Instance, VMGcRef, ValRaw, I31};
-use anyhow::{anyhow, bail, Result};
 use smallvec::SmallVec;
 use wasmtime_environ::{ConstExpr, FuncIndex, GlobalIndex, Module};
 

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -5,7 +5,6 @@ use crate::prelude::*;
 use crate::runtime::vm::sys::vm::{self, MemoryImageSource};
 use crate::runtime::vm::{MmapVec, SendSyncPtr};
 use alloc::sync::Arc;
-use anyhow::Result;
 use core::ffi::c_void;
 use core::ops::Range;
 use core::ptr::{self, NonNull};
@@ -744,11 +743,10 @@ impl Drop for MemoryImageSlot {
 
 #[cfg(all(test, target_os = "linux", not(miri)))]
 mod test {
-    use super::{MemoryImage, MemoryImageSlot, MemoryImageSource, MemoryPlan, MemoryStyle};
+    use super::*;
     use crate::runtime::vm::host_page_size;
     use crate::runtime::vm::mmap::Mmap;
     use crate::runtime::vm::sys::vm::decommit_pages;
-    use anyhow::Result;
     use std::sync::Arc;
     use wasmtime_environ::Memory;
 

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -20,7 +20,6 @@ pub use i31::*;
 
 use crate::prelude::*;
 use crate::runtime::vm::GcHeapAllocationIndex;
-use anyhow::{bail, Result};
 use core::ptr;
 use core::{any::Any, num::NonZeroUsize};
 use wasmtime_environ::StackMap;

--- a/crates/wasmtime/src/runtime/vm/gc/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/disabled.rs
@@ -7,7 +7,6 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::{GcHeap, GcRuntime};
-use anyhow::Result;
 
 pub fn default_gc_runtime() -> impl GcRuntime {
     DisabledCollector

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -47,7 +47,6 @@ use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
     GcProgress, GcRootsIter, GcRuntime, Mmap, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
 };
-use anyhow::Result;
 use core::ops::{Deref, DerefMut};
 use core::{
     alloc::Layout,

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use alloc::collections::BTreeMap;
-use anyhow::{anyhow, ensure, Context, Result};
 use core::cmp;
 use core::{alloc::Layout, num::NonZeroU32, ops::Bound};
 

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::runtime::vm::{GcHeap, GcStore, I31};
-use anyhow::{Context, Result};
 use core::fmt;
 use core::marker;
 use core::num::NonZeroU32;

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, SendSyncPtr, VMExternRef, VMGcHeader, VMGcRef,
 };
-use anyhow::Result;
 use core::marker;
 use core::ptr;
 use core::{any::Any, num::NonZeroUsize};

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -17,7 +17,6 @@ use crate::runtime::vm::{
     SendSyncPtr, Store, VMFunctionBody, VMGcRef, WasmFault,
 };
 use alloc::sync::Arc;
-use anyhow::{Error, Result};
 use core::alloc::Layout;
 use core::any::Any;
 use core::ops::Range;

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -6,7 +6,6 @@ use crate::runtime::vm::memory::Memory;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::table::Table;
 use crate::runtime::vm::{CompiledModuleId, ModuleRuntimeInfo, Store, VMFuncRef, VMGcRef};
-use anyhow::{bail, Result};
 use core::{any::Any, mem, ptr};
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, HostPtr, InitMemory, MemoryInitialization,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
@@ -8,7 +8,6 @@ use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::table::Table;
 use crate::runtime::vm::CompiledModuleId;
 use alloc::sync::Arc;
-use anyhow::Result;
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, HostPtr, MemoryPlan, Module, TablePlan, VMOffsets,
 };

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -52,7 +52,6 @@ use crate::runtime::vm::{
     mpk::{self, MpkEnabled, ProtectionKey, ProtectionMask},
     CompiledModuleId, Memory, Table,
 };
-use anyhow::{bail, Result};
 use std::borrow::Cow;
 use std::fmt::Display;
 use std::sync::{Mutex, MutexGuard};

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
@@ -2,7 +2,6 @@ use super::index_allocator::{SimpleIndexAllocator, SlotId};
 use super::GcHeapAllocationIndex;
 use crate::prelude::*;
 use crate::runtime::vm::{GcHeap, GcRuntime, PoolingInstanceAllocatorConfig, Result};
-use anyhow::anyhow;
 use std::sync::Mutex;
 
 /// A pool of reusable GC heaps.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(asan), allow(dead_code))]
 
+use crate::prelude::*;
 use crate::{runtime::vm::PoolingInstanceAllocatorConfig, PoolConcurrencyLimitError};
-use anyhow::{bail, Result};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A generic implementation of a stack pool.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -60,7 +60,6 @@ use crate::runtime::vm::{
     MpkEnabled, PoolingInstanceAllocatorConfig,
 };
 use crate::{prelude::*, vm::round_usize_up_to_host_pages};
-use anyhow::{anyhow, bail, Context, Result};
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -2,11 +2,11 @@ use super::{
     index_allocator::{SimpleIndexAllocator, SlotId},
     round_up_to_pow2, TableAllocationIndex,
 };
+use crate::prelude::*;
 use crate::runtime::vm::{
     InstanceAllocationRequest, Mmap, PoolingInstanceAllocatorConfig, SendSyncPtr, Table,
 };
 use crate::{runtime::vm::sys::vm::commit_pages, vm::round_usize_up_to_host_pages};
-use anyhow::{anyhow, bail, Context, Result};
 use std::mem;
 use std::ptr::NonNull;
 use wasmtime_environ::{Module, TablePlan};

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -4,9 +4,9 @@ use super::{
     index_allocator::{SimpleIndexAllocator, SlotId},
     round_up_to_pow2,
 };
+use crate::prelude::*;
 use crate::runtime::vm::sys::vm::commit_pages;
 use crate::runtime::vm::{round_usize_up_to_host_pages, Mmap, PoolingInstanceAllocatorConfig};
-use anyhow::{anyhow, bail, Context, Result};
 
 /// Represents a pool of execution stacks (used for the async fiber implementation).
 ///
@@ -213,7 +213,6 @@ impl StackPool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::*;
     use crate::runtime::vm::InstanceLimits;
 
     #[cfg(all(unix, target_pointer_width = "64", feature = "async", not(miri)))]

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -54,12 +54,10 @@
 //! }
 //! ```
 
+use crate::prelude::*;
 use crate::runtime::vm::table::{Table, TableElementType};
 use crate::runtime::vm::vmcontext::VMFuncRef;
 use crate::runtime::vm::{Instance, TrapReason, VMGcRef};
-#[cfg(feature = "wmemcheck")]
-use anyhow::bail;
-use anyhow::Result;
 #[cfg(feature = "threads")]
 use core::time::Duration;
 use wasmtime_environ::{DataIndex, ElemIndex, FuncIndex, MemoryIndex, TableIndex, Trap, Unsigned};

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -10,8 +10,6 @@ use crate::runtime::vm::{
     MemoryImageSlot, SendSyncPtr, SharedMemory, Store, WaitResult,
 };
 use alloc::sync::Arc;
-use anyhow::Error;
-use anyhow::{bail, format_err, Result};
 use core::ops::Range;
 use core::ptr::NonNull;
 use core::time::Duration;

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -3,7 +3,6 @@
 
 use crate::runtime::vm::sys::mmap;
 use crate::{prelude::*, vm::usize_is_multiple_of_host_page_size};
-use anyhow::{Context, Result};
 use core::ops::Range;
 #[cfg(feature = "std")]
 use std::{fs::File, path::Path, sync::Arc};

--- a/crates/wasmtime/src/runtime/vm/mmap_vec.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap_vec.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::runtime::vm::Mmap;
 use alloc::sync::Arc;
-use anyhow::Result;
 use core::ops::{Deref, DerefMut, Range};
 #[cfg(feature = "std")]
 use std::{fs::File, path::Path};
@@ -64,8 +63,6 @@ impl MmapVec {
     /// it's too large to be fully mapped into memory.
     #[cfg(feature = "std")]
     pub fn from_file(path: &Path) -> Result<MmapVec> {
-        use anyhow::Context;
-
         let mmap = Mmap::from_file(path)
             .with_context(|| format!("failed to create mmap for file: {}", path.display()))?;
         let len = mmap.len();

--- a/crates/wasmtime/src/runtime/vm/mpk/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/disabled.rs
@@ -3,7 +3,7 @@
 
 #![allow(missing_docs)]
 
-use anyhow::Result;
+use crate::prelude::*;
 
 pub fn is_supported() -> bool {
     false

--- a/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
@@ -2,7 +2,6 @@
 
 use super::{pkru, sys};
 use crate::prelude::*;
-use anyhow::{Context, Result};
 use std::sync::OnceLock;
 
 /// Check if the MPK feature is supported.

--- a/crates/wasmtime/src/runtime/vm/mpk/sys.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/sys.rs
@@ -9,8 +9,8 @@
 //! [`pkey_mprotect`]: https://man7.org/linux/man-pages/man2/pkey_mprotect.2.html
 //! [`pkeys`]: https://man7.org/linux/man-pages/man7/pkeys.7.html
 
+use crate::prelude::*;
 use crate::runtime::vm::host_page_size;
-use anyhow::Result;
 use std::io::Error;
 
 /// Protection mask disallowing reads and writes of pkey-protected memory (see
@@ -74,7 +74,6 @@ pub fn pkey_mprotect(addr: usize, len: usize, prot: u32, key: u32) -> Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::*;
 
     #[ignore = "cannot be run when keys() has already allocated all keys"]
     #[test]

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -1,7 +1,7 @@
 use super::cvt;
+use crate::prelude::*;
 use crate::runtime::vm::sys::capi;
 use crate::runtime::vm::SendSyncPtr;
-use anyhow::Result;
 use core::ops::Range;
 use core::ptr::{self, NonNull};
 #[cfg(feature = "std")]

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mod.rs
@@ -8,7 +8,7 @@
 //! For more information about this see `./examples/min-platform` as well as
 //! `./docs/examples-minimal.md`.
 
-use anyhow::{bail, Result};
+use crate::prelude::*;
 
 pub mod capi;
 pub mod mmap;

--- a/crates/wasmtime/src/runtime/vm/sys/custom/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/unwind.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use anyhow::Result;
+use crate::prelude::*;
 
 pub struct UnwindRegistration {}
 

--- a/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
@@ -1,8 +1,8 @@
 use super::cvt;
+use crate::prelude::*;
 use crate::runtime::vm::sys::capi;
 use crate::runtime::vm::SendSyncPtr;
 use crate::vm::sys::DecommitBehavior;
-use anyhow::Result;
 use core::ptr::{self, NonNull};
 #[cfg(feature = "std")]
 use std::{fs::File, sync::Arc};

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -5,8 +5,8 @@
 //! like becoming executable or becoming readonly or being created from files,
 //! but it's enough to get various tests running relying on memories and such.
 
+use crate::prelude::*;
 use crate::runtime::vm::SendSyncPtr;
-use anyhow::{bail, Result};
 use std::alloc::{self, Layout};
 use std::fs::File;
 use std::ops::Range;

--- a/crates/wasmtime/src/runtime/vm/sys/miri/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/unwind.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use anyhow::Result;
+use crate::prelude::*;
 
 pub struct UnwindRegistration {}
 

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::runtime::vm::SendSyncPtr;
-use anyhow::Result;
 use rustix::mm::{mprotect, MprotectFlags};
 use std::ops::Range;
 use std::ptr::{self, NonNull};
@@ -52,8 +51,6 @@ impl Mmap {
 
     #[cfg(feature = "std")]
     pub fn from_file(path: &Path) -> Result<(Self, File)> {
-        use anyhow::Context;
-
         let file = File::open(path)
             .err2anyhow()
             .context("failed to open file")?;

--- a/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
@@ -2,7 +2,6 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::SendSyncPtr;
-use anyhow::Result;
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::runtime::vm::SendSyncPtr;
-use anyhow::{anyhow, bail, Context, Result};
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::ops::Range;

--- a/crates/wasmtime/src/runtime/vm/sys/windows/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/unwind.rs
@@ -1,6 +1,6 @@
 //! Module for Windows x64 ABI unwind registry.
 
-use anyhow::{bail, Result};
+use crate::prelude::*;
 use std::mem;
 use windows_sys::Win32::System::Diagnostics::Debug::*;
 

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -7,7 +7,6 @@
 use crate::prelude::*;
 use crate::runtime::vm::vmcontext::{VMFuncRef, VMTableDefinition};
 use crate::runtime::vm::{GcStore, SendSyncPtr, Store, VMGcRef};
-use anyhow::{bail, ensure, format_err, Error, Result};
 use core::cmp;
 use core::ops::Range;
 use core::ptr::{self, NonNull};

--- a/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
+++ b/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
@@ -3,8 +3,6 @@ use crate::runtime::vm::memory::{validate_atomic_addr, MmapMemory};
 use crate::runtime::vm::threads::parking_spot::{ParkingSpot, Waiter};
 use crate::runtime::vm::vmcontext::VMMemoryDefinition;
 use crate::runtime::vm::{Memory, RuntimeLinearMemory, Store, WaitResult};
-use anyhow::Error;
-use anyhow::{bail, Result};
 use std::cell::RefCell;
 use std::ops::Range;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};

--- a/crates/wasmtime/src/runtime/vm/threads/shared_memory_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/threads/shared_memory_disabled.rs
@@ -2,7 +2,6 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::{RuntimeLinearMemory, Store, VMMemoryDefinition, WaitResult};
-use anyhow::{bail, Result};
 use core::ops::Range;
 use core::time::Duration;
 use wasmtime_environ::{MemoryPlan, Trap};

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -14,7 +14,6 @@ use crate::prelude::*;
 use crate::runtime::vm::sys::traphandlers;
 use crate::runtime::vm::{Instance, VMContext, VMRuntimeLimits};
 use crate::sync::OnceLock;
-use anyhow::Error;
 use core::cell::{Cell, UnsafeCell};
 use core::mem::MaybeUninit;
 use core::ptr;


### PR DESCRIPTION
We use it basically everywhere and it is annoying to have to import.

I also did an audit of existing `use` statements and removed the now-redundant ones and replaced one-off imports with usage of the prelude, so that the prelude is available by default in more places.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
