### PR TITLE
Update the spec test suite submodule

### DIFF
--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -78,6 +78,10 @@ fn ignore(test: &Path, strategy: Strategy) -> bool {
         if part == "extended-const" {
             return true;
         }
+        // Wasmtime doesn't implement the table64 extension yet.
+        if part == "memory64" {
+            return true;
+        }
 
         // TODO(#6530): These tests require tail calls, but s390x doesn't
         // support them yet.
@@ -175,6 +179,7 @@ fn ignore(test: &Path, strategy: Strategy) -> bool {
                 "type-subtyping.wast",
                 "unreached-invalid.wast",
                 "unreached_valid.wast",
+                "i31.wast",
             ]
             .iter()
             .any(|i| test.ends_with(i));

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -80,7 +80,20 @@ fn ignore(test: &Path, strategy: Strategy) -> bool {
         }
         // Wasmtime doesn't implement the table64 extension yet.
         if part == "memory64" {
-            return true;
+            return [
+                "call_indirect.wast",
+                "table_copy.wast",
+                "table_get.wast",
+                "table_set.wast",
+                "table_fill.wast",
+                "table.wast",
+                "table_init.wast",
+                "table_copy_mixed.wast",
+                "table_grow.wast",
+                "table_size.wast",
+            ]
+            .iter()
+            .any(|i| test.ends_with(i));
         }
 
         // TODO(#6530): These tests require tail calls, but s390x doesn't

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -80,7 +80,7 @@ fn ignore(test: &Path, strategy: Strategy) -> bool {
         }
         // Wasmtime doesn't implement the table64 extension yet.
         if part == "memory64" {
-            return [
+            if [
                 "call_indirect.wast",
                 "table_copy.wast",
                 "table_get.wast",
@@ -93,7 +93,10 @@ fn ignore(test: &Path, strategy: Strategy) -> bool {
                 "table_size.wast",
             ]
             .iter()
-            .any(|i| test.ends_with(i));
+            .any(|i| test.ends_with(i))
+            {
+                return true;
+            }
         }
 
         // TODO(#6530): These tests require tail calls, but s390x doesn't


### PR DESCRIPTION
* Ignore the `memory64` tests since Wasmtime doesn't implement the table64 extension yet.
* Ignore `gc/i31.wast` as it's got new tests which Wasmtime doesn't currently pass.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
