### PR TITLE
Const-propagate some offsets in `VMOffsets`

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -193,9 +193,7 @@ impl wasmtime_environ::Compiler for Compiler {
             .create_global_value(ir::GlobalValueData::VMContext);
         let interrupts_ptr = context.func.create_global_value(ir::GlobalValueData::Load {
             base: vmctx,
-            offset: i32::try_from(func_env.offsets.vmctx_runtime_limits())
-                .unwrap()
-                .into(),
+            offset: i32::from(func_env.offsets.ptr.vmctx_runtime_limits()).into(),
             global_type: isa.pointer_type(),
             flags: MemFlags::trusted().with_readonly(),
         });
@@ -282,12 +280,12 @@ impl wasmtime_environ::Compiler for Compiler {
         // what we are assuming with our offsets below.
         debug_assert_vmctx_kind(isa, &mut builder, vmctx, wasmtime_environ::VMCONTEXT_MAGIC);
         let offsets = VMOffsets::new(isa.pointer_bytes(), &translation.module);
-        let vm_runtime_limits_offset = offsets.vmctx_runtime_limits();
+        let vm_runtime_limits_offset = offsets.ptr.vmctx_runtime_limits();
         save_last_wasm_entry_sp(
             &mut builder,
             pointer_type,
             &offsets.ptr,
-            vm_runtime_limits_offset,
+            vm_runtime_limits_offset.into(),
             vmctx,
         );
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -287,7 +287,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         let pointer_type = self.pointer_type();
         let vmctx = self.vmctx(builder.func);
         let base = builder.ins().global_value(pointer_type, vmctx);
-        let offset = i32::try_from(self.offsets.vmctx_runtime_limits()).unwrap();
+        let offset = i32::from(self.offsets.ptr.vmctx_runtime_limits());
         debug_assert!(self.vmruntime_limits_ptr.is_reserved_value());
         self.vmruntime_limits_ptr =
             builder
@@ -580,7 +580,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         let vmctx = self.vmctx(builder.func);
         let pointer_type = self.pointer_type();
         let base = builder.ins().global_value(pointer_type, vmctx);
-        let offset = i32::try_from(self.offsets.vmctx_epoch_ptr()).unwrap();
+        let offset = i32::try_from(self.offsets.ptr.vmctx_epoch_ptr()).unwrap();
         let epoch_ptr = builder
             .ins()
             .load(pointer_type, ir::MemFlags::trusted(), base, offset);
@@ -1518,7 +1518,7 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
             pointer_type,
             mem_flags,
             base,
-            i32::try_from(self.env.offsets.vmctx_type_ids_array()).unwrap(),
+            i32::from(self.env.offsets.ptr.vmctx_type_ids_array()),
         );
         let sig_index = self.env.module.types[ty_index];
         let offset =

--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -5,7 +5,7 @@ use cranelift_frontend::FunctionBuilder;
 use cranelift_wasm::{
     TargetEnvironment, WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult, WasmValType,
 };
-use wasmtime_environ::{I31_DISCRIMINANT, NON_NULL_NON_I31_MASK};
+use wasmtime_environ::{PtrSize, I31_DISCRIMINANT, NON_NULL_NON_I31_MASK};
 
 /// Get the default GC compiler.
 pub fn gc_compiler(_func_env: &FuncEnvironment<'_>) -> Box<dyn GcCompiler> {
@@ -97,11 +97,11 @@ impl FuncEnvironment<'_> {
         let vmctx = self.vmctx(builder.func);
         let vmctx = builder.ins().global_value(ptr_ty, vmctx);
 
-        let base_offset = self.offsets.vmctx_gc_heap_base();
-        let base_offset = i32::try_from(base_offset).unwrap();
+        let base_offset = self.offsets.ptr.vmctx_gc_heap_base();
+        let base_offset = i32::from(base_offset);
 
-        let bound_offset = self.offsets.vmctx_gc_heap_bound();
-        let bound_offset = i32::try_from(bound_offset).unwrap();
+        let bound_offset = self.offsets.ptr.vmctx_gc_heap_bound();
+        let bound_offset = i32::from(bound_offset);
 
         let base = builder.ins().load(ptr_ty, flags, vmctx, base_offset);
         let bound = builder.ins().load(ptr_ty, flags, vmctx, bound_offset);
@@ -289,7 +289,7 @@ impl DrcCompiler {
             ptr_ty,
             ir::MemFlags::trusted(),
             vmctx,
-            i32::try_from(func_env.offsets.vmctx_gc_heap_data()).unwrap(),
+            i32::from(func_env.offsets.ptr.vmctx_gc_heap_data()),
         );
         let next = builder.ins().load(
             ptr_ty,

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -408,9 +408,7 @@ impl RootSet {
     /// Calls to `{enter,exit}_lifo_scope` must happen in a strict LIFO order.
     #[inline]
     pub(crate) fn enter_lifo_scope(&self) -> usize {
-        let len = self.lifo_roots.len();
-        log::debug!("Entering GC root set LIFO scope: {len}");
-        len
+        self.lifo_roots.len()
     }
 
     /// Exit a LIFO rooting scope.
@@ -421,7 +419,6 @@ impl RootSet {
     /// Calls to `{enter,exit}_lifo_scope` must happen in a strict LIFO order.
     #[inline]
     pub(crate) fn exit_lifo_scope(&mut self, gc_store: &mut GcStore, scope: usize) {
-        log::debug!("Exiting GC root set LIFO scope: {scope}");
         debug_assert!(self.lifo_roots.len() >= scope);
 
         // If we actually have roots to unroot, call an out-of-line slow path.

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -841,16 +841,6 @@ mod test_vmruntime_limits {
     use wasmtime_environ::{Module, PtrSize, VMOffsets};
 
     #[test]
-    fn vmctx_runtime_limits_offset() {
-        let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
-        assert_eq!(
-            offsets.vmctx_runtime_limits(),
-            u32::from(offsets.ptr.vmcontext_runtime_limits())
-        );
-    }
-
-    #[test]
     fn field_offsets() {
         let module = Module::new();
         let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -655,7 +655,7 @@ instance allocation for this module requires 256 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
  * 62.50% - 160 bytes - instance state management
- * 6.25% - 16 bytes - jit store state
+ * 34.38% - 88 bytes - static vmctx data
 "
     };
     match Module::new(&engine, "(module)") {

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -648,6 +648,7 @@ fn instance_too_large() -> Result<()> {
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
  * 72.73% - 256 bytes - instance state management
+ * 25.00% - 88 bytes - static vmctx data
 "
     } else {
         "\

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -328,13 +328,13 @@ where
             .as_u32()
             .checked_mul(sig_index_bytes.into())
             .unwrap();
-        let signatures_base_offset = self.env.vmoffsets.vmctx_type_ids_array();
+        let signatures_base_offset = self.env.vmoffsets.ptr.vmctx_type_ids_array();
         let scratch = <M::ABI as ABI>::scratch_reg();
         let funcref_sig_offset = self.env.vmoffsets.ptr.vm_func_ref_type_index();
 
         // Load the signatures address into the scratch register.
         self.masm.load(
-            self.masm.address_at_vmctx(signatures_base_offset),
+            self.masm.address_at_vmctx(signatures_base_offset.into()),
             scratch,
             ptr_size,
         );


### PR DESCRIPTION
Before this commit all offsets to all fields in `VMOffsets` were stored as fields within `VMOffset` itself. All of the fields at the start of `VMOffsets`, however, are statically known given the pointer size. Notably this means that the use of `HostPtr` in the runtime still was forcing a dynamic lookup of these static offsets.

This commit refactors this to reflect all static offsets based solely on the pointer size in the `PtrSize` trait, removing all the fields from `VMOffsets`. All the dynamically sized fields, however, remain in `VMOffsets`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
