### PR TITLE
Skip `AutoAssertNoGc` checks for applicable signatures

### DIFF
--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -315,6 +315,14 @@ pub unsafe trait WasmTy: Send {
     #[doc(hidden)]
     fn valtype() -> ValType;
 
+    #[doc(hidden)]
+    fn may_gc() -> bool {
+        match Self::valtype() {
+            ValType::Ref(_) => true,
+            ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => false,
+        }
+    }
+
     // Dynamic checks that this value is being used with the correct store
     // context.
     #[doc(hidden)]

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -421,6 +421,29 @@ impl<'a> AutoAssertNoGc<'a> {
 
         AutoAssertNoGc { store, entered }
     }
+
+    /// Creates an `AutoAssertNoGc` value which is forcibly "not entered" and
+    /// disables checks for no GC happening for the duration of this value.
+    ///
+    /// This is used when it is statically otherwise known that a GC doesn't
+    /// happen for the various types involved.
+    ///
+    /// # Unsafety
+    ///
+    /// This method is `unsafe` as it does not provide the same safety
+    /// guarantees as `AutoAssertNoGc::new`. It must be guaranteed by the
+    /// caller that a GC doesn't happen.
+    #[inline]
+    pub unsafe fn disabled(store: &'a mut StoreOpaque) -> Self {
+        if cfg!(debug_assertions) {
+            AutoAssertNoGc::new(store)
+        } else {
+            AutoAssertNoGc {
+                store,
+                entered: false,
+            }
+        }
+    }
 }
 
 impl core::ops::Deref for AutoAssertNoGc<'_> {


### PR DESCRIPTION
This commit skips the safety checks of `AutoAssertNoGc` for the duration of host calls where the types involved are statically known to not perform any GCs (e.g. integers and floats). This helps recover some performance loss from indirect calls made on entry/exit of an `AutoAssertNoGc` scope when the `gc` feature is enabled in Wasmtime.

This is in reference to [this discussion](https://github.com/bytecodealliance/wasmtime/pull/8795#issuecomment-2166840673)