### PR TITLE
Disable `call-hook` crate feature by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -297,16 +297,15 @@ jobs:
     - run: (cd docs && mdbook test -L ../target/debug/deps)
 
     # Build Rust API documentation.
-    # We pass in the `component-model` feature
-    # to match the docs.rs metadata in
-    # crates/wasmtime/Cargo.toml.
+    #
+    # Enable all features to ensure all optional items are documented.
     - run: |
         cargo doc --no-deps --workspace \
           --exclude wasmtime-cli \
           --exclude test-programs \
           --exclude wasi-http-tests \
           --exclude cranelift-codegen-meta \
-          --features component-model
+          --all-features
       env:
         RUSTDOCFLAGS: --cfg=docsrs
     - run: cargo doc --package cranelift-codegen-meta --document-private-items

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -298,14 +298,13 @@ jobs:
 
     # Build Rust API documentation.
     #
-    # Enable all features to ensure all optional items are documented.
+    # Enable extra features in crates as well to ensure they're documented
     - run: |
         cargo doc --no-deps --workspace \
           --exclude wasmtime-cli \
           --exclude test-programs \
-          --exclude wasi-http-tests \
           --exclude cranelift-codegen-meta \
-          --all-features
+          --features call-hook
       env:
         RUSTDOCFLAGS: --cfg=docsrs
     - run: cargo doc --package cranelift-codegen-meta --document-private-items

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ rustix = { workspace = true, features = ["mm", "param", "process"] }
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests
-wasmtime = { workspace = true, features = ['component-model', 'async', 'default', 'winch', 'debug-builtins', 'all-arch'] }
+wasmtime = { workspace = true, features = ['default', 'winch', 'all-arch', 'call-hook'] }
 env_logger = { workspace = true }
 log = { workspace = true }
 filecheck = { workspace = true }

--- a/crates/wasi-preview1-component-adapter/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/Cargo.toml
@@ -22,6 +22,7 @@ object = { workspace = true, default-features = false, features = ["archive", "s
 test = false
 crate-type = ["cdylib"]
 name = "wasi_snapshot_preview1"
+doc = false
 
 [features]
 default = ["reactor"]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -125,7 +125,6 @@ default = [
   'component-model',
   'threads',
   'std',
-  'call-hook',
 ]
 
 # An on-by-default feature enabling runtime compilation of WebAssembly modules
@@ -263,6 +262,5 @@ std = [
 
 # Enables support for the `Store::call_hook` API which enables injecting custom
 # logic around all entries/exits from WebAssembly. This has a slight performance
-# cost for all host functions so is provided as a compile-time feature if
-# embedders would like to disable it.
+# cost for all host functions.
 call-hook = []

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -254,7 +254,7 @@
 //! * `threads` - Enabled by default, this enables compile-time support for the
 //!   WebAssembly `threads` proposal, notably shared memories.
 //!
-//! * `call-hook` - Enabled by default, this enables support for the
+//! * `call-hook` - Disabled by default, this enables support for the
 //!   [`Store::call_hook`] API. This incurs a small overhead on all
 //!   entries/exits from WebAssembly and may want to be disabled by some
 //!   embedders.


### PR DESCRIPTION
This commit disables the `call-hook` feature for the Wasmtime crate added in #8795 by default. The rationale is that this has a slight cost to all embeddings even if the feature isn't used and it's not expected to be that widely used of a feature, so off-by-default seems like a more appropriate default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
