### PR TITLE
Cranelift: Traps need not be considered GC safepoints anymore

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1114,10 +1114,7 @@ impl MachInst for Inst {
 
     fn is_safepoint(&self) -> bool {
         match self {
-            &Inst::Call { .. }
-            | &Inst::CallInd { .. }
-            | &Inst::TrapIf { .. }
-            | &Inst::Udf { .. } => true,
+            Inst::Call { .. } | Inst::CallInd { .. } => true,
             _ => false,
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -731,10 +731,7 @@ impl MachInst for Inst {
 
     fn is_safepoint(&self) -> bool {
         match self {
-            &Inst::Call { .. }
-            | &Inst::CallInd { .. }
-            | &Inst::TrapIf { .. }
-            | &Inst::Udf { .. } => true,
+            Inst::Call { .. } | Inst::CallInd { .. } => true,
             _ => false,
         }
     }

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1073,13 +1073,7 @@ impl MachInst for Inst {
 
     fn is_safepoint(&self) -> bool {
         match self {
-            &Inst::Call { .. }
-            | &Inst::CallInd { .. }
-            | &Inst::Trap { .. }
-            | Inst::TrapIf { .. }
-            | &Inst::CmpTrapRR { .. }
-            | &Inst::CmpTrapRSImm16 { .. }
-            | &Inst::CmpTrapRUImm16 { .. } => true,
+            Inst::Call { .. } | Inst::CallInd { .. } => true,
             _ => false,
         }
     }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2687,10 +2687,7 @@ impl MachInst for Inst {
 
     fn is_safepoint(&self) -> bool {
         match self {
-            Inst::CallKnown { .. }
-            | Inst::CallUnknown { .. }
-            | Inst::TrapIf { .. }
-            | Inst::Ud2 { .. } => true,
+            Inst::CallKnown { .. } | Inst::CallUnknown { .. } => true,
             _ => false,
         }
     }


### PR DESCRIPTION
After https://github.com/bytecodealliance/wasmtime/pull/8809, the mutator cannot resume from a trap so we don't need to consider them safepoints, as no GC-managed references are live after the trap. The one exception being the `debugtrap` CLIF instruction, which is technically still a resumable trap, but which exists only for emitting the equivalent of an `int3` breakpoint instruction for pausing in a debugger to inspect state, and should never be used for mutator-collector interactions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
