### PR TITLE
Force some more permission checks with 0-length writes

### DIFF
--- a/crates/test-programs/src/bin/preview1_file_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_write.rs
@@ -80,6 +80,30 @@ unsafe fn test_file_long_write(dir_fd: wasi::Fd, filename: &str) {
     assert_eq!(buffer, &content[end_cursor..], "contents of end read chunk");
 
     wasi::fd_close(file_fd).expect("closing the file");
+
+    // Open a file for writing
+    let filename = "test-zero-write-fails.txt";
+    let file_fd = wasi::path_open(
+        dir_fd,
+        0,
+        filename,
+        wasi::OFLAGS_CREAT,
+        wasi::RIGHTS_FD_WRITE,
+        0,
+        0,
+    )
+    .expect("creating a file for writing");
+    wasi::fd_close(file_fd).expect("closing the file");
+    let file_fd = wasi::path_open(dir_fd, 0, filename, 0, wasi::RIGHTS_FD_READ, 0, 0)
+        .expect("creating a file for writing");
+    let res = wasi::fd_write(
+        file_fd,
+        &[wasi::Ciovec {
+            buf: 3 as *const u8,
+            buf_len: 0,
+        }],
+    );
+    assert_eq!(res, Err(wasi::ERRNO_BADF));
 }
 
 fn main() {

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -1047,8 +1047,8 @@ pub unsafe extern "C" fn fd_pread(
     nread: *mut Size,
 ) -> Errno {
     cfg_filesystem_available! {
-        // Advance to the first non-empty buffer.
-        while iovs_len != 0 && (*iovs_ptr).buf_len == 0 {
+        // Skip leading non-empty buffers.
+        while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
             iovs_ptr = iovs_ptr.add(1);
             iovs_len -= 1;
         }
@@ -1162,8 +1162,8 @@ pub unsafe extern "C" fn fd_pwrite(
     nwritten: *mut Size,
 ) -> Errno {
     cfg_filesystem_available! {
-        // Advance to the first non-empty buffer.
-        while iovs_len != 0 && (*iovs_ptr).buf_len == 0 {
+        // Skip leading non-empty buffers.
+        while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
             iovs_ptr = iovs_ptr.add(1);
             iovs_len -= 1;
         }
@@ -1194,8 +1194,8 @@ pub unsafe extern "C" fn fd_read(
     mut iovs_len: usize,
     nread: *mut Size,
 ) -> Errno {
-    // Advance to the first non-empty buffer.
-    while iovs_len != 0 && (*iovs_ptr).buf_len == 0 {
+    // Skip leading non-empty buffers.
+    while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
         iovs_ptr = iovs_ptr.add(1);
         iovs_len -= 1;
     }
@@ -1243,9 +1243,6 @@ pub unsafe extern "C" fn fd_read(
                 if let StreamType::File(file) = &streams.type_ {
                     file.position
                         .set(file.position.get() + data.len() as filesystem::Filesize);
-                    if len == 0 {
-                        return Err(ERRNO_INTR);
-                    }
                 }
 
                 let len = data.len();
@@ -1618,8 +1615,8 @@ pub unsafe extern "C" fn fd_write(
         return ERRNO_IO;
     }
 
-    // Advance to the first non-empty buffer.
-    while iovs_len != 0 && (*iovs_ptr).buf_len == 0 {
+    // Skip leading empty buffers.
+    while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
         iovs_ptr = iovs_ptr.add(1);
         iovs_len -= 1;
     }
@@ -2506,11 +2503,12 @@ impl BlockingMode {
         match self {
             BlockingMode::Blocking => {
                 let total = bytes.len();
-                while !bytes.is_empty() {
+                loop {
                     let len = bytes.len().min(4096);
                     let (chunk, rest) = bytes.split_at(len);
                     bytes = rest;
                     match output_stream.blocking_write_and_flush(chunk) {
+                        Ok(()) if bytes.is_empty() => break,
                         Ok(()) => {}
                         Err(streams::StreamError::Closed) => return Err(ERRNO_IO),
                         Err(streams::StreamError::LastOperationFailed(e)) => {
@@ -2531,9 +2529,6 @@ impl BlockingMode {
                 };
 
                 let len = bytes.len().min(permit as usize);
-                if len == 0 {
-                    return Ok(0);
-                }
 
                 match output_stream.write(&bytes[..len]) {
                     Ok(_) => {}

--- a/crates/wasi/src/host/io.rs
+++ b/crates/wasi/src/host/io.rs
@@ -75,11 +75,14 @@ where
         }
 
         let mut bytes = bytes::Bytes::from(bytes);
-        while !bytes.is_empty() {
+        loop {
             let permit = s.write_ready().await?;
             let len = bytes.len().min(permit);
             let chunk = bytes.split_to(len);
             s.write(chunk)?;
+            if bytes.is_empty() {
+                break;
+            }
         }
 
         s.flush()?;


### PR DESCRIPTION
When a 0-length write is performed try to send the write all the way to the underlying file descriptor to at least check that it's valid to write.

Closes #8818

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
