### PR TITLE
Inherit Linux semantics for `fd_pwrite` with `O_APPEND`

### DIFF
--- a/crates/wasi-common/tests/all/async_.rs
+++ b/crates/wasi-common/tests/all/async_.rs
@@ -130,7 +130,7 @@ async fn preview1_file_allocate() {
 }
 // see sync.rs for notes about ignores here
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(target_os = "macos", ignore)]
+#[cfg_attr(not(target_os = "linux"), ignore)]
 async fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE, true).await.unwrap()
 }

--- a/crates/wasi-common/tests/all/async_.rs
+++ b/crates/wasi-common/tests/all/async_.rs
@@ -128,7 +128,9 @@ async fn preview1_fd_readdir() {
 async fn preview1_file_allocate() {
     run(PREVIEW1_FILE_ALLOCATE, true).await.unwrap()
 }
+// see sync.rs for notes about ignores here
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE, true).await.unwrap()
 }

--- a/crates/wasi-common/tests/all/sync.rs
+++ b/crates/wasi-common/tests/all/sync.rs
@@ -120,7 +120,12 @@ fn preview1_fd_readdir() {
 fn preview1_file_allocate() {
     run(PREVIEW1_FILE_ALLOCATE, true).unwrap()
 }
+// This test is ignored on macos because the behavior of `pwrite`, which this
+// test bottoms out into, differs across platforms. The wasi-common crate
+// doesn't have the infrastructure in place to manually track the append-mode
+// flag easily, but `wasmtime-wasi` has the "correct" behavior here.
 #[test_log::test]
+#[cfg_attr(target_os = "macos", ignore)]
 fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE, true).unwrap()
 }

--- a/crates/wasi-common/tests/all/sync.rs
+++ b/crates/wasi-common/tests/all/sync.rs
@@ -120,12 +120,12 @@ fn preview1_fd_readdir() {
 fn preview1_file_allocate() {
     run(PREVIEW1_FILE_ALLOCATE, true).unwrap()
 }
-// This test is ignored on macos because the behavior of `pwrite`, which this
+// This test is outside of linux because the behavior of `pwrite`, which this
 // test bottoms out into, differs across platforms. The wasi-common crate
 // doesn't have the infrastructure in place to manually track the append-mode
 // flag easily, but `wasmtime-wasi` has the "correct" behavior here.
 #[test_log::test]
-#[cfg_attr(target_os = "macos", ignore)]
+#[cfg_attr(not(target_os = "linux"), ignore)]
 fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE, true).unwrap()
 }


### PR DESCRIPTION
This commit updates the implementation of `fd_pwrite` in WASI to match Linux semantics for an under-specified corner of WASI. Specifically if `fd_pwrite` is used the offset specified is ignored if the file is opened in append mode and the bytes are instead appended.

This commit additionally refactors `fd_write` and `fd_pwrite` to have basically the same code with only a minor branch internally when the final write is being performed to help deduplicate more logic.

Closes #8817

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
