### PR TITLE
Fix `fcntl(fd, F_GETFL)` from wasi-libc with write-only files

### DIFF
--- a/crates/test-programs/src/bin/preview1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_read_write.rs
@@ -53,6 +53,10 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
         "writeonly does not have read right"
     );
     assert!(
+        stat.fs_rights_base & wasi::RIGHTS_FD_READDIR == 0,
+        "writeonly does not have readdir right"
+    );
+    assert!(
         stat.fs_rights_base & wasi::RIGHTS_FD_WRITE == wasi::RIGHTS_FD_WRITE,
         "writeonly has write right"
     );

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -823,6 +823,7 @@ pub unsafe extern "C" fn fd_fdstat_get(fd: Fd, stat: *mut Fdstat) -> Errno {
                             let mut fs_rights_base = !0;
                             if !flags.contains(filesystem::DescriptorFlags::READ) {
                                 fs_rights_base &= !RIGHTS_FD_READ;
+                                fs_rights_base &= !RIGHTS_FD_READDIR;
                             }
                             if !flags.contains(filesystem::DescriptorFlags::WRITE) {
                                 fs_rights_base &= !RIGHTS_FD_WRITE;

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -1405,6 +1405,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         }
         if !flags.contains(filesystem::DescriptorFlags::READ) {
             fs_rights_base &= !types::Rights::FD_READ;
+            fs_rights_base &= !types::Rights::FD_READDIR;
         }
         if !flags.contains(filesystem::DescriptorFlags::WRITE) {
             fs_rights_base &= !types::Rights::FD_WRITE;


### PR DESCRIPTION
Looks like wasi-libc is testing for the READDIR right in addition to the READ right in the reported flags. Update write-only files to remove both the READ and READDIR rights accordingly.

Closes #8816

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
