### PR TITLE
`cranelift-entity`: Remove the unused `EntitySet::cardinality` method

### DIFF
--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -69,16 +69,6 @@ where
         }
     }
 
-    /// Returns the cardinality of the set. More precisely, it returns the number of calls to
-    /// `insert` with different key values, that have happened since the set was most recently
-    /// `clear`ed or created with `new`.
-    pub fn cardinality(&self) -> usize {
-        self.elems[..(self.len + (BITS - 1)) / BITS]
-            .iter()
-            .map(|x| x.count_ones() as usize)
-            .sum()
-    }
-
     /// Remove all entries from this set.
     pub fn clear(&mut self) {
         self.len = 0;
@@ -247,44 +237,5 @@ mod tests {
         }
 
         assert!(m.is_empty());
-    }
-
-    #[test]
-    fn cardinality() {
-        let mut m = EntitySet::new();
-
-        m.insert(E(1));
-        assert!(m.cardinality() == 1);
-
-        m.insert(E(0));
-        assert!(m.cardinality() == 2);
-
-        m.insert(E(1));
-        assert!(m.cardinality() == 2);
-
-        m.insert(E(BITS as u32 - 1));
-        assert!(m.cardinality() == 3);
-
-        m.insert(E(BITS as u32));
-        assert!(m.cardinality() == 4);
-
-        m.insert(E(BITS as u32 - 1));
-        assert!(m.cardinality() == 4);
-
-        assert!(m.pop() == Some(E(BITS as u32)));
-        assert!(m.cardinality() == 3);
-        assert!(m.pop() == Some(E(BITS as u32 - 1)));
-        assert!(m.cardinality() == 2);
-
-        m.insert(E(100));
-        assert!(m.cardinality() == 3);
-
-        assert!(m.pop() == Some(E(100)));
-        assert!(m.cardinality() == 2);
-
-        m.insert(E(100));
-        m.insert(E(101));
-        m.insert(E(102));
-        assert!(m.cardinality() == 5);
     }
 }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
