### PR TITLE
Improve name lookup for `trappable_error_type` configuration

### DIFF
--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -649,3 +649,50 @@ mod with_and_mixing_async {
         });
     }
 }
+
+mod trappable_error_type_and_versions {
+    struct MyError;
+
+    mod package_no_version_path_no_version {
+        wasmtime::component::bindgen!({
+            inline: "
+                package my:inline;
+                interface i {
+                    enum e { a, b, c }
+                }
+                world foo {}
+            ",
+            trappable_error_type: {
+                "my:inline/i/e" => super::MyError,
+            },
+        });
+    }
+    mod package_version_path_no_version {
+        wasmtime::component::bindgen!({
+            inline: "
+                package my:inline@1.0.0;
+                interface i {
+                    enum e { a, b, c }
+                }
+                world foo {}
+            ",
+            trappable_error_type: {
+                "my:inline/i/e" => super::MyError,
+            },
+        });
+    }
+    mod package_version_path_version {
+        wasmtime::component::bindgen!({
+            inline: "
+                package my:inline@1.0.0;
+                interface i {
+                    enum e { a, b, c }
+                }
+                world foo {}
+            ",
+            trappable_error_type: {
+                "my:inline/i@1.0.0/e" => super::MyError,
+            },
+        });
+    }
+}


### PR DESCRIPTION
This commit improves the experience around using the `trappable_error_type` configuration by fixing two issues:

* When an error can't be resolved it doesn't result in a `unwrap()`, instead a first-class error is returned to get reported.

* The name lookup procedure is now consistent with the name lookup that the `with` key does, notably allowing the version to be optional but still supporting the version.

This fixes an issue that came up recently where a path with a version was specified but the old lookup logic ended up requiring that the version wasn't specified because there was only one package with that version. This behavior resulted in a panic with a very long backtrace-based error message which was confusing to parse. By returning an error the error is much more succinct and by supporting more names the original intuition will work.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
