### PR TITLE
Remove leftover debugging `dbg!` in CLIF parser

### DIFF
--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2487,11 +2487,7 @@ impl<'a> Parser<'a> {
                         self.match_uimm32("expected a u32 offset")?.into()
                     }
                     _ => {
-                        self.match_token(Token::Plus, "expected `+ <offset>`")
-                            .map_err(|e| {
-                                dbg!(self.lookahead);
-                                e
-                            })?;
+                        self.match_token(Token::Plus, "expected `+ <offset>`")?;
                         self.match_uimm32("expected a u32 offset")?.into()
                     }
                 };


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
