### PR TITLE
upgrade to wasm-tools 0.211.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmtime-types",
  "wat",
 ]
@@ -2774,7 +2774,7 @@ dependencies = [
  "heck 0.4.0",
  "wasi-preview1-component-adapter-provider",
  "wasmtime",
- "wit-component 0.211.0",
+ "wit-component 0.211.1",
 ]
 
 [[package]]
@@ -3104,7 +3104,7 @@ name = "verify-component-adapter"
 version = "23.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wat",
 ]
 
@@ -3197,7 +3197,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.36.0",
  "wasi",
- "wasm-encoder 0.211.0",
+ "wasm-encoder 0.211.1",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3270,12 +3270,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edac552f5404c9083b446afddf3f1b9e2eb35950e8f5155fa3d7b460b4835be"
+checksum = "5e7d931a1120ef357f32b74547646b6fa68ea25e377772b72874b131a9ed70d4"
 dependencies = [
  "leb128",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
 ]
 
 [[package]]
@@ -3296,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e56c3d0178b926f44e7b6cddeaeb0f6269b505c5c6ac36cb107a8fe68cf0a"
+checksum = "7f56bad1c68558c44e7f60be865117dc9d8c3a066bcf3b2232cb9a9858965fd5"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3306,36 +3306,36 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.211.0",
- "wasmparser 0.211.0",
+ "wasm-encoder 0.211.1",
+ "wasmparser 0.211.1",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696fca4af22a322a327138f02bcbf24203bdb4439a3dbf2d361a8899fcfab67e"
+checksum = "b4281d9c72b0a3c47eec052755ad98cb854309e3a40edf9887aa8f3ed939f7ab"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.211.0",
- "wasmparser 0.211.0",
+ "wasm-encoder 0.211.1",
+ "wasmparser 0.211.1",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e6c1c655fdee613641cc4f3cefe271824d557a07b7f9af3a265240e7d43548"
+checksum = "94ae0d1bd7d17e7ae175f9e3cf646d9b39b7115240ed8d40141c4670bab49f96"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder 0.211.0",
+ "wasm-encoder 0.211.1",
 ]
 
 [[package]]
@@ -3393,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fdc36907b68eb391c201401b3e342e175610dae14566e61b6b317216d531355"
+checksum = "3189cc8a91f547390e2f043ca3b3e3fe0892f7d581767fd4e4b7f3dc3fe8e561"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -3416,13 +3416,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e1fdb1c73d0682457bd1f00bbd3faec09be8471885d22514cc31e4b5d48173"
+checksum = "23708dd7a986bd9b12fca26eff525bbc3659a336e947fd9ed9fdf79086825aec"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
 ]
 
 [[package]]
@@ -3465,8 +3465,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder 0.211.0",
- "wasmparser 0.211.0",
+ "wasm-encoder 0.211.1",
+ "wasmparser 0.211.1",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3608,7 +3608,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3622,10 +3622,10 @@ dependencies = [
  "wasmtime-wasi-nn",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 211.0.0",
+ "wast 211.0.1",
  "wat",
  "windows-sys 0.52.0",
- "wit-component 0.211.0",
+ "wit-component 0.211.1",
 ]
 
 [[package]]
@@ -3658,7 +3658,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.211.0",
+ "wit-parser 0.211.1",
 ]
 
 [[package]]
@@ -3682,7 +3682,7 @@ dependencies = [
  "object 0.36.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3707,8 +3707,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.211.0",
- "wasmparser 0.211.0",
+ "wasm-encoder 0.211.1",
+ "wasmparser 0.211.1",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3723,7 +3723,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3781,7 +3781,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3802,12 +3802,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.211.0",
+ "wasm-encoder 0.211.1",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3857,7 +3857,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
 ]
 
 [[package]]
@@ -3965,7 +3965,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 211.0.0",
+ "wast 211.0.1",
 ]
 
 [[package]]
@@ -3977,7 +3977,7 @@ dependencies = [
  "gimli",
  "object 0.36.0",
  "target-lexicon",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3990,7 +3990,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.0",
  "indexmap 2.2.6",
- "wit-parser 0.211.0",
+ "wit-parser 0.211.1",
 ]
 
 [[package]]
@@ -4008,24 +4008,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "211.0.0"
+version = "211.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01019afce6a03155ce7cda8f7eeb4b846a114d0978e16e1a32f7cd9932e282c3"
+checksum = "b25506dd82d00da6b14a87436b3d52b1d264083fa79cdb72a0d1b04a8595ccaa"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.211.0",
+ "wasm-encoder 0.211.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.211.0"
+version = "1.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779365ca4640d48cd714788626bb622b4f491d7cd3d3ecb1a48bad4082f420ac"
+checksum = "eb716ca6c86eecac2d82541ffc39860118fc0af9309c4f2670637bea2e1bdd7d"
 dependencies = [
- "wast 211.0.0",
+ "wast 211.0.1",
 ]
 
 [[package]]
@@ -4145,7 +4145,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4399,9 +4399,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527854bf3c712340abdb71f2e44aea9c8a98c13fdd32e67efff3c27ee6775fe6"
+checksum = "079a38b7d679867424bf2bcbdd553a2acf364525307e43dfb910fa4a2c6fd9f2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4410,10 +4410,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.211.0",
- "wasm-metadata 0.211.0",
- "wasmparser 0.211.0",
- "wit-parser 0.211.0",
+ "wasm-encoder 0.211.1",
+ "wasm-metadata 0.211.1",
+ "wasmparser 0.211.1",
+ "wit-parser 0.211.1",
 ]
 
 [[package]]
@@ -4436,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.211.0"
+version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafc0ef6c5b790a3df1ec53dee41c37ebe560bc465e509e8a5ed9fe620ef1865"
+checksum = "a3cc90c50c7ec8a824b5d2cddddff13b2dc12b7a96bf8684d11474223c2ea22f"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4449,7 +4449,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.211.0",
+ "wasmparser 0.211.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmtime-types",
  "wat",
 ]
@@ -2722,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -2774,7 +2774,7 @@ dependencies = [
  "heck 0.4.0",
  "wasi-preview1-component-adapter-provider",
  "wasmtime",
- "wit-component",
+ "wit-component 0.211.0",
 ]
 
 [[package]]
@@ -3104,7 +3104,7 @@ name = "verify-component-adapter"
 version = "23.0.0"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wat",
 ]
 
@@ -3197,7 +3197,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.36.0",
  "wasi",
- "wasm-encoder",
+ "wasm-encoder 0.211.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3269,6 +3269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.211.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edac552f5404c9083b446afddf3f1b9e2eb35950e8f5155fa3d7b460b4835be"
+dependencies = [
+ "leb128",
+ "wasmparser 0.211.0",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,36 +3290,52 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.211.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e56c3d0178b926f44e7b6cddeaeb0f6269b505c5c6ac36cb107a8fe68cf0a"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.211.0",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.209.1"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58dddabebff47e1a4f22fbe7fbb769ab699cd9efe7552f50ce5d0881f006884"
+checksum = "696fca4af22a322a327138f02bcbf24203bdb4439a3dbf2d361a8899fcfab67e"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.211.0",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.209.1"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38482bb6ce309f7b5b8a168209d0e5c1df8643f1026fc21aaa196058f16d42e8"
+checksum = "13e6c1c655fdee613641cc4f3cefe271824d557a07b7f9af3a265240e7d43548"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder",
+ "wasm-encoder 0.211.0",
 ]
 
 [[package]]
@@ -3363,6 +3389,19 @@ dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.211.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdc36907b68eb391c201401b3e342e175610dae14566e61b6b317216d531355"
+dependencies = [
+ "ahash",
+ "bitflags 2.4.1",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.6",
+ "semver",
  "serde",
 ]
 
@@ -3377,12 +3416,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.209.1"
+version = "0.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
+checksum = "b1e1fdb1c73d0682457bd1f00bbd3faec09be8471885d22514cc31e4b5d48173"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "termcolor",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]
@@ -3425,8 +3465,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.211.0",
+ "wasmparser 0.211.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3568,7 +3608,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3582,10 +3622,10 @@ dependencies = [
  "wasmtime-wasi-nn",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 209.0.1",
+ "wast 211.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component",
+ "wit-component 0.211.0",
 ]
 
 [[package]]
@@ -3618,7 +3658,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -3642,7 +3682,7 @@ dependencies = [
  "object 0.36.0",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3667,8 +3707,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.211.0",
+ "wasmparser 0.211.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3683,7 +3723,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3741,7 +3781,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3762,12 +3802,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder",
+ "wasm-encoder 0.211.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3817,7 +3857,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]
@@ -3925,7 +3965,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 209.0.1",
+ "wast 211.0.0",
 ]
 
 [[package]]
@@ -3937,7 +3977,7 @@ dependencies = [
  "gimli",
  "object 0.36.0",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3950,7 +3990,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.0",
  "indexmap 2.2.6",
- "wit-parser",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -3968,24 +4008,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "209.0.1"
+version = "211.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fffef2ff6147e4d12e972765fd75332c6a11c722571d4ab7a780d81ffc8f0a4"
+checksum = "01019afce6a03155ce7cda8f7eeb4b846a114d0978e16e1a32f7cd9932e282c3"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.211.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.209.1"
+version = "1.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42203ec0271d113f8eb1f77ebc624886530cecb35915a7f63a497131f16e4d24"
+checksum = "779365ca4640d48cd714788626bb622b4f491d7cd3d3ecb1a48bad4082f420ac"
 dependencies = [
- "wast 209.0.1",
+ "wast 211.0.0",
 ]
 
 [[package]]
@@ -4105,7 +4145,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.211.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4298,7 +4338,7 @@ checksum = "36d4706efb67fadfbbde77955b299b111dd096e6776d8c6561d92f6147941880"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -4319,9 +4359,9 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.2.6",
- "wasm-metadata",
+ "wasm-metadata 0.209.1",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.209.1",
 ]
 
 [[package]]
@@ -4351,10 +4391,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.209.1",
+ "wasm-metadata 0.209.1",
+ "wasmparser 0.209.1",
+ "wit-parser 0.209.1",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.211.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527854bf3c712340abdb71f2e44aea9c8a98c13fdd32e67efff3c27ee6775fe6"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "indexmap 2.2.6",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.211.0",
+ "wasm-metadata 0.211.0",
+ "wasmparser 0.211.0",
+ "wit-parser 0.211.0",
 ]
 
 [[package]]
@@ -4372,7 +4431,25 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.211.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafc0ef6c5b790a3df1ec53dee41c37ebe560bc465e509e8a5ed9fe620ef1865"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.211.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,15 +255,15 @@ wit-bindgen = { version = "0.26.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.26.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.209.1", default-features = false }
-wat = "1.209.1"
-wast = "209.0.1"
-wasmprinter = "0.209.1"
-wasm-encoder = "0.209.1"
-wasm-smith = "0.209.1"
-wasm-mutate = "0.209.1"
-wit-parser = "0.209.1"
-wit-component = "0.209.1"
+wasmparser = { version = "0.211.1", default-features = false }
+wat = "1.211.1"
+wast = "211.0.1"
+wasmprinter = "0.211.1"
+wasm-encoder = "0.211.1"
+wasm-smith = "0.211.1"
+wasm-mutate = "0.211.1"
+wit-parser = "0.211.1"
+wit-component = "0.211.1"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -639,7 +639,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::CallIndirect {
             type_index,
             table_index,
-            table_byte: _,
         } => {
             // `type_index` is the index of the function's signature and
             // `table_index` is the index of the table to search the function
@@ -750,7 +749,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
          * Memory management is handled by environment. It is usually translated into calls to
          * special functions.
          ************************************************************************************/
-        Operator::MemoryGrow { mem, mem_byte: _ } => {
+        Operator::MemoryGrow { mem } => {
             // The WebAssembly MVP only supports one linear memory, but we expect the reserved
             // argument to be a memory index.
             let heap_index = MemoryIndex::from_u32(*mem);
@@ -759,7 +758,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             environ.before_memory_grow(builder, val, heap_index);
             state.push1(environ.translate_memory_grow(builder.cursor(), heap_index, heap, val)?)
         }
-        Operator::MemorySize { mem, mem_byte: _ } => {
+        Operator::MemorySize { mem } => {
             let heap_index = MemoryIndex::from_u32(*mem);
             let heap = state.get_heap(builder.func, *mem, environ)?;
             state.push1(environ.translate_memory_size(builder.cursor(), heap_index, heap)?);

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -273,12 +273,14 @@ impl<'a, 'data> Translator<'a, 'data> {
         types: &'a mut ComponentTypesBuilder,
         scope_vec: &'data ScopeVec<u8>,
     ) -> Self {
+        let mut parser = Parser::new(0);
+        parser.set_features(*validator.features());
         Self {
             result: Translation::default(),
             tunables,
             validator,
             types: PreInliningComponentTypes::new(types),
-            parser: Parser::new(0),
+            parser,
             lexical_scopes: Vec::new(),
             static_components: Default::default(),
             static_modules: Default::default(),

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -66,9 +66,10 @@ struct AnnotatedWatChunk {
 }
 
 fn annotate_wat(wasm: &[u8]) -> Result<AnnotatedWat> {
-    let mut printer = wasmprinter::Printer::new();
+    let printer = wasmprinter::Config::new();
+    let mut storage = String::new();
     let chunks = printer
-        .offsets_and_lines(wasm)?
+        .offsets_and_lines(wasm, &mut storage)?
         .map(|(offset, wat)| AnnotatedWatChunk {
             wasm_offset: offset.map(|o| WasmOffset(u32::try_from(o).unwrap())),
             wat: wat.to_string(),

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -97,7 +97,7 @@ impl TableOps {
                     mutable: true,
                     shared: false,
                 },
-                &ConstExpr::ref_null(wasm_encoder::HeapType::Extern),
+                &ConstExpr::ref_null(wasm_encoder::HeapType::EXTERN),
             );
         }
 
@@ -263,7 +263,7 @@ impl TableOp {
                 func.instruction(&Instruction::Drop);
             }
             Self::Null => {
-                func.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Extern));
+                func.instruction(&Instruction::RefNull(wasm_encoder::HeapType::EXTERN));
             }
         }
     }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1736,7 +1736,7 @@ pub trait TypeConvert {
     fn convert_heap_type(&self, ty: wasmparser::HeapType) -> WasmHeapType {
         match ty {
             wasmparser::HeapType::Concrete(i) => self.lookup_heap_type(i),
-            wasmparser::HeapType::Abstract { ty, shared: _ } => match ty {
+            wasmparser::HeapType::Abstract { ty, shared: false } => match ty {
                 wasmparser::AbstractHeapType::Extern => WasmHeapType::Extern,
                 wasmparser::AbstractHeapType::NoExtern => WasmHeapType::NoExtern,
                 wasmparser::AbstractHeapType::Func => WasmHeapType::Func,
@@ -1752,6 +1752,7 @@ pub trait TypeConvert {
                     unimplemented!("unsupported heap type {ty:?}");
                 }
             },
+            _ => unimplemented!("unsupported heap type {ty:?}"),
         }
     }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1735,21 +1735,23 @@ pub trait TypeConvert {
     /// Converts a wasmparser heap type to a wasmtime type
     fn convert_heap_type(&self, ty: wasmparser::HeapType) -> WasmHeapType {
         match ty {
-            wasmparser::HeapType::Extern => WasmHeapType::Extern,
-            wasmparser::HeapType::NoExtern => WasmHeapType::NoExtern,
-            wasmparser::HeapType::Func => WasmHeapType::Func,
-            wasmparser::HeapType::NoFunc => WasmHeapType::NoFunc,
             wasmparser::HeapType::Concrete(i) => self.lookup_heap_type(i),
-            wasmparser::HeapType::Any => WasmHeapType::Any,
-            wasmparser::HeapType::Eq => WasmHeapType::Eq,
-            wasmparser::HeapType::I31 => WasmHeapType::I31,
-            wasmparser::HeapType::Array => WasmHeapType::Array,
-            wasmparser::HeapType::Struct => WasmHeapType::Struct,
-            wasmparser::HeapType::None => WasmHeapType::None,
+            wasmparser::HeapType::Abstract { ty, shared: _ } => match ty {
+                wasmparser::AbstractHeapType::Extern => WasmHeapType::Extern,
+                wasmparser::AbstractHeapType::NoExtern => WasmHeapType::NoExtern,
+                wasmparser::AbstractHeapType::Func => WasmHeapType::Func,
+                wasmparser::AbstractHeapType::NoFunc => WasmHeapType::NoFunc,
+                wasmparser::AbstractHeapType::Any => WasmHeapType::Any,
+                wasmparser::AbstractHeapType::Eq => WasmHeapType::Eq,
+                wasmparser::AbstractHeapType::I31 => WasmHeapType::I31,
+                wasmparser::AbstractHeapType::Array => WasmHeapType::Array,
+                wasmparser::AbstractHeapType::Struct => WasmHeapType::Struct,
+                wasmparser::AbstractHeapType::None => WasmHeapType::None,
 
-            wasmparser::HeapType::Exn | wasmparser::HeapType::NoExn => {
-                unimplemented!("unsupported heap type {ty:?}");
-            }
+                wasmparser::AbstractHeapType::Exn | wasmparser::AbstractHeapType::NoExn => {
+                    unimplemented!("unsupported heap type {ty:?}");
+                }
+            },
         }
     }
 

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -69,8 +69,9 @@ pub(crate) fn build_artifacts<T: FinishedObject>(
     // about the wasm module. This is where the WebAssembly is parsed and
     // validated. Afterwards `types` will have all the type information for
     // this module.
-    let parser = wasmparser::Parser::new(0);
+    let mut parser = wasmparser::Parser::new(0);
     let mut validator = wasmparser::Validator::new_with_features(engine.config().features.clone());
+    parser.set_features(*validator.features());
     let mut types = ModuleTypesBuilder::new(&validator);
     let mut translation = ModuleEnvironment::new(tunables, &mut validator, &mut types)
         .translate(parser, wasm)

--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -181,13 +181,7 @@ impl WasmCoreDump {
 
                         HeapType::Func => wasm_encoder::ValType::FUNCREF,
 
-                        HeapType::Any => wasm_encoder::ValType::Ref(wasm_encoder::RefType {
-                            nullable: true,
-                            heap_type: wasm_encoder::HeapType::Abstract {
-                                ty: wasm_encoder::AbstractHeapType::Any,
-                                shared: false,
-                            },
-                        }),
+                        HeapType::Any => wasm_encoder::ValType::Ref(wasm_encoder::RefType::ANYREF),
 
                         ty => unreachable!("not a top type: {ty:?}"),
                     },
@@ -203,22 +197,13 @@ impl WasmCoreDump {
                     }
                     Val::V128(x) => wasm_encoder::ConstExpr::v128_const(x.as_u128() as i128),
                     Val::FuncRef(_) => {
-                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Abstract {
-                            ty: wasm_encoder::AbstractHeapType::Func,
-                            shared: false,
-                        })
+                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::FUNC)
                     }
                     Val::ExternRef(_) => {
-                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Abstract {
-                            ty: wasm_encoder::AbstractHeapType::Extern,
-                            shared: false,
-                        })
+                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::EXTERN)
                     }
                     Val::AnyRef(_) => {
-                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Abstract {
-                            ty: wasm_encoder::AbstractHeapType::Any,
-                            shared: false,
-                        })
+                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::ANY)
                     }
                 };
                 globals.global(

--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -183,7 +183,10 @@ impl WasmCoreDump {
 
                         HeapType::Any => wasm_encoder::ValType::Ref(wasm_encoder::RefType {
                             nullable: true,
-                            heap_type: wasm_encoder::HeapType::Any,
+                            heap_type: wasm_encoder::HeapType::Abstract {
+                                ty: wasm_encoder::AbstractHeapType::Any,
+                                shared: false,
+                            },
                         }),
 
                         ty => unreachable!("not a top type: {ty:?}"),
@@ -200,13 +203,22 @@ impl WasmCoreDump {
                     }
                     Val::V128(x) => wasm_encoder::ConstExpr::v128_const(x.as_u128() as i128),
                     Val::FuncRef(_) => {
-                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Func)
+                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Abstract {
+                            ty: wasm_encoder::AbstractHeapType::Func,
+                            shared: false,
+                        })
                     }
                     Val::ExternRef(_) => {
-                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Extern)
+                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Abstract {
+                            ty: wasm_encoder::AbstractHeapType::Extern,
+                            shared: false,
+                        })
                     }
                     Val::AnyRef(_) => {
-                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Any)
+                        wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::Abstract {
+                            ty: wasm_encoder::AbstractHeapType::Any,
+                            shared: false,
+                        })
                     }
                 };
                 globals.global(

--- a/crates/wast/src/core.rs
+++ b/crates/wast/src/core.rs
@@ -16,11 +16,11 @@ pub fn val<T>(store: &mut Store<T>, v: &WastArgCore<'_>) -> Result<Val> {
         V128(x) => Val::V128(u128::from_le_bytes(x.to_le_bytes()).into()),
         RefNull(HeapType::Abstract {
             ty: AbstractHeapType::Extern,
-            ..
+            shared: false,
         }) => Val::ExternRef(None),
         RefNull(HeapType::Abstract {
             ty: AbstractHeapType::Func,
-            ..
+            shared: false,
         }) => Val::FuncRef(None),
         RefExtern(x) => Val::ExternRef(Some(ExternRef::new(store, *x)?)),
         other => bail!("couldn't convert {:?} to a runtime value", other),
@@ -78,7 +78,7 @@ pub fn match_val<T>(store: &Store<T>, actual: &Val, expected: &WastRetCore) -> R
             Val::ExternRef(Some(x)),
             WastRetCore::RefNull(Some(HeapType::Abstract {
                 ty: AbstractHeapType::Extern,
-                ..
+                shared: false,
             })),
         ) => {
             let x = x

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1662,6 +1662,13 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
+[[publisher.termcolor]]
+version = "1.4.1"
+when = "2024-01-10"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.thiserror]]
 version = "1.0.43"
 when = "2023-07-07"
@@ -1831,6 +1838,12 @@ when = "2024-05-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-encoder]]
+version = "0.211.1"
+when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-metadata]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -1885,6 +1898,12 @@ when = "2024-05-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-metadata]]
+version = "0.211.1"
+when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-mutate]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -2011,6 +2030,12 @@ when = "2024-05-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmparser]]
+version = "0.211.1"
+when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmprinter]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -2062,6 +2087,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmprinter]]
 version = "0.209.1"
 when = "2024-05-29"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmprinter]]
+version = "0.211.1"
+when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2671,6 +2702,12 @@ when = "2024-05-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wast]]
+version = "211.0.1"
+when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wat]]
 version = "1.201.0"
 when = "2024-02-27"
@@ -2722,6 +2759,12 @@ user-login = "wasmtime-publish"
 [[publisher.wat]]
 version = "1.209.1"
 when = "2024-05-29"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wat]]
+version = "1.211.1"
+when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -3157,6 +3200,12 @@ when = "2024-05-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-component]]
+version = "0.211.1"
+when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-parser]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -3208,6 +3257,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-parser]]
 version = "0.209.1"
 when = "2024-05-29"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-parser]]
+version = "0.211.1"
+when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1357,7 +1357,7 @@ where
         FnCall::emit::<M>(&mut self.env, self.masm, &mut self.context, callee)
     }
 
-    fn visit_call_indirect(&mut self, type_index: u32, table_index: u32, _: u8) {
+    fn visit_call_indirect(&mut self, type_index: u32, table_index: u32) {
         // Spill now because `emit_lazy_init_funcref` and the `FnCall::emit`
         // invocations will both trigger spills since they both call functions.
         // However, the machine instructions for the spill emitted by
@@ -1603,12 +1603,12 @@ where
         )
     }
 
-    fn visit_memory_size(&mut self, mem: u32, _: u8) {
+    fn visit_memory_size(&mut self, mem: u32) {
         let heap = self.env.resolve_heap(MemoryIndex::from_u32(mem));
         self.emit_compute_memory_size(&heap);
     }
 
-    fn visit_memory_grow(&mut self, mem: u32, _: u8) {
+    fn visit_memory_grow(&mut self, mem: u32) {
         debug_assert!(self.context.stack.len() >= 1);
         // The stack at this point contains: [ delta ]
         // The desired state is


### PR DESCRIPTION
Only one change I wasn't certain of, for the `storage: &mut String` parameter in wasmprinter:
https://github.com/bytecodealliance/wasmtime/compare/pch/wasm_tools_211?expand=1#diff-4863961fda2fef6610662e23fb35b7d7c2a367032798634425f2f407e0ee932aR70