### PR TITLE
wasmtime Config: debug impl now iterates complete WasmFeatures flag set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "addr2line",
  "anyhow",
  "async-trait",
+ "bitflags 2.4.1",
  "bumpalo",
  "cc",
  "cfg-if",

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -58,6 +58,7 @@ semver = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 libm = "0.2.7"
+bitflags = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2139,34 +2139,22 @@ impl Default for Config {
 impl fmt::Debug for Config {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut f = f.debug_struct("Config");
-        f.field("debug_info", &self.tunables.generate_native_debuginfo)
-            .field(
-                "wasm_threads",
-                &self.features.contains(WasmFeatures::THREADS),
-            )
-            .field(
-                "wasm_reference_types",
-                &self.features.contains(WasmFeatures::REFERENCE_TYPES),
-            )
-            .field(
-                "wasm_function_references",
-                &self.features.contains(WasmFeatures::FUNCTION_REFERENCES),
-            )
-            .field("wasm_gc", &self.features.contains(WasmFeatures::GC))
-            .field(
-                "wasm_bulk_memory",
-                &self.features.contains(WasmFeatures::BULK_MEMORY),
-            )
-            .field("wasm_simd", &self.features.contains(WasmFeatures::SIMD))
-            .field(
-                "wasm_relaxed_simd",
-                &self.features.contains(WasmFeatures::RELAXED_SIMD),
-            )
-            .field(
-                "wasm_multi_value",
-                &self.features.contains(WasmFeatures::MULTI_VALUE),
-            )
-            .field("parallel_compilation", &self.parallel_compilation);
+        f.field("debug_info", &self.tunables.generate_native_debuginfo);
+
+        // Not every flag in WasmFeatures can be enabled as part of creating
+        // a Config. This impl gives a complete picture of all WasmFeatures
+        // enabled, and doesn't require maintence by hand (which has become out
+        // of date in the past), at the cost of possible confusion for why
+        // a flag in this set doesn't have a Config setter.
+        use bitflags::Flags;
+        for flag in WasmFeatures::FLAGS.iter() {
+            f.field(
+                &format!("wasm_{}", flag.name().to_lowercase()),
+                &self.features.contains(*flag.value()),
+            );
+        }
+
+        f.field("parallel_compilation", &self.parallel_compilation);
         #[cfg(any(feature = "cranelift", feature = "winch"))]
         {
             f.field("compiler_config", &self.compiler_config);


### PR DESCRIPTION
I noticed that the wasm_memory64 flag was left out of Config's debug impl, so rather than add it, I decided to use the `bitflags::Flags::FLAGS` const to iterate the complete set of flags.

THe downside of this change is that it will print flags which do not have a setter in Config, e.g. `wasm_component_model_nested_names`.

An alternative to this change is, rather than expanding out the single `features: WasmFeatures` member into many different debug_struct fields, the debug impl of WasmFeatures is used.

Here is a sample debug of Config with this change:

```
Config { debug_info: None, wasm_mutable_global: true, wasm_saturating_float_to_int: true, wasm_sign_extension: true, wasm_reference_types: true, wasm_multi_value: true, wasm_bulk_memory: true, wasm_simd: true, wasm_relaxed_simd: false, wasm_threads: false, wasm_shared_everything_threads: false, wasm_tail_call: false, wasm_floats: true, wasm_multi_memory: false, wasm_exceptions: false, wasm_memory64: false, wasm_extended_const: false, wasm_component_model: false, wasm_function_references: false, wasm_memory_control: false, wasm_gc: false, wasm_custom_page_sizes: false, wasm_component_model_values: false, wasm_component_model_nested_names: false, parallel_compilation: true, compiler_config: CompilerConfig { strategy: Some(Cranelift), target: None, settings: {"opt_level": "speed", "enable_verifier": "true"}, flags: {}, cache_store: None, clif_dir: None, wmemcheck: false }, parse_wasm_debuginfo: false }
```
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
