### PR TITLE
Allow 4G memories by default in the pooling allocator

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -166,7 +166,7 @@ impl Default for InstanceLimits {
             // have 10k+ elements.
             table_elements: 20_000,
             max_memories_per_module: 1,
-            max_memory_size: 10 * (1 << 20), // 10 MiB
+            max_memory_size: 1 << 32, // 4G,
             #[cfg(feature = "gc")]
             total_gc_heaps: 1000,
         }


### PR DESCRIPTION
This commit raises the default setting of `max_memory_size` in the pooling allocator from 10M to 4G. This won't actually impact the virtual memory reserved in the pooling allocator because we already reserved 6G of virtual memory for each linear memory this instead allows access to all of it by default. This matches the default behavior of Wasmtime for the non-pooling allocator which is to not artificially limit memory by default.

The main impact of this setting is that the memory-protection-keys feature, which is disabled by default, will have no effect by default unless `max_memory_size` is also configured to something smaller than 4G. The documentation has been updated to this effect.

Closes #8846

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
