### PR TITLE
riscv64: Add support for `bitcast.i128` with a `i128` argument 

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -2465,19 +2465,24 @@
 
 ;; These rules should probably be handled in `gen_bitcast`, but it's convenient to have that return
 ;; a single register, instead of a `ValueRegs`
-(rule 2 (lower (has_type $I128 (bitcast _ v @ (value_type (ty_vec_fits_in_register _)))))
+(rule 3 (lower (has_type $I128 (bitcast _ v @ (value_type (ty_vec_fits_in_register _)))))
     (value_regs
       (gen_extractlane $I64X2 v 0)
       (gen_extractlane $I64X2 v 1)))
 
 ;; Move the high half into a vector register, and then use vslide1up to move it up and
 ;; insert the lower half in one instruction.
-(rule 1 (lower (has_type (ty_vec_fits_in_register _) (bitcast _ v @ (value_type $I128))))
+(rule 2 (lower (has_type (ty_vec_fits_in_register _) (bitcast _ v @ (value_type $I128))))
     (let ((lo XReg (value_regs_get v 0))
           (hi XReg (value_regs_get v 1))
           (vstate VState (vstate_from_type $I64X2))
           (vec VReg (rv_vmv_sx hi vstate)))
       (rv_vslide1up_vx vec vec lo (unmasked) vstate)))
+
+;; `gen_bitcast` below only works with single register values, so handle I128
+;; specially here.
+(rule 1 (lower (has_type $I128 (bitcast _ v @ (value_type $I128))))
+   v)
 
 (rule 0 (lower (has_type out_ty (bitcast _ v @ (value_type in_ty))))
    (gen_bitcast v in_ty out_ty))

--- a/cranelift/filetests/filetests/runtests/i128-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitcast.clif
@@ -1,0 +1,15 @@
+test interpret
+test run
+set enable_llvm_abi_extensions=true
+target aarch64
+target x86_64
+target s390x
+target riscv64
+target riscv64 has_c has_zcb
+
+function %bitcast_i128_i128(i128) -> i128 {
+block0(v0: i128):
+  v1 = bitcast.i128 v0
+  return v1
+}
+; run: %bitcast_i128_i128(0) == 0


### PR DESCRIPTION
👋 Hey,

This PR fixes an issue discovered by fuzzing. #8692 expanded our support for bitcasts, and also enabled them in the cranelift fuzzer for the RISC-V backend.

It turns out that `bitcast.i128` with a `i128` argument wasn't supported in the backend, but was technically legal CLIF.

This PR adds that lowering and a testcase to ensure this doesn't regress.