### PR TITLE
wasmtime: Remove redundant epoch check on function entry

### DIFF
--- a/tests/disas/epoch-interruption-x86.wat
+++ b/tests/disas/epoch-interruption-x86.wat
@@ -1,0 +1,39 @@
+;;! target = "x86_64"
+;;! test = "compile"
+;;! flags = ["-Wepoch-interruption=y"]
+
+(module (func (loop (br 0))))
+
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r10
+;;       movq    (%r10), %r10
+;;       addq    $0x30, %r10
+;;       cmpq    %rsp, %r10
+;;       ja      0x7f
+;;   18: subq    $0x20, %rsp
+;;       movq    %rbx, (%rsp)
+;;       movq    %r12, 8(%rsp)
+;;       movq    %r13, 0x10(%rsp)
+;;       movq    8(%rdi), %r12
+;;       movq    0x20(%rdi), %rbx
+;;       movq    %rdi, %r13
+;;       movq    (%rbx), %r9
+;;       movq    0x10(%r12), %rax
+;;       cmpq    %rax, %r9
+;;       jae     0x57
+;;   46: movq    (%rbx), %rdi
+;;       cmpq    %rax, %rdi
+;;       jae     0x64
+;;       jmp     0x46
+;;   57: movq    %r13, %rdi
+;;       callq   0xdf
+;;       jmp     0x46
+;;   64: movq    0x10(%r12), %rax
+;;       cmpq    %rax, %rdi
+;;       jb      0x46
+;;   72: movq    %r13, %rdi
+;;       callq   0xdf
+;;       jmp     0x46
+;;   7f: ud2

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -1,0 +1,47 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+;;! flags = ["-Wepoch-interruption=y"]
+
+(module (func (loop (br 0))))
+
+;; function u0:0(i64 vmctx, i64) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx) -> i64 system_v
+;;     fn0 = colocated u1:16 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @0016                               v3 = load.i64 notrap aligned v0+8
+;; @0016                               v5 = load.i64 notrap aligned v0+32
+;; @0016                               v6 = load.i64 notrap aligned v5
+;; @0016                               v7 = load.i64 notrap aligned v3+16
+;; @0016                               v8 = icmp uge v6, v7
+;; @0016                               brif v8, block3, block2(v7)
+;;
+;;                                 block3 cold:
+;; @0016                               v10 = call fn0(v0)
+;; @0016                               jump block2(v10)
+;;
+;;                                 block2(v21: i64):
+;; @0017                               jump block4(v21)
+;;
+;;                                 block4(v13: i64):
+;; @0017                               v12 = load.i64 notrap aligned v5
+;; @0017                               v14 = icmp uge v12, v13
+;; @0017                               brif v14, block7, block6(v13)
+;;
+;;                                 block7 cold:
+;; @0017                               v15 = load.i64 notrap aligned v3+16
+;; @0017                               v16 = icmp.i64 uge v12, v15
+;; @0017                               brif v16, block8, block6(v15)
+;;
+;;                                 block8 cold:
+;; @0017                               v18 = call fn0(v0)
+;; @0017                               jump block6(v18)
+;;
+;;                                 block6(v22: i64):
+;; @0019                               jump block4(v22)
+;; }


### PR DESCRIPTION
The epoch interruption implementation caches the current deadline in a register, and avoids reloading that cache until the cached deadline has passed.

However, the first epoch check happens immediately after the cache has been populated on function entry, so there's never a reason to reload the cache at that point. It only needs to be reloaded in loops. So this commit eliminates the double-check on function entry.

When Cranelift optimizations are enabled, the alias analysis pass correctly detected that this load was redundant, and the egraph pass optimized away the `icmp` as well. However, since we don't do conditional constant propagation, the branch couldn't be optimized away. On x86 this lowered to a redundant `cmp`/`jae` pair of instructions in every function entry, which this commit eliminates.

To keep track of what code we're generating for epoch interruptions, I've also added disas tests with a trivial infinite loop.