### PR TITLE
clif: Fix parsing the `cold` calling convention

### DIFF
--- a/cranelift/filetests/filetests/parser/cold.clif
+++ b/cranelift/filetests/filetests/parser/cold.clif
@@ -1,0 +1,12 @@
+test cat
+
+function %cold() cold {
+    sig0 = () cold
+    sig1 = () -> i8 cold
+block1:
+    return
+}
+
+; sameln: function %cold() cold {
+; nextln:     sig0 = () cold
+; nextln:     sig1 = () -> i8 cold

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -1347,14 +1347,20 @@ impl<'a> Parser<'a> {
         }
 
         // The calling convention is optional.
-        if let Some(Token::Identifier(text)) = self.token() {
-            match text.parse() {
+        match self.token() {
+            Some(Token::Identifier(text)) => match text.parse() {
                 Ok(cc) => {
                     self.consume();
                     sig.call_conv = cc;
                 }
                 _ => return err!(self.loc, "unknown calling convention: {}", text),
+            },
+
+            Some(Token::Cold) => {
+                self.consume();
+                sig.call_conv = CallConv::Cold;
             }
+            _ => {}
         }
 
         Ok(sig)


### PR DESCRIPTION
The identifier for the `cold` calling convention overlaps with the `cold` keyword for basic blocks so handle another kind of token when parsing signatures.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
