### PR TITLE
Fix `cargo binstall` metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,22 +14,22 @@ default-run = "wasmtime"
 rust-version.workspace = true
 
 [package.metadata.binstall]
-pkg-url = "{repo}/releases/download/v{version}/{name}-v{version}-{target-arch}-{target-family}{archive-suffix}"
-bin-dir = "{name}-{version}-{target-arch}-{target-family}/{bin}{binary-ext}"
+pkg-url = "{repo}/releases/download/v{version}/wasmtime-v{version}-{target-arch}-{target-family}{archive-suffix}"
+bin-dir = "wasmtime-{version}-{target-arch}-{target-family}/{bin}{binary-ext}"
 pkg-fmt = "txz"
 [package.metadata.binstall.overrides.x86_64-apple-darwin]
-pkg-url = "{repo}/releases/download/v{version}/{name}-v{version}-{target-arch}-macos{archive-suffix}"
-bin-dir = "{name}-v{version}-{target-arch}-macos/{bin}{binary-ext}"
+pkg-url = "{repo}/releases/download/v{version}/wasmtime-v{version}-{target-arch}-macos{archive-suffix}"
+bin-dir = "wasmtime-v{version}-{target-arch}-macos/{bin}{binary-ext}"
 [package.metadata.binstall.overrides.aarch64-apple-darwin]
-pkg-url = "{repo}/releases/download/v{version}/{name}-v{version}-{target-arch}-macos{archive-suffix}"
-bin-dir = "{name}-v{version}-{target-arch}-macos/{bin}{binary-ext}"
+pkg-url = "{repo}/releases/download/v{version}/wasmtime-v{version}-{target-arch}-macos{archive-suffix}"
+bin-dir = "wasmtime-v{version}-{target-arch}-macos/{bin}{binary-ext}"
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"
 [package.metadata.binstall.overrides.x86_64-pc-windows-gnu]
 pkg-fmt = "zip"
 [package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
-pkg-url = "{repo}/releases/download/v{version}/{name}-v{version}-{target-arch}-musl{archive-suffix}"
-bin-dir = "{name}-v{version}-{target-arch}-musl/{bin}{binary-ext}"
+pkg-url = "{repo}/releases/download/v{version}/wasmtime-v{version}-{target-arch}-musl{archive-suffix}"
+bin-dir = "wasmtime-v{version}-{target-arch}-musl/{bin}{binary-ext}"
 
 [lints]
 workspace = true


### PR DESCRIPTION
I forgot that `{name}` expands to `wasmtime-cli` here when our packages are named `wasmtime`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
