### PR TITLE
Reduce the size of the wasp1 component adapter by 4.6k

### DIFF
--- a/ci/build-wasi-preview1-component-adapter.sh
+++ b/ci/build-wasi-preview1-component-adapter.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+# These flags reduce binary size by a combined 4.6k
+export CARGO_PROFILE_RELEASE_LTO=fat
+export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="$RUSTFLAGS -Ctarget-feature=+bulk-memory"
+
 build_adapter="cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown"
 verify="cargo run -p verify-component-adapter --"
 


### PR DESCRIPTION
This reduces the size of wasi_snapshot_preview1.command.wasm from 79625 bytes to 75029 bytes for a total win of 4596 bytes. Of this reduction enabling LTO is responsible for 3103 bytes, while enabling bulk-memory is responsible for 1493 bytes.