### PR TITLE
Initial `f16` and `f128` support

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/types.rs
+++ b/cranelift/codegen/meta/src/cdsl/types.rs
@@ -136,6 +136,12 @@ impl LaneType {
     /// Return a string containing the documentation comment for this lane type.
     pub fn doc(self) -> String {
         match self {
+            LaneType::Float(shared_types::Float::F16) => String::from(
+                "A 16-bit floating point type represented in the IEEE 754-2008
+                *binary16* interchange format. This corresponds to the :c:type:`_Float16`
+                type in most C implementations.
+                WARNING: f16 support is a work-in-progress and is incomplete",
+            ),
             LaneType::Float(shared_types::Float::F32) => String::from(
                 "A 32-bit floating point type represented in the IEEE 754-2008
                 *binary32* interchange format. This corresponds to the :c:type:`float`
@@ -145,6 +151,12 @@ impl LaneType {
                 "A 64-bit floating point type represented in the IEEE 754-2008
                 *binary64* interchange format. This corresponds to the :c:type:`double`
                 type in most C implementations.",
+            ),
+            LaneType::Float(shared_types::Float::F128) => String::from(
+                "A 128-bit floating point type represented in the IEEE 754-2008
+                *binary128* interchange format. This corresponds to the :c:type:`_Float128`
+                type in most C implementations.
+                WARNING: f128 support is a work-in-progress and is incomplete",
             ),
             LaneType::Int(_) if self.lane_bits() < 32 => format!(
                 "An integer type with {} bits.
@@ -168,13 +180,15 @@ impl LaneType {
     pub fn number(self) -> u16 {
         constants::LANE_BASE
             + match self {
-                LaneType::Int(shared_types::Int::I8) => 6,
-                LaneType::Int(shared_types::Int::I16) => 7,
-                LaneType::Int(shared_types::Int::I32) => 8,
-                LaneType::Int(shared_types::Int::I64) => 9,
-                LaneType::Int(shared_types::Int::I128) => 10,
-                LaneType::Float(shared_types::Float::F32) => 11,
-                LaneType::Float(shared_types::Float::F64) => 12,
+                LaneType::Int(shared_types::Int::I8) => 4,
+                LaneType::Int(shared_types::Int::I16) => 5,
+                LaneType::Int(shared_types::Int::I32) => 6,
+                LaneType::Int(shared_types::Int::I64) => 7,
+                LaneType::Int(shared_types::Int::I128) => 8,
+                LaneType::Float(shared_types::Float::F16) => 9,
+                LaneType::Float(shared_types::Float::F32) => 10,
+                LaneType::Float(shared_types::Float::F64) => 11,
+                LaneType::Float(shared_types::Float::F128) => 12,
             }
     }
 
@@ -191,8 +205,10 @@ impl LaneType {
 
     pub fn float_from_bits(num_bits: u16) -> LaneType {
         LaneType::Float(match num_bits {
+            16 => shared_types::Float::F16,
             32 => shared_types::Float::F32,
             64 => shared_types::Float::F64,
+            128 => shared_types::Float::F128,
             _ => unreachable!("unexpected num bits for float"),
         })
     }

--- a/cranelift/codegen/meta/src/shared/types.rs
+++ b/cranelift/codegen/meta/src/shared/types.rs
@@ -43,8 +43,10 @@ impl Iterator for IntIterator {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub(crate) enum Float {
+    F16 = 16,
     F32 = 32,
     F64 = 64,
+    F128 = 128,
 }
 
 /// Iterator through the variants of the Float enum.
@@ -63,8 +65,10 @@ impl Iterator for FloatIterator {
     type Item = Float;
     fn next(&mut self) -> Option<Self::Item> {
         let res = match self.index {
-            0 => Some(Float::F32),
-            1 => Some(Float::F64),
+            0 => Some(Float::F16),
+            1 => Some(Float::F32),
+            2 => Some(Float::F64),
+            3 => Some(Float::F128),
             _ => return None,
         };
         self.index += 1;
@@ -122,8 +126,10 @@ mod iter_tests {
     #[test]
     fn float_iter_works() {
         let mut float_iter = FloatIterator::new();
+        assert_eq!(float_iter.next(), Some(Float::F16));
         assert_eq!(float_iter.next(), Some(Float::F32));
         assert_eq!(float_iter.next(), Some(Float::F64));
+        assert_eq!(float_iter.next(), Some(Float::F128));
         assert_eq!(float_iter.next(), None);
     }
 

--- a/cranelift/filetests/filetests/runtests/bitcast-f16-f128.clif
+++ b/cranelift/filetests/filetests/runtests/bitcast-f16-f128.clif
@@ -1,0 +1,61 @@
+test interpret
+
+function %bitcast_i16_f16(i16) -> f16 fast {
+block0(v0: i16):
+    v1 = bitcast.f16 v0
+    return v1
+}
+; run: %bitcast_i16_f16(0x0000) == 0x0.0
+; run: %bitcast_i16_f16(0x0001) == 0x0.004p-14
+; run: %bitcast_i16_f16(0x7c00) == Inf
+; run: %bitcast_i16_f16(0xfe00) == -NaN
+; run: %bitcast_i16_f16(0x7c01) == +sNaN:0x1
+; run: %bitcast_i16_f16(0x3c00) == 0x1.0
+; run: %bitcast_i16_f16(0x47fe) == 0x7.fe
+; run: %bitcast_i16_f16(0xf0e0) == -0x1.380p13
+; run: %bitcast_i16_f16(0xabcd) == -0x1.f34p-5
+
+function %bitcast_i128_f128(i128) -> f128 fast {
+block0(v0: i128):
+    v1 = bitcast.f128 v0
+    return v1
+}
+; run: %bitcast_i128_f128(0x00000000000000000000000000000000) == 0x0.0
+; run: %bitcast_i128_f128(0x00000000000000000000000000000001) == 0x0.0000000000000000000000000001p-16382
+; run: %bitcast_i128_f128(0x7fff0000000000000000000000000000) == Inf
+; run: %bitcast_i128_f128(0xffff8000000000000000000000000000) == -NaN
+; run: %bitcast_i128_f128(0x7fff0000000000000000000000000001) == +sNaN:0x1
+; run: %bitcast_i128_f128(0x3fff0000000000000000000000000000) == 0x1.0
+; run: %bitcast_i128_f128(0x3fff7fef123456789abcdefcda456987) == 0x1.7fef123456789abcdefcda456987
+; run: %bitcast_i128_f128(0xf0e0d0c0b0a090807060504030201000) == -0x1.d0c0b0a090807060504030201000p12513
+; run: %bitcast_i128_f128(0xabcdef01234567890123456789abcdef) == -0x1.ef01234567890123456789abcdefp-5170
+
+function %bitcast_f16_i16(f16) -> i16 fast {
+block0(v0: f16):
+    v1 = bitcast.i16 v0
+    return v1
+}
+; run: %bitcast_f16_i16(0x0.0) == 0x0000
+; run: %bitcast_f16_i16(0x0.004p-14) == 0x0001
+; run: %bitcast_f16_i16(Inf) == 0x7c00
+; run: %bitcast_f16_i16(-NaN) == 0xfe00
+; run: %bitcast_f16_i16(+sNaN:0x1) == 0x7c01
+; run: %bitcast_f16_i16(0x1.0) == 0x3c00
+; run: %bitcast_f16_i16(0x7.fe) == 0x47fe
+; run: %bitcast_f16_i16(-0x1.3c0p13) == 0xf0f0
+; run: %bitcast_f16_i16(-0x1.f34p-5) == 0xabcd
+
+function %bitcast_f128_i128(f128) -> i128 fast {
+block0(v0: f128):
+    v1 = bitcast.i128 v0
+    return v1
+}
+; run: %bitcast_f128_i128(0x0.0) == 0x00000000000000000000000000000000
+; run: %bitcast_f128_i128(0x0.0000000000000000000000000001p-16382) == 0x00000000000000000000000000000001
+; run: %bitcast_f128_i128(Inf) == 0x7fff0000000000000000000000000000
+; run: %bitcast_f128_i128(-NaN) == 0xffff8000000000000000000000000000
+; run: %bitcast_f128_i128(+sNaN:0x1) == 0x7fff0000000000000000000000000001
+; run: %bitcast_f128_i128(0x1.0) == 0x3fff0000000000000000000000000000
+; run: %bitcast_f128_i128(0x1.7fef123456789abcdefcda456987) == 0x3fff7fef123456789abcdefcda456987
+; run: %bitcast_f128_i128(-0x1.d0c0b0a090807060504030201000p12513) == 0xf0e0d0c0b0a090807060504030201000
+; run: %bitcast_f128_i128(-0x1.ef01234567890123456789abcdefp-5170) == 0xabcdef01234567890123456789abcdef

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -1419,7 +1419,7 @@ pub(crate) fn extractlanes(
 
     let iterations = match lane_type {
         types::I8 => 1,
-        types::I16 => 2,
+        types::I16 | types::F16 => 2,
         types::I32 | types::F32 => 4,
         types::I64 | types::F64 => 8,
         _ => unimplemented!("vectors with lanes wider than 64-bits are currently unsupported."),
@@ -1458,7 +1458,7 @@ fn vectorizelanes_all(x: &[DataValue], vector_type: types::Type) -> ValueResult<
     let lane_type = vector_type.lane_type();
     let iterations = match lane_type {
         types::I8 => 1,
-        types::I16 => 2,
+        types::I16 | types::F16 => 2,
         types::I32 | types::F32 => 4,
         types::I64 | types::F64 => 8,
         _ => unimplemented!("vectors with lanes wider than 64-bits are currently unsupported."),

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -5,7 +5,7 @@
 
 use core::fmt::{self, Display, Formatter};
 use cranelift_codegen::data_value::{DataValue, DataValueCastFailure};
-use cranelift_codegen::ir::immediates::{Ieee32, Ieee64};
+use cranelift_codegen::ir::immediates::{Ieee128, Ieee16, Ieee32, Ieee64};
 use cranelift_codegen::ir::{types, Type};
 use thiserror::Error;
 
@@ -318,7 +318,7 @@ impl DataValueExt for DataValue {
 
     fn is_float(&self) -> bool {
         match self {
-            DataValue::F32(_) | DataValue::F64(_) => true,
+            DataValue::F16(_) | DataValue::F32(_) | DataValue::F64(_) | DataValue::F128(_) => true,
             _ => false,
         }
     }
@@ -399,10 +399,14 @@ impl DataValueExt for DataValue {
                 (val, ty) if val.ty().is_int() && ty.is_int() => {
                     DataValue::from_integer(val.into_int_signed()?, ty)?
                 }
+                (DataValue::I16(n), types::F16) => DataValue::F16(Ieee16::with_bits(n as u16)),
                 (DataValue::I32(n), types::F32) => DataValue::F32(f32::from_bits(n as u32).into()),
                 (DataValue::I64(n), types::F64) => DataValue::F64(f64::from_bits(n as u64).into()),
+                (DataValue::I128(n), types::F128) => DataValue::F128(Ieee128::with_bits(n as u128)),
+                (DataValue::F16(n), types::I16) => DataValue::I16(n.bits() as i16),
                 (DataValue::F32(n), types::I32) => DataValue::I32(n.bits() as i32),
                 (DataValue::F64(n), types::I64) => DataValue::I64(n.bits() as i64),
+                (DataValue::F128(n), types::I128) => DataValue::I128(n.bits() as i128),
                 (DataValue::F32(n), types::F64) => DataValue::F64((n.as_f32() as f64).into()),
                 (dv, t) if (t.is_int() || t.is_float()) && dv.ty() == t => dv,
                 (dv, _) => unimplemented!("conversion: {} -> {:?}", dv.ty(), kind),
@@ -502,8 +506,10 @@ impl DataValueExt for DataValue {
             DataValue::I32(f) => Ok(*f == 0),
             DataValue::I64(f) => Ok(*f == 0),
             DataValue::I128(f) => Ok(*f == 0),
+            DataValue::F16(f) => Ok(f.is_zero()),
             DataValue::F32(f) => Ok(f.is_zero()),
             DataValue::F64(f) => Ok(f.is_zero()),
+            DataValue::F128(f) => Ok(f.is_zero()),
             DataValue::V64(_) | DataValue::V128(_) => {
                 Err(ValueError::InvalidType(ValueTypeClass::Float, self.ty()))
             }

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -369,8 +369,10 @@ impl<'a> Lexer<'a> {
             "i32" => types::I32,
             "i64" => types::I64,
             "i128" => types::I128,
+            "f16" => types::F16,
             "f32" => types::F32,
             "f64" => types::F64,
+            "f128" => types::F128,
             "r32" => types::R32,
             "r64" => types::R64,
             _ => return None,
@@ -626,7 +628,7 @@ mod tests {
     fn lex_identifiers() {
         let mut lex = Lexer::new(
             "v0 v00 vx01 block1234567890 block5234567890 v1x vx1 vxvx4 \
-             function0 function i8 i32x4 f32x5",
+             function0 function i8 i32x4 f32x5 f16 f128",
         );
         assert_eq!(
             lex.next(),
@@ -647,6 +649,8 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Type(types::I8), 1));
         assert_eq!(lex.next(), token(Token::Type(types::I32X4), 1));
         assert_eq!(lex.next(), token(Token::Identifier("f32x5"), 1));
+        assert_eq!(lex.next(), token(Token::Type(types::F16), 1));
+        assert_eq!(lex.next(), token(Token::Type(types::F128), 1));
         assert_eq!(lex.next(), None);
     }
 

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -10,7 +10,9 @@ use crate::testfile::{Comment, Details, Feature, TestFile};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::entity::{EntityRef, PrimaryMap};
 use cranelift_codegen::ir::entities::{AnyEntity, DynamicType, MemoryType};
-use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, Uimm32, Uimm64};
+use cranelift_codegen::ir::immediates::{
+    Ieee128, Ieee16, Ieee32, Ieee64, Imm64, Offset32, Uimm32, Uimm64,
+};
 use cranelift_codegen::ir::instructions::{InstructionData, InstructionFormat, VariableArgs};
 use cranelift_codegen::ir::pcc::{BaseExpr, Expr, Fact};
 use cranelift_codegen::ir::types;
@@ -855,6 +857,18 @@ impl<'a> Parser<'a> {
         Ok(Imm64::new(0))
     }
 
+    // Match and consume an Ieee16 immediate.
+    fn match_ieee16(&mut self, err_msg: &str) -> ParseResult<Ieee16> {
+        if let Some(Token::Float(text)) = self.token() {
+            self.consume();
+            // Lexer just gives us raw text that looks like a float.
+            // Parse it as an Ieee16 to check for the right number of digits and other issues.
+            text.parse().map_err(|e| self.error(e))
+        } else {
+            err!(self.loc, err_msg)
+        }
+    }
+
     // Match and consume an Ieee32 immediate.
     fn match_ieee32(&mut self, err_msg: &str) -> ParseResult<Ieee32> {
         if let Some(Token::Float(text)) = self.token() {
@@ -873,6 +887,18 @@ impl<'a> Parser<'a> {
             self.consume();
             // Lexer just gives us raw text that looks like a float.
             // Parse it as an Ieee64 to check for the right number of digits and other issues.
+            text.parse().map_err(|e| self.error(e))
+        } else {
+            err!(self.loc, err_msg)
+        }
+    }
+
+    // Match and consume an Ieee128 immediate.
+    fn match_ieee128(&mut self, err_msg: &str) -> ParseResult<Ieee128> {
+        if let Some(Token::Float(text)) = self.token() {
+            self.consume();
+            // Lexer just gives us raw text that looks like a float.
+            // Parse it as an Ieee128 to check for the right number of digits and other issues.
             text.parse().map_err(|e| self.error(e))
         } else {
             err!(self.loc, err_msg)
@@ -2793,8 +2819,10 @@ impl<'a> Parser<'a> {
             I32 => DataValue::from(self.match_imm32("expected an i32")?),
             I64 => DataValue::from(Into::<i64>::into(self.match_imm64("expected an i64")?)),
             I128 => DataValue::from(self.match_imm128("expected an i128")?),
+            F16 => DataValue::from(self.match_ieee16("expected an f16")?),
             F32 => DataValue::from(self.match_ieee32("expected an f32")?),
             F64 => DataValue::from(self.match_ieee64("expected an f64")?),
+            F128 => DataValue::from(self.match_ieee128("expected an f128")?),
             _ if (ty.is_vector() || ty.is_dynamic_vector()) => {
                 let as_vec = self.match_uimm128(ty)?.into_vec();
                 if as_vec.len() == 16 {
@@ -3254,12 +3282,13 @@ mod tests {
         assert_eq!(sig.returns.len(), 0);
         assert_eq!(sig.call_conv, CallConv::SystemV);
 
-        let sig2 = Parser::new("(i8 uext, f32, f64, i32 sret) -> i32 sext, f64 system_v")
-            .parse_signature()
-            .unwrap();
+        let sig2 =
+            Parser::new("(i8 uext, f16, f32, f64, f128, i32 sret) -> i32 sext, f64 system_v")
+                .parse_signature()
+                .unwrap();
         assert_eq!(
             sig2.to_string(),
-            "(i8 uext, f32, f64, i32 sret) -> i32 sext, f64 system_v"
+            "(i8 uext, f16, f32, f64, f128, i32 sret) -> i32 sext, f64 system_v"
         );
         assert_eq!(sig2.call_conv, CallConv::SystemV);
 
@@ -3865,8 +3894,13 @@ mod tests {
             "1512366032949150931280199141537564007"
         );
         assert_eq!(parse("1234567", I128).to_string(), "1234567");
+        assert_eq!(parse("0x16.1", F16).to_string(), "0x1.610p4");
         assert_eq!(parse("0x32.32", F32).to_string(), "0x1.919000p5");
         assert_eq!(parse("0x64.64", F64).to_string(), "0x1.9190000000000p6");
+        assert_eq!(
+            parse("0x128.128", F128).to_string(),
+            "0x1.2812800000000000000000000000p8"
+        );
         assert_eq!(
             parse("[0 1 2 3]", I32X4).to_string(),
             "0x00000003000000020000000100000000"


### PR DESCRIPTION
Issue #8312

This PR adds initial basic support for `f16` and `f128` to Cranelift. This is enough to allow the interpreter to bitcast to and from `f16`s and `f128`s, as shown in the added filetest.