### PR TITLE
cranelift/isle: fix parser extern error message

### DIFF
--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -356,7 +356,7 @@ impl<'a> Parser<'a> {
         } else {
             Err(self.error(
                 pos,
-                "Invalid extern: must be (extern constructor ...) or (extern extractor ...)"
+                "Invalid extern: must be (extern constructor ...), (extern extractor ...) or (extern const ...)"
                     .to_string(),
             ))
         }


### PR DESCRIPTION
This PR corrects the error message for `extern` to cover the `extern const` case.