### PR TITLE
cranelift/aarch64: Support fmsub

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1331,7 +1331,10 @@
 ;; A floating-point unit (FPU) operation with three args.
 (type FPUOp3
   (enum
+    ;; Multiply-add
     (MAdd)
+    ;; Multiply-sub
+    (MSub)
 ))
 
 ;; A conversion from an FP to an integer value.

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -1860,6 +1860,7 @@ impl MachInstEmit for Inst {
             } => {
                 let top17 = match fpu_op {
                     FPUOp3::MAdd => 0b000_11111_00_0_00000_0,
+                    FPUOp3::MSub => 0b000_11111_00_0_00000_1,
                 };
                 let top17 = top17 | size.ftype() << 7;
                 sink.put4(enc_fpurrrr(top17, rd, rn, rm, ra));

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -6442,6 +6442,19 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::FpuRRRR {
+            fpu_op: FPUOp3::MSub,
+            size: ScalarSize::Size32,
+            rd: writable_vreg(15),
+            rn: vreg(30),
+            rm: vreg(31),
+            ra: vreg(1),
+        },
+        "CF871F1F",
+        "fmsub s15, s30, s31, s1",
+    ));
+
+    insns.push((
+        Inst::FpuRRRR {
             fpu_op: FPUOp3::MAdd,
             size: ScalarSize::Size64,
             rd: writable_vreg(15),
@@ -6451,6 +6464,19 @@ fn test_aarch64_binemit() {
         },
         "CF075F1F",
         "fmadd d15, d30, d31, d1",
+    ));
+
+    insns.push((
+        Inst::FpuRRRR {
+            fpu_op: FPUOp3::MSub,
+            size: ScalarSize::Size64,
+            rd: writable_vreg(15),
+            rn: vreg(30),
+            rm: vreg(31),
+            ra: vreg(1),
+        },
+        "CF875F1F",
+        "fmsub d15, d30, d31, d1",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1803,6 +1803,7 @@ impl Inst {
             } => {
                 let op = match fpu_op {
                     FPUOp3::MAdd => "fmadd",
+                    FPUOp3::MSub => "fmsub",
                 };
                 let rd = pretty_print_vreg_scalar(rd.to_reg(), size);
                 let rn = pretty_print_vreg_scalar(rn, size);

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -527,7 +527,7 @@
   (if-let (IsFneg.Result neg_x x) (is_fneg x_src))
   (if-let (IsFneg.Result neg_y y) (is_fneg y_src))
   (fmadd_series ty (u64_xor neg_x neg_y) x y z))
-       
+
 ;; Delegate vector-based lowerings to helpers below
 (rule 1 (lower (has_type ty @ (multi_lane _ _) (fma x y z)))
         (lower_fmla (VecALUModOp.Fmla) x y z (vector_size ty)))

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -513,9 +513,21 @@
 
 ;;;; Rules for `fma` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type (ty_scalar_float ty) (fma x y z)))
-       (fpu_rrrr (FPUOp3.MAdd) (scalar_size ty) x y z))
+(type IsFneg (enum (Result (negate u64) (value Value))))
 
+(decl pure is_fneg (Value) IsFneg)
+(rule 1 (is_fneg (fneg x)) (IsFneg.Result 1 x))
+(rule 0 (is_fneg x) (IsFneg.Result 0 x))
+
+(decl fmadd_series (Type u64 Value Value Value) InstOutput)
+(rule 0 (fmadd_series (ty_scalar_float ty) 0 x y z) (fpu_rrrr (FPUOp3.MAdd) (scalar_size ty) x y z))
+(rule 0 (fmadd_series (ty_scalar_float ty) 1 x y z) (fpu_rrrr (FPUOp3.MSub) (scalar_size ty) x y z))
+
+(rule (lower (has_type (ty_scalar_float ty) (fma x_src y_src z)))
+  (if-let (IsFneg.Result neg_x x) (is_fneg x_src))
+  (if-let (IsFneg.Result neg_y y) (is_fneg y_src))
+  (fmadd_series ty (u64_xor neg_x neg_y) x y z))
+       
 ;; Delegate vector-based lowerings to helpers below
 (rule 1 (lower (has_type ty @ (multi_lane _ _) (fma x y z)))
         (lower_fmla (VecALUModOp.Fmla) x y z (vector_size ty)))

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -516,17 +516,24 @@
 (type IsFneg (enum (Result (negate u64) (value Value))))
 
 (decl pure is_fneg (Value) IsFneg)
-(rule 1 (is_fneg (fneg x)) (IsFneg.Result 1 x))
-(rule 0 (is_fneg x) (IsFneg.Result 0 x))
+(rule 1 (is_fneg (fneg n)) (IsFneg.Result 1 n))
+(rule 0 (is_fneg n) (IsFneg.Result 0 n))
+
+(decl pure is_fneg_neg (IsFneg) u64)
+(rule (is_fneg_neg (IsFneg.Result n _)) n)
+
+(decl pure get_fneg_value (IsFneg) Value)
+(rule (get_fneg_value (IsFneg.Result _ v)) v)
 
 (decl fmadd_series (Type u64 Value Value Value) InstOutput)
 (rule 0 (fmadd_series (ty_scalar_float ty) 0 x y z) (fpu_rrrr (FPUOp3.MAdd) (scalar_size ty) x y z))
 (rule 0 (fmadd_series (ty_scalar_float ty) 1 x y z) (fpu_rrrr (FPUOp3.MSub) (scalar_size ty) x y z))
 
 (rule (lower (has_type (ty_scalar_float ty) (fma x_src y_src z)))
-  (if-let (IsFneg.Result neg_x x) (is_fneg x_src))
-  (if-let (IsFneg.Result neg_y y) (is_fneg y_src))
-  (fmadd_series ty (u64_xor neg_x neg_y) x y z))
+  (let
+      ((x_res IsFneg (is_fneg x_src))
+       (y_res IsFneg (is_fneg y_src)))
+      (fmadd_series ty (u64_xor (is_fneg_neg x_res) (is_fneg_neg y_res)) (get_fneg_value x_res) (get_fneg_value y_res) z)))
 
 ;; Delegate vector-based lowerings to helpers below
 (rule 1 (lower (has_type ty @ (multi_lane _ _) (fma x y z)))

--- a/cranelift/filetests/filetests/isa/aarch64/fma.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fma.clif
@@ -33,6 +33,40 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   fmadd d0, d0, d1, d2
 ;   ret
 
+function %fmsub_f32(f32, f32, f32) -> f32 {
+block0(v0: f32, v1: f32, v2: f32):
+    v3 = fneg v1
+    v4 = fma v0, v3, v2
+    return v4
+}
+
+; VCode:
+; block0:
+;   fmsub s0, s0, s1, s2
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmsub s0, s0, s1, s2
+;   ret
+
+function %fmsub_f64(f64, f64, f64) -> f64 {
+block0(v0: f64, v1: f64, v2: f64):
+    v3 = fneg v1
+    v4 = fma v0, v3, v2
+    return v4
+}
+
+; VCode:
+; block0:
+;   fmsub d0, d0, d1, d2
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmsub d0, d0, d1, d2
+;   ret
+
 function %fma_f32x4(f32x4, f32x4, f32x4) -> f32x4 {
 block0(v0: f32x4, v1: f32x4, v2: f32x4):
     v3 = fma v0, v1, v2


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This PR wants to add the fmsub instruction lowering supporting for aarch64.
Part of #8603.