### PR TITLE
component-macro: normalize the path parameter in component bindgen

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -197,7 +197,14 @@ fn parse_source(
     let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
     let mut parse = |resolve: &mut Resolve, path: &Path| -> anyhow::Result<_> {
-        let (pkg, sources) = resolve.push_path(path)?;
+        // Try to normalize the path to make the error message more understandable when
+        // the path is not correct. Fallback to the original path if normalization fails
+        // (probably return an error somewhere else).
+        let normalized_path = match std::fs::canonicalize(path) {
+            Ok(p) => p,
+            Err(_) => path.to_path_buf(),
+        };
+        let (pkg, sources) = resolve.push_path(normalized_path)?;
         files.extend(sources);
         Ok(pkg)
     };


### PR DESCRIPTION
I encountered a file path issue while using the `wasmtime::component::bindgen!` macro, I used a relative file path (e.g., `../wit`) in the `path` parameter, and then I received an error message:

```
failed to read path for WIT [/Users/code/test-component/examples/../wit]
```

The file path in the error message was quite confusing, in reality, the path that was not found should be `/Users/code/test-component/wit`. The relative file path in the error message made it hard for me to immediately understand which directory `wasmtime::component::bindgen!` was using to look for WIT files. Therefore, this patch normalizes the `path` before resolving WIT files.

Error message before:

```
failed to read path for WIT [/Users/code/test-component/examples/../wit]
```

after:

```
failed to read path for WIT [/Users/code/test-component/wit]
```

The `wit_bindgen::generate!` macro has the same issue. If this patch is reasonable, I will make the same changes to `wit_bindgen::generate!` afterward.