### PR TITLE
wasi-adapter: Implement provider crate that embeds the adapter binaries [v2]

### DIFF
--- a/.github/actions/build-adapter-provider/action.yml
+++ b/.github/actions/build-adapter-provider/action.yml
@@ -1,0 +1,23 @@
+name: 'Build wasi component adapter provider'
+description: 'Build the wasi-preview1-component-adapter provider using the adapter artefacts'
+
+inputs:
+  run-id:
+    description: 'run id of the main.yml action that produced the adapter artefacts'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: bins-wasi-preview1-component-adapter
+        path: crates/wasi-preview1-component-adapter/provider/artefacts
+        github-token: ${{ github.token }}
+        run-id: ${{ inputs.run-id }}
+
+    - run: rustup component add rustfmt clippy
+
+    - name: Build and checl the adapter provider
+      shell: bash
+      run: ./ci/build-wasi-preview1-component-adapter-provider.sh

--- a/.github/actions/build-adapter-provider/action.yml
+++ b/.github/actions/build-adapter-provider/action.yml
@@ -16,7 +16,9 @@ runs:
         github-token: ${{ github.token }}
         run-id: ${{ inputs.run-id }}
 
-    - run: rustup component add rustfmt clippy
+    - name: Install required Rust components
+      shell: bash
+      run: rustup component add rustfmt clippy
 
     - name: Build and checl the adapter provider
       shell: bash

--- a/.github/actions/fetch-run-id/action.yml
+++ b/.github/actions/fetch-run-id/action.yml
@@ -1,0 +1,18 @@
+name: 'Fetch run id for commit'
+description: 'Fetch the main.yml run id for the current commit'
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch run id
+      shell: bash
+      run: |
+        run_id=$(
+          gh api -H 'Accept: application/vnd.github+json' \
+              /repos/${{ github.repository }}/actions/workflows/main.yml/runs\?exclude_pull_requests=true \
+              | jq '.workflow_runs' \
+              | jq "map(select(.head_commit.id == \"${{ github.sha }}\"))[0].id" \
+        )
+        echo COMMIT_RUN_ID=${run_id} >> "$GITHUB_ENV"
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -826,16 +826,9 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: rustup component add rustfmt clippy
-
-    - uses: actions/download-artifact@v4
+    - uses: ./.github/actions/build-adapter-provider
       with:
-        name: bins-wasi-preview1-component-adapter
-        path: crates/wasi-preview1-component-adapter/provider/artefacts
-    
-    - run: ./ci/build-wasi-preview1-component-adapter-provider.sh
-      env:
-        CHECK: 1
+        run-id: ${{ github.run_id }}
     
 
     # common logic to cancel the entire run if this job fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -794,9 +794,7 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: |
-        rustup target add wasm32-wasi wasm32-unknown-unknown
-        rustup component add rustfmt clippy
+    - run: rustup target add wasm32-wasi wasm32-unknown-unknown
 
     - name: Install wasm-tools
       run: |
@@ -812,6 +810,33 @@ jobs:
         name: bins-wasi-preview1-component-adapter
         path: target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.*.wasm
 
+
+    # common logic to cancel the entire run if this job fails
+    - run: gh run cancel ${{ github.run_id }}
+      if: failure() && github.event_name != 'pull_request'
+      env:
+        GH_TOKEN: ${{ github.token }}
+  
+  build-preview1-component-adapter-provider:
+    name: Build wasi-preview1-component-adapter-provider
+    needs: build-preview1-component-adapter
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - run: rustup component add rustfmt clippy
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: bins-wasi-preview1-component-adapter
+        path: crates/wasi-preview1-component-adapter/provider/artefacts
+    
+    - run: ./ci/build-wasi-preview1-component-adapter-provider.sh
+      env:
+        CHECK: 1
+    
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1105,6 +1105,7 @@ jobs:
       - determine
       - miri
       - build-preview1-component-adapter
+      - build-preview1-component-adapter-provider
       - build-wasmtime-target-wasm32
       - test-min-platform-example
       - check_js

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -794,7 +794,9 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: rustup target add wasm32-wasi wasm32-unknown-unknown
+    - run: |
+        rustup target add wasm32-wasi wasm32-unknown-unknown
+        rustup component add rustfmt clippy
 
     - name: Install wasm-tools
       run: |

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: |
         sha=${{ github.sha }}
+        # Remember to update this logic in publish-to-cratesio.yml as well
         run_id=$(
           gh api -H 'Accept: application/vnd.github+json' \
               /repos/${{ github.repository }}/actions/workflows/main.yml/runs\?exclude_pull_requests=true \

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -14,16 +14,9 @@ jobs:
     if: github.repository == 'bytecodealliance/wasmtime'
     steps:
     - uses: actions/checkout@v4
+    - uses: ./.github/actions/fetch-run-id
     - run: |
-        sha=${{ github.sha }}
-        # Remember to update this logic in publish-to-cratesio.yml as well
-        run_id=$(
-          gh api -H 'Accept: application/vnd.github+json' \
-              /repos/${{ github.repository }}/actions/workflows/main.yml/runs\?exclude_pull_requests=true \
-              | jq '.workflow_runs' \
-              | jq "map(select(.head_commit.id == \"$sha\"))[0].id" \
-        )
-        gh run download $run_id
+        gh run download ${COMMIT_RUN_ID}
         ls
         find bins-*
       env:

--- a/.github/workflows/publish-to-cratesio.yml
+++ b/.github/workflows/publish-to-cratesio.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: ./.github/actions/fetch-run-id
     - uses: ./.github/actions/build-adapter-provider
       with:
-        run-id: ${COMMIT_COMMIT_RUN_ID}
+        run-id: ${COMMIT_RUN_ID}
     - run: cargo publish -p wasi-preview1-component-adapter-provider --allow-dirty
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-to-cratesio.yml
+++ b/.github/workflows/publish-to-cratesio.yml
@@ -17,22 +17,30 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+    - run: |
+        sha=${{ github.sha }}
+        # Remember to update this logic in publish-artifacts.yml as well
+        echo ARTIFACT_RUN_ID=$(
+          gh api -H 'Accept: application/vnd.github+json' \
+              /repos/${{ github.repository }}/actions/workflows/main.yml/runs\?exclude_pull_requests=true \
+              | jq '.workflow_runs' \
+              | jq "map(select(.head_commit.id == \"$sha\"))[0].id" \
+        ) >> "$GITHUB_ENV"
     - run: rustup update stable && rustup default stable
     - run: |
         rustc scripts/publish.rs
         ./publish publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-    - run: |
-        # Download the published versions of the adapters
-        wget https://github.com/bytecodealliance/wasmtime/releases/download/${{github.event.release.tag_name}}/wasi_snapshot_preview1.command.wasm -O crates/wasi-preview1-component-adapter/provider/artefacts/wasi_snapshot_preview1.command.wasm
-        wget https://github.com/bytecodealliance/wasmtime/releases/download/${{github.event.release.tag_name}}/wasi_snapshot_preview1.reactor.wasm -O crates/wasi-preview1-component-adapter/provider/artefacts/wasi_snapshot_preview1.reactor.wasm
-        wget https://github.com/bytecodealliance/wasmtime/releases/download/${{github.event.release.tag_name}}/wasi_snapshot_preview1.proxy.wasm -O crates/wasi-preview1-component-adapter/provider/artefacts/wasi_snapshot_preview1.proxy.wasm
-
-        # Materialise the adapter provider crate inside the workspace
-        cp crates/wasi-preview1-component-adapter/provider/Cargo.toml.in crates/wasi-preview1-component-adapter/provider/Cargo.toml
-        sed -i '/"crates\/wasi-preview1-component-adapter",/a\ \ "crates\/wasi-preview1-component-adapter\/provider",' Cargo.toml
-
-        cargo publish -p wasi-preview1-component-adapter-provider --allow-dirty
+    
+    # Manifest and publish the wasi-preview1-component-adapter-provider
+    - uses: actions/download-artifact@v4
+      with:
+        name: bins-wasi-preview1-component-adapter
+        path: crates/wasi-preview1-component-adapter/provider/artefacts
+        github-token: ${{ github.token }}
+        run-id: ${ARTIFACT_RUN_ID}
+    - run: ./ci/build-wasi-preview1-component-adapter-provider.sh
+    - run: cargo publish -p wasi-preview1-component-adapter-provider --allow-dirty
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-to-cratesio.yml
+++ b/.github/workflows/publish-to-cratesio.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: ./.github/actions/fetch-run-id
     - uses: ./.github/actions/build-adapter-provider
       with:
-        run-id: ${COMMIT_RUN_ID}
+        run-id: ${{ env.COMMIT_RUN_ID }}
     - run: cargo publish -p wasi-preview1-component-adapter-provider --allow-dirty
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-to-cratesio.yml
+++ b/.github/workflows/publish-to-cratesio.yml
@@ -17,15 +17,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - run: |
-        sha=${{ github.sha }}
-        # Remember to update this logic in publish-artifacts.yml as well
-        echo ARTIFACT_RUN_ID=$(
-          gh api -H 'Accept: application/vnd.github+json' \
-              /repos/${{ github.repository }}/actions/workflows/main.yml/runs\?exclude_pull_requests=true \
-              | jq '.workflow_runs' \
-              | jq "map(select(.head_commit.id == \"$sha\"))[0].id" \
-        ) >> "$GITHUB_ENV"
     - run: rustup update stable && rustup default stable
     - run: |
         rustc scripts/publish.rs
@@ -34,13 +25,10 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     
     # Manifest and publish the wasi-preview1-component-adapter-provider
-    - uses: actions/download-artifact@v4
+    - uses: ./.github/actions/fetch-run-id
+    - uses: ./.github/actions/build-adapter-provider
       with:
-        name: bins-wasi-preview1-component-adapter
-        path: crates/wasi-preview1-component-adapter/provider/artefacts
-        github-token: ${{ github.token }}
-        run-id: ${ARTIFACT_RUN_ID}
-    - run: ./ci/build-wasi-preview1-component-adapter-provider.sh
+        run-id: ${COMMIT_COMMIT_RUN_ID}
     - run: cargo publish -p wasi-preview1-component-adapter-provider --allow-dirty
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-to-cratesio.yml
+++ b/.github/workflows/publish-to-cratesio.yml
@@ -23,3 +23,16 @@ jobs:
         ./publish publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    - run: |
+        # Download the published versions of the adapters
+        wget https://github.com/bytecodealliance/wasmtime/releases/download/${{github.event.release.tag_name}}/wasi_snapshot_preview1.command.wasm -O crates/wasi-preview1-component-adapter/provider/artefacts/wasi_snapshot_preview1.command.wasm
+        wget https://github.com/bytecodealliance/wasmtime/releases/download/${{github.event.release.tag_name}}/wasi_snapshot_preview1.reactor.wasm -O crates/wasi-preview1-component-adapter/provider/artefacts/wasi_snapshot_preview1.reactor.wasm
+        wget https://github.com/bytecodealliance/wasmtime/releases/download/${{github.event.release.tag_name}}/wasi_snapshot_preview1.proxy.wasm -O crates/wasi-preview1-component-adapter/provider/artefacts/wasi_snapshot_preview1.proxy.wasm
+
+        # Materialise the adapter provider crate inside the workspace
+        cp crates/wasi-preview1-component-adapter/provider/Cargo.toml.in crates/wasi-preview1-component-adapter/provider/Cargo.toml
+        sed -i '/"crates\/wasi-preview1-component-adapter",/a\ \ "crates\/wasi-preview1-component-adapter\/provider",' Cargo.toml
+
+        cargo publish -p wasi-preview1-component-adapter-provider --allow-dirty
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/ci/build-wasi-preview1-component-adapter-provider.sh
+++ b/ci/build-wasi-preview1-component-adapter-provider.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -ex
+
+# Manifest the adapter provider into the workspace
+cp crates/wasi-preview1-component-adapter/provider/Cargo.toml.in crates/wasi-preview1-component-adapter/provider/Cargo.toml
+sed -i '/"crates\/wasi-preview1-component-adapter",/a\ \ "crates\/wasi-preview1-component-adapter\/provider",' Cargo.toml
+
+set +x
+if [ "$CHECK" = "1" ]; then
+  cargo fmt -p wasi-preview1-component-adapter-provider -- --check
+  cargo check -p wasi-preview1-component-adapter-provider
+  cargo clippy -p wasi-preview1-component-adapter-provider
+  cargo publish -p wasi-preview1-component-adapter-provider --dry-run --allow-dirty
+fi
+set -x

--- a/ci/build-wasi-preview1-component-adapter-provider.sh
+++ b/ci/build-wasi-preview1-component-adapter-provider.sh
@@ -5,11 +5,10 @@ set -ex
 cp crates/wasi-preview1-component-adapter/provider/Cargo.toml.in crates/wasi-preview1-component-adapter/provider/Cargo.toml
 sed -i '/"crates\/wasi-preview1-component-adapter",/a\ \ "crates\/wasi-preview1-component-adapter\/provider",' Cargo.toml
 
-set +x
-if [ "$CHECK" = "1" ]; then
-  cargo fmt -p wasi-preview1-component-adapter-provider -- --check
-  cargo check -p wasi-preview1-component-adapter-provider
-  cargo clippy -p wasi-preview1-component-adapter-provider
-  cargo publish -p wasi-preview1-component-adapter-provider --dry-run --allow-dirty
-fi
-set -x
+# Check the adapter provider's code formatting and style
+cargo fmt -p wasi-preview1-component-adapter-provider -- --check
+cargo check -p wasi-preview1-component-adapter-provider
+cargo clippy -p wasi-preview1-component-adapter-provider
+
+# Check that publishing the adapter provider should work
+cargo publish -p wasi-preview1-component-adapter-provider --dry-run --allow-dirty

--- a/ci/build-wasi-preview1-component-adapter.sh
+++ b/ci/build-wasi-preview1-component-adapter.sh
@@ -15,24 +15,38 @@ release="target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm"
 $build_adapter
 $verify $debug
 
+build() {
+  input=$1
+  flavor=$2
+  $verify $input
+  name=wasi_snapshot_preview1.$flavor.wasm
+  dst=$(dirname $input)/$name
+  provider=crates/wasi-preview1-component-adapter/provider/artefacts/$name
+  wasm-tools metadata add --name "wasi_preview1_component_adapter.$flavor.adapter" $input \
+    -o $dst
+  cp $dst $provider
+}
+
 # Debug build, command
 $build_adapter --no-default-features --features command
 $verify $debug
 
 # Release build, command
 $build_adapter --release --no-default-features --features command
-$verify $release
-wasm-tools metadata add --name "wasi_preview1_component_adapter.command.adapter:${VERSION}" $release \
-  -o target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.command.wasm
+build $release command
 
 # Release build, default features (reactor)
 $build_adapter --release
-$verify $release
-wasm-tools metadata add --name "wasi_preview1_component_adapter.reactor.adapter:${VERSION}" $release \
-  -o target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.reactor.wasm
+build $release reactor
 
 # Release build, proxy
 $build_adapter --release --no-default-features --features proxy
-$verify $release
-wasm-tools metadata add --name "wasi_preview1_component_adapter.proxy.adapter:${VERSION}" $release \
-  -o target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.proxy.wasm
+build $release proxy
+
+# Add the adapter provider to the workspace
+cp crates/wasi-preview1-component-adapter/provider/Cargo.toml.in crates/wasi-preview1-component-adapter/provider/Cargo.toml
+sed -i '/"crates\/wasi-preview1-component-adapter",/a\ \ "crates\/wasi-preview1-component-adapter\/provider",' Cargo.toml
+
+cargo fmt -p wasi-preview1-component-adapter-provider -- --check
+cargo check -p wasi-preview1-component-adapter-provider
+cargo clippy -p wasi-preview1-component-adapter-provider

--- a/ci/build-wasi-preview1-component-adapter.sh
+++ b/ci/build-wasi-preview1-component-adapter.sh
@@ -21,10 +21,8 @@ build() {
   $verify $input
   name=wasi_snapshot_preview1.$flavor.wasm
   dst=$(dirname $input)/$name
-  provider=crates/wasi-preview1-component-adapter/provider/artefacts/$name
   wasm-tools metadata add --name "wasi_preview1_component_adapter.$flavor.adapter" $input \
     -o $dst
-  cp $dst $provider
 }
 
 # Debug build, command
@@ -42,11 +40,3 @@ build $release reactor
 # Release build, proxy
 $build_adapter --release --no-default-features --features proxy
 build $release proxy
-
-# Add the adapter provider to the workspace
-cp crates/wasi-preview1-component-adapter/provider/Cargo.toml.in crates/wasi-preview1-component-adapter/provider/Cargo.toml
-sed -i '/"crates\/wasi-preview1-component-adapter",/a\ \ "crates\/wasi-preview1-component-adapter\/provider",' Cargo.toml
-
-cargo fmt -p wasi-preview1-component-adapter-provider -- --check
-cargo check -p wasi-preview1-component-adapter-provider
-cargo clippy -p wasi-preview1-component-adapter-provider

--- a/crates/wasi-preview1-component-adapter/provider/.gitignore
+++ b/crates/wasi-preview1-component-adapter/provider/.gitignore
@@ -1,0 +1,1 @@
+/Cargo.toml

--- a/crates/wasi-preview1-component-adapter/provider/Cargo.toml.in
+++ b/crates/wasi-preview1-component-adapter/provider/Cargo.toml.in
@@ -1,0 +1,19 @@
+[package]
+name = "wasi-preview1-component-adapter-provider"
+version.workspace = true
+authors.workspace = true
+description = "Embedded wasi-preview1-component-adapter binaries"
+license = "Apache-2.0 WITH LLVM-exception"
+repository = "https://github.com/bytecodealliance/wasmtime"
+documentation = "https://docs.rs/wasi-preview1-component-adapter-provider/"
+categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]

--- a/crates/wasi-preview1-component-adapter/provider/artefacts/.gitignore
+++ b/crates/wasi-preview1-component-adapter/provider/artefacts/.gitignore
@@ -1,0 +1,3 @@
+/wasi_snapshot_preview1.reactor.wasm
+/wasi_snapshot_preview1.command.wasm
+/wasi_snapshot_preview1.proxy.wasm

--- a/crates/wasi-preview1-component-adapter/provider/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/provider/src/lib.rs
@@ -1,0 +1,51 @@
+//! This crate contains the binaries of three WebAssembly modules:
+//!
+//! - [`WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER`]
+//! - [`WASI_SNAPSHOT_PREVIEW1_COMMAND_ADAPTER`]
+//! - [`WASI_SNAPSHOT_PREVIEW1_PROXY_ADAPTER`]
+//!
+//! These three modules bridge the wasip1 ABI to the wasip2 ABI of the component
+//! model.
+//!
+//! They can be given to the [`wit_component::ComponentEncoder::adapter`]
+//! method, using the [`WASI_SNAPSHOT_PREVIEW1_ADAPTER_NAME`], to translate a
+//! module from the historical WASM ABI to the canonical ABI.
+//!
+//! [`wit_component::ComponentEncoder::adapter`]: https://docs.rs/wit-component/latest/wit_component/struct.ComponentEncoder.html#method.adapter
+
+/// The name of the adapters in this crate, which may be provided to
+/// [`wit_component::ComponentEncoder::adapter`].
+///
+/// [`wit_component::ComponentEncoder::adapter`]: https://docs.rs/wit-component/latest/wit_component/struct.ComponentEncoder.html#method.adapter
+pub const WASI_SNAPSHOT_PREVIEW1_ADAPTER_NAME: &str = "wasi_snapshot_preview1";
+
+/// The "reactor" adapter provides the default adaptation from preview1 to
+/// preview2.
+///
+/// This adapter implements the [`wasi:cli/imports`] world.
+///
+/// [`wasi:cli/imports`]: https://github.com/WebAssembly/WASI/blob/01bb90d8b66cbc1d50349aaaab9ac5b143c9c98c/preview2/cli/imports.wit
+pub const WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER: &[u8] =
+    include_bytes!("../artefacts/wasi_snapshot_preview1.reactor.wasm");
+
+/// The "command" adapter extends the ["reactor" adapter] and additionally
+/// exports a `run` function entrypoint.
+///
+/// This adapter implements the [`wasi:cli/command`] world.
+///
+/// ["reactor" adapter]: WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER
+/// [`wasi:cli/command`]: https://github.com/WebAssembly/WASI/blob/01bb90d8b66cbc1d50349aaaab9ac5b143c9c98c/preview2/cli/command.wit
+pub const WASI_SNAPSHOT_PREVIEW1_COMMAND_ADAPTER: &[u8] =
+    include_bytes!("../artefacts/wasi_snapshot_preview1.command.wasm");
+
+/// The "proxy" adapter provides implements a HTTP proxy which is more
+/// restricted than the ["reactor" adapter] adapter, as it lacks filesystem,
+/// socket, environment, exit, and terminal support, but includes HTTP handlers
+/// for incoming and outgoing requests.
+///
+/// This adapter implements the [`wasi:http/proxy`] world.
+///
+/// ["reactor" adapter]: WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER
+/// [`wasi:http/proxy`]: https://github.com/WebAssembly/WASI/blob/01bb90d8b66cbc1d50349aaaab9ac5b143c9c98c/preview2/http/proxy.wit
+pub const WASI_SNAPSHOT_PREVIEW1_PROXY_ADAPTER: &[u8] =
+    include_bytes!("../artefacts/wasi_snapshot_preview1.proxy.wasm");


### PR DESCRIPTION
Follow-up to #8792, which was reverted in #8856. The new design follows @alexcrichton's suggestions in https://github.com/bytecodealliance/wasmtime/pull/8856#issuecomment-2182798604.

The provider repo is materialised into the workspace to ensure that it is built with the same version, lints, etc as the other crates.

- [x] repo contains a template for the provider crate
- [x] template crate is materialised in CI to be tested
- [x] template crate is materialised just before publishing

