### PR TITLE
serve: Fix logging prints to stdout/stderr

### DIFF
--- a/crates/test-programs/src/bin/cli_serve_with_print.rs
+++ b/crates/test-programs/src/bin/cli_serve_with_print.rs
@@ -1,0 +1,30 @@
+use std::io::Write;
+use test_programs::proxy;
+use test_programs::wasi::http::types::{
+    Fields, IncomingRequest, OutgoingResponse, ResponseOutparam,
+};
+
+struct T;
+
+proxy::export!(T);
+
+impl proxy::exports::wasi::http::incoming_handler::Guest for T {
+    fn handle(_request: IncomingRequest, outparam: ResponseOutparam) {
+        print!("this is half a print ");
+        std::io::stdout().flush().unwrap();
+        println!("to stdout");
+        println!(); // empty line
+        println!("after empty");
+
+        eprint!("this is half a print ");
+        std::io::stderr().flush().unwrap();
+        eprintln!("to stderr");
+        eprintln!(); // empty line
+        eprintln!("after empty");
+
+        let resp = OutgoingResponse::new(Fields::new());
+        ResponseOutparam::set(outparam, Ok(resp));
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This commit fixes writes to stdout/stderr which don't end in a newline to not get split across lines with a prefix on each line. Instead internally a flag is used to track whether a prefix is required at the beginning of each chunk.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
