### PR TITLE
Update the wasm-tools family of crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmtime-types",
  "wat",
 ]
@@ -2752,7 +2752,7 @@ dependencies = [
  "cargo_metadata",
  "heck 0.4.0",
  "wasmtime",
- "wit-component 0.211.1",
+ "wit-component 0.212.0",
 ]
 
 [[package]]
@@ -3082,7 +3082,7 @@ name = "verify-component-adapter"
 version = "23.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wat",
 ]
 
@@ -3175,7 +3175,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.36.0",
  "wasi",
- "wasm-encoder 0.211.1",
+ "wasm-encoder 0.212.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3244,12 +3244,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7d931a1120ef357f32b74547646b6fa68ea25e377772b72874b131a9ed70d4"
+checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
@@ -3270,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f56bad1c68558c44e7f60be865117dc9d8c3a066bcf3b2232cb9a9858965fd5"
+checksum = "8a1849fac257fd76c43268555e73d74848c8dff23975c238c2cbad61cffe5045"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3280,36 +3280,36 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.211.1",
- "wasmparser 0.211.1",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4281d9c72b0a3c47eec052755ad98cb854309e3a40edf9887aa8f3ed939f7ab"
+checksum = "ff58202fe6f3750ba930d160a2451087973d902e09a2632b9a78ab7c86150a59"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.211.1",
- "wasmparser 0.211.1",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ae0d1bd7d17e7ae175f9e3cf646d9b39b7115240ed8d40141c4670bab49f96"
+checksum = "a8185faf41a5630ec7cf301fa1f63bb757f4c267a057f8b6b56bde0cba1144c1"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder 0.211.1",
+ "wasm-encoder 0.212.0",
 ]
 
 [[package]]
@@ -3367,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3189cc8a91f547390e2f043ca3b3e3fe0892f7d581767fd4e4b7f3dc3fe8e561"
+checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -3390,13 +3390,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23708dd7a986bd9b12fca26eff525bbc3659a336e947fd9ed9fdf79086825aec"
+checksum = "dfac65326cc561112af88c3028f6dfdb140acff67ede33a8e86be2dc6b8956f7"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
@@ -3440,8 +3440,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder 0.211.1",
- "wasmparser 0.211.1",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3583,7 +3583,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3597,10 +3597,10 @@ dependencies = [
  "wasmtime-wasi-nn",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 211.0.1",
+ "wast 212.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component 0.211.1",
+ "wit-component 0.212.0",
 ]
 
 [[package]]
@@ -3633,7 +3633,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.211.1",
+ "wit-parser 0.212.0",
 ]
 
 [[package]]
@@ -3657,7 +3657,7 @@ dependencies = [
  "object 0.36.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3682,8 +3682,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.211.1",
- "wasmparser 0.211.1",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3698,7 +3698,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3756,7 +3756,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3777,12 +3777,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.211.1",
+ "wasm-encoder 0.212.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3832,7 +3832,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
@@ -3941,7 +3941,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 211.0.1",
+ "wast 212.0.0",
 ]
 
 [[package]]
@@ -3953,7 +3953,7 @@ dependencies = [
  "gimli",
  "object 0.36.0",
  "target-lexicon",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3966,7 +3966,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.0",
  "indexmap 2.2.6",
- "wit-parser 0.211.1",
+ "wit-parser 0.212.0",
 ]
 
 [[package]]
@@ -3984,24 +3984,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "211.0.1"
+version = "212.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25506dd82d00da6b14a87436b3d52b1d264083fa79cdb72a0d1b04a8595ccaa"
+checksum = "4606a05fb0aae5d11dd7d8280a640d88a63ee019360ba9be552da3d294b8d1f5"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.211.1",
+ "wasm-encoder 0.212.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.211.1"
+version = "1.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb716ca6c86eecac2d82541ffc39860118fc0af9309c4f2670637bea2e1bdd7d"
+checksum = "c74ca7f93f11a5d6eed8499f2a8daaad6e225cab0151bc25a091fff3b987532f"
 dependencies = [
- "wast 211.0.1",
+ "wast 212.0.0",
 ]
 
 [[package]]
@@ -4131,7 +4131,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4385,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079a38b7d679867424bf2bcbdd553a2acf364525307e43dfb910fa4a2c6fd9f2"
+checksum = "8ed5b0f9fc3d6424787d2a49e1142bf954ae4f26ee891992c144f0cfd68c4b7f"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4396,10 +4396,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.211.1",
- "wasm-metadata 0.211.1",
- "wasmparser 0.211.1",
- "wit-parser 0.211.1",
+ "wasm-encoder 0.212.0",
+ "wasm-metadata 0.212.0",
+ "wasmparser 0.212.0",
+ "wit-parser 0.212.0",
 ]
 
 [[package]]
@@ -4422,9 +4422,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.211.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cc90c50c7ec8a824b5d2cddddff13b2dc12b7a96bf8684d11474223c2ea22f"
+checksum = "ceeb0424aa8679f3fcf2d6e3cfa381f3d6fa6179976a2c05a6249dd2bb426716"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4435,7 +4435,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.211.1",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,15 +253,15 @@ wit-bindgen = { version = "0.26.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.26.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.211.1", default-features = false }
-wat = "1.211.1"
-wast = "211.0.1"
-wasmprinter = "0.211.1"
-wasm-encoder = "0.211.1"
-wasm-smith = "0.211.1"
-wasm-mutate = "0.211.1"
-wit-parser = "0.211.1"
-wit-component = "0.211.1"
+wasmparser = { version = "0.212.0", default-features = false }
+wat = "1.212.0"
+wast = "212.0.0"
+wasmprinter = "0.212.0"
+wasm-encoder = "0.212.0"
+wasm-smith = "0.212.0"
+wasm-mutate = "0.212.0"
+wit-parser = "0.212.0"
+wit-component = "0.212.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -254,6 +254,8 @@ wasmtime_option_group! {
         pub memory64: Option<bool>,
         /// Configure support for the component-model proposal.
         pub component_model: Option<bool>,
+        /// Configure support for 33+ flags in the component model.
+        pub component_model_more_flags: Option<bool>,
         /// Configure support for the function-references proposal.
         pub function_references: Option<bool>,
         /// Configure support for the GC proposal.
@@ -672,6 +674,7 @@ impl CommonOptions {
 
         handle_conditionally_compiled! {
             ("component-model", component_model, wasm_component_model)
+            ("component-model", component_model_more_flags, wasm_component_model_more_flags)
             ("threads", threads, wasm_threads)
             ("gc", gc, wasm_gc)
             ("gc", reference_types, wasm_reference_types)

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -984,6 +984,18 @@ impl Config {
         self
     }
 
+    /// Configures whether components support more than 32 flags in each `flags`
+    /// type.
+    ///
+    /// This is part of the transition plan in
+    /// https://github.com/WebAssembly/component-model/issues/370.
+    #[cfg(feature = "component-model")]
+    pub fn wasm_component_model_more_flags(&mut self, enable: bool) -> &mut Self {
+        self.features
+            .set(WasmFeatures::COMPONENT_MODEL_MORE_FLAGS, enable);
+        self
+    }
+
     /// Configures which compilation strategy will be used for wasm modules.
     ///
     /// This method can be used to configure which compiler is used for wasm

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -202,6 +202,7 @@ struct WasmFeatures {
     function_references: bool,
     gc: bool,
     custom_page_sizes: bool,
+    component_model_more_flags: bool,
 }
 
 impl Metadata<'_> {
@@ -227,6 +228,7 @@ impl Metadata<'_> {
             shared_everything_threads,
             component_model_values,
             component_model_nested_names,
+            component_model_more_flags,
 
             // Always on; we don't currently have knobs for these.
             mutable_global: _,
@@ -264,6 +266,7 @@ impl Metadata<'_> {
                 function_references,
                 gc,
                 custom_page_sizes,
+                component_model_more_flags,
             },
         }
     }
@@ -469,6 +472,7 @@ impl Metadata<'_> {
             function_references,
             gc,
             custom_page_sizes,
+            component_model_more_flags,
         } = self.features;
 
         use wasmparser::WasmFeatures as F;
@@ -549,6 +553,11 @@ impl Metadata<'_> {
             custom_page_sizes,
             other.contains(F::CUSTOM_PAGE_SIZES),
             "WebAssembly custom-page-sizes support",
+        )?;
+        Self::check_bool(
+            component_model_more_flags,
+            other.contains(F::COMPONENT_MODEL_MORE_FLAGS),
+            "WebAssembly component model support for more than 32 flags",
         )?;
 
         Ok(())

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1844,6 +1844,12 @@ when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-encoder]]
+version = "0.212.0"
+when = "2024-06-27"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-metadata]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -1904,6 +1910,12 @@ when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-metadata]]
+version = "0.212.0"
+when = "2024-06-27"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-mutate]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -2036,6 +2048,12 @@ when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmparser]]
+version = "0.212.0"
+when = "2024-06-27"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmprinter]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -2093,6 +2111,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmprinter]]
 version = "0.211.1"
 when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmprinter]]
+version = "0.212.0"
+when = "2024-06-27"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2708,6 +2732,12 @@ when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wast]]
+version = "212.0.0"
+when = "2024-06-27"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wat]]
 version = "1.201.0"
 when = "2024-02-27"
@@ -2765,6 +2795,12 @@ user-login = "wasmtime-publish"
 [[publisher.wat]]
 version = "1.211.1"
 when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wat]]
+version = "1.212.0"
+when = "2024-06-27"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -3206,6 +3242,12 @@ when = "2024-06-19"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-component]]
+version = "0.212.0"
+when = "2024-06-27"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-parser]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -3263,6 +3305,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-parser]]
 version = "0.211.1"
 when = "2024-06-19"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-parser]]
+version = "0.212.0"
+when = "2024-06-27"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/tests/all/component_model/macros.rs
+++ b/tests/all/component_model/macros.rs
@@ -4,7 +4,7 @@ use super::{make_echo_component, TypedFuncExt};
 use anyhow::Result;
 use component_macro_test::{add_variants, flags_test};
 use wasmtime::component::{Component, ComponentType, Lift, Linker, Lower};
-use wasmtime::Store;
+use wasmtime::{Engine, Store};
 
 #[test]
 fn record_derive() -> Result<()> {
@@ -337,7 +337,9 @@ fn enum_derive() -> Result<()> {
 
 #[test]
 fn flags() -> Result<()> {
-    let engine = super::engine();
+    let mut config = component_test_util::config();
+    config.wasm_component_model_more_flags(true);
+    let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
 
     // Simple 8-bit flags

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -254,7 +254,9 @@ fn run_wast(wast: &Path, strategy: Strategy, pooling: bool) -> anyhow::Result<()
         cfg.cranelift_debug_verifier(true);
     }
 
-    cfg.wasm_component_model(feature_found(wast, "component-model"));
+    let component_model = feature_found(wast, "component-model");
+    cfg.wasm_component_model(component_model)
+        .wasm_component_model_more_flags(component_model);
 
     if feature_found(wast, "canonicalize-nan") && is_cranelift {
         cfg.cranelift_nan_canonicalization(true);


### PR DESCRIPTION
This notably brings in a limitation where component model flags types must have 32 or fewer flags in accordance with the transition plan of https://github.com/WebAssembly/component-model/issues/370. A feature flag is added to go back to the previous behavior to avoid breaking anyone too much.

This additionally brings in a fix for a panic when validating invalid modules with tail calls.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
