### PR TITLE
closes #2827: remove srclocs from bugpoint

### DIFF
--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -839,6 +839,8 @@ fn reduce(isa: &dyn TargetIsa, mut func: Function, verbose: bool) -> Result<(Fun
     }
 
     try_resolve_aliases(&mut context, &mut func);
+    // Remove SourceLocs to make reduced clif IR easier to read
+    func.srclocs.clear();
 
     let progress_bar = ProgressBar::with_draw_target(0, ProgressDrawTarget::stdout());
     progress_bar.set_style(

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -838,7 +838,6 @@ fn try_remove_srclocs(context: &mut CrashCheckContext, func: &mut Function) {
     if let CheckResult::Crash(_) = context.check_for_crash(&func_with_removed_sourcelocs) {
         *func = func_with_removed_sourcelocs;
     }
-
 }
 
 fn reduce(isa: &dyn TargetIsa, mut func: Function, verbose: bool) -> Result<(Function, String)> {

--- a/cranelift/tests/bugpoint_test.clif
+++ b/cranelift/tests/bugpoint_test.clif
@@ -300,12 +300,12 @@ block0(v0: i64, v1: i64, v2: i64):
     v241 -> v1
     v256 -> v1
     v262 -> v1
-    v3 = imul v0, v1
+    @0001 v3 = imul v0, v1
     v4 = imul v1, v2
     store aligned v4, v3
     v5 = load.i64 aligned v2+8
     store aligned v5, v3+8
-    v6 = stack_addr.i64 ss1
+    @0002 v6 = stack_addr.i64 ss1
     v7 = stack_addr.i64 ss2
     v8 = stack_addr.i64 ss3
     v9 = stack_addr.i64 ss4
@@ -366,7 +366,7 @@ block0(v0: i64, v1: i64, v2: i64):
     v64 = stack_addr.i64 ss59
     v65 = stack_addr.i64 ss60
     v66 = stack_addr.i64 ss61
-    v67 = stack_addr.i64 ss62
+    @0003 v67 = stack_addr.i64 ss62
     v68 = stack_addr.i64 ss63
     v69 = stack_addr.i64 ss64
     v70 = stack_addr.i64 ss65


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Prior conversation:
https://github.com/bytecodealliance/wasmtime/issues/2827#issuecomment-2184904073

https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/Removing.20srclocs.20with.20bugpoint

This change removes sourcelocs from bugpoint output to make the reduced clif IR easier to read.