### PR TITLE
Fix build of `wasmtime-cli` with only the pooling allocator enabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -369,8 +369,10 @@ jobs:
           - name: wasmtime-cli
             checks: |
               -p wasmtime-cli --no-default-features
+              -p wasmtime-cli --no-default-features --features pooling-allocator
               -p wasmtime-cli --no-default-features --features run
               -p wasmtime-cli --no-default-features --features run,component-model
+              -p wasmtime-cli --no-default-features --features run,pooling-allocator
               -p wasmtime-cli --no-default-features --features compile
               -p wasmtime-cli --no-default-features --features compile,cranelift
               -p wasmtime-cli --no-default-features --features compile,cranelift,component-model

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -21,6 +21,7 @@ wasmtime = { workspace = true, features = ["gc"] }
 humantime = { workspace = true }
 
 [features]
+async = ["wasmtime/async"]
 pooling-allocator = ["wasmtime/pooling-allocator"]
 component-model = ["wasmtime/component-model"]
 cache = ["wasmtime/cache"]

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -589,8 +589,10 @@ impl CommonOptions {
                     if let Some(limit) = self.opts.pooling_total_tables {
                         cfg.total_tables(limit);
                     }
-                    if let Some(limit) = self.opts.pooling_total_stacks {
-                        cfg.total_stacks(limit);
+                    match_feature! {
+                        ["async" : self.opts.pooling_total_stacks]
+                        limit => cfg.total_stacks(limit),
+                        _ => err,
                     }
                     if let Some(limit) = self.opts.pooling_max_memory_size {
                         cfg.max_memory_size(limit);


### PR DESCRIPTION
Fixes #8889

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
