### PR TITLE
Use AlmaLinux:8 for x86_64-linux binary-compatible-builds

### DIFF
--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,8 +1,8 @@
-FROM centos:7
+FROM almalinux:8
 
-RUN yum install -y git gcc make
+RUN dnf install -y git gcc make
 
-# The CMake in Centos 7 was a bit too old for us to use so download one from
+# The CMake in AlmaLinux 8 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,8 +1,8 @@
-FROM centos:7
+FROM ubuntu:16.04
 
-RUN yum install -y git gcc make
+RUN apt-get update -y && apt-get install -y git gcc curl make
 
-# The CMake in Centos 7 was a bit too old for us to use so download one from
+# The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:16.04
+FROM centos:7
 
-RUN apt-get update -y && apt-get install -y git gcc curl make
+RUN yum install -y git gcc make
 
-# The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
+# The CMake in Centos 7 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin


### PR DESCRIPTION
CentOS 7 has hit EOL, and is beginning to cause build failures due to mirror lists being unavailable. This PR switches us over to using AlmaLinux 8 instead.

AlmaLinux 8 has cmake-3.26, so it's reasonable to continue explicitly installing cmake-3.29.