### PR TITLE
Use cmake 3.26, which is available in AlmaLinux 8

### DIFF
--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,10 +1,5 @@
 FROM almalinux:8
 
-RUN dnf install -y git gcc make
-
-# The CMake in AlmaLinux 8 was a bit too old for us to use so download one from
-# CMake's own releases and use that instead.
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
-ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
+RUN dnf install -y git gcc make cmake
 
 ENV PATH=$PATH:/rust/bin


### PR DESCRIPTION
As a follow-up to #8892, use cmake 3.26 from AlmaLinux instead of installing a release from github.
