### PR TITLE
Wasmtime: Pop GC LIFO roots even when there is no GC heap

### DIFF
--- a/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
@@ -45,7 +45,7 @@ impl RootSet {
         usize::MAX
     }
 
-    pub(crate) fn exit_lifo_scope(&mut self, _gc_store: &mut GcStore, _scope: usize) {}
+    pub(crate) fn exit_lifo_scope(&mut self, _gc_store: Option<&mut GcStore>, _scope: usize) {}
 
     pub(crate) fn with_lifo_scope<T>(
         store: &mut StoreOpaque,

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1584,9 +1584,7 @@ impl StoreOpaque {
 
     #[inline]
     pub(crate) fn exit_gc_lifo_scope(&mut self, scope: usize) {
-        if let Some(gc_store) = self.gc_store.as_mut() {
-            self.gc_roots.exit_lifo_scope(gc_store, scope);
-        }
+        self.gc_roots.exit_lifo_scope(self.gc_store.as_mut(), scope);
     }
 
     #[cfg(feature = "gc")]

--- a/tests/all/i31ref.rs
+++ b/tests/all/i31ref.rs
@@ -1,0 +1,21 @@
+use wasmtime::*;
+
+#[test]
+fn always_pop_i31ref_lifo_roots() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let anyref = {
+        let mut scope = RootScope::new(&mut store);
+        AnyRef::from_i31(&mut scope, I31::wrapping_u32(42))
+    };
+
+    // The anyref has left its rooting scope and been unrooted.
+    assert!(anyref.is_i31(&store).is_err());
+
+    Ok(())
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -16,6 +16,7 @@ mod funcref;
 mod gc;
 mod globals;
 mod host_funcs;
+mod i31ref;
 mod iloop;
 mod import_calling_export;
 mod import_indexes;


### PR DESCRIPTION
We can create and root `i31ref`s without ever allocating a GC heap for the store, so we can't guard popping LIFO roots on the presence of a GC heap or else we risk unbounded growth of the LIFO root set.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
