### PR TITLE
`wasi-common`: remove `wasmtime` dependency from `sync` crate feature

### DIFF
--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -79,7 +79,6 @@ wasmtime = [
 # This feature enables an implementation of the Wasi traits for a
 # synchronous wasmtime embedding.
 sync = [
-    "wasmtime",
     "dep:cap-fs-ext",
     "dep:cap-time-ext",
     "dep:fs-set-times",


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/8894.

**Motivation:** This allows usage of `wasi-common` in non-Wasmtime Wasm runtimes.

This was probably an oversight in https://github.com/bytecodealliance/wasmtime/pull/7881.

The only optional usage of the `wasmtime` crate that I could find within the `wasi-common/sync` module is the following:
```rust
#[cfg(feature = "wasmtime")]
super::define_wasi!(block_on);
```
Link: https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-common/src/sync/mod.rs

Which defines the `add_to_linker` methods for Wasmtime which is entirely optional.
Non Wasmtime users of `wasi-common` might want to define their own `add_to_linker` functions.

Locally I did not see any compile errors with the removal of this dependency of this PR.