### PR TITLE
Add more documentation to `ArgumentPurpose::StructArgument`

### DIFF
--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -233,7 +233,13 @@ pub enum ArgumentPurpose {
     Normal,
 
     /// A C struct passed as argument.
-    StructArgument(u32),
+    ///
+    /// Note that this should only be used when interacting with code following
+    /// a C ABI which is expecting a struct passed *by value*.
+    StructArgument(
+        /// The size, in bytes, of the struct.
+        u32,
+    ),
 
     /// Struct return pointer.
     ///


### PR DESCRIPTION
I was a bit unclear on what exactly it was for. I thought the u32 field
could also use some documentation to clarify its meaning.

cc #8852
cc https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/docs.20for.20StructArgument.2FStructReturn
