### PR TITLE
Expose Engine::clone to c-api

### DIFF
--- a/crates/c-api/README.md
+++ b/crates/c-api/README.md
@@ -8,7 +8,7 @@ For more information you can find the documentation for this library
 To use Wasmtime from a C or C++ project, you can use Cargo to build the Wasmtime C bindings. From the root of the Wasmtime repository, run the following command:
 
 ```
-cargo build --release wasmtime-c-api
+cargo build --release -p wasmtime-c-api
 ```
 
 This will create static and dynamic libraries called `libwasmtime` in the `target/release` directory.

--- a/crates/c-api/include/wasmtime/engine.h
+++ b/crates/c-api/include/wasmtime/engine.h
@@ -14,6 +14,14 @@ extern "C" {
 #endif
 
 /**
+ * \brief Create a new reference to the same underlying engine.
+ *
+ * This function clones the reference-counted pointer to the internal object,
+ * and must be freed using #wasm_engine_delete.
+ */
+WASM_API_EXTERN wasm_engine_t *wasmtime_engine_clone(wasm_engine_t *engine);
+
+/**
  * \brief Increments the engine-local epoch variable.
  *
  * This function will increment the engine's current epoch which can be used to

--- a/crates/c-api/src/engine.rs
+++ b/crates/c-api/src/engine.rs
@@ -29,10 +29,18 @@ pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
 
 #[no_mangle]
 pub extern "C" fn wasm_engine_new_with_config(c: Box<wasm_config_t>) -> Box<wasm_engine_t> {
+    #[cfg(feature = "logging")]
+    drop(env_logger::try_init());
+
     let config = c.config;
     Box::new(wasm_engine_t {
         engine: Engine::new(&config).unwrap(),
     })
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_engine_clone(engine: &wasm_engine_t) -> Box<wasm_engine_t> {
+    Box::new(engine.clone())
 }
 
 #[no_mangle]


### PR DESCRIPTION
This creates an API to allow cloning references to wasm_engine_t in the C API. This is simple in the Rust API which implements Clone, however it is not exposed to the C API.

Use case: in tree-sitter's wasm support, we create a store object and want to instantiate modules into it over the course of the object's lifetime. This requires a handle to the underlying engine, which means our store must be kept alongside a reference to the engine (since tree-sitter is a library, it doesn't want to assume a global wasm engine). This currently requires transferring ownership of the engine to the tree sitter store container, which means we can't reuse engine objects between multiple stores.

This pertains to https://github.com/tree-sitter/tree-sitter/issues/3454.