### PR TITLE
Fix panic with invalid DWARF file indices

### DIFF
--- a/crates/cranelift/src/debug/transform/attr.rs
+++ b/crates/cranelift/src/debug/transform/attr.rs
@@ -116,7 +116,15 @@ where
                     ..
                 } = file_context
                 {
-                    write::AttributeValue::FileIndex(Some(file_map[(i - file_index_base) as usize]))
+                    let index = usize::try_from(i - file_index_base)
+                        .ok()
+                        .and_then(|i| file_map.get(i).copied());
+                    match index {
+                        Some(index) => write::AttributeValue::FileIndex(Some(index)),
+                        // This was seen to be invalid in #8884 and #8904 so
+                        // ignore this seemingly invalid DWARF from LLVM
+                        None => continue,
+                    }
                 } else {
                     return Err(TransformError("unexpected file index attribute").into());
                 }


### PR DESCRIPTION
I'm not entirely sure what causes this but Wasmtime shouldn't panic with invalid DWARF. In general (#5537) Wasmtime's support for DWARF needs to be rewritten, but in the meantime let's play whack-a-mole with panics and try to paper over issues.

Closes #8884
Closes #8904

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
