### PR TITLE
Refactor internal profiling APIs to be safer

### DIFF
--- a/crates/jit-debug/src/perf_jitdump.rs
+++ b/crates/jit-debug/src/perf_jitdump.rs
@@ -252,8 +252,7 @@ impl JitDumpFile {
     pub fn dump_code_load_record(
         &mut self,
         method_name: &str,
-        addr: *const u8,
-        len: usize,
+        code: &[u8],
         timestamp: u64,
         pid: u32,
         tid: u32,
@@ -263,7 +262,7 @@ impl JitDumpFile {
 
         let rh = RecordHeader {
             id: RecordId::JitCodeLoad as u32,
-            record_size: size_limit as u32 + name_len as u32 + len as u32,
+            record_size: size_limit as u32 + name_len as u32 + code.len() as u32,
             timestamp,
         };
 
@@ -271,16 +270,13 @@ impl JitDumpFile {
             header: rh,
             pid,
             tid,
-            virtual_address: addr as u64,
-            address: addr as u64,
-            size: len as u64,
+            virtual_address: code.as_ptr() as u64,
+            address: code.as_ptr() as u64,
+            size: code.len() as u64,
             index: self.next_code_index(),
         };
 
-        unsafe {
-            let code_buffer: &[u8] = std::slice::from_raw_parts(addr, len);
-            self.write_code_load_record(method_name, clr, code_buffer)
-        }
+        self.write_code_load_record(method_name, clr, code)
     }
 }
 

--- a/crates/wasmtime/src/profiling_agent/jitdump.rs
+++ b/crates/wasmtime/src/profiling_agent/jitdump.rs
@@ -50,14 +50,13 @@ pub fn new() -> Result<Box<dyn ProfilingAgent>> {
 }
 
 impl ProfilingAgent for JitDumpAgent {
-    fn register_function(&self, name: &str, addr: *const u8, size: usize) {
+    fn register_function(&self, name: &str, code: &[u8]) {
         let mut jitdump_file = JITDUMP_FILE.lock().unwrap();
         let jitdump_file = jitdump_file.as_mut().unwrap();
         let timestamp = jitdump_file.get_time_stamp();
         #[allow(trivial_numeric_casts)]
         let tid = rustix::thread::gettid().as_raw_nonzero().get() as u32;
-        if let Err(err) =
-            jitdump_file.dump_code_load_record(&name, addr, size, timestamp, self.pid, tid)
+        if let Err(err) = jitdump_file.dump_code_load_record(&name, code, timestamp, self.pid, tid)
         {
             println!("Jitdump: write_code_load_failed_record failed: {:?}\n", err);
         }


### PR DESCRIPTION
Pass around `&[u8]` instead of `*const u8` and `usize` to avoid the need for raw unsafe abstractions.

Closes #8905

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
