### PR TITLE
Fix segfault with custom page sizes on aarch64

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -732,7 +732,11 @@ fn initialize_memories(instance: &mut Instance, module: &Module) -> Result<()> {
 
             unsafe {
                 let src = self.instance.wasm_data(init.data.clone());
-                let dst = memory.base.add(usize::try_from(init.offset).unwrap());
+                let offset = usize::try_from(init.offset).unwrap();
+                let dst = memory.base.add(offset);
+
+                assert!(offset + src.len() <= memory.current_length());
+
                 // FIXME audit whether this is safe in the presence of shared
                 // memory
                 // (https://github.com/bytecodealliance/wasmtime/issues/4203).

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -294,8 +294,10 @@ fn run_wast(wast: &Path, strategy: Strategy, pooling: bool) -> anyhow::Result<()
             cfg.static_memory_maximum_size(0);
         }
         cfg.dynamic_memory_reserved_for_growth(0);
-        cfg.static_memory_guard_size(0);
-        cfg.dynamic_memory_guard_size(0);
+
+        let small_guard = 64 * 1024;
+        cfg.static_memory_guard_size(small_guard);
+        cfg.dynamic_memory_guard_size(small_guard);
     }
 
     let _pooling_lock = if pooling {


### PR DESCRIPTION
This commit fixes an issue with static memory initialization and custom page sizes interacting together on aarch64 Linux. (is that specific enough?)

When static memory initialization is enabled chunks of memory to initialize the linear memory are made in host-page-size increments of memory. This is done to enable page-mapping via copy-on-write if customized. With the custom page sizes proposal, however, for the first time it's possible for a linear memory to be smaller than this chunk of memory. This means that a virtual memory allocation of a single host page can be made which is smaller than the initialization chunk.

This currently only happens on aarch64 Linux where we coarsely approximate that the host page size is 64k but many hosts run with 4k pages. This means that a 64k initializer is created but the host only allocates 4k for a linear memory. This means that memory initialization can crash when a 64k initializer is copied into a 4k memory.

This was not caught via fuzzing because fuzzing only runs on x86_64. This was not caught via CI because on CI guard pages are disabled entirely on QEMU and we got lucky in that a number of virtual memory allocations were all placed next to each other meaning that this copy was probably corrupting some other memory. Locally this was found by running tests on `main` as-is on AArch64 Linux (by bjorn3).

This commit implements a few safeguards and a fix for this issue:

* On CI with QEMU modestly-size guard pages are now enabled to catch this sooner in development should it happen again in the future.
* An `assert!` is added during memory initialization that the memory copy is indeed valid. This causes the tests to fail as-is on `main` even on x86_64.
* The issue itself is fixed by bailing out of static memory initialization should the host page size exceed the wasm page size which can now happen on aarch64 Linux with smaller page sizes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
