### PR TITLE
winch(arm64): and, or, xor, shifts

### DIFF
--- a/tests/disas/winch/aarch64/i32_and/const.wat
+++ b/tests/disas/winch/aarch64/i32_and/const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.and)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       and     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_and/locals.wat
+++ b/tests/disas/winch/aarch64/i32_and/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.and)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       and     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_and/params.wat
+++ b/tests/disas/winch/aarch64/i32_and/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.and)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       and     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_or/const.wat
+++ b/tests/disas/winch/aarch64/i32_or/const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.or)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       orr     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_or/locals.wat
+++ b/tests/disas/winch/aarch64/i32_or/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.or)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       orr     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_or/params.wat
+++ b/tests/disas/winch/aarch64/i32_or/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.or)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       orr     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/16_const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       sub     w0, w0, wzr
+;;       mov     x16, #0x200
+;;       ror     w0, w0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/8_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       sub     w0, w0, wzr
+;;       ror     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       sub     w0, w0, wzr
+;;       ror     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       sub     w0, w0, wzr
+;;       ror     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/16_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       mov     x16, #0x200
+;;       ror     w0, w0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/8_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       ror     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       ror     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       ror     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/16_const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.shl)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       mov     x16, #0x200
+;;       lsl     w0, w0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/8_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.shl)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       lsl     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shl/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.shl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       lsl     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/params.wat
+++ b/tests/disas/winch/aarch64/i32_shl/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.shl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       lsl     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       mov     x16, #0x200
+;;       asr     w0, w0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       asr     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       asr     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       asr     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       mov     x16, #0x200
+;;       lsr     w0, w0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       lsr     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       lsr     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       lsr     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/const.wat
+++ b/tests/disas/winch/aarch64/i32_xor/const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.xor)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       eor     w0, w0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i32_xor/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.xor)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       eor     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/params.wat
+++ b/tests/disas/winch/aarch64/i32_xor/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.xor)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       eor     w1, w1, w0
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_and/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/32_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.and)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       and     x0, x0, #3
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_and/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/64_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.and)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0x7ffffffffffffffe
+;;       mov     x0, x16
+;;       and     x0, x0, #0x7fffffffffffffff
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_and/locals.wat
+++ b/tests/disas/winch/aarch64/i64_and/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.and)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       and     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_and/params.wat
+++ b/tests/disas/winch/aarch64/i64_and/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.and)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       and     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_or/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/32_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.or)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       orr     x0, x0, #3
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_or/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/64_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.or)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0x7ffffffffffffffe
+;;       mov     x0, x16
+;;       orr     x0, x0, #0x7fffffffffffffff
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_or/locals.wat
+++ b/tests/disas/winch/aarch64/i64_or/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.or)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       orr     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_or/params.wat
+++ b/tests/disas/winch/aarch64/i64_or/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.or)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       orr     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/16_const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       sub     x0, x0, xzr
+;;       mov     x16, #0x200
+;;       ror     x0, x0, x16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/8_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       sub     x0, x0, xzr
+;;       ror     x0, x0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       sub     x0, x0, xzr
+;;       ror     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.rotl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       sub     x0, x0, xzr
+;;       ror     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/16_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       mov     x16, #0x200
+;;       ror     x0, x0, x16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/8_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       ror     x0, x0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       ror     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.rotr)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       ror     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/16_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.shl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       mov     x16, #0x200
+;;       lsl     x0, x0, x16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/8_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.shl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       lsl     x0, x0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shl/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.shl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       lsl     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/params.wat
+++ b/tests/disas/winch/aarch64/i64_shl/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.shl)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       lsl     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       mov     x16, #0x200
+;;       asr     x0, x0, x16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       asr     x0, x0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       asr     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.shr_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       asr     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       mov     x16, #0x200
+;;       lsr     x0, x0, x16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       lsr     x0, x0, #2
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       lsr     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.shr_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       lsr     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/32_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.xor)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       eor     x0, x0, #3
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/64_const.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.xor)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0x7ffffffffffffffe
+;;       mov     x0, x16
+;;       eor     x0, x0, #0x7fffffffffffffff
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i64_xor/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.xor)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       eor     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/params.wat
+++ b/tests/disas/winch/aarch64/i64_xor/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.xor)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       eor     x1, x1, x0
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -320,8 +320,6 @@ impl<'a> CodeGenContext<'a> {
     }
 
     /// Prepares arguments for emitting an i32 shift operation.
-    ///
-    /// The `emit` function returns the `TypedReg` to put on the value stack.
     pub fn i32_shift<M>(&mut self, masm: &mut M, kind: ShiftKind)
     where
         M: MacroAssembler,
@@ -348,8 +346,6 @@ impl<'a> CodeGenContext<'a> {
     }
 
     /// Prepares arguments for emitting an i64 binary operation.
-    ///
-    /// The `emit` function returns the `TypedReg` to put on the value stack.
     pub fn i64_shift<M>(&mut self, masm: &mut M, kind: ShiftKind)
     where
         M: MacroAssembler,

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -341,7 +341,7 @@ impl<'a> CodeGenContext<'a> {
             );
             self.stack.push(typed_reg.into());
         } else {
-            masm.shift_rr(self, kind, OperandSize::S32);
+            masm.shift(self, kind, OperandSize::S32);
         }
     }
 
@@ -366,7 +366,7 @@ impl<'a> CodeGenContext<'a> {
             );
             self.stack.push(typed_reg.into());
         } else {
-            masm.shift_rr(self, kind, OperandSize::S64);
+            masm.shift(self, kind, OperandSize::S64);
         };
     }
 

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -29,19 +29,6 @@ impl From<OperandSize> for inst::OperandSize {
     }
 }
 
-impl Into<ALUOp> for ShiftKind {
-    fn into(self) -> ALUOp {
-        match self {
-            ShiftKind::Shl => ALUOp::Lsl,
-            ShiftKind::ShrS => ALUOp::Asr,
-            ShiftKind::ShrU => ALUOp::Lsr,
-            ShiftKind::Rotr => ALUOp::RotR,
-            // Rotl is implemented as neg+ROR.
-            ShiftKind::Rotl => unimplemented!(),
-        }
-    }
-}
-
 impl Into<ScalarSize> for OperandSize {
     fn into(self) -> ScalarSize {
         match self {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -509,38 +509,6 @@ impl Assembler {
         });
     }
 
-    // fn emit_alu_rrr_shift(
-    //     &mut self,
-    //     op: ALUOp,
-    //     rd: Reg,
-    //     rn: Reg,
-    //     rm: Reg,
-    //     kind: ShiftKind,
-    //     amount: u64,
-    //     size: OperandSize,
-    // ) {
-
-    //     let shift_op: ShiftOp =
-    //         if kind == ShiftKind::Rotl {
-    //             // Emulate Rotr with rm := neg(rm); with neg(x) := sub(zero, x).
-    //             self.emit_alu_rrr(ALUOp::Sub, regs::zero(), rm, rm, size);
-    //             ShiftOp::ROR
-    //         } else { kind.into() };
-
-    //     let sh_op_amt =
-    //         ShiftOpShiftImm::maybe_from_shift(amount)
-    //         .expect("amount should be smaller than MAX_SHIFT");
-
-    //     self.emit(Inst::AluRRRShift {
-    //         alu_op: op,
-    //         shiftop: ShiftOpAndAmt::new(shift_op, sh_op_amt),
-    //         size: size.into(),
-    //         rd: Writable::from_reg(rd.into()),
-    //         rn: rn.into(),
-    //         rm: rm.into(),
-    //     });
-    // }
-
     fn emit_fpu_rrr(&mut self, op: FPUOp2, rm: Reg, rn: Reg, rd: Reg, size: OperandSize) {
         self.emit(Inst::FpuRRR {
             fpu_op: op,

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -5,7 +5,8 @@ use crate::masm::RoundingMode;
 use crate::{masm::OperandSize, reg::Reg};
 use cranelift_codegen::isa::aarch64::inst::FPUOpRI::{UShr32, UShr64};
 use cranelift_codegen::isa::aarch64::inst::{
-    FPULeftShiftImm, FPUOp1, FPUOp2, FPUOpRI, FPUOpRIMod, FPURightShiftImm, FpuRoundMode, ImmLogic, ScalarSize
+    FPULeftShiftImm, FPUOp1, FPUOp2, FPUOpRI, FPUOpRIMod, FPURightShiftImm, FpuRoundMode, ImmLogic,
+    ScalarSize,
 };
 use cranelift_codegen::{
     ir::{MemFlags, SourceLoc},
@@ -396,9 +397,15 @@ impl Assembler {
         });
     }
 
-
-    fn emit_alu_rri_logic(&mut self, op: ALUOp, imm: ImmLogic, rn: Reg, rd: Reg, size: OperandSize) {
-        self.emit(Inst::AluRRImmLogic { 
+    fn emit_alu_rri_logic(
+        &mut self,
+        op: ALUOp,
+        imm: ImmLogic,
+        rn: Reg,
+        rd: Reg,
+        size: OperandSize,
+    ) {
+        self.emit(Inst::AluRRImmLogic {
             alu_op: op,
             size: size.into(),
             rd: Writable::from_reg(rd.into()),

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -35,9 +35,9 @@ impl Into<ALUOp> for ShiftKind {
             ShiftKind::Shl => ALUOp::Lsl,
             ShiftKind::ShrS => ALUOp::Asr,
             ShiftKind::ShrU => ALUOp::Lsr,
-            ShiftKind::Rotl => ALUOp::RotR,
-            // Rotr is implemented as neg+ROR.
-            ShiftKind::Rotr => unimplemented!(),
+            ShiftKind::Rotr => ALUOp::RotR,
+            // Rotl is implemented as neg+ROR.
+            ShiftKind::Rotl => unimplemented!(),
         }
     }
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -405,8 +405,7 @@ impl Masm for MacroAssembler {
         self.asm.shift_ir(imm, lhs, dst, kind, size)
     }
 
-    fn shift_rr(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize) {
-        // Number of bits to shift must be in the CL register.
+    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize) {
         let src = context.pop_to_reg(self, None);
         let dst = context.pop_to_reg(self, None);
 

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -347,16 +347,58 @@ impl Masm for MacroAssembler {
         self.asm.fsqrt_rr(src, dst, size);
     }
 
-    fn and(&mut self, _dst: Reg, _lhs: Reg, _rhs: RegImm, _size: OperandSize) {
-        todo!()
+    fn and(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize) {
+        match (rhs, lhs, dst) {
+            (RegImm::Imm(v), rn, rd) => {
+                let imm = match v {
+                    I::I32(v) => v as u64,
+                    I::I64(v) => v,
+                    _ => unreachable!(),
+                };
+
+                self.asm.and_ir(imm, rn, rd, size);
+            }
+
+            (RegImm::Reg(rm), rn, rd) => {
+                self.asm.and_rrr(rm, rn, rd, size);
+            }
+        }
     }
 
-    fn or(&mut self, _dst: Reg, _lhs: Reg, _rhs: RegImm, _size: OperandSize) {
-        todo!()
+    fn or(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize) {
+        match (rhs, lhs, dst) {
+            (RegImm::Imm(v), rn, rd) => {
+                let imm = match v {
+                    I::I32(v) => v as u64,
+                    I::I64(v) => v,
+                    _ => unreachable!(),
+                };
+
+                self.asm.or_ir(imm, rn, rd, size);
+            }
+
+            (RegImm::Reg(rm), rn, rd) => {
+                self.asm.or_rrr(rm, rn, rd, size);
+            }
+        }
     }
 
-    fn xor(&mut self, _dst: Reg, _lhs: Reg, _rhs: RegImm, _size: OperandSize) {
-        todo!()
+    fn xor(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize) {
+        match (rhs, lhs, dst) {
+            (RegImm::Imm(v), rn, rd) => {
+                let imm = match v {
+                    I::I32(v) => v as u64,
+                    I::I64(v) => v,
+                    _ => unreachable!(),
+                };
+
+                self.asm.xor_ir(imm, rn, rd, size);
+            }
+
+            (RegImm::Reg(rm), rn, rd) => {
+                self.asm.xor_rrr(rm, rn, rd, size);
+            }
+        }
     }
 
     fn shift(&mut self, _context: &mut CodeGenContext, _kind: ShiftKind, _size: OperandSize) {

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -530,39 +530,20 @@ impl Masm for MacroAssembler {
         }
     }
 
-    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize) {
-        let top = context.stack.peek().expect("value at stack top");
+    fn shift_ir(&mut self, dst: Reg, imm: u64, lhs: Reg, kind: ShiftKind, size: OperandSize) {
+        Self::ensure_two_argument_form(&dst, &lhs);
+        self.asm.shift_ir(imm as u8, dst, kind, size)
+    }
 
-        if size == OperandSize::S32 && top.is_i32_const() {
-            let val = context
-                .stack
-                .pop_i32_const()
-                .expect("i32 const value at stack top");
-            let typed_reg = context.pop_to_reg(self, None);
+    fn shift_rr(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize) {
+        // Number of bits to shift must be in the CL register.
+        let src = context.pop_to_reg(self, Some(regs::rcx()));
+        let dst = context.pop_to_reg(self, None);
 
-            self.asm.shift_ir(val as u8, typed_reg.into(), kind, size);
+        self.asm.shift_rr(src.into(), dst.into(), kind, size);
 
-            context.stack.push(typed_reg.into());
-        } else if size == OperandSize::S64 && top.is_i64_const() {
-            let val = context
-                .stack
-                .pop_i64_const()
-                .expect("i64 const value at stack top");
-            let typed_reg = context.pop_to_reg(self, None);
-
-            self.asm.shift_ir(val as u8, typed_reg.into(), kind, size);
-
-            context.stack.push(typed_reg.into());
-        } else {
-            // Number of bits to shift must be in the CL register.
-            let src = context.pop_to_reg(self, Some(regs::rcx()));
-            let dst = context.pop_to_reg(self, None);
-
-            self.asm.shift_rr(src.into(), dst.into(), kind, size);
-
-            context.free_reg(src);
-            context.stack.push(dst.into());
-        }
+        context.free_reg(src);
+        context.stack.push(dst.into());
     }
 
     fn div(&mut self, context: &mut CodeGenContext, kind: DivKind, size: OperandSize) {

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -535,7 +535,7 @@ impl Masm for MacroAssembler {
         self.asm.shift_ir(imm as u8, dst, kind, size)
     }
 
-    fn shift_rr(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize) {
+    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize) {
         // Number of bits to shift must be in the CL register.
         let src = context.pop_to_reg(self, Some(regs::rcx()));
         let dst = context.pop_to_reg(self, None);

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -704,7 +704,7 @@ pub(crate) trait MacroAssembler {
     /// caller from having to deal with the architecture specific constraints
     /// we give this function access to the code generation context, allowing
     /// each implementation to decide the lowering path.
-    fn shift_rr(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize);
+    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize);
 
     /// Perform division operation.
     /// Division is special in that some architectures have specific

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1,9 +1,10 @@
 use crate::abi::{self, align_to, LocalSlot};
 use crate::codegen::{CodeGenContext, FuncEnv};
 use crate::isa::reg::Reg;
+use cranelift_codegen::ir::Type;
 use cranelift_codegen::{
     binemit::CodeOffset,
-    ir::{Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef},
+    ir::{Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef, types},
     Final, MachBufferFinalized, MachLabel,
 };
 use std::{fmt::Debug, ops::Range};
@@ -229,6 +230,16 @@ impl OperandSize {
             _ => panic!("Invalid bytes {} for OperandSize", bytes),
         }
     }
+
+    /// Convert to I32, I64, or I128.
+    pub fn to_ty(self) -> Type {
+        match self {
+            OperandSize::S32 => types::I32,
+            OperandSize::S64 => types::I64,
+            _ => unimplemented!()
+        }
+    }
+    
 }
 
 /// An abstraction over a register or immediate.

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -695,13 +695,16 @@ pub(crate) trait MacroAssembler {
     /// Perform logical exclusive or operation.
     fn xor(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
-    /// Perform a shift operation.
-    /// Shift is special in that some architectures have specific expectations
+    /// Perform a shift operation between a register and an immediate.
+    fn shift_ir(&mut self, dst: Reg, imm: u64, lhs: Reg, kind: ShiftKind, size: OperandSize);
+
+    /// Perform a shift operation between two registers.
+    /// This case is special in that some architectures have specific expectations
     /// regarding the location of the instruction arguments. To free the
     /// caller from having to deal with the architecture specific constraints
     /// we give this function access to the code generation context, allowing
     /// each implementation to decide the lowering path.
-    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize);
+    fn shift_rr(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize);
 
     /// Perform division operation.
     /// Division is special in that some architectures have specific

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -138,6 +138,7 @@ pub(crate) enum FloatCmpKind {
 /// Kinds of shifts in WebAssembly.The [`masm`] implementation for each ISA is
 /// responsible for emitting the correct sequence of instructions when
 /// lowering to machine code.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum ShiftKind {
     /// Left shift.
     Shl,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -4,7 +4,7 @@ use crate::isa::reg::Reg;
 use cranelift_codegen::ir::Type;
 use cranelift_codegen::{
     binemit::CodeOffset,
-    ir::{Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef, types},
+    ir::{types, Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef},
     Final, MachBufferFinalized, MachLabel,
 };
 use std::{fmt::Debug, ops::Range};
@@ -236,10 +236,9 @@ impl OperandSize {
         match self {
             OperandSize::S32 => types::I32,
             OperandSize::S64 => types::I64,
-            _ => unimplemented!()
+            _ => unimplemented!(),
         }
     }
-    
 }
 
 /// An abstraction over a register or immediate.

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -231,7 +231,7 @@ impl OperandSize {
         }
     }
 
-    /// Convert to I32, I64, or I128.
+    /// Convert to I32 and I64.
     pub fn to_ty(self) -> Type {
         match self {
             OperandSize::S32 => types::I32,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1,10 +1,9 @@
 use crate::abi::{self, align_to, LocalSlot};
 use crate::codegen::{CodeGenContext, FuncEnv};
 use crate::isa::reg::Reg;
-use cranelift_codegen::ir::Type;
 use cranelift_codegen::{
     binemit::CodeOffset,
-    ir::{types, Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef},
+    ir::{Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef},
     Final, MachBufferFinalized, MachLabel,
 };
 use std::{fmt::Debug, ops::Range};
@@ -229,15 +228,6 @@ impl OperandSize {
             8 => S64,
             16 => S128,
             _ => panic!("Invalid bytes {} for OperandSize", bytes),
-        }
-    }
-
-    /// Convert to I32 and I64.
-    pub fn to_ty(self) -> Type {
-        match self {
-            OperandSize::S32 => types::I32,
-            OperandSize::S64 => types::I64,
-            _ => unimplemented!(),
         }
     }
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1070,73 +1070,63 @@ where
     }
 
     fn visit_i32_shl(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, Shl, S32);
+        self.context.i32_shift(self.masm, Shl);
     }
 
     fn visit_i64_shl(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, Shl, S64);
+        self.context.i64_shift(self.masm, Shl);
     }
 
     fn visit_i32_shr_s(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, ShrS, S32);
+        self.context.i32_shift(self.masm, ShrS);
     }
 
     fn visit_i64_shr_s(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, ShrS, S64);
+        self.context.i64_shift(self.masm, ShrS);
     }
 
     fn visit_i32_shr_u(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, ShrU, S32);
+        self.context.i32_shift(self.masm, ShrU);
     }
 
     fn visit_i64_shr_u(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, ShrU, S64);
+        self.context.i64_shift(self.masm, ShrU);
     }
 
     fn visit_i32_rotl(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, Rotl, S32);
+        self.context.i32_shift(self.masm, Rotl);
     }
 
     fn visit_i64_rotl(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, Rotl, S64);
+        self.context.i64_shift(self.masm, Rotl);
     }
 
     fn visit_i32_rotr(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, Rotr, S32);
+        self.context.i32_shift(self.masm, Rotr);
     }
 
     fn visit_i64_rotr(&mut self) {
-        use OperandSize::*;
         use ShiftKind::*;
 
-        self.masm.shift(&mut self.context, Rotr, S64);
+        self.context.i64_shift(self.masm, Rotr);
     }
 
     fn visit_end(&mut self) {


### PR DESCRIPTION
Follow up to #8321.

Adds support to binary and, binary or, binary xor (eor), shl, shrS, shrU, rotr, rotl.
