### PR TITLE
[23.0.0] A few more backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmtime-types",
  "wat",
 ]
@@ -2094,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn 2.0.60",
@@ -2752,7 +2752,7 @@ dependencies = [
  "cargo_metadata",
  "heck 0.4.0",
  "wasmtime",
- "wit-component 0.212.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -3082,7 +3082,7 @@ name = "verify-component-adapter"
 version = "23.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wat",
 ]
 
@@ -3175,7 +3175,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.36.0",
  "wasi",
- "wasm-encoder 0.212.0",
+ "wasm-encoder",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3235,37 +3235,12 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
- "wasmparser 0.212.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
-dependencies = [
- "anyhow",
- "indexmap 2.2.6",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.209.1",
- "wasmparser 0.209.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3280,8 +3255,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3294,8 +3269,8 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3309,7 +3284,7 @@ dependencies = [
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder 0.212.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -3354,19 +3329,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
-dependencies = [
- "ahash",
- "bitflags 2.4.1",
- "hashbrown 0.14.3",
- "indexmap 2.2.6",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
@@ -3396,7 +3358,7 @@ checksum = "dfac65326cc561112af88c3028f6dfdb140acff67ede33a8e86be2dc6b8956f7"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.212.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3440,8 +3402,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3583,7 +3545,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3600,7 +3562,7 @@ dependencies = [
  "wast 212.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component 0.212.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -3633,7 +3595,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.212.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3657,7 +3619,7 @@ dependencies = [
  "object 0.36.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3682,8 +3644,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3698,7 +3660,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3756,7 +3718,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3777,12 +3739,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.212.0",
+ "wasm-encoder",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3832,7 +3794,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.212.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3953,7 +3915,7 @@ dependencies = [
  "gimli",
  "object 0.36.0",
  "target-lexicon",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3966,7 +3928,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.0",
  "indexmap 2.2.6",
- "wit-parser 0.212.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3992,7 +3954,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.212.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -4131,7 +4093,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.212.0",
+ "wasmparser",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4308,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84376ff4f74ed07674a1157c0bd19e6627ab01fc90952a27ccefb52a24530f0"
+checksum = "fabce76bbb8938536c437da0c3e1d4dda9065453f72a68f797c0cb3d67356a28"
 dependencies = [
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
@@ -4318,69 +4280,53 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d4706efb67fadfbbde77955b299b111dd096e6776d8c6561d92f6147941880"
+checksum = "1b43fbdd3497c471bbfb6973b1fb9ffe6949f158248cb43171d6f1cf3de7eaa3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.209.1",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c7526379ace8709ee9ab9f2bb50f112d95581063a59ef3097d9c10153886c9"
+checksum = "75956ff0a04a87ca0526b07199ce3b9baee899f2e4723b5b63aa296ab172ec52"
 dependencies = [
  "bitflags 2.4.1",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514295193d1a2f42e6a948cd7d9fd81e2b8fadc319667dcf19fd7aceaf2113a2"
+checksum = "bf509c4ef97b18ec0218741c8318706ac30ff16bc1731f990319a42bbbcfe8e3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.2.6",
- "wasm-metadata 0.209.1",
+ "prettyplease",
+ "syn 2.0.60",
+ "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.209.1",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0409a3356ca02599aff78f717968fd7f12df4bf879f325e2a97b45c84c90fff"
+checksum = "88d6f2e025e38395d71fc1bf064e581b2ad275ce322d6f8d87ddc5e76a7b8c42"
 dependencies = [
  "anyhow",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
  "wit-bindgen-core",
  "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
-dependencies = [
- "anyhow",
- "bitflags 2.4.1",
- "indexmap 2.2.6",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.209.1",
- "wasm-metadata 0.209.1",
- "wasmparser 0.209.1",
- "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -4396,28 +4342,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.212.0",
- "wasm-metadata 0.212.0",
- "wasmparser 0.212.0",
- "wit-parser 0.212.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.209.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.2.6",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.209.1",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4435,7 +4363,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.212.0",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,8 +249,8 @@ io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.1"
 rustix = "0.38.31"
 # wit-bindgen:
-wit-bindgen = { version = "0.26.0", default-features = false }
-wit-bindgen-rust-macro = { version = "0.26.0", default-features = false }
+wit-bindgen = { version = "0.27.0", default-features = false }
+wit-bindgen-rust-macro = { version = "0.27.0", default-features = false }
 
 # wasm-tools family:
 wasmparser = { version = "0.212.0", default-features = false }

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -260,6 +260,8 @@ wasmtime_option_group! {
         pub function_references: Option<bool>,
         /// Configure support for the GC proposal.
         pub gc: Option<bool>,
+        /// Configure support for the custom-page-sizes proposal.
+        pub custom_page_sizes: Option<bool>,
     }
 
     enum Wasm {
@@ -659,6 +661,9 @@ impl CommonOptions {
         }
         if let Some(enable) = self.wasm.memory64.or(all) {
             config.wasm_memory64(enable);
+        }
+        if let Some(enable) = self.wasm.custom_page_sizes.or(all) {
+            config.wasm_custom_page_sizes(enable);
         }
 
         macro_rules! handle_conditionally_compiled {

--- a/crates/cranelift/src/debug/transform/attr.rs
+++ b/crates/cranelift/src/debug/transform/attr.rs
@@ -116,7 +116,15 @@ where
                     ..
                 } = file_context
                 {
-                    write::AttributeValue::FileIndex(Some(file_map[(i - file_index_base) as usize]))
+                    let index = usize::try_from(i - file_index_base)
+                        .ok()
+                        .and_then(|i| file_map.get(i).copied());
+                    match index {
+                        Some(index) => write::AttributeValue::FileIndex(Some(index)),
+                        // This was seen to be invalid in #8884 and #8904 so
+                        // ignore this seemingly invalid DWARF from LLVM
+                        None => continue,
+                    }
                 } else {
                     return Err(TransformError("unexpected file index attribute").into());
                 }

--- a/crates/test-programs/src/bin/api_reactor.rs
+++ b/crates/test-programs/src/bin/api_reactor.rs
@@ -1,6 +1,7 @@
 wit_bindgen::generate!({
     world: "test-reactor",
     path: "../wasi/wit",
+    generate_all,
 });
 
 struct T;

--- a/crates/test-programs/src/lib.rs
+++ b/crates/test-programs/src/lib.rs
@@ -3,7 +3,11 @@ pub mod nn;
 pub mod preview1;
 pub mod sockets;
 
-wit_bindgen::generate!("test-command" in "../wasi/wit");
+wit_bindgen::generate!({
+    world: "test-command",
+    path: "../wasi/wit",
+    generate_all,
+});
 
 pub mod proxy {
     wit_bindgen::generate!({
@@ -14,6 +18,15 @@ pub mod proxy {
         with: {
             "wasi:http/types@0.2.0": crate::wasi::http::types,
             "wasi:http/outgoing-handler@0.2.0": crate::wasi::http::outgoing_handler,
+            "wasi:random/random@0.2.0": crate::wasi::random::random,
+            "wasi:io/error@0.2.0": crate::wasi::io::error,
+            "wasi:io/poll@0.2.0": crate::wasi::io::poll,
+            "wasi:io/streams@0.2.0": crate::wasi::io::streams,
+            "wasi:cli/stdout@0.2.0": crate::wasi::cli::stdout,
+            "wasi:cli/stderr@0.2.0": crate::wasi::cli::stderr,
+            "wasi:cli/stdin@0.2.0": crate::wasi::cli::stdin,
+            "wasi:clocks/monotonic-clock@0.2.0": crate::wasi::clocks::monotonic_clock,
+            "wasi:clocks/wall-clock@0.2.0": crate::wasi::clocks::wall_clock,
         },
     });
 }

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -62,6 +62,7 @@ pub mod bindings {
         // Instead, we manually define the bindings for these functions in
         // terms of raw pointers.
         skip: ["run", "get-environment", "poll"],
+        generate_all,
     });
 
     #[cfg(feature = "reactor")]
@@ -78,6 +79,7 @@ pub mod bindings {
         // Instead, we manually define the bindings for these functions in
         // terms of raw pointers.
         skip: ["get-environment", "poll"],
+        generate_all,
     });
 
     #[cfg(feature = "proxy")]
@@ -99,6 +101,7 @@ pub mod bindings {
         raw_strings,
         runtime_path: "crate::bindings::wit_bindgen_rt_shim",
         skip: ["poll"],
+        generate_all,
     });
 
     pub mod wit_bindgen_rt_shim {

--- a/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
@@ -45,7 +45,7 @@ impl RootSet {
         usize::MAX
     }
 
-    pub(crate) fn exit_lifo_scope(&mut self, _gc_store: &mut GcStore, _scope: usize) {}
+    pub(crate) fn exit_lifo_scope(&mut self, _gc_store: Option<&mut GcStore>, _scope: usize) {}
 
     pub(crate) fn with_lifo_scope<T>(
         store: &mut StoreOpaque,

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1584,9 +1584,7 @@ impl StoreOpaque {
 
     #[inline]
     pub(crate) fn exit_gc_lifo_scope(&mut self, scope: usize) {
-        if let Some(gc_store) = self.gc_store.as_mut() {
-            self.gc_roots.exit_lifo_scope(gc_store, scope);
-        }
+        self.gc_roots.exit_lifo_scope(self.gc_store.as_mut(), scope);
     }
 
     #[cfg(feature = "gc")]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1488,6 +1488,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.prettyplease]]
+version = "0.2.20"
+when = "2024-05-07"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.proc-macro2]]
 version = "1.0.81"
 when = "2024-04-17"
@@ -3092,6 +3099,12 @@ when = "2024-05-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-bindgen]]
+version = "0.27.0"
+when = "2024-06-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-bindgen-core]]
 version = "0.20.0"
 when = "2024-02-29"
@@ -3116,6 +3129,12 @@ when = "2024-05-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-bindgen-core]]
+version = "0.27.0"
+when = "2024-06-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-bindgen-rt]]
 version = "0.22.0"
 when = "2024-03-11"
@@ -3131,6 +3150,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-bindgen-rt]]
 version = "0.26.0"
 when = "2024-05-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-bindgen-rt]]
+version = "0.27.0"
+when = "2024-06-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -3158,6 +3183,12 @@ when = "2024-05-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-bindgen-rust]]
+version = "0.27.0"
+when = "2024-06-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.20.0"
 when = "2024-02-29"
@@ -3179,6 +3210,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.26.0"
 when = "2024-05-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.27.0"
+when = "2024-06-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/tests/all/i31ref.rs
+++ b/tests/all/i31ref.rs
@@ -1,0 +1,21 @@
+use wasmtime::*;
+
+#[test]
+fn always_pop_i31ref_lifo_roots() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let anyref = {
+        let mut scope = RootScope::new(&mut store);
+        AnyRef::from_i31(&mut scope, I31::wrapping_u32(42))
+    };
+
+    // The anyref has left its rooting scope and been unrooted.
+    assert!(anyref.is_i31(&store).is_err());
+
+    Ok(())
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -16,6 +16,7 @@ mod funcref;
 mod gc;
 mod globals;
 mod host_funcs;
+mod i31ref;
 mod iloop;
 mod import_calling_export;
 mod import_indexes;


### PR DESCRIPTION
This backports a few more PRs to the release-23.0.0 branch:

* https://github.com/bytecodealliance/wasmtime/pull/8917 - enables using the custom-page-sizes proposal from the CLI (accidental omission from the original PR)
* https://github.com/bytecodealliance/wasmtime/pull/8911 - trying to keep wasm-tools deps in sync on Wasmtime and this keeps everything at the same version
* https://github.com/bytecodealliance/wasmtime/pull/8913 - seemed like a good candidate for an "easy bugfix"
* https://github.com/bytecodealliance/wasmtime/pull/8899 - also seemed like a good bugfix candidate