### PR TITLE
A handful of clean ups for `AnyRef`

### DIFF
--- a/crates/wasmtime/src/runtime/gc/disabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/anyref.rs
@@ -1,7 +1,7 @@
 use crate::runtime::vm::VMGcRef;
 use crate::{
     store::{AutoAssertNoGc, StoreOpaque},
-    AsContext, AsContextMut, GcRefImpl, Result, Rooted, I31,
+    AsContext, AsContextMut, GcRefImpl, HeapType, Result, Rooted, I31,
 };
 
 /// Support for `anyref` disabled at compile time because the `gc` cargo feature
@@ -25,6 +25,14 @@ impl AnyRef {
     }
 
     pub unsafe fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
+        match *self {}
+    }
+
+    pub fn ty(&self, _store: impl AsContext) -> Result<HeapType> {
+        match *self {}
+    }
+
+    pub fn matches_ty(&self, _store: impl AsContext, _ty: &HeapType) -> Result<bool> {
         match *self {}
     }
 


### PR DESCRIPTION
Adding `ty`, `matches_ty`, etc... methods that we have for other kinds of values.

Cleaning up doc comments.

Add some same-store asserts.

Splitting this out from a larger PR to make review easier.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
