### PR TITLE
Fix set_epoch_deadline docs

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -915,7 +915,7 @@ impl<T> Store<T> {
     /// yield and then continue.
     ///
     /// This deadline is always set relative to the current epoch:
-    /// `delta_beyond_current` ticks in the future. The deadline can
+    /// `ticks_beyond_current` ticks in the future. The deadline can
     /// be set explicitly via this method, or refilled automatically
     /// on a yield if configured via
     /// [`epoch_deadline_async_yield_and_update()`](Store::epoch_deadline_async_yield_and_update). After


### PR DESCRIPTION
The parameter is named `ticks_beyond_current` but the docs refer to it as `delta_beyond_current`.