### PR TITLE
fuzzgen: Add stack map variables

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1892,6 +1892,14 @@ where
             let var = Variable::new(id);
             builder.declare_var(var, ty);
             builder.def_var(var, value);
+
+            // Randomly declare variables as needing a stack map.
+            // We limit these to only types that have fewer than 16 bytes
+            // since the stack map mechanism does not support larger types.
+            if ty.bytes() <= 16 && self.u.arbitrary()? {
+                builder.declare_var_needs_stack_map(var);
+            }
+
             self.resources
                 .vars
                 .entry(ty)


### PR DESCRIPTION
👋 Hey,

This PR adds the new variable stack map apis (added in #8937) to cranelift fuzzgen.

I've tried to fuzz this for a bit, but it seems to generate invalid functions that don't pass the validator. I don't know enough about how stackmaps work to debug this. (cc @fitzgen)

I also don't know if this feature is ready for fuzzing yet, so if it isn't let me know!

Here's one of the fuzz bugs:

<details>
<summary>Panic</summary>

```
thread '<unnamed>' panicked at fuzz/fuzz_targets/cranelift-fuzzgen.rs:402:14:
called `Result::unwrap()` on an `Err` value: Compilation error: Verifier errors

Caused by:
    0: Verifier errors
    1: - inst10 (stack_store.f32 v24, ss1): uses value v24 from non-dominating inst6
```
</details>


<details>
<summary>base64</summary>

```
/34Vbf91NDQzW23Ny8vLNMvFNDQ3ycvKLjg4ODg4ODAwMHIwMTUxbTMwMDL/Gv8jygI0ODh4MDAwcjAxNTFtMzAwMv8CNDQ0eHg0NDQjygD///8+Pl0+Pj4+PgEBAQEBAQH3AQ==
```
</details>

<details>
<summary>CLIF</summary>

```
test interpret
test run
set probestack_size_log2=11
set probestack_strategy=inline
set enable_safepoints=true
set enable_llvm_abi_extensions=true
set preserve_frame_pointers=true
set machine_code_cfg_info=true
set enable_probestack=true
set enable_jump_tables=false
set enable_heap_access_spectre_mitigation=false
set enable_incremental_compilation_cache_checks=true
target x86_64 has_sse3 has_ssse3 has_sse41 has_sse42 has_avx has_avx2 has_fma has_popcnt has_bmi1 has_bmi2 has_lzcnt 

function u1:0(i64x2, i16 uext, f32, f64x2, i32x4, i32x4, f32x4, i16x8, i8 sext, i32x4, i8x16, i32 uext, i128, i64 sext) -> i32x4, i32x4, i64x2, i32x4, i64x2, i16 uext, f32, f64x2, i32x4, i32x4, f32x4, i16x8 fast {
    ss0 = explicit_slot 2, align = 2
    ss1 = explicit_slot 4, align = 4
    ss2 = explicit_slot 16, align = 16
    sig0 = (f32) -> f32 system_v
    sig1 = (f64) -> f64 system_v
    sig2 = (f32) -> f32 system_v
    sig3 = (f64) -> f64 system_v
    sig4 = (f32) -> f32 system_v
    sig5 = (f64) -> f64 system_v
    fn0 = %CeilF32 sig0
    fn1 = %CeilF64 sig1
    fn2 = %FloorF32 sig2
    fn3 = %FloorF64 sig3
    fn4 = %TruncF32 sig4
    fn5 = %TruncF64 sig5

block0(v0: i64x2, v1: i16, v2: f32, v3: f64x2, v4: i32x4, v5: i32x4, v6: f32x4, v7: i16x8, v8: i8, v9: i32x4, v10: i8x16, v11: i32, v12: i128, v13: i64):
    v22 -> v0
    v23 -> v1
    v25 -> v3
    v26 -> v6
    v27 -> v7
    v15 = iconst.i16 257
    v16 = iconst.i8 0
    v17 = iconst.i16 0
    v18 = iconst.i32 0
    v19 = iconst.i64 0
    v20 = uextend.i128 v19  ; v19 = 0
    stack_store v23, ss0
    stack_store v24, ss1
    stack_store v22, ss2
    v21 = call fn0(v2), stack_map=[i16 @ ss0+0, f32 @ ss1+0, i64x2 @ ss2+0]
    v24 -> v21
    brif v8, block1(v4), block1(v4)

block1(v14: i32x4):
    return v14, v14, v22, v14, v22, v23, v24, v25, v14, v14, v26, v27
}


; Note: the results in the below test cases are simply a placeholder and probably will be wrong

; run: u1:0(0x00000000000000000000000000000000, 0, 0.0, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0, 0, 0) == [0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0, 0.0, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000]
```
</details>