### PR TITLE
Fix component_api fuzzer by reducing flags

### DIFF
--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -176,9 +176,7 @@ impl Type {
                 err: Type::generate_opt(u, depth - 1, fuel)?.map(Box::new),
             },
             20 => {
-                // Generate 1 flag all the way up to 65 flags which exercises
-                // the 1 to 3 x u32 cases.
-                let amt = u.int_in_range(1..=(*fuel).min(65))?;
+                let amt = u.int_in_range(1..=(*fuel).min(32))?;
                 *fuel -= amt;
                 Type::Flags(amt)
             }


### PR DESCRIPTION
This fixes fuzzing with a recent update to wasm-tools which limited the number of flags to 32.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
