### PR TITLE
Remove `unchecked_*` methods on `Rooted`s for getting `VMGcRef`s

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -253,7 +253,7 @@ impl AnyRef {
     }
 
     pub(crate) fn _ty(&self, store: &StoreOpaque) -> Result<HeapType> {
-        let gc_ref = self.inner.unchecked_try_gc_ref(store)?;
+        let gc_ref = self.inner.try_gc_ref(store)?;
         if gc_ref.is_i31() {
             return Ok(HeapType::I31);
         }
@@ -323,9 +323,7 @@ impl AnyRef {
 
     pub(crate) fn _is_i31(&self, store: &StoreOpaque) -> Result<bool> {
         assert!(self.comes_from_same_store(store));
-        // NB: Can't use `AutoAssertNoGc` here because we only have a shared
-        // context, not a mutable context.
-        let gc_ref = self.inner.unchecked_try_gc_ref(store)?;
+        let gc_ref = self.inner.try_gc_ref(store)?;
         Ok(gc_ref.is_i31())
     }
 
@@ -348,9 +346,7 @@ impl AnyRef {
 
     pub(crate) fn _as_i31(&self, store: &StoreOpaque) -> Result<Option<I31>> {
         assert!(self.comes_from_same_store(store));
-        // NB: Can't use `AutoAssertNoGc` here because we only have a shared
-        // context, not a mutable context.
-        let gc_ref = self.inner.unchecked_try_gc_ref(store)?;
+        let gc_ref = self.inner.try_gc_ref(store)?;
         Ok(gc_ref.as_i31().map(Into::into))
     }
 
@@ -383,9 +379,7 @@ impl AnyRef {
     }
 
     pub(crate) fn _is_struct(&self, store: &StoreOpaque) -> Result<bool> {
-        // NB: Can't use `AutoAssertNoGc` here because we only have a shared
-        // context, not a mutable context.
-        let gc_ref = self.inner.unchecked_try_gc_ref(store)?;
+        let gc_ref = self.inner.try_gc_ref(store)?;
         Ok(!gc_ref.is_i31() && store.gc_store()?.kind(gc_ref).matches(VMGcKind::StructRef))
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -319,7 +319,7 @@ impl ExternRef {
         T: 'a,
     {
         let store = store.into().0;
-        let gc_ref = self.inner.unchecked_try_gc_ref(&store)?;
+        let gc_ref = self.inner.try_gc_ref(&store)?;
         let externref = gc_ref.as_externref_unchecked();
         Ok(store.gc_store()?.externref_host_data(externref))
     }
@@ -359,7 +359,10 @@ impl ExternRef {
         T: 'a,
     {
         let store = store.into().0;
-        let gc_ref = self.inner.unchecked_try_gc_ref(store)?.unchecked_copy();
+        // NB: need to do an unchecked copy to release the borrow on the store
+        // so that we can get the store's GC store. But importantly we cannot
+        // trigger a GC while we are working with `gc_ref` here.
+        let gc_ref = self.inner.try_gc_ref(store)?.unchecked_copy();
         let externref = gc_ref.as_externref_unchecked();
         Ok(store.gc_store_mut()?.externref_host_data_mut(externref))
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -534,7 +534,7 @@ impl StructRef {
     }
 
     pub(crate) fn type_index(&self, store: &StoreOpaque) -> Result<VMSharedTypeIndex> {
-        let gc_ref = self.inner.unchecked_try_gc_ref(store)?;
+        let gc_ref = self.inner.try_gc_ref(store)?;
         let header = store.gc_store()?.header(gc_ref);
         debug_assert!(header.kind().matches(VMGcKind::StructRef));
         Ok(header.ty().expect("structrefs should have concrete types"))

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2614,7 +2614,7 @@ unsafe impl<T> crate::runtime::vm::Store for StoreInner<T> {
             None => None,
             Some(r) => {
                 let r = r
-                    .unchecked_get_gc_ref(store)
+                    .get_gc_ref(store)
                     .expect("still in scope")
                     .unchecked_copy();
                 Some(store.gc_store_mut()?.clone_gc_ref(&r))


### PR DESCRIPTION
Because they take a shared borrow of the store and return a shared borrow of the `VMGcRef` with the same lifetime, and because performing a GC requires a mutable borrow of the store, there actually was no reason to differentiate between checked and unchecked methods or require `AutoAssertNoGc` arguments.

Fixes https://github.com/bytecodealliance/wasmtime/issues/8940

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
