### PR TITLE
Reduce typo count

### DIFF
--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `imports`.
+/// component which implements the world `imports`.
 ///
 /// This structure is created through [`ImportsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `ImportsPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `imports`.
+/// component which implements the world `imports`.
 ///
 /// This structure is created through [`ImportsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `ImportsPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -49,7 +49,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -51,7 +51,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/empty.rs
+++ b/crates/component-macro/tests/expanded/empty.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `empty`.
+/// component which implements the world `empty`.
 ///
 /// This structure is created through [`EmptyPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `EmptyPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/empty_async.rs
+++ b/crates/component-macro/tests/expanded/empty_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `empty`.
+/// component which implements the world `empty`.
 ///
 /// This structure is created through [`EmptyPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `EmptyPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-flags`.
+/// component which implements the world `the-flags`.
 ///
 /// This structure is created through [`TheFlagsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheFlagsPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-flags`.
+/// component which implements the world `the-flags`.
 ///
 /// This structure is created through [`TheFlagsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheFlagsPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/function-new_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-lists`.
+/// component which implements the world `the-lists`.
 ///
 /// This structure is created through [`TheListsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheListsPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-lists`.
+/// component which implements the world `the-lists`.
 ///
 /// This structure is created through [`TheListsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheListsPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/multi-return.rs
+++ b/crates/component-macro/tests/expanded/multi-return.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/multi-return_async.rs
+++ b/crates/component-macro/tests/expanded/multi-return_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -36,7 +36,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -36,7 +36,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `neptune`.
+/// component which implements the world `neptune`.
 ///
 /// This structure is created through [`NeptunePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `NeptunePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `neptune`.
+/// component which implements the world `neptune`.
 ///
 /// This structure is created through [`NeptunePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `NeptunePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `w`.
+/// component which implements the world `w`.
 ///
 /// This structure is created through [`WPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -42,7 +42,7 @@ const _: () = {
         /// Creates a new copy of `WPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `w`.
+/// component which implements the world `w`.
 ///
 /// This structure is created through [`WPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -42,7 +42,7 @@ const _: () = {
         /// Creates a new copy of `WPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -26,7 +26,7 @@ impl<_T: HostWorldResource + ?Sized> HostWorldResource for &mut _T {
     }
 }
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -83,7 +83,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -28,7 +28,7 @@ impl<_T: HostWorldResource + ?Sized + Send> HostWorldResource for &mut _T {
     }
 }
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -87,7 +87,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `http-interface`.
+/// component which implements the world `http-interface`.
 ///
 /// This structure is created through [`HttpInterfacePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `HttpInterfacePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `http-interface`.
+/// component which implements the world `http-interface`.
 ///
 /// This structure is created through [`HttpInterfacePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `HttpInterfacePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `my-world`.
+/// component which implements the world `my-world`.
 ///
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `MyWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `my-world`.
+/// component which implements the world `my-world`.
 ///
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `MyWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `wasi`.
+/// component which implements the world `wasi`.
 ///
 /// This structure is created through [`WasiPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `WasiPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `wasi`.
+/// component which implements the world `wasi`.
 ///
 /// This structure is created through [`WasiPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `WasiPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/smoke-default_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `the-world`.
+/// component which implements the world `the-world`.
 ///
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `TheWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `nope`.
+/// component which implements the world `nope`.
 ///
 /// This structure is created through [`NopePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `NopePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `nope`.
+/// component which implements the world `nope`.
 ///
 /// This structure is created through [`NopePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `NopePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `d`.
+/// component which implements the world `d`.
 ///
 /// This structure is created through [`DPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `DPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `d`.
+/// component which implements the world `d`.
 ///
 /// This structure is created through [`DPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -29,7 +29,7 @@ const _: () = {
         /// Creates a new copy of `DPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `my-world`.
+/// component which implements the world `my-world`.
 ///
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `MyWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `my-world`.
+/// component which implements the world `my-world`.
 ///
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `MyWorldPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/wat.rs
+++ b/crates/component-macro/tests/expanded/wat.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `example`.
+/// component which implements the world `example`.
 ///
 /// This structure is created through [`ExamplePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `ExamplePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/wat_async.rs
+++ b/crates/component-macro/tests/expanded/wat_async.rs
@@ -1,5 +1,5 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `example`.
+/// component which implements the world `example`.
 ///
 /// This structure is created through [`ExamplePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -33,7 +33,7 @@ const _: () = {
         /// Creates a new copy of `ExamplePre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -24,7 +24,7 @@ const _: () = {
     assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
 };
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -58,7 +58,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -24,7 +24,7 @@ const _: () = {
     assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
 };
 /// Auto-generated bindings for a pre-instantiated version of a
-/// copmonent which implements the world `foo`.
+/// component which implements the world `foo`.
 ///
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
@@ -58,7 +58,7 @@ const _: () = {
         /// Creates a new copy of `FooPre` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the compoennt behind `instance_pre`
+        /// This method may fail if the component behind `instance_pre`
         /// does not have the required exports.
         pub fn new(
             instance_pre: wasmtime::component::InstancePre<_T>,

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -528,7 +528,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
         // Now it's time to delegate to the actual builtin. Builtins are stored
         // in an array in all `VMContext`s. First load the base pointer of the
-        // array and then load the entry of the array that correspons to this
+        // array and then load the entry of the array that corresponds to this
         // builtin.
         let mem_flags = ir::MemFlags::trusted().with_readonly();
         let array_addr = builder.ins().load(

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasmtime-environ"
 version.workspace = true
 authors.workspace = true
-description = "Standalone environment support for WebAsssembly code in Cranelift"
+description = "Standalone environment support for WebAssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-environ/"

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -346,7 +346,7 @@ pub trait Compiler: Send + Sync {
     /// Get a flag indicating whether branch protection is enabled.
     fn is_branch_protection_enabled(&self) -> bool;
 
-    /// Returns a suitable compiler usable for component-related compliations.
+    /// Returns a suitable compiler usable for component-related compilations.
     ///
     /// Note that the `ComponentCompiler` trait can also be implemented for
     /// `Self` in which case this function would simply return `self`.

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -87,7 +87,7 @@ pub struct ComponentDfg {
     ///
     /// This map is not filled in on the initial creation of a `ComponentDfg`.
     /// Instead these modules are filled in by the `inline::adapt` phase where
-    /// adapter modules are identifed and filled in here.
+    /// adapter modules are identified and filled in here.
     ///
     /// The payload here is the static module index representing the core wasm
     /// adapter module that was generated as well as the arguments to the

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -164,7 +164,7 @@ pub(super) fn compile_helper(module: &mut Module<'_>, result: FunctionId, helper
                 .unwrap();
             Destination::Stack(&dst_flat, &helper.dst.opts)
         }
-        // This is the same as a memroy-based source but note that the address
+        // This is the same as a memory-based source but note that the address
         // of the destination is passed as the final parameter to the function.
         HelperLocation::Memory => {
             nlocals += 1;

--- a/crates/environ/src/gc.rs
+++ b/crates/environ/src/gc.rs
@@ -33,7 +33,7 @@ pub const NON_NULL_NON_I31_MASK: u64 = !I31_DISCRIMINANT;
 /// We say "abstract-ish" type because in addition to the abstract heap types
 /// (other than `i31`) we also have variants for `externref`s that have been
 /// converted into an `anyref` via `extern.convert_any` and `externref`s that
-/// have been convered into an `anyref` via `any.convert_extern`. Note that in
+/// have been converted into an `anyref` via `any.convert_extern`. Note that in
 /// the latter case, because `any.convert_extern $foo` produces a value that is
 /// not an instance of `eqref`, `VMGcKind::AnyOfExternRef & VMGcKind::EqRef !=
 /// VMGcKind::EqRef`.

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -15,7 +15,7 @@ pub struct CompiledFunctionInfo {
     /// The [`WasmFunctionInfo`] for this function.
     pub wasm_func_info: WasmFunctionInfo,
     /// The [`FunctionLoc`] indicating the location of this function in the text
-    /// section of the compition artifact.
+    /// section of the competition artifact.
     pub wasm_func_loc: FunctionLoc,
     /// A trampoline for array callers (e.g. `Func::new`) calling into this function (if needed).
     pub array_to_wasm_trampoline: Option<FunctionLoc>,

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -173,7 +173,7 @@ pub trait PtrSize {
         self.vmruntime_limits_last_wasm_exit_fp() + self.size()
     }
 
-    /// Return the offset of the `last_enty_sp` field of `VMRuntimeLimits`.
+    /// Return the offset of the `last_wasm_entry_sp` field of `VMRuntimeLimits`.
     fn vmruntime_limits_last_wasm_entry_sp(&self) -> u8 {
         self.vmruntime_limits_last_wasm_exit_pc() + self.size()
     }

--- a/crates/test-programs/src/bin/preview1_poll_oneoff_files.rs
+++ b/crates/test-programs/src/bin/preview1_poll_oneoff_files.rs
@@ -13,7 +13,7 @@ unsafe fn poll_oneoff_impl(r#in: &[wasi::Subscription]) -> Result<Vec<wasi::Even
     Ok(out)
 }
 
-/// Repeatedly call `poll_oneoff` until all the subcriptions in `in` have
+/// Repeatedly call `poll_oneoff` until all the subscriptions in `in` have
 /// seen their events occur.
 unsafe fn poll_oneoff_with_retry(
     r#in: &[wasi::Subscription],

--- a/crates/wasi-common/witx/preview0/typenames.witx
+++ b/crates/wasi-common/witx/preview0/typenames.witx
@@ -521,7 +521,7 @@
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
-    ;;; The type of event that occured
+    ;;; The type of event that occurred
     (field $type $eventtype)
     ;;; The contents of the event, if it is an `eventtype::fd_read` or
     ;;; `eventtype::fd_write`. `eventtype::clock` events ignore this field.

--- a/crates/wasi-common/witx/preview1/typenames.witx
+++ b/crates/wasi-common/witx/preview1/typenames.witx
@@ -525,7 +525,7 @@
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
-    ;;; The type of event that occured
+    ;;; The type of event that occurred
     (field $type $eventtype)
     ;;; The contents of the event, if it is an `eventtype::fd_read` or
     ;;; `eventtype::fd_write`. `eventtype::clock` events ignore this field.

--- a/crates/wasi-nn/examples/classification-example-winml/src/main.rs
+++ b/crates/wasi-nn/examples/classification-example-winml/src/main.rs
@@ -41,7 +41,7 @@ pub fn main() {
     let mut output_buffer = vec![0f32; 1000];
     context.get_output(0, &mut output_buffer[..]).unwrap();
 
-    // Postprocessing. Calculating the softmax probablility scores.
+    // Postprocessing. Calculating the softmax probability scores.
     let result = postprocess(output_buffer);
 
     // Load labels for classification

--- a/crates/wasi/src/poll.rs
+++ b/crates/wasi/src/poll.rs
@@ -81,7 +81,7 @@ pub trait Subscribe: Send + 'static {
     async fn ready(&mut self);
 }
 
-/// Creates a `pollable` resource which is susbcribed to the provided
+/// Creates a `pollable` resource which is subscribed to the provided
 /// `resource`.
 ///
 /// If `resource` is an owned resource then it will be deleted when the returned

--- a/crates/wasi/witx/preview0/typenames.witx
+++ b/crates/wasi/witx/preview0/typenames.witx
@@ -521,7 +521,7 @@
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
-    ;;; The type of event that occured
+    ;;; The type of event that occurred
     (field $type $eventtype)
     ;;; The contents of the event, if it is an `eventtype::fd_read` or
     ;;; `eventtype::fd_write`. `eventtype::clock` events ignore this field.

--- a/crates/wasi/witx/preview1/typenames.witx
+++ b/crates/wasi/witx/preview1/typenames.witx
@@ -525,7 +525,7 @@
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
-    ;;; The type of event that occured
+    ;;; The type of event that occurred
     (field $type $eventtype)
     ;;; The contents of the event, if it is an `eventtype::fd_read` or
     ;;; `eventtype::fd_write`. `eventtype::clock` events ignore this field.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1534,7 +1534,7 @@ impl Config {
         self
     }
 
-    /// Configure the version information used in serialized and deserialzied [`crate::Module`]s.
+    /// Configure the version information used in serialized and deserialized [`crate::Module`]s.
     /// This effects the behavior of [`crate::Module::serialize()`], as well as
     /// [`crate::Module::deserialize()`] and related functions.
     ///
@@ -2100,7 +2100,7 @@ impl fmt::Debug for Config {
 
         // Not every flag in WasmFeatures can be enabled as part of creating
         // a Config. This impl gives a complete picture of all WasmFeatures
-        // enabled, and doesn't require maintence by hand (which has become out
+        // enabled, and doesn't require maintenance by hand (which has become out
         // of date in the past), at the cost of possible confusion for why
         // a flag in this set doesn't have a Config setter.
         use bitflags::Flags;

--- a/crates/wasmtime/src/runtime/code.rs
+++ b/crates/wasmtime/src/runtime/code.rs
@@ -37,7 +37,7 @@ pub struct CodeObject {
 
 impl CodeObject {
     pub fn new(mmap: Arc<CodeMemory>, signatures: TypeCollection, types: Types) -> CodeObject {
-        // The corresopnding unregister for this is below in `Drop for
+        // The corresponding unregister for this is below in `Drop for
         // CodeObject`.
         crate::module::register_code(&mmap);
 

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -243,7 +243,7 @@ impl Component {
     /// An important point to note here is that the precise type of imports and
     /// exports of a component change when it is instantiated with respect to
     /// resources. For example a [`Component`] represents an un-instantiated
-    /// component meaning that its imported resources are represeted as abstract
+    /// component meaning that its imported resources are represented as abstract
     /// resource types. These abstract types are not equal to any other
     /// component's types.
     ///

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -152,7 +152,7 @@ where
     /// # Panics
     ///
     /// Panics if this is called on a function in an asynchronous store. This
-    /// only works with functions defined within a synchonous store. Also
+    /// only works with functions defined within a synchronous store. Also
     /// panics if `store` does not own this function.
     pub fn call(&self, store: impl AsContextMut, params: Params) -> Result<Return> {
         assert!(

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -730,7 +730,7 @@ impl<T: GcRef> Rooted<T> {
     /// Create a new `Rooted<T>` from a `GcRootIndex`.
     ///
     /// Note that `Rooted::from_gc_root_index(my_rooted.index)` is not
-    /// necessarily an identity funciton, as it allows changing the `T` type
+    /// necessarily an identity function, as it allows changing the `T` type
     /// parameter.
     ///
     /// The given index should be a LIFO index of a GC reference pointing to an

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -96,7 +96,7 @@ use syn::parse_macro_input;
 /// /// is an asynchronous method. Therefore, we use the `async_trait` proc macro
 /// /// to define this trait, so that `double_int_return_float` can be an `async fn`.
 /// /// `wiggle::async_trait` is defined as `#[async_trait::async_trait(?Send)]` -
-/// /// in wiggle, async methods do not have the Send constaint.
+/// /// in wiggle, async methods do not have the Send constraint.
 /// impl example::Example for YourCtxType {
 ///     /// The arrays module has two methods, shown here.
 ///     /// Note that the `GuestPtr` type comes from `wiggle`,

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -90,7 +90,7 @@ impl<'a> GuestMemory<'a> {
     /// Acquires a slice or owned copy of the memory pointed to by `ptr`.
     ///
     /// This method will attempt to borrow `ptr` directly from linear memory. If
-    /// memory is shared and cannot be borrowed directy then an owned copy is
+    /// memory is shared and cannot be borrowed directly then an owned copy is
     /// returned instead.
     ///
     /// # Errors

--- a/crates/wiggle/tests/typenames.witx
+++ b/crates/wiggle/tests/typenames.witx
@@ -523,7 +523,7 @@
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
-    ;;; The type of event that occured
+    ;;; The type of event that occurred
     (field $type $eventtype)
     ;;; The contents of the event, if it is an `eventtype::fd_read` or
     ;;; `eventtype::fd_write`. `eventtype::clock` events ignore this field.

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -442,7 +442,7 @@ impl Wasmtime {
                     // If this interface is remapped then that means that it was
                     // provided via the `with` key in the bindgen configuration.
                     // That means that bindings generation is skipped here. To
-                    // accomodate future bindgens depending on this bindgen
+                    // accommodate future bindgens depending on this bindgen
                     // though we still generate a module which reexports the
                     // original module. This helps maintain the same output
                     // structure regardless of whether `with` is used.
@@ -734,7 +734,7 @@ pub fn new(
             self.src,
             "
             /// Auto-generated bindings for a pre-instantiated version of a
-            /// copmonent which implements the world `{world_name}`.
+            /// component which implements the world `{world_name}`.
             ///
             /// This structure is created through [`{camel}Pre::new`] which
             /// takes a [`InstancePre`]({wt}::component::InstancePre) that
@@ -791,7 +791,7 @@ pub fn new(
                 /// Creates a new copy of `{camel}Pre` bindings which can then
                 /// be used to instantiate into a particular store.
                 ///
-                /// This method may fail if the compoennt behind `instance_pre`
+                /// This method may fail if the component behind `instance_pre`
                 /// does not have the required exports.
                 pub fn new(
                     instance_pre: {wt}::component::InstancePre<_T>,

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -309,7 +309,7 @@ impl RetArea {
         }
     }
 
-    /// Returns true if the return area is uninitiliazed.
+    /// Returns true if the return area is uninitialized.
     pub fn is_uninit(&self) -> bool {
         match self {
             Self::Uninit => true,

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -176,7 +176,7 @@ pub(crate) struct StackState {
     /// The base stack pointer offset.
     /// This offset is set when entering the block, after saving any live
     /// registers and locals.
-    /// It is calcuated by subtracting the size, in bytes, of any block params
+    /// It is calculated by subtracting the size, in bytes, of any block params
     /// to the current stack pointer offset.
     pub base_offset: SPOffset,
     /// The target stack pointer offset.

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -122,7 +122,7 @@ impl Frame {
                     )),
                     defined_locals_end,
                 ),
-                // If the resuls operand is a register, we give this register
+                // If the results operand is a register, we give this register
                 // the same treatment as all the other argument registers and
                 // spill it, therefore, we need to increase the locals size by
                 // one slot.

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1276,7 +1276,7 @@ impl Assembler {
         // emitting to binary.
         //
         // See [wasmtime::engine::Engine::check_compatible_with_shared_flag] and
-        // [wasmtime_cranelift::obj::ModuleTextBuilder::apend_func]
+        // [wasmtime_cranelift::obj::ModuleTextBuilder::append_func]
         self.emit(Inst::LoadExtName {
             dst: Writable::from_reg(dst.into()),
             name: Box::new(dest),

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -536,7 +536,7 @@ pub(crate) trait MacroAssembler {
     fn store_ptr(&mut self, src: Reg, dst: Self::Address);
 
     /// Perform a WebAssembly store.
-    /// A WebAssebly store introduces several additional invariants compared to
+    /// A WebAssembly store introduces several additional invariants compared to
     /// [Self::store], more precisely, it can implicitly trap, in certain
     /// circumstances, even if explicit bounds checks are elided, in that sense,
     /// we consider this type of load as untrusted. It can also differ with
@@ -549,7 +549,7 @@ pub(crate) trait MacroAssembler {
     fn load(&mut self, src: Self::Address, dst: Reg, size: OperandSize);
 
     /// Perform a WebAssembly load.
-    /// A WebAssebly load introduces several additional invariants compared to
+    /// A WebAssembly load introduces several additional invariants compared to
     /// [Self::load], more precisely, it can implicitly trap, in certain
     /// circumstances, even if explicit bounds checks are elided, in that sense,
     /// we consider this type of load as untrusted. It can also differ with


### PR DESCRIPTION
This reduces the number of typos within the codebase's comments and text.