### PR TITLE
Fix `clippy::doc_lazy_continuation` lints.

### DIFF
--- a/crates/slab/src/lib.rs
+++ b/crates/slab/src/lib.rs
@@ -55,13 +55,13 @@
 //! * Value `A` is allocated into the slab, yielding id `i`.
 //!
 //! * `A` is deallocated, and so `i`'s associated entry is added to the slab's
-//! free list.
+//!   free list.
 //!
 //! * Value `B` is allocated into the slab, reusing `i`'s associated entry,
-//! yielding id `i`.
+//!   yielding id `i`.
 //!
 //! * The "original" id `i` is used to access the arena, expecting the
-//! deallocated value `A`, but getting the new value `B`.
+//!   deallocated value `A`, but getting the new value `B`.
 //!
 //! That is, it does not detect and prevent against the memory-safe version of
 //! use-after-free bugs.

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -27,8 +27,8 @@ use syn::parse_macro_input;
 ///       and return `Result<($return_types),$error_type>`
 ///
 ///     * When the `wiggle` crate is built with the `wasmtime_integration`
-///     feature, each module contains an `add_to_linker` function to add it to
-///     a `wasmtime::Linker`.
+///       feature, each module contains an `add_to_linker` function to add it to
+///       a `wasmtime::Linker`.
 ///
 /// Arguments are provided using Rust struct value syntax.
 ///


### PR DESCRIPTION
These make it easier to read ordered and unordered lists by having more consistent indentation.
