### PR TITLE
Inherit lints in a few more crates

### DIFF
--- a/crates/slab/Cargo.toml
+++ b/crates/slab/Cargo.toml
@@ -7,6 +7,7 @@ name = "wasmtime-slab"
 repository = "https://github.com/bytecodealliance/wasmtime"
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -9,6 +9,9 @@ categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 test = false

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;


### PR DESCRIPTION
It's intended that all crates in this workspace have uniform lints, so add inheritance to a few forgotten crates.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
