### PR TITLE
Update the docs for building the C API

### DIFF
--- a/crates/c-api/README.md
+++ b/crates/c-api/README.md
@@ -1,7 +1,9 @@
 # Wasmtime's C API
 
-For more information you can find the documentation for this library
-[online](https://bytecodealliance.github.io/wasmtime/c-api/).
+## API Documentation
+
+[The API documentation for the Wasmtime C library is hosted
+here.](https://bytecodealliance.github.io/wasmtime/c-api/).
 
 ## Using in a C Project
 
@@ -21,29 +23,20 @@ toolchain](https://www.rust-lang.org/tools/install) installed.
 From the root of the Wasmtime repository, run the following commands:
 
 ```
-$ cmake -S crates/c-api -B target/c-api
+$ cmake -S crates/c-api -B target/c-api --install-prefix "$(pwd)/artifacts"
 $ cmake --build target/c-api
+$ cmake --install target/c-api
 ```
 
 These commands will produce the following files:
 
-* `target/<triple>/release/libwasmtime.{a,lib}`: Static Wasmtime library. Exact
-  extension depends on your operating system. `<triple>` is your platform's
-  target triple, such as `x86_64-unknown-linux-gnu`.
+* `artifacts/lib/libwasmtime.{a,lib}`: Static Wasmtime library. Exact extension
+  depends on your operating system.
 
-* `target/<triple>/release/libwasmtime.{so,dylib,dll}`: Dynamic Wasmtime
-  library. Exact extension depends on your operating system.  `<triple>` is your
-  platform's target triple, such as `x86_64-unknown-linux-gnu`.
+* `artifacts/lib/libwasmtime.{so,dylib,dll}`: Dynamic Wasmtime library. Exact
+  extension depends on your operating system.
 
-* `target/c-api/include/wasmtime/conf.h`: A header file that tells the main
-  Wasmtime header which optional features were compiled into these libraries.
-
-* `crates/c-api/html/index.html`: Doxygen documentation for the Wasmtime C API.
-
-Other header files you will want:
-
-* `crates/c-api/include/wasmtime.h`
-* `crates/c-api/include/wasmtime/*.h`
+* `artifacts/include/**.h`: Header files for working with Wasmtime.
 
 ## Using in a Rust Project
 

--- a/crates/c-api/README.md
+++ b/crates/c-api/README.md
@@ -5,13 +5,45 @@ For more information you can find the documentation for this library
 
 ## Using in a C Project
 
-To use Wasmtime from a C or C++ project, you can use Cargo to build the Wasmtime C bindings. From the root of the Wasmtime repository, run the following command:
+### Using a Pre-Built Static or Dynamic Library
+
+Each release on Wasmtime's [GitHub Releases
+page](https://github.com/bytecodealliance/wasmtime/releases) has pre-built
+binaries for both static and dynamic libraries for a variety of architectures
+and operating systems attached, as well as header files you can include.
+
+### Building Wasmtime's C API from Source
+
+To use Wasmtime from a C or C++ project, you must have
+[CMake](https://cmake.org/) and [a Rust
+toolchain](https://www.rust-lang.org/tools/install) installed.
+
+From the root of the Wasmtime repository, run the following commands:
 
 ```
-cargo build --release -p wasmtime-c-api
+$ cmake -S crates/c-api -B target/c-api
+$ cmake --build target/c-api
 ```
 
-This will create static and dynamic libraries called `libwasmtime` in the `target/release` directory.
+These commands will produce the following files:
+
+* `target/<triple>/release/libwasmtime.{a,lib}`: Static Wasmtime library. Exact
+  extension depends on your operating system. `<triple>` is your platform's
+  target triple, such as `x86_64-unknown-linux-gnu`.
+
+* `target/<triple>/release/libwasmtime.{so,dylib,dll}`: Dynamic Wasmtime
+  library. Exact extension depends on your operating system.  `<triple>` is your
+  platform's target triple, such as `x86_64-unknown-linux-gnu`.
+
+* `target/c-api/include/wasmtime/conf.h`: A header file that tells the main
+  Wasmtime header which optional features were compiled into these libraries.
+
+* `crates/c-api/html/index.html`: Doxygen documentation for the Wasmtime C API.
+
+Other header files you will want:
+
+* `crates/c-api/include/wasmtime.h`
+* `crates/c-api/include/wasmtime/*.h`
 
 ## Using in a Rust Project
 

--- a/docs/contributing-building.md
+++ b/docs/contributing-building.md
@@ -54,16 +54,9 @@ with `cargo run`.
 
 ## Building the Wasmtime C API
 
-To build the C API of Wasmtime you can run:
-
-```shell
-cargo build --release -p wasmtime-c-api
-```
-
-This will place the shared library inside of `target/release`. On Linux it will
-be called `libwasmtime.{a,so}`, on macOS it will be called
-`libwasmtime.{a,dylib}`, and on Windows it will be called
-`wasmtime.{lib,dll,dll.lib}`.
+See
+[`crates/c-api/README.md`](https://github.com/bytecodealliance/wasmtime/blob/main/crates/c-api/README.md)
+for details.
 
 ## Building Other Wasmtime Crates
 


### PR DESCRIPTION
Suggest `cmake` since that is what we test in CI and keep working.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
