### PR TITLE
Add support for `wasmtime run --argv0 NAME ...`

### DIFF
--- a/crates/test-programs/src/bin/cli_argv0.rs
+++ b/crates/test-programs/src/bin/cli_argv0.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let mut args = std::env::args();
+    assert_eq!(args.next(), args.next());
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -54,6 +54,15 @@ pub struct RunCommand {
     )]
     pub preloads: Vec<(String, PathBuf)>,
 
+    /// Override the value of `argv[0]`, typically the name of the executable of
+    /// the application being run.
+    ///
+    /// This can be useful to pass in situations where a CLI tool is being
+    /// executed that dispatches its functionality on the value of `argv[0]`
+    /// without needing to rename the original wasm binary.
+    #[arg(long)]
+    pub argv0: Option<String>,
+
     /// The WebAssembly module to run and arguments to pass to it.
     ///
     /// Arguments passed to the wasm module will be configured as WASI CLI
@@ -233,7 +242,10 @@ impl RunCommand {
             // For argv[0], which is the program name. Only include the base
             // name of the main wasm module, to avoid leaking path information.
             let arg = if i == 0 {
-                Path::new(arg).components().next_back().unwrap().as_os_str()
+                match &self.argv0 {
+                    Some(s) => s.as_ref(),
+                    None => Path::new(arg).components().next_back().unwrap().as_os_str(),
+                }
             } else {
                 arg.as_ref()
             };

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1845,6 +1845,14 @@ stderr [1] :: after empty
 
         Ok(())
     }
+
+    #[test]
+    fn cli_argv0() -> Result<()> {
+        run_wasmtime(&["run", "--argv0=a", CLI_ARGV0, "a"])?;
+        run_wasmtime(&["run", "--argv0=b", CLI_ARGV0_COMPONENT, "b"])?;
+        run_wasmtime(&["run", "--argv0=foo.wasm", CLI_ARGV0, "foo.wasm"])?;
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
This commit adds support for a new `--argv0` flag to the `wasmtime run` CLI (and only `wasmtime run`, not other subcommands). This flag is used to override the inferred value of the first argument which is sometimes used to dispatch on various pieces of functionality. This enables avoiding the need to copy around wasm files.

Closes #8955

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
