### PR TITLE
Clear stack map data structures upon `FunctionBuilderContext` reuse

### DIFF
--- a/cranelift/codegen/src/traversals.rs
+++ b/cranelift/codegen/src/traversals.rs
@@ -52,8 +52,7 @@ impl Dfs {
     /// This iterator can be used to perform either pre- or post-order
     /// traversals, or a combination of the two.
     pub fn iter<'a>(&'a mut self, func: &'a ir::Function) -> DfsIter<'a> {
-        self.seen.clear();
-        self.stack.clear();
+        self.clear();
         if let Some(e) = func.layout.entry_block() {
             self.stack.push((Event::Enter, e));
         }
@@ -72,6 +71,13 @@ impl Dfs {
     /// Yields `ir::Block` items.
     pub fn post_order_iter<'a>(&'a mut self, func: &'a ir::Function) -> DfsPostOrderIter<'a> {
         DfsPostOrderIter(self.iter(func))
+    }
+
+    /// Clear this DFS, but keep its allocations for future reuse.
+    pub fn clear(&mut self) {
+        let Dfs { stack, seen } = self;
+        stack.clear();
+        seen.clear();
     }
 }
 

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -66,9 +66,20 @@ impl FunctionBuilderContext {
     }
 
     fn clear(&mut self) {
-        self.ssa.clear();
-        self.status.clear();
-        self.types.clear();
+        let FunctionBuilderContext {
+            ssa,
+            status,
+            types,
+            stack_map_vars,
+            stack_map_values,
+            dfs,
+        } = self;
+        ssa.clear();
+        status.clear();
+        types.clear();
+        stack_map_values.clear();
+        stack_map_vars.clear();
+        dfs.clear();
     }
 
     fn is_empty(&self) -> bool {


### PR DESCRIPTION
We were previously failing to clear `self.stack_map_vars` and `self.stack_map_values`. Clearing `self.dfs` is not strictly necessary, since calling `self.dfs.iter()` internally clears its internal data before iteration begins, but its nice to tidy up anyways. Additionally, match on all the fields of `self` so that if we add more, we get compiler errors to remind us to clear the new fields as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
