### PR TITLE
CLIF in explorer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ wasmparser = { workspace = true }
 tracing = { workspace = true }
 log = { workspace = true }
 humantime = { workspace = true }
+tempfile = { workspace = true }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ wasmparser = { workspace = true }
 tracing = { workspace = true }
 log = { workspace = true }
 humantime = { workspace = true }
-tempfile = { workspace = true }
+tempfile = { workspace = true, optional = true }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }
@@ -418,7 +418,7 @@ gc = ["wasmtime-cli-flags/gc"]
 # CLI subcommands for the `wasmtime` executable. See `wasmtime $cmd --help`
 # for more information on each subcommand.
 serve = ["wasi-http", "component-model", "dep:http-body-util", "dep:http"]
-explore = ["dep:wasmtime-explorer"]
+explore = ["dep:wasmtime-explorer", "dep:tempfile"]
 wast = ["dep:wasmtime-wast"]
 config = ["cache"]
 compile = ["cranelift"]

--- a/crates/explorer/src/index.css
+++ b/crates/explorer/src/index.css
@@ -15,13 +15,19 @@ body {
 }
 
 #wat {
-  width: 50%;
+  width: 33%;
+  height: 100%;
+  overflow: scroll;
+}
+
+#clif {
+  width: 33%;
   height: 100%;
   overflow: scroll;
 }
 
 #asm {
-  width: 50%;
+  width: 33%;
   height: 100%;
   overflow: scroll;
 }

--- a/crates/explorer/src/index.css
+++ b/crates/explorer/src/index.css
@@ -15,19 +15,19 @@ body {
 }
 
 #wat {
-  width: 33%;
+  flex: 1;
   height: 100%;
   overflow: scroll;
 }
 
 #clif {
-  width: 33%;
+  flex: 1;
   height: 100%;
   overflow: scroll;
 }
 
 #asm {
-  width: 33%;
+  flex: 1;
   height: 100%;
   overflow: scroll;
 }

--- a/crates/explorer/src/index.js
+++ b/crates/explorer/src/index.js
@@ -157,33 +157,35 @@ asmElem.addEventListener(
   { passive: true },
 );
 const clifElem = document.getElementById("clif");
-clifElem.addEventListener(
-  "click",
-  event => {
-    if (event.target.dataset.wasmOffset == null) {
-      return;
-    }
+if (clifElem) {
+  clifElem.addEventListener(
+    "click",
+    event => {
+      if (event.target.dataset.wasmOffset == null) {
+        return;
+      }
 
-    const offset = parseInt(event.target.dataset.wasmOffset);
-    if (!watByOffset.get(offset)) {
-      return;
-    }
+      const offset = parseInt(event.target.dataset.wasmOffset);
+      if (!watByOffset.get(offset)) {
+        return;
+      }
 
-    const firstWatElem = watByOffset.get(offset)[0];
-    firstWatElem.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-      inline: "nearest",
-    });
-    const firstAsmElem = asmByOffset.get(offset)[0];
-    firstAsmElem.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-      inline: "nearest",
-    });
-  },
-  { passive: true },
-);
+      const firstWatElem = watByOffset.get(offset)[0];
+      firstWatElem.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+        inline: "nearest",
+      });
+      const firstAsmElem = asmByOffset.get(offset)[0];
+      firstAsmElem.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+        inline: "nearest",
+      });
+    },
+    { passive: true },
+  );
+}
 
 const onMouseEnter = event => {
   if (event.target.dataset.wasmOffset == null) {
@@ -242,35 +244,37 @@ const renderInst = (mnemonic, operands) => {
 
 // Render the CLIF.
 
-for (const func of state.clif.functions) {
-  const funcElem = document.createElement("div");
+if (clifElem) {
+  for (const func of state.clif.functions) {
+    const funcElem = document.createElement("div");
 
-  const funcHeader = document.createElement("h3");
-  let func_name =
-    func.name === null ? `function[${func.func_index}]` : func.name;
-  let demangled_name =
-    func.demangled_name !== null ? func.demangled_name : func_name;
-  funcHeader.textContent = `Intermediate Representation of function <${demangled_name}>:`;
-  funcHeader.title = `Function ${func.func_index}: ${func_name}`;
-  funcElem.appendChild(funcHeader);
+    const funcHeader = document.createElement("h3");
+    let func_name =
+      func.name === null ? `function[${func.func_index}]` : func.name;
+    let demangled_name =
+      func.demangled_name !== null ? func.demangled_name : func_name;
+    funcHeader.textContent = `Intermediate Representation of function <${demangled_name}>:`;
+    funcHeader.title = `Function ${func.func_index}: ${func_name}`;
+    funcElem.appendChild(funcHeader);
 
-  const bodyElem = document.createElement("pre");
-  for (const inst of func.instructions) {
-    const instElem = document.createElement("span");
-    instElem.textContent = `${inst.clif}\n`;
-    if (inst.wasm_offset != null) {
-      instElem.setAttribute("data-wasm-offset", inst.wasm_offset);
-      const hue = hueForOffset(inst.wasm_offset);
-      instElem.style.backgroundColor = `hsl(${hue} 50% 90%)`;
-      instElem.addEventListener("mouseenter", onMouseEnter);
-      instElem.addEventListener("mouseleave", onMouseLeave);
-      addClifElem(inst.wasm_offset, instElem);
+    const bodyElem = document.createElement("pre");
+    for (const inst of func.instructions) {
+      const instElem = document.createElement("span");
+      instElem.textContent = `${inst.clif}\n`;
+      if (inst.wasm_offset != null) {
+        instElem.setAttribute("data-wasm-offset", inst.wasm_offset);
+        const hue = hueForOffset(inst.wasm_offset);
+        instElem.style.backgroundColor = `hsl(${hue} 50% 90%)`;
+        instElem.addEventListener("mouseenter", onMouseEnter);
+        instElem.addEventListener("mouseleave", onMouseLeave);
+        addClifElem(inst.wasm_offset, instElem);
+      }
+      bodyElem.appendChild(instElem);
     }
-    bodyElem.appendChild(instElem);
-  }
-  funcElem.appendChild(bodyElem);
+    funcElem.appendChild(bodyElem);
 
-  clifElem.appendChild(funcElem);
+    clifElem.appendChild(funcElem);
+  }
 }
 
 // Render the ASM.

--- a/crates/explorer/src/index.js
+++ b/crates/explorer/src/index.js
@@ -55,6 +55,9 @@ const watByOffset = new Map();
 // Get asm instruction elements by Wasm offset.
 const asmByOffset = new Map();
 
+// Get clif instruction elements by Wasm offset.
+const clifByOffset = new Map();
+
 // Get all (WAT chunk or asm instruction) elements by offset.
 const anyByOffset = new Map();
 
@@ -82,6 +85,18 @@ const addAsmElem = (offset, elem) => {
   anyByOffset.get(offset).push(elem);
 };
 
+const addClifElem = (offset, elem) => {
+  if (!clifByOffset.has(offset)) {
+    clifByOffset.set(offset, []);
+  }
+  clifByOffset.get(offset).push(elem);
+
+  if (!anyByOffset.has(offset)) {
+    anyByOffset.set(offset, []);
+  }
+  anyByOffset.get(offset).push(elem);
+};
+
 /*** Event Handlers ************************************************************/
 
 const watElem = document.getElementById("wat");
@@ -97,6 +112,12 @@ watElem.addEventListener(
       return;
     }
 
+    const firstClifElem = clifByOffset.get(offset)[0];
+    firstClifElem.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
     const firstAsmElem = asmByOffset.get(offset)[0];
     firstAsmElem.scrollIntoView({
       behavior: "smooth",
@@ -126,6 +147,12 @@ asmElem.addEventListener(
       block: "center",
       inline: "nearest",
     });
+    const firstClifElem = clifByOffset.get(offset)[0];
+    firstClifElem.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
   },
   { passive: true },
 );
@@ -144,6 +171,12 @@ clifElem.addEventListener(
 
     const firstWatElem = watByOffset.get(offset)[0];
     firstWatElem.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
+    const firstAsmElem = asmByOffset.get(offset)[0];
+    firstAsmElem.scrollIntoView({
       behavior: "smooth",
       block: "center",
       inline: "nearest",
@@ -231,7 +264,7 @@ for (const func of state.clif.functions) {
       instElem.style.backgroundColor = `hsl(${hue} 50% 90%)`;
       instElem.addEventListener("mouseenter", onMouseEnter);
       instElem.addEventListener("mouseleave", onMouseLeave);
-      addAsmElem(inst.wasm_offset, instElem);
+      addClifElem(inst.wasm_offset, instElem);
     }
     bodyElem.appendChild(instElem);
   }

--- a/crates/explorer/src/index.js
+++ b/crates/explorer/src/index.js
@@ -217,8 +217,7 @@ for (const func of state.clif.functions) {
     func.name === null ? `function[${func.func_index}]` : func.name;
   let demangled_name =
     func.demangled_name !== null ? func.demangled_name : func_name;
-  funcHeader.textContent =
-    `Intermediate Representation of function <${demangled_name}>:`;
+  funcHeader.textContent = `Intermediate Representation of function <${demangled_name}>:`;
   funcHeader.title = `Function ${func.func_index}: ${func_name}`;
   funcElem.appendChild(funcHeader);
 

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -1,12 +1,18 @@
 use anyhow::Result;
 use capstone::arch::BuildsCapstone;
 use serde_derive::Serialize;
-use std::{io::Write, str::FromStr};
+use std::{
+    fs::File,
+    io::{read_to_string, Write},
+    path::Path,
+    str::FromStr,
+};
 use wasmtime_environ::demangle_function_name;
 
 pub fn generate(
     config: &wasmtime::Config,
     target: Option<&str>,
+    clif_dir: Option<&Path>,
     wasm: &[u8],
     dest: &mut dyn Write,
 ) -> Result<()> {
@@ -19,6 +25,8 @@ pub fn generate(
     let wat_json = serde_json::to_string(&wat)?;
     let asm = annotate_asm(config, &target, wasm)?;
     let asm_json = serde_json::to_string(&asm)?;
+    let clif = annotate_clif(clif_dir, &asm)?;
+    let clif_json = serde_json::to_string(&clif)?;
 
     let index_css = include_str!("./index.css");
     let index_js = include_str!("./index.js");
@@ -36,9 +44,11 @@ pub fn generate(
   </head>
   <body class="hbox">
     <pre id="wat"></pre>
+    <div id="clif"></div>
     <div id="asm"></div>
     <script>
       window.WAT = {wat_json};
+      window.CLIF = {clif_json};
       window.ASM = {asm_json};
     </script>
     <script>
@@ -207,4 +217,63 @@ fn annotate_asm(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(AnnotatedAsm { functions })
+}
+
+#[derive(Serialize, Debug)]
+struct AnnotatedClif {
+    functions: Vec<AnnotatedClifFunction>,
+}
+
+#[derive(Serialize, Debug)]
+struct AnnotatedClifFunction {
+    func_index: u32,
+    name: Option<String>,
+    demangled_name: Option<String>,
+    instructions: Vec<AnnotatedClifInstruction>,
+}
+
+#[derive(Serialize, Debug)]
+struct AnnotatedClifInstruction {
+    wasm_offset: Option<WasmOffset>,
+    clif: String,
+}
+
+fn annotate_clif(clif_dir: Option<&Path>, asm: &AnnotatedAsm) -> Result<AnnotatedClif> {
+    let mut clif = AnnotatedClif {
+        functions: Vec::new(),
+    };
+    let Some(clif_dir) = clif_dir else {
+        return Ok(clif);
+    };
+    for function in &asm.functions {
+        let function_path = clif_dir.join(format!("wasm_func_{}.clif", function.func_index));
+        if !function_path.exists() {
+            continue;
+        }
+        let mut clif_function = AnnotatedClifFunction {
+            func_index: function.func_index,
+            name: function.name.clone(),
+            demangled_name: function.demangled_name.clone(),
+            instructions: Vec::new(),
+        };
+        let file = File::open(&function_path)?;
+        for mut line in read_to_string(file)?.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let mut wasm_offset = None;
+            if line.starts_with('@') {
+                wasm_offset = Some(WasmOffset(u32::from_str_radix(&line[1..5], 16)?));
+                line = &line[28..];
+            } else if line.starts_with("     ") {
+                line = &line[28..];
+            }
+            clif_function.instructions.push(AnnotatedClifInstruction {
+                wasm_offset,
+                clif: line.to_string(),
+            });
+        }
+        clif.functions.push(clif_function);
+    }
+    Ok(clif)
 }

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -12,7 +12,7 @@ use wasmtime_environ::demangle_function_name;
 pub fn generate(
     config: &wasmtime::Config,
     target: Option<&str>,
-    clif_dir: Option<&Path>,
+    clif_dir: &Path,
     wasm: &[u8],
     dest: &mut dyn Write,
 ) -> Result<()> {
@@ -238,12 +238,9 @@ struct AnnotatedClifInstruction {
     clif: String,
 }
 
-fn annotate_clif(clif_dir: Option<&Path>, asm: &AnnotatedAsm) -> Result<AnnotatedClif> {
+fn annotate_clif(clif_dir: &Path, asm: &AnnotatedAsm) -> Result<AnnotatedClif> {
     let mut clif = AnnotatedClif {
         functions: Vec::new(),
-    };
-    let Some(clif_dir) = clif_dir else {
-        return Ok(clif);
     };
     for function in &asm.functions {
         let function_path = clif_dir.join(format!("wasm_func_{}.clif", function.func_index));

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -1,6 +1,6 @@
 //! The module that implements the `wasmtime explore` command.
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use std::{
     borrow::Cow,
@@ -61,7 +61,9 @@ impl ExploreCommand {
                 let clif_dir = output_dir.join("clif");
                 if let Err(err) = create_dir(&clif_dir) {
                     match err.kind() {
-                        io::ErrorKind::AlreadyExists => {}
+                        io::ErrorKind::AlreadyExists => {
+                            return Err(anyhow!("clif directory exists"));
+                        }
                         _ => return Err(err.into()),
                     }
                 }


### PR DESCRIPTION
As discussed in #8626, I added a new pane to the explorer to see the CLIF emitted. 

It creates a temporary directory next to the html file, and discards it when it's done. 

Feel free to criticize as it is my first contribution on this project 🙂

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
