### PR TITLE
wasmtime-wasi-http: provide Debug impls in all pub types

### DIFF
--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -23,6 +23,7 @@ pub type HyperIncomingBody = BoxBody<Bytes, types::ErrorCode>;
 pub type HyperOutgoingBody = BoxBody<Bytes, types::ErrorCode>;
 
 /// The concrete type behind a `was:http/types/incoming-body` resource.
+#[derive(Debug)]
 pub struct HostIncomingBody {
     body: IncomingBodyState,
     /// An optional worker task to keep alive while this body is being read.
@@ -72,6 +73,7 @@ impl HostIncomingBody {
 }
 
 /// Internal state of a [`HostIncomingBody`].
+#[derive(Debug)]
 enum IncomingBodyState {
     /// The body is stored here meaning that within `HostIncomingBody` the
     /// `take_stream` method can be called for example.
@@ -84,6 +86,7 @@ enum IncomingBodyState {
 }
 
 /// Small wrapper around [`HyperIncomingBody`] which adds a timeout to every frame.
+#[derive(Debug)]
 struct BodyWithTimeout {
     /// Underlying stream that frames are coming from.
     inner: HyperIncomingBody,
@@ -146,6 +149,7 @@ impl Body for BodyWithTimeout {
 
 /// Message sent when a `HostIncomingBodyStream` is done to the
 /// `HostFutureTrailers` state.
+#[derive(Debug)]
 enum StreamEnd {
     /// The body wasn't completely read and was dropped early. May still have
     /// trailers, but requires reading more frames.
@@ -158,6 +162,7 @@ enum StreamEnd {
 
 /// The concrete type behind the `wasi:io/streams/input-stream` resource returned
 /// by `wasi:http/types/incoming-body`'s `stream` method.
+#[derive(Debug)]
 pub struct HostIncomingBodyStream {
     state: IncomingBodyStreamState,
     buffer: Bytes,
@@ -209,6 +214,7 @@ impl HostIncomingBodyStream {
     }
 }
 
+#[derive(Debug)]
 enum IncomingBodyStreamState {
     /// The body is currently open for reading and present here.
     ///
@@ -293,6 +299,7 @@ impl Drop for HostIncomingBodyStream {
 }
 
 /// The concrete type behind a `wasi:http/types/future-trailers` resource.
+#[derive(Debug)]
 pub enum HostFutureTrailers {
     /// Trailers aren't here yet.
     ///
@@ -378,7 +385,7 @@ impl Subscribe for HostFutureTrailers {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct WrittenState {
     expected: u64,
     written: Arc<std::sync::atomic::AtomicU64>,
@@ -540,6 +547,7 @@ impl HostOutgoingBody {
 }
 
 /// Message sent to end the `[HostOutgoingBody]` stream.
+#[derive(Debug)]
 enum FinishMessage {
     Finished,
     Trailers(hyper::HeaderMap),
@@ -566,6 +574,7 @@ impl StreamContext {
 }
 
 /// Provides a [`HostOutputStream`] impl from a [`tokio::sync::mpsc::Sender`].
+#[derive(Debug)]
 struct BodyWriteStream {
     context: StreamContext,
     writer: mpsc::Sender<Bytes>,

--- a/crates/wasi-http/src/io.rs
+++ b/crates/wasi-http/src/io.rs
@@ -8,6 +8,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 /// A type that wraps any type implementing [`tokio::io::AsyncRead`] and [`tokio::io::AsyncWrite`]
 /// and itself implements [`hyper::rt::Read`] and [`hyper::rt::Write`].
+#[derive(Debug)]
 pub struct TokioIo<T> {
     inner: T,
 }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -21,6 +21,7 @@ use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi::{runtime::AbortOnDropJoinHandle, Subscribe};
 
 /// Capture the state necessary for use in the wasi-http API implementation.
+#[derive(Debug)]
 pub struct WasiHttpCtx {
     _priv: (),
 }
@@ -486,6 +487,7 @@ impl TryInto<http::Method> for types::Method {
 }
 
 /// The concrete type behind a `wasi:http/types/incoming-request` resource.
+#[derive(Debug)]
 pub struct HostIncomingRequest {
     pub(crate) parts: http::request::Parts,
     pub(crate) scheme: Scheme,
@@ -561,6 +563,7 @@ impl TryFrom<HostOutgoingResponse> for hyper::Response<HyperOutgoingBody> {
 }
 
 /// The concrete type behind a `wasi:http/types/outgoing-request` resource.
+#[derive(Debug)]
 pub struct HostOutgoingRequest {
     /// The method of the request.
     pub method: Method,
@@ -577,7 +580,7 @@ pub struct HostOutgoingRequest {
 }
 
 /// The concrete type behind a `wasi:http/types/request-options` resource.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct HostRequestOptions {
     /// How long to wait for a connection to be established.
     pub connect_timeout: Option<std::time::Duration>,
@@ -588,6 +591,7 @@ pub struct HostRequestOptions {
 }
 
 /// The concrete type behind a `wasi:http/types/incoming-response` resource.
+#[derive(Debug)]
 pub struct HostIncomingResponse {
     /// The response status
     pub status: u16,
@@ -598,6 +602,7 @@ pub struct HostIncomingResponse {
 }
 
 /// The concrete type behind a `wasi:http/types/fields` resource.
+#[derive(Debug)]
 pub enum HostFields {
     /// A reference to the fields of a parent entry.
     Ref {
@@ -626,6 +631,7 @@ pub type FutureIncomingResponseHandle =
     AbortOnDropJoinHandle<anyhow::Result<Result<IncomingResponse, types::ErrorCode>>>;
 
 /// A response that is in the process of being received.
+#[derive(Debug)]
 pub struct IncomingResponse {
     /// The response itself.
     pub resp: hyper::Response<HyperIncomingBody>,
@@ -636,6 +642,7 @@ pub struct IncomingResponse {
 }
 
 /// The concrete type behind a `wasi:http/types/future-incoming-response` resource.
+#[derive(Debug)]
 pub enum HostFutureIncomingResponse {
     /// A pending response
     Pending(FutureIncomingResponseHandle),

--- a/crates/wasi/src/runtime.rs
+++ b/crates/wasi/src/runtime.rs
@@ -37,6 +37,7 @@ pub(crate) static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> =
 ///
 /// This behavior makes it easier to tie a worker task to the lifetime of a Resource
 /// by keeping this handle owned by the Resource.
+#[derive(Debug)]
 pub struct AbortOnDropJoinHandle<T>(tokio::task::JoinHandle<T>);
 impl<T> Drop for AbortOnDropJoinHandle<T> {
     fn drop(&mut self) {


### PR DESCRIPTION
In another project I was using tracing::instrument on functions that took some of these types, and it didn't seem like there was any good reason not to provide Debug impls.

Added one for wasmtime-wasi AbortOnDropJoinHandle as well, since it was used in some of these public types.