### PR TITLE
Refactor `Ieee{16,32,64,128}`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -3577,7 +3577,7 @@ pub(crate) fn emit(
                 let output_bits = dst_size.to_bits();
                 match *src_size {
                     OperandSize::Size32 => {
-                        let cst = Ieee32::pow2(output_bits - 1).neg().bits();
+                        let cst = (-Ieee32::pow2(output_bits - 1)).bits();
                         let inst = Inst::imm(OperandSize::Size32, cst as u64, tmp_gpr);
                         inst.emit(sink, info, state);
                     }
@@ -3588,7 +3588,7 @@ pub(crate) fn emit(
                             no_overflow_cc = CC::NBE; // >
                             Ieee64::fcvt_to_sint_negative_overflow(output_bits)
                         } else {
-                            Ieee64::pow2(output_bits - 1).neg()
+                            -Ieee64::pow2(output_bits - 1)
                         };
                         let inst = Inst::imm(OperandSize::Size64, cst.bits(), tmp_gpr);
                         inst.emit(sink, info, state);

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -1007,7 +1007,7 @@ macro_rules! isle_common_prelude_methods {
         }
 
         fn f32_neg(&mut self, n: Ieee32) -> Ieee32 {
-            n.neg()
+            -n
         }
 
         fn f32_abs(&mut self, n: Ieee32) -> Ieee32 {
@@ -1075,7 +1075,7 @@ macro_rules! isle_common_prelude_methods {
         }
 
         fn f64_neg(&mut self, n: Ieee64) -> Ieee64 {
-            n.neg()
+            -n
         }
 
         fn f64_abs(&mut self, n: Ieee64) -> Ieee64 {

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1929,7 +1929,7 @@ mod tests {
         // Build instruction "f64const 0.0" (missing one required result)
         let inst = func.dfg.make_inst(InstructionData::UnaryIeee64 {
             opcode: Opcode::F64const,
-            imm: 0.into(),
+            imm: 0.0.into(),
         });
         func.layout.append_inst(inst, block0);
 

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -4,6 +4,7 @@
 #![allow(trivial_numeric_casts)]
 
 use core::fmt::{self, Display, Formatter};
+use core::ops::Neg;
 use cranelift_codegen::data_value::{DataValue, DataValueCastFailure};
 use cranelift_codegen::ir::immediates::{Ieee128, Ieee16, Ieee32, Ieee64};
 use cranelift_codegen::ir::{types, Type};


### PR DESCRIPTION
Deduplicate the `Ieee{16,32,64,128}` implementations using a macro.

The only methods/trait impls removed are:

- The inherent `neg()` method on `Ieee32` and `Ieee64`: This was redundant to the `Neg` trait implementation (whose method is also called `neg`). Anywhere that want to call `x.neg()` instead of `-x` can still do so by `use`ing `core::ops::Neg`.
- `impl From<u64> for Ieee64`: This only existed for `Ieee64`, was redundant to `Ieee64::with_bits`, and was only used in one place in a test. Using either `Ieee64::with_bits` or the `From<f64> for Ieee64` impl as required is much clearer about intent.