### PR TITLE
Run `cargo publish --dry-run` instead of `cargo package`

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -507,7 +507,7 @@ fn verify(crates: &[Crate]) {
         cmd.arg("publish")
             .arg("--manifest-path")
             .arg(&krate.manifest)
-            .arg("--dry-run");
+            .arg("--dry-run")
             .env("CARGO_TARGET_DIR", "./target");
         if krate.name.contains("wasi-nn") {
             cmd.arg("--no-verify");

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -504,9 +504,10 @@ fn verify(crates: &[Crate]) {
 
     fn verify_and_vendor(krate: &Crate) {
         let mut cmd = Command::new("cargo");
-        cmd.arg("package")
+        cmd.arg("publish")
             .arg("--manifest-path")
             .arg(&krate.manifest)
+            .arg("--dry-run");
             .env("CARGO_TARGET_DIR", "./target");
         if krate.name.contains("wasi-nn") {
             cmd.arg("--no-verify");


### PR DESCRIPTION
This commit updates the `./scripts/publish.rs` script used on CI to manage this workspace to run `cargo publish --dry-run`. That seems to have a few more checks than `cargo package` and would have caught one failure condition from #8987. The missing categories failure condition can't be caught by Cargo right now without actually publishing, so that'll have to be left for a future fix on a future day.

Closes #8987

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
