### PR TITLE
cranelift-control: support no_std compilation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -431,11 +431,8 @@ jobs:
     # Checks for no_std support, ensure that crates can build on a no_std
     # target
     - run: rustup target add x86_64-unknown-none
-    - run: |
-        cargo check -p wasmtime --no-default-features --features runtime,gc,component-model
-        cargo check -p cranelift-control --no-default-features
-      env:
-        CARGO_BUILD_TARGET: x86_64-unknown-none
+    - run: cargo check --target x86_64-unknown-none -p wasmtime --no-default-features --features runtime,gc,component-model
+    - run: cargo check --target x86_64-unknown-none -p cranelift-control --no-default-features
 
     # Check that wasmtime compiles with panic=abort since there's some `#[cfg]`
     # for specifically panic=abort there.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -431,7 +431,9 @@ jobs:
     # Checks for no_std support, ensure that crates can build on a no_std
     # target
     - run: rustup target add x86_64-unknown-none
-    - run: cargo check -p wasmtime --no-default-features --features runtime,gc,component-model
+    - run: |
+        cargo check -p wasmtime --no-default-features --features runtime,gc,component-model
+        cargo check -p cranelift-control --no-default-features
       env:
         CARGO_BUILD_TARGET: x86_64-unknown-none
 

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -10,11 +10,15 @@ keywords = ["fuzz", "test"]
 edition.workspace = true
 
 [dependencies]
-arbitrary = { workspace = true }
+arbitrary = { workspace = true, optional = true }
 
 [features]
+default = ["fuzz"]
+
+# Enable fuzzing support with `arbitrary`. Does not work on `no_std` targets.
+fuzz = ["dep:arbitrary"]
 
 # Turn on chaos mode.
 # Without this feature, a zero-sized dummy will be compiled
 # for the control plane.
-chaos = []
+chaos = ["fuzz"]

--- a/cranelift/control/src/chaos.rs
+++ b/cranelift/control/src/chaos.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use arbitrary::{Arbitrary, Unstructured};
 
 /// The control plane of chaos mode.
@@ -73,7 +74,7 @@ impl ControlPlane {
         let rest = u.take_rest();
         self.tmp.resize(rest.len(), 0); // allocates once per control plane
         self.tmp.copy_from_slice(rest);
-        std::mem::swap(&mut self.data, &mut self.tmp);
+        core::mem::swap(&mut self.data, &mut self.tmp);
 
         res
     }
@@ -107,7 +108,7 @@ impl ControlPlane {
         let rest = u.take_rest();
         self.tmp.resize(rest.len(), 0); // allocates once per control plane
         self.tmp.copy_from_slice(rest);
-        std::mem::swap(&mut self.data, &mut self.tmp);
+        core::mem::swap(&mut self.data, &mut self.tmp);
     }
 
     /// Returns a new iterator over the same items as the input iterator in

--- a/cranelift/control/src/lib.rs
+++ b/cranelift/control/src/lib.rs
@@ -12,7 +12,7 @@
 //! etc.
 //!
 //! There are two ways to acquire a [ControlPlane]:
-//! - [arbitrary] for the real deal
+//! - [arbitrary] for the real deal (requires the `fuzz` feature, enabled by default)
 //! - [default] for an "empty" control plane which always returns default
 //!   values
 //!
@@ -31,8 +31,22 @@
 //! cargo fuzz run --features chaos $TARGET -- --fuel=16
 //! ```
 //!
+//! ## `no_std` support
+//!
+//! This crate compiles in `no_std` environments, although both the `fuzz`
+//! or `chaos` features have a dependency on `std`. This means that on `no_std`
+//! you can't use [arbitrary] to initialize [ControlPlane] and can't enable
+//! chaos mode, although the rest of the usual [ControlPlane] API is available.
+//!
 //! [arbitrary]: ControlPlane#method.arbitrary
 //! [default]: ControlPlane#method.default
+
+#![no_std]
+
+// The `alloc` crate is only needed by chaos mode, which guarantees that
+// `alloc` is present because of its dependency on `std`.
+#[cfg(feature = "chaos")]
+extern crate alloc;
 
 #[cfg(not(feature = "chaos"))]
 mod zero_sized;

--- a/cranelift/control/src/zero_sized.rs
+++ b/cranelift/control/src/zero_sized.rs
@@ -12,6 +12,7 @@ pub struct ControlPlane {
 /// A shim for ControlPlane's `Arbitrary` implementation when chaos mode is
 /// disabled. It doesn't consume any bytes and always returns a default
 /// control plane.
+#[cfg(feature = "fuzz")]
 impl arbitrary::Arbitrary<'_> for ControlPlane {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())
@@ -33,7 +34,7 @@ impl ControlPlane {
     /// Returns an arbitrary value. This variant is used when chaos mode is
     /// disabled. It always returns the default value.
     #[inline]
-    pub fn get_arbitrary<T: for<'a> arbitrary::Arbitrary<'a> + Default>(&mut self) -> T {
+    pub fn get_arbitrary<T: Default>(&mut self) -> T {
         T::default()
     }
 


### PR DESCRIPTION
Follows discussion in #1158. Ratchets cranelift-control's no_std support in CI.