### PR TITLE
doc: fix lang-c link

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Languages supported by the community:
 * **Perl** - the [`Wasm` Perl package's `Wasm::Wasmtime`]
 
 [Rust]: https://bytecodealliance.github.io/wasmtime/lang-rust.html
-[C]: https://bytecodealliance.github.io/wasmtime/examples-c-embed.html
+[C]: https://bytecodealliance.github.io/wasmtime/lang-c.html
 [`wasmtime` crate]: https://crates.io/crates/wasmtime
 [c-headers]: https://bytecodealliance.github.io/wasmtime/c-api/
 [Python]: https://bytecodealliance.github.io/wasmtime/lang-python.html

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -90,7 +90,7 @@
  *   issue](https://github.com/bytecodealliance/wasmtime/issues/new).
  *
  * * [C embedding
- *   examples](https://bytecodealliance.github.io/wasmtime/examples-c-embed.html)
+ *   examples](https://bytecodealliance.github.io/wasmtime/lang-c.html)
  *   are available online and are tested from the Wasmtime repository itself.
  *
  * * [Contribution documentation for

--- a/docs/WASI-intro.md
+++ b/docs/WASI-intro.md
@@ -32,7 +32,7 @@ guide](https://bytecodealliance.github.io/wasmtime/examples-rust-embed.html)
 ### C/C++
 
 To install a WASI-enabled C/C++ toolchain, see the [online section of the
-guide](https://bytecodealliance.github.io/wasmtime/examples-c-embed.html)
+guide](https://bytecodealliance.github.io/wasmtime/lang-c.html)
 
 ## How can I run programs that use WASI?
 


### PR DESCRIPTION
Page https://docs.wasmtime.dev/examples-c-embed.html move to https://docs.wasmtime.dev/lang-c.html