### PR TITLE
Fix a fuzz issue from #8965

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -900,6 +900,9 @@ pub fn dynamic_component_api_target(input: &mut arbitrary::Unstructured) -> arbi
     };
 
     let mut config = component_test_util::config();
+    if case.results.len() > 1 {
+        config.wasm_component_model_multiple_returns(true);
+    }
     config.debug_adapter_modules(input.arbitrary()?);
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::new(&engine, (Vec::new(), None));


### PR DESCRIPTION
This commit fixes an issue from the last upgrade of wasm-tools where multiple returns on component model functions are now gated by default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
