### PR TITLE
Cranelift(x64): provide better panic messages for `Gpr::new(reg).unwrap()` et al

### DIFF
--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -552,8 +552,8 @@ mod tests {
                 regs::xmm9(),
                 Amode::ImmRegRegShift {
                     simm32: 0,
-                    base: Gpr::new(regs::rbx()).unwrap(),
-                    index: Gpr::new(regs::rsi()).unwrap(),
+                    base: Gpr::unwrap_new(regs::rbx()),
+                    index: Gpr::unwrap_new(regs::rsi()),
                     shift: 3,
                     flags: MemFlags::trusted(),
                 }
@@ -565,8 +565,8 @@ mod tests {
                 regs::xmm13(),
                 Amode::ImmRegRegShift {
                     simm32: 1,
-                    base: Gpr::new(regs::r11()).unwrap(),
-                    index: Gpr::new(regs::rdi()).unwrap(),
+                    base: Gpr::unwrap_new(regs::r11()),
+                    index: Gpr::unwrap_new(regs::rdi()),
                     shift: 2,
                     flags: MemFlags::trusted(),
                 }
@@ -580,8 +580,8 @@ mod tests {
                 regs::xmm5(),
                 Amode::ImmRegRegShift {
                     simm32: 128,
-                    base: Gpr::new(regs::rsp()).unwrap(),
-                    index: Gpr::new(regs::r10()).unwrap(),
+                    base: Gpr::unwrap_new(regs::rsp()),
+                    index: Gpr::unwrap_new(regs::r10()),
                     shift: 1,
                     flags: MemFlags::trusted(),
                 }
@@ -593,8 +593,8 @@ mod tests {
                 regs::xmm6(),
                 Amode::ImmRegRegShift {
                     simm32: 112,
-                    base: Gpr::new(regs::rbp()).unwrap(),
-                    index: Gpr::new(regs::r13()).unwrap(),
+                    base: Gpr::unwrap_new(regs::rbp()),
+                    index: Gpr::unwrap_new(regs::r13()),
                     shift: 0,
                     flags: MemFlags::trusted(),
                 }
@@ -606,8 +606,8 @@ mod tests {
                 regs::xmm7(),
                 Amode::ImmRegRegShift {
                     simm32: 0,
-                    base: Gpr::new(regs::rbp()).unwrap(),
-                    index: Gpr::new(regs::r13()).unwrap(),
+                    base: Gpr::unwrap_new(regs::rbp()),
+                    index: Gpr::unwrap_new(regs::r13()),
                     shift: 0,
                     flags: MemFlags::trusted(),
                 }

--- a/cranelift/codegen/src/isa/x64/encoding/vex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/vex.rs
@@ -465,8 +465,8 @@ mod tests {
         let dst = regs::xmm2().to_real_reg().unwrap().hw_enc();
         let src1 = regs::xmm1().to_real_reg().unwrap().hw_enc();
         let src2 = Amode::ImmRegRegShift {
-            base: Gpr::new(regs::rax()).unwrap(),
-            index: Gpr::new(regs::r13()).unwrap(),
+            base: Gpr::unwrap_new(regs::rax()),
+            index: Gpr::unwrap_new(regs::r13()),
             flags: MemFlags::trusted(),
             simm32: 100,
             shift: 2,

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -65,6 +65,21 @@ macro_rules! newtype_of_reg {
                 }
             }
 
+            /// Like `Self::new(r).unwrap()` but with a better panic message on
+            /// failure.
+            pub fn unwrap_new($check_reg: Reg) -> Self {
+                if $check {
+                    Self($check_reg)
+                } else {
+                    panic!(
+                        "cannot construct {} from register {:?} with register class {:?}",
+                        stringify!($newtype_reg),
+                        $check_reg,
+                        $check_reg.class(),
+                    )
+                }
+            }
+
             /// Get this newtype's underlying `Reg`.
             pub fn to_reg(self) -> Reg {
                 self.0
@@ -154,8 +169,26 @@ macro_rules! newtype_of_reg {
                                 None
                             }
                         }
-                        RegMem::Reg { reg: $check_reg } if $check => Some(Self(rm)),
-                        RegMem::Reg { reg: _ } => None,
+                        RegMem::Reg { reg } => Some($newtype_reg::new(reg)?.into()),
+                    }
+                }
+
+                /// Like `Self::new(rm).unwrap()` but with better panic messages
+                /// in case of failure.
+                pub fn unwrap_new(rm: RegMem) -> Self {
+                    match rm {
+                        RegMem::Mem { addr } => {
+                            $(
+                                if $aligned && !addr.aligned() {
+                                    panic!(
+                                        "cannot create {} from an unaligned memory address: {addr:?}",
+                                        stringify!($newtype_reg_mem),
+                                    );
+                                }
+                            )?
+                            Self(RegMem::Mem { addr })
+                        }
+                        RegMem::Reg { reg } => $newtype_reg::unwrap_new(reg).into(),
                     }
                 }
 
@@ -218,8 +251,29 @@ macro_rules! newtype_of_reg {
                                 None
                             }
                         }
-                        RegMemImm::Reg { reg: $check_reg } if $check => Some(Self(rmi)),
-                        RegMemImm::Reg { reg: _ } => None,
+                        RegMemImm::Reg { reg } => Some($newtype_reg::new(reg)?.into()),
+                    }
+                }
+
+                /// Like `Self::new(rmi).unwrap()` but with better panic
+                /// messages in case of failure.
+                pub fn unwrap_new(rmi: RegMemImm) -> Self {
+                    match rmi {
+                        RegMemImm::Imm { .. } => Self(rmi),
+                        RegMemImm::Mem { addr } => {
+                            $(
+                                if $aligned_imm && !addr.aligned() {
+                                    panic!(
+                                        "cannot construct {} from unaligned memory address: {:?}",
+                                        stringify!($newtype_reg_mem_imm),
+                                        addr,
+                                    );
+                                }
+                            )?
+                            Self(RegMemImm::Mem { addr })
+
+                        }
+                        RegMemImm::Reg { reg } => $newtype_reg::unwrap_new(reg).into(),
                     }
                 }
 
@@ -260,8 +314,16 @@ macro_rules! newtype_of_reg {
             pub fn new(imm8_reg: Imm8Reg) -> Option<Self> {
                 match imm8_reg {
                     Imm8Reg::Imm8 { .. } => Some(Self(imm8_reg)),
-                    Imm8Reg::Reg { reg: $check_reg } if $check => Some(Self(imm8_reg)),
-                    Imm8Reg::Reg { reg: _ } => None,
+                    Imm8Reg::Reg { reg } => Some($newtype_reg::new(reg)?.into()),
+                }
+            }
+
+            /// Like `Self::new(imm8_reg).unwrap()` but with better panic
+            /// messages on failure.
+            pub fn unwrap_new(imm8_reg: Imm8Reg) -> Self {
+                match imm8_reg {
+                    Imm8Reg::Imm8 { .. } => Self(imm8_reg),
+                    Imm8Reg::Reg { reg } => $newtype_reg::unwrap_new(reg).into(),
                 }
             }
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -32,7 +32,7 @@ fn emit_signed_cvt(
         op,
         dst,
         src1: dst.to_reg(),
-        src2: GprMem::new(RegMem::reg(src)).unwrap(),
+        src2: GprMem::unwrap_new(RegMem::reg(src)),
         src2_size: OperandSize::Size64,
     }
     .emit(sink, info, state);
@@ -788,18 +788,18 @@ pub(crate) fn emit(
                     DivSignedness::Signed,
                     TrapCode::IntegerDivisionByZero,
                     RegMem::reg(divisor),
-                    Gpr::new(regs::rax()).unwrap(),
-                    Writable::from_reg(Gpr::new(regs::rax()).unwrap()),
+                    Gpr::unwrap_new(regs::rax()),
+                    Writable::from_reg(Gpr::unwrap_new(regs::rax())),
                 ),
                 _ => Inst::div(
                     size,
                     DivSignedness::Signed,
                     TrapCode::IntegerDivisionByZero,
                     RegMem::reg(divisor),
-                    Gpr::new(regs::rax()).unwrap(),
-                    Gpr::new(regs::rdx()).unwrap(),
-                    Writable::from_reg(Gpr::new(regs::rax()).unwrap()),
-                    Writable::from_reg(Gpr::new(regs::rdx()).unwrap()),
+                    Gpr::unwrap_new(regs::rax()),
+                    Gpr::unwrap_new(regs::rdx()),
+                    Writable::from_reg(Gpr::unwrap_new(regs::rax())),
+                    Writable::from_reg(Gpr::unwrap_new(regs::rdx())),
                 ),
             };
             inst.emit(sink, info, state);
@@ -884,7 +884,7 @@ pub(crate) fn emit(
         Inst::MovFromPReg { src, dst } => {
             let src: Reg = (*src).into();
             debug_assert!([regs::rsp(), regs::rbp(), regs::pinned_reg()].contains(&src));
-            let src = Gpr::new(src).unwrap();
+            let src = Gpr::unwrap_new(src);
             let size = OperandSize::Size64;
             let dst = WritableGpr::from_writable_reg(dst.to_writable_reg()).unwrap();
             Inst::MovRR { size, src, dst }.emit(sink, info, state);
@@ -892,7 +892,7 @@ pub(crate) fn emit(
 
         Inst::MovToPReg { src, dst } => {
             let src = src.to_reg();
-            let src = Gpr::new(src).unwrap();
+            let src = Gpr::unwrap_new(src);
             let dst: Reg = (*dst).into();
             debug_assert!([regs::rsp(), regs::rbp(), regs::pinned_reg()].contains(&dst));
             let dst = WritableGpr::from_writable_reg(Writable::from_reg(dst)).unwrap();
@@ -1866,8 +1866,8 @@ pub(crate) fn emit(
                 ExtMode::LQ,
                 RegMem::mem(Amode::imm_reg_reg_shift(
                     0,
-                    Gpr::new(tmp1.to_reg()).unwrap(),
-                    Gpr::new(idx).unwrap(),
+                    Gpr::unwrap_new(tmp1.to_reg()),
+                    Gpr::unwrap_new(idx),
                     2,
                 )),
                 tmp2,
@@ -1939,7 +1939,7 @@ pub(crate) fn emit(
             emit(
                 &Inst::XmmUnaryRmRUnaligned {
                     op: *op,
-                    src: XmmMem::new(src.clone().into()).unwrap(),
+                    src: XmmMem::unwrap_new(src.clone().into()),
                     dst: *dst,
                 },
                 sink,
@@ -2097,7 +2097,7 @@ pub(crate) fn emit(
                 op: *op,
                 dst: *dst,
                 src1: *src1,
-                src2: XmmMem::new(src2.clone().to_reg_mem()).unwrap(),
+                src2: XmmMem::unwrap_new(src2.clone().to_reg_mem()),
             },
             sink,
             info,
@@ -3397,7 +3397,7 @@ pub(crate) fn emit(
             let inst = Inst::shift_r(
                 OperandSize::Size64,
                 ShiftKind::ShiftRightLogical,
-                Imm8Gpr::new(Imm8Reg::Imm8 { imm: 1 }).unwrap(),
+                Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 1 }),
                 tmp_gpr1.to_reg(),
                 tmp_gpr1,
             );

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -23,7 +23,7 @@ impl Inst {
         debug_assert_eq!(src.to_reg().class(), RegClass::Int);
         Inst::Neg {
             size,
-            src: Gpr::new(src.to_reg()).unwrap(),
+            src: Gpr::unwrap_new(src.to_reg()),
             dst: WritableGpr::from_writable_reg(src).unwrap(),
         }
     }
@@ -33,7 +33,7 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmUnaryRmRImm {
             op,
-            src: XmmMemAligned::new(src).unwrap(),
+            src: XmmMemAligned::unwrap_new(src),
             imm,
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
@@ -44,7 +44,7 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmUnaryRmREvex {
             op,
-            src: XmmMem::new(src).unwrap(),
+            src: XmmMem::unwrap_new(src),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -54,8 +54,8 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmRmiReg {
             opcode,
-            src1: Xmm::new(dst.to_reg()).unwrap(),
-            src2: XmmMemAlignedImm::new(src).unwrap(),
+            src1: Xmm::unwrap_new(dst.to_reg()),
+            src2: XmmMemAlignedImm::unwrap_new(src),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -67,8 +67,8 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmRmREvex {
             op,
-            src1: Xmm::new(src1).unwrap(),
-            src2: XmmMem::new(src2).unwrap(),
+            src1: Xmm::unwrap_new(src1),
+            src2: XmmMem::unwrap_new(src2),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -87,9 +87,9 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmRmREvex3 {
             op,
-            src1: Xmm::new(src1).unwrap(),
-            src2: Xmm::new(src2).unwrap(),
-            src3: XmmMem::new(src3).unwrap(),
+            src1: Xmm::unwrap_new(src1),
+            src2: Xmm::unwrap_new(src2),
+            src3: XmmMem::unwrap_new(src3),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -100,7 +100,7 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmUnaryRmR {
             op,
-            src: XmmMemAligned::new(src).unwrap(),
+            src: XmmMemAligned::unwrap_new(src),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -113,7 +113,7 @@ impl Inst {
 
     fn bswap(size: OperandSize, dst: Writable<Reg>) -> Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Int);
-        let src = Gpr::new(dst.to_reg()).unwrap();
+        let src = Gpr::unwrap_new(dst.to_reg());
         let dst = WritableGpr::from_writable_reg(dst).unwrap();
         Inst::Bswap { size, src, dst }
     }
@@ -139,9 +139,9 @@ impl Inst {
     fn xmm_rm_r_blend(op: SseOpcode, src2: RegMem, dst: Writable<Reg>) -> Inst {
         Inst::XmmRmRBlend {
             op,
-            src1: Xmm::new(dst.to_reg()).unwrap(),
-            src2: XmmMemAligned::new(src2).unwrap(),
-            mask: Xmm::new(regs::xmm0()).unwrap(),
+            src1: Xmm::unwrap_new(dst.to_reg()),
+            src2: XmmMemAligned::unwrap_new(src2),
+            mask: Xmm::unwrap_new(regs::xmm0()),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -814,7 +814,7 @@ fn test_x64_emit() {
     // Addr_IRRS, offset max simm8
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(rax).unwrap(), Gpr::new(rax).unwrap(), 0),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(rax), Gpr::unwrap_new(rax), 0),
             w_r11,
         ),
         "4C8B5C007F",
@@ -822,7 +822,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(rdi).unwrap(), Gpr::new(rax).unwrap(), 1),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(rdi), Gpr::unwrap_new(rax), 1),
             w_r11,
         ),
         "4C8B5C477F",
@@ -830,7 +830,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(r8).unwrap(), Gpr::new(rax).unwrap(), 2),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(r8), Gpr::unwrap_new(rax), 2),
             w_r11,
         ),
         "4D8B5C807F",
@@ -838,7 +838,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(r15).unwrap(), Gpr::new(rax).unwrap(), 3),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(r15), Gpr::unwrap_new(rax), 3),
             w_r11,
         ),
         "4D8B5CC77F",
@@ -846,7 +846,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(rax).unwrap(), Gpr::new(rdi).unwrap(), 3),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(rax), Gpr::unwrap_new(rdi), 3),
             w_r11,
         ),
         "4C8B5CF87F",
@@ -854,7 +854,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(rdi).unwrap(), Gpr::new(rdi).unwrap(), 2),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(rdi), Gpr::unwrap_new(rdi), 2),
             w_r11,
         ),
         "4C8B5CBF7F",
@@ -862,7 +862,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(r8).unwrap(), Gpr::new(rdi).unwrap(), 1),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(r8), Gpr::unwrap_new(rdi), 1),
             w_r11,
         ),
         "4D8B5C787F",
@@ -870,7 +870,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(127, Gpr::new(r15).unwrap(), Gpr::new(rdi).unwrap(), 0),
+            Amode::imm_reg_reg_shift(127, Gpr::unwrap_new(r15), Gpr::unwrap_new(rdi), 0),
             w_r11,
         ),
         "4D8B5C3F7F",
@@ -881,7 +881,7 @@ fn test_x64_emit() {
     // Addr_IRRS, offset min simm8
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(rax).unwrap(), Gpr::new(r8).unwrap(), 2),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(rax), Gpr::unwrap_new(r8), 2),
             w_r11,
         ),
         "4E8B5C8080",
@@ -889,7 +889,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(rdi).unwrap(), Gpr::new(r8).unwrap(), 3),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(rdi), Gpr::unwrap_new(r8), 3),
             w_r11,
         ),
         "4E8B5CC780",
@@ -897,7 +897,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(r8).unwrap(), Gpr::new(r8).unwrap(), 0),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(r8), Gpr::unwrap_new(r8), 0),
             w_r11,
         ),
         "4F8B5C0080",
@@ -905,7 +905,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(r15).unwrap(), Gpr::new(r8).unwrap(), 1),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(r15), Gpr::unwrap_new(r8), 1),
             w_r11,
         ),
         "4F8B5C4780",
@@ -913,7 +913,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(rax).unwrap(), Gpr::new(r15).unwrap(), 1),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(rax), Gpr::unwrap_new(r15), 1),
             w_r11,
         ),
         "4E8B5C7880",
@@ -921,7 +921,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(rdi).unwrap(), Gpr::new(r15).unwrap(), 0),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(rdi), Gpr::unwrap_new(r15), 0),
             w_r11,
         ),
         "4E8B5C3F80",
@@ -929,7 +929,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(r8).unwrap(), Gpr::new(r15).unwrap(), 3),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(r8), Gpr::unwrap_new(r15), 3),
             w_r11,
         ),
         "4F8B5CF880",
@@ -937,7 +937,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(-128i32, Gpr::new(r15).unwrap(), Gpr::new(r15).unwrap(), 2),
+            Amode::imm_reg_reg_shift(-128i32, Gpr::unwrap_new(r15), Gpr::unwrap_new(r15), 2),
             w_r11,
         ),
         "4F8B5CBF80",
@@ -948,12 +948,7 @@ fn test_x64_emit() {
     // Addr_IRRS, offset large positive simm32
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                0x4f6625be,
-                Gpr::new(rax).unwrap(),
-                Gpr::new(rax).unwrap(),
-                0,
-            ),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(rax), Gpr::unwrap_new(rax), 0),
             w_r11,
         ),
         "4C8B9C00BE25664F",
@@ -961,12 +956,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                0x4f6625be,
-                Gpr::new(rdi).unwrap(),
-                Gpr::new(rax).unwrap(),
-                1,
-            ),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(rdi), Gpr::unwrap_new(rax), 1),
             w_r11,
         ),
         "4C8B9C47BE25664F",
@@ -974,7 +964,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::new(r8).unwrap(), Gpr::new(rax).unwrap(), 2),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(r8), Gpr::unwrap_new(rax), 2),
             w_r11,
         ),
         "4D8B9C80BE25664F",
@@ -982,12 +972,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                0x4f6625be,
-                Gpr::new(r15).unwrap(),
-                Gpr::new(rax).unwrap(),
-                3,
-            ),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(r15), Gpr::unwrap_new(rax), 3),
             w_r11,
         ),
         "4D8B9CC7BE25664F",
@@ -995,12 +980,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                0x4f6625be,
-                Gpr::new(rax).unwrap(),
-                Gpr::new(rdi).unwrap(),
-                3,
-            ),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(rax), Gpr::unwrap_new(rdi), 3),
             w_r11,
         ),
         "4C8B9CF8BE25664F",
@@ -1008,12 +988,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                0x4f6625be,
-                Gpr::new(rdi).unwrap(),
-                Gpr::new(rdi).unwrap(),
-                2,
-            ),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(rdi), Gpr::unwrap_new(rdi), 2),
             w_r11,
         ),
         "4C8B9CBFBE25664F",
@@ -1021,7 +996,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::new(r8).unwrap(), Gpr::new(rdi).unwrap(), 1),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(r8), Gpr::unwrap_new(rdi), 1),
             w_r11,
         ),
         "4D8B9C78BE25664F",
@@ -1029,12 +1004,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                0x4f6625be,
-                Gpr::new(r15).unwrap(),
-                Gpr::new(rdi).unwrap(),
-                0,
-            ),
+            Amode::imm_reg_reg_shift(0x4f6625be, Gpr::unwrap_new(r15), Gpr::unwrap_new(rdi), 0),
             w_r11,
         ),
         "4D8B9C3FBE25664F",
@@ -1045,12 +1015,7 @@ fn test_x64_emit() {
     // Addr_IRRS, offset large negative simm32
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                -0x264d1690i32,
-                Gpr::new(rax).unwrap(),
-                Gpr::new(r8).unwrap(),
-                2,
-            ),
+            Amode::imm_reg_reg_shift(-0x264d1690i32, Gpr::unwrap_new(rax), Gpr::unwrap_new(r8), 2),
             w_r11,
         ),
         "4E8B9C8070E9B2D9",
@@ -1058,12 +1023,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                -0x264d1690i32,
-                Gpr::new(rdi).unwrap(),
-                Gpr::new(r8).unwrap(),
-                3,
-            ),
+            Amode::imm_reg_reg_shift(-0x264d1690i32, Gpr::unwrap_new(rdi), Gpr::unwrap_new(r8), 3),
             w_r11,
         ),
         "4E8B9CC770E9B2D9",
@@ -1071,12 +1031,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                -0x264d1690i32,
-                Gpr::new(r8).unwrap(),
-                Gpr::new(r8).unwrap(),
-                0,
-            ),
+            Amode::imm_reg_reg_shift(-0x264d1690i32, Gpr::unwrap_new(r8), Gpr::unwrap_new(r8), 0),
             w_r11,
         ),
         "4F8B9C0070E9B2D9",
@@ -1084,12 +1039,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                -0x264d1690i32,
-                Gpr::new(r15).unwrap(),
-                Gpr::new(r8).unwrap(),
-                1,
-            ),
+            Amode::imm_reg_reg_shift(-0x264d1690i32, Gpr::unwrap_new(r15), Gpr::unwrap_new(r8), 1),
             w_r11,
         ),
         "4F8B9C4770E9B2D9",
@@ -1099,8 +1049,8 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(
                 -0x264d1690i32,
-                Gpr::new(rax).unwrap(),
-                Gpr::new(r15).unwrap(),
+                Gpr::unwrap_new(rax),
+                Gpr::unwrap_new(r15),
                 1,
             ),
             w_r11,
@@ -1112,8 +1062,8 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(
                 -0x264d1690i32,
-                Gpr::new(rdi).unwrap(),
-                Gpr::new(r15).unwrap(),
+                Gpr::unwrap_new(rdi),
+                Gpr::unwrap_new(r15),
                 0,
             ),
             w_r11,
@@ -1123,12 +1073,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(
-                -0x264d1690i32,
-                Gpr::new(r8).unwrap(),
-                Gpr::new(r15).unwrap(),
-                3,
-            ),
+            Amode::imm_reg_reg_shift(-0x264d1690i32, Gpr::unwrap_new(r8), Gpr::unwrap_new(r15), 3),
             w_r11,
         ),
         "4F8B9CF870E9B2D9",
@@ -1138,8 +1083,8 @@ fn test_x64_emit() {
         Inst::mov64_m_r(
             Amode::imm_reg_reg_shift(
                 -0x264d1690i32,
-                Gpr::new(r15).unwrap(),
-                Gpr::new(r15).unwrap(),
+                Gpr::unwrap_new(r15),
+                Gpr::unwrap_new(r15),
                 2,
             ),
             w_r11,
@@ -1671,7 +1616,7 @@ fn test_x64_emit() {
             size: OperandSize::Size32,
             op: AluRmiROpcode::Add,
             src1_dst: Amode::imm_reg(99, rdi).into(),
-            src2: Gpr::new(r12).unwrap(),
+            src2: Gpr::unwrap_new(r12),
         },
         "44016763",
         "addl    %r12d, 99(%rdi)",
@@ -1681,14 +1626,9 @@ fn test_x64_emit() {
         Inst::AluRM {
             size: OperandSize::Size64,
             op: AluRmiROpcode::Add,
-            src1_dst: Amode::imm_reg_reg_shift(
-                0,
-                Gpr::new(rbp).unwrap(),
-                Gpr::new(rax).unwrap(),
-                3,
-            )
-            .into(),
-            src2: Gpr::new(rax).unwrap(),
+            src1_dst: Amode::imm_reg_reg_shift(0, Gpr::unwrap_new(rbp), Gpr::unwrap_new(rax), 3)
+                .into(),
+            src2: Gpr::unwrap_new(rax),
         },
         "480144C500",
         "addq    %rax, 0(%rbp,%rax,8)",
@@ -1699,7 +1639,7 @@ fn test_x64_emit() {
             size: OperandSize::Size32,
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rsp).into(),
-            src2: Gpr::new(rcx).unwrap(),
+            src2: Gpr::unwrap_new(rcx),
         },
         "290C24",
         "subl    %ecx, 0(%rsp)",
@@ -1710,7 +1650,7 @@ fn test_x64_emit() {
             size: OperandSize::Size64,
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(rax).unwrap(),
+            src2: Gpr::unwrap_new(rax),
         },
         "48294500",
         "subq    %rax, 0(%rbp)",
@@ -1721,7 +1661,7 @@ fn test_x64_emit() {
             size: OperandSize::Size32,
             op: AluRmiROpcode::And,
             src1_dst: Amode::imm_reg(0, rsp).into(),
-            src2: Gpr::new(rcx).unwrap(),
+            src2: Gpr::unwrap_new(rcx),
         },
         "210C24",
         "andl    %ecx, 0(%rsp)",
@@ -1732,7 +1672,7 @@ fn test_x64_emit() {
             size: OperandSize::Size64,
             op: AluRmiROpcode::And,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(rax).unwrap(),
+            src2: Gpr::unwrap_new(rax),
         },
         "48214500",
         "andq    %rax, 0(%rbp)",
@@ -1743,7 +1683,7 @@ fn test_x64_emit() {
             size: OperandSize::Size32,
             op: AluRmiROpcode::Or,
             src1_dst: Amode::imm_reg(0, rsp).into(),
-            src2: Gpr::new(rcx).unwrap(),
+            src2: Gpr::unwrap_new(rcx),
         },
         "090C24",
         "orl     %ecx, 0(%rsp)",
@@ -1754,7 +1694,7 @@ fn test_x64_emit() {
             size: OperandSize::Size64,
             op: AluRmiROpcode::Or,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(rax).unwrap(),
+            src2: Gpr::unwrap_new(rax),
         },
         "48094500",
         "orq     %rax, 0(%rbp)",
@@ -1765,7 +1705,7 @@ fn test_x64_emit() {
             size: OperandSize::Size32,
             op: AluRmiROpcode::Xor,
             src1_dst: Amode::imm_reg(0, rsp).into(),
-            src2: Gpr::new(rcx).unwrap(),
+            src2: Gpr::unwrap_new(rcx),
         },
         "310C24",
         "xorl    %ecx, 0(%rsp)",
@@ -1776,7 +1716,7 @@ fn test_x64_emit() {
             size: OperandSize::Size64,
             op: AluRmiROpcode::Xor,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(rax).unwrap(),
+            src2: Gpr::unwrap_new(rax),
         },
         "48314500",
         "xorq    %rax, 0(%rbp)",
@@ -1787,7 +1727,7 @@ fn test_x64_emit() {
             size: OperandSize::Size16,
             op: AluRmiROpcode::Add,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(rax).unwrap(),
+            src2: Gpr::unwrap_new(rax),
         },
         "66014500",
         "addw    %ax, 0(%rbp)",
@@ -1797,7 +1737,7 @@ fn test_x64_emit() {
             size: OperandSize::Size16,
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(r12).unwrap(),
+            src2: Gpr::unwrap_new(r12),
         },
         "6644296500",
         "subw    %r12w, 0(%rbp)",
@@ -1808,7 +1748,7 @@ fn test_x64_emit() {
             size: OperandSize::Size8,
             op: AluRmiROpcode::Add,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(rax).unwrap(),
+            src2: Gpr::unwrap_new(rax),
         },
         "004500",
         "addb    %al, 0(%rbp)",
@@ -1818,7 +1758,7 @@ fn test_x64_emit() {
             size: OperandSize::Size8,
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(rbp).unwrap(),
+            src2: Gpr::unwrap_new(rbp),
         },
         "40286D00",
         "subb    %bpl, 0(%rbp)",
@@ -1828,7 +1768,7 @@ fn test_x64_emit() {
             size: OperandSize::Size8,
             op: AluRmiROpcode::Xor,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(r10).unwrap(),
+            src2: Gpr::unwrap_new(r10),
         },
         "44305500",
         "xorb    %r10b, 0(%rbp)",
@@ -1838,7 +1778,7 @@ fn test_x64_emit() {
             size: OperandSize::Size8,
             op: AluRmiROpcode::And,
             src1_dst: Amode::imm_reg(0, rbp).into(),
-            src2: Gpr::new(r15).unwrap(),
+            src2: Gpr::unwrap_new(r15),
         },
         "44207D00",
         "andb    %r15b, 0(%rbp)",
@@ -1942,10 +1882,10 @@ fn test_x64_emit() {
             DivSignedness::Signed,
             TrapCode::IntegerDivisionByZero,
             RegMem::reg(regs::rsi()),
-            Gpr::new(regs::rax()).unwrap(),
-            Gpr::new(regs::rdx()).unwrap(),
-            WritableGpr::from_reg(Gpr::new(regs::rax()).unwrap()),
-            WritableGpr::from_reg(Gpr::new(regs::rdx()).unwrap()),
+            Gpr::unwrap_new(regs::rax()),
+            Gpr::unwrap_new(regs::rdx()),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rax())),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rdx())),
         ),
         "F7FE",
         "idiv    %eax, %edx, %esi, %eax, %edx ; trap=int_divz",
@@ -1956,10 +1896,10 @@ fn test_x64_emit() {
             DivSignedness::Signed,
             TrapCode::IntegerDivisionByZero,
             RegMem::reg(regs::r15()),
-            Gpr::new(regs::rax()).unwrap(),
-            Gpr::new(regs::rdx()).unwrap(),
-            WritableGpr::from_reg(Gpr::new(regs::rax()).unwrap()),
-            WritableGpr::from_reg(Gpr::new(regs::rdx()).unwrap()),
+            Gpr::unwrap_new(regs::rax()),
+            Gpr::unwrap_new(regs::rdx()),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rax())),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rdx())),
         ),
         "49F7FF",
         "idiv    %rax, %rdx, %r15, %rax, %rdx ; trap=int_divz",
@@ -1970,10 +1910,10 @@ fn test_x64_emit() {
             DivSignedness::Unsigned,
             TrapCode::IntegerDivisionByZero,
             RegMem::reg(regs::r14()),
-            Gpr::new(regs::rax()).unwrap(),
-            Gpr::new(regs::rdx()).unwrap(),
-            WritableGpr::from_reg(Gpr::new(regs::rax()).unwrap()),
-            WritableGpr::from_reg(Gpr::new(regs::rdx()).unwrap()),
+            Gpr::unwrap_new(regs::rax()),
+            Gpr::unwrap_new(regs::rdx()),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rax())),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rdx())),
         ),
         "41F7F6",
         "div     %eax, %edx, %r14d, %eax, %edx ; trap=int_divz",
@@ -1984,10 +1924,10 @@ fn test_x64_emit() {
             DivSignedness::Unsigned,
             TrapCode::IntegerDivisionByZero,
             RegMem::reg(regs::rdi()),
-            Gpr::new(regs::rax()).unwrap(),
-            Gpr::new(regs::rdx()).unwrap(),
-            WritableGpr::from_reg(Gpr::new(regs::rax()).unwrap()),
-            WritableGpr::from_reg(Gpr::new(regs::rdx()).unwrap()),
+            Gpr::unwrap_new(regs::rax()),
+            Gpr::unwrap_new(regs::rdx()),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rax())),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rdx())),
         ),
         "48F7F7",
         "div     %rax, %rdx, %rdi, %rax, %rdx ; trap=int_divz",
@@ -1997,8 +1937,8 @@ fn test_x64_emit() {
             DivSignedness::Unsigned,
             TrapCode::IntegerDivisionByZero,
             RegMem::reg(regs::rax()),
-            Gpr::new(regs::rax()).unwrap(),
-            WritableGpr::from_reg(Gpr::new(regs::rax()).unwrap()),
+            Gpr::unwrap_new(regs::rax()),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rax())),
         ),
         "F6F0",
         "div     %al, %al, %al ; trap=int_divz",
@@ -2008,8 +1948,8 @@ fn test_x64_emit() {
             DivSignedness::Unsigned,
             TrapCode::IntegerDivisionByZero,
             RegMem::reg(regs::rsi()),
-            Gpr::new(regs::rax()).unwrap(),
-            WritableGpr::from_reg(Gpr::new(regs::rax()).unwrap()),
+            Gpr::unwrap_new(regs::rax()),
+            WritableGpr::from_reg(Gpr::unwrap_new(regs::rax())),
         ),
         "40F6F6",
         "div     %al, %sil, %al ; trap=int_divz",
@@ -2259,7 +2199,7 @@ fn test_x64_emit() {
     // Mov64_M_R
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(rax).unwrap(), Gpr::new(rbx).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(rax), Gpr::unwrap_new(rbx), 0),
             w_rcx,
         ),
         "488B8C18B3000000",
@@ -2267,7 +2207,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(rax).unwrap(), Gpr::new(rbx).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(rax), Gpr::unwrap_new(rbx), 0),
             w_r8,
         ),
         "4C8B8418B3000000",
@@ -2275,7 +2215,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(rax).unwrap(), Gpr::new(r9).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(rax), Gpr::unwrap_new(r9), 0),
             w_rcx,
         ),
         "4A8B8C08B3000000",
@@ -2283,7 +2223,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(rax).unwrap(), Gpr::new(r9).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(rax), Gpr::unwrap_new(r9), 0),
             w_r8,
         ),
         "4E8B8408B3000000",
@@ -2291,7 +2231,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(r10).unwrap(), Gpr::new(rbx).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(r10), Gpr::unwrap_new(rbx), 0),
             w_rcx,
         ),
         "498B8C1AB3000000",
@@ -2299,7 +2239,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(r10).unwrap(), Gpr::new(rbx).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(r10), Gpr::unwrap_new(rbx), 0),
             w_r8,
         ),
         "4D8B841AB3000000",
@@ -2307,7 +2247,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(r10).unwrap(), Gpr::new(r9).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(r10), Gpr::unwrap_new(r9), 0),
             w_rcx,
         ),
         "4B8B8C0AB3000000",
@@ -2315,7 +2255,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::mov64_m_r(
-            Amode::imm_reg_reg_shift(179, Gpr::new(r10).unwrap(), Gpr::new(r9).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(r10), Gpr::unwrap_new(r9), 0),
             w_r8,
         ),
         "4F8B840AB3000000",
@@ -2336,7 +2276,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::lea(
-            Amode::imm_reg_reg_shift(179, Gpr::new(r10).unwrap(), Gpr::new(r9).unwrap(), 0),
+            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(r10), Gpr::unwrap_new(r9), 0),
             w_r8,
         ),
         "4F8D840AB3000000",
@@ -2963,7 +2903,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rdi,
             w_rdi,
         ),
@@ -2974,7 +2914,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             r12,
             w_r12,
         ),
@@ -2985,7 +2925,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 2 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 2 }),
             r8,
             w_r8,
         ),
@@ -2996,7 +2936,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 31 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 31 }),
             r13,
             w_r13,
         ),
@@ -3007,7 +2947,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             r13,
             w_r13,
         ),
@@ -3018,7 +2958,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rdi,
             w_rdi,
         ),
@@ -3029,7 +2969,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 2 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 2 }),
             r8,
             w_r8,
         ),
@@ -3040,7 +2980,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 3 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 3 }),
             rbx,
             w_rbx,
         ),
@@ -3051,7 +2991,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftLeft,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 63 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 63 }),
             r13,
             w_r13,
         ),
@@ -3062,7 +3002,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftRightLogical,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rdi,
             w_rdi,
         ),
@@ -3073,7 +3013,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftRightLogical,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 2 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 2 }),
             r8,
             w_r8,
         ),
@@ -3084,7 +3024,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftRightLogical,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 31 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 31 }),
             r13,
             w_r13,
         ),
@@ -3095,7 +3035,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftRightLogical,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rdi,
             w_rdi,
         ),
@@ -3106,7 +3046,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftRightLogical,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 2 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 2 }),
             r8,
             w_r8,
         ),
@@ -3117,7 +3057,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftRightLogical,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 63 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 63 }),
             r13,
             w_r13,
         ),
@@ -3128,7 +3068,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftRightArithmetic,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rdi,
             w_rdi,
         ),
@@ -3139,7 +3079,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftRightArithmetic,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 2 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 2 }),
             r8,
             w_r8,
         ),
@@ -3150,7 +3090,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::ShiftRightArithmetic,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 31 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 31 }),
             r13,
             w_r13,
         ),
@@ -3161,7 +3101,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftRightArithmetic,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rdi,
             w_rdi,
         ),
@@ -3172,7 +3112,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftRightArithmetic,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 2 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 2 }),
             r8,
             w_r8,
         ),
@@ -3183,7 +3123,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::ShiftRightArithmetic,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 63 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 63 }),
             r13,
             w_r13,
         ),
@@ -3194,7 +3134,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::RotateLeft,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             r8,
             w_r8,
         ),
@@ -3205,7 +3145,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::RotateLeft,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 3 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 3 }),
             r9,
             w_r9,
         ),
@@ -3216,7 +3156,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size32,
             ShiftKind::RotateRight,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rsi,
             w_rsi,
         ),
@@ -3227,7 +3167,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size64,
             ShiftKind::RotateRight,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 5 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 5 }),
             r15,
             w_r15,
         ),
@@ -3238,7 +3178,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size8,
             ShiftKind::RotateRight,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rsi,
             w_rsi,
         ),
@@ -3249,7 +3189,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size8,
             ShiftKind::RotateRight,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rax,
             w_rax,
         ),
@@ -3260,7 +3200,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size8,
             ShiftKind::RotateRight,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 5 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 5 }),
             r15,
             w_r15,
         ),
@@ -3271,7 +3211,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size16,
             ShiftKind::RotateRight,
-            Imm8Gpr::new(Imm8Reg::Reg { reg: regs::rcx() }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: regs::rcx() }),
             rsi,
             w_rsi,
         ),
@@ -3282,7 +3222,7 @@ fn test_x64_emit() {
         Inst::shift_r(
             OperandSize::Size16,
             ShiftKind::RotateRight,
-            Imm8Gpr::new(Imm8Reg::Imm8 { imm: 5 }).unwrap(),
+            Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm: 5 }),
             r15,
             w_r15,
         ),
@@ -3685,8 +3625,8 @@ fn test_x64_emit() {
             CC::NO,
             RegMem::mem(Amode::imm_reg_reg_shift(
                 37,
-                Gpr::new(rdi).unwrap(),
-                Gpr::new(rsi).unwrap(),
+                Gpr::unwrap_new(rdi),
+                Gpr::unwrap_new(rsi),
                 2,
             )),
             w_r15,
@@ -3732,8 +3672,8 @@ fn test_x64_emit() {
     insns.push((
         Inst::push64(RegMemImm::mem(Amode::imm_reg_reg_shift(
             321,
-            Gpr::new(rsi).unwrap(),
-            Gpr::new(rcx).unwrap(),
+            Gpr::unwrap_new(rsi),
+            Gpr::unwrap_new(rcx),
             3,
         ))),
         "FFB4CE41010000",
@@ -3742,8 +3682,8 @@ fn test_x64_emit() {
     insns.push((
         Inst::push64(RegMemImm::mem(Amode::imm_reg_reg_shift(
             321,
-            Gpr::new(r9).unwrap(),
-            Gpr::new(rbx).unwrap(),
+            Gpr::unwrap_new(r9),
+            Gpr::unwrap_new(rbx),
             2,
         ))),
         "41FFB49941010000",
@@ -3817,8 +3757,8 @@ fn test_x64_emit() {
     insns.push((
         call_unknown(RegMem::mem(Amode::imm_reg_reg_shift(
             321,
-            Gpr::new(rsi).unwrap(),
-            Gpr::new(rcx).unwrap(),
+            Gpr::unwrap_new(rsi),
+            Gpr::unwrap_new(rcx),
             3,
         ))),
         "FF94CE41010000",
@@ -3827,8 +3767,8 @@ fn test_x64_emit() {
     insns.push((
         call_unknown(RegMem::mem(Amode::imm_reg_reg_shift(
             321,
-            Gpr::new(r10).unwrap(),
-            Gpr::new(rdx).unwrap(),
+            Gpr::unwrap_new(r10),
+            Gpr::unwrap_new(rdx),
             2,
         ))),
         "41FF949241010000",
@@ -3897,8 +3837,8 @@ fn test_x64_emit() {
     insns.push((
         Inst::jmp_unknown(RegMem::mem(Amode::imm_reg_reg_shift(
             321,
-            Gpr::new(rsi).unwrap(),
-            Gpr::new(rcx).unwrap(),
+            Gpr::unwrap_new(rsi),
+            Gpr::unwrap_new(rcx),
             3,
         ))),
         "FFA4CE41010000",
@@ -3907,8 +3847,8 @@ fn test_x64_emit() {
     insns.push((
         Inst::jmp_unknown(RegMem::mem(Amode::imm_reg_reg_shift(
             321,
-            Gpr::new(r10).unwrap(),
-            Gpr::new(rdx).unwrap(),
+            Gpr::unwrap_new(r10),
+            Gpr::unwrap_new(rdx),
             2,
         ))),
         "41FFA49241010000",
@@ -3987,8 +3927,8 @@ fn test_x64_emit() {
             SseOpcode::Addss,
             RegMem::mem(Amode::imm_reg_reg_shift(
                 123,
-                Gpr::new(r10).unwrap(),
-                Gpr::new(rdx).unwrap(),
+                Gpr::unwrap_new(r10),
+                Gpr::unwrap_new(rdx),
                 2,
             )),
             w_xmm0,
@@ -4017,8 +3957,8 @@ fn test_x64_emit() {
             SseOpcode::Subss,
             RegMem::mem(Amode::imm_reg_reg_shift(
                 321,
-                Gpr::new(r10).unwrap(),
-                Gpr::new(rax).unwrap(),
+                Gpr::unwrap_new(r10),
+                Gpr::unwrap_new(rax),
                 3,
             )),
             w_xmm10,
@@ -4820,9 +4760,9 @@ fn test_x64_emit() {
     insns.push((
         Inst::XmmRmiRVex {
             op: AvxOpcode::Vpmaxub,
-            dst: Writable::from_reg(Xmm::new(xmm13).unwrap()),
-            src1: Xmm::new(xmm1).unwrap(),
-            src2: XmmMemImm::new(xmm12.into()).unwrap(),
+            dst: Writable::from_reg(Xmm::unwrap_new(xmm13)),
+            src1: Xmm::unwrap_new(xmm1),
+            src2: XmmMemImm::unwrap_new(xmm12.into()),
         },
         "C44171DEEC",
         "vpmaxub %xmm1, %xmm12, %xmm13",
@@ -4832,17 +4772,16 @@ fn test_x64_emit() {
     insns.push((
         Inst::XmmRmiRVex {
             op: AvxOpcode::Vpmaxub,
-            dst: Writable::from_reg(Xmm::new(xmm13).unwrap()),
-            src1: Xmm::new(xmm1).unwrap(),
-            src2: XmmMemImm::new(RegMemImm::Mem {
+            dst: Writable::from_reg(Xmm::unwrap_new(xmm13)),
+            src1: Xmm::unwrap_new(xmm1),
+            src2: XmmMemImm::unwrap_new(RegMemImm::Mem {
                 addr: Amode::ImmReg {
                     simm32: 10,
                     base: rax,
                     flags: MemFlags::trusted(),
                 }
                 .into(),
-            })
-            .unwrap(),
+            }),
         },
         "C571DE680A",
         "vpmaxub %xmm1, 10(%rax), %xmm13",
@@ -4852,9 +4791,9 @@ fn test_x64_emit() {
     insns.push((
         Inst::XmmRmiRVex {
             op: AvxOpcode::Vpsrlw,
-            dst: Writable::from_reg(Xmm::new(xmm13).unwrap()),
-            src1: Xmm::new(xmm1).unwrap(),
-            src2: XmmMemImm::new(RegMemImm::Imm { simm32: 36 }).unwrap(),
+            dst: Writable::from_reg(Xmm::unwrap_new(xmm13)),
+            src1: Xmm::unwrap_new(xmm1),
+            src2: XmmMemImm::unwrap_new(RegMemImm::Imm { simm32: 36 }),
         },
         "C59171D124",
         "vpsrlw  %xmm1, $36, %xmm13",
@@ -4866,9 +4805,9 @@ fn test_x64_emit() {
     insns.push((
         Inst::XmmRmiRVex {
             op: AvxOpcode::Vmulsd,
-            dst: Writable::from_reg(Xmm::new(xmm13).unwrap()),
-            src1: Xmm::new(xmm1).unwrap(),
-            src2: XmmMemImm::new(xmm12.into()).unwrap(),
+            dst: Writable::from_reg(Xmm::unwrap_new(xmm13)),
+            src1: Xmm::unwrap_new(xmm1),
+            src2: XmmMemImm::unwrap_new(xmm12.into()),
         },
         "C51B59E9",
         "vmulsd  %xmm1, %xmm12, %xmm13",
@@ -4876,9 +4815,9 @@ fn test_x64_emit() {
     insns.push((
         Inst::XmmRmiRVex {
             op: AvxOpcode::Vmulsd,
-            dst: Writable::from_reg(Xmm::new(xmm13).unwrap()),
-            src1: Xmm::new(xmm12).unwrap(),
-            src2: XmmMemImm::new(xmm1.into()).unwrap(),
+            dst: Writable::from_reg(Xmm::unwrap_new(xmm13)),
+            src1: Xmm::unwrap_new(xmm12),
+            src2: XmmMemImm::unwrap_new(xmm1.into()),
         },
         "C51B59E9",
         "vmulsd  %xmm12, %xmm1, %xmm13",
@@ -4889,9 +4828,9 @@ fn test_x64_emit() {
     insns.push((
         Inst::XmmVexPinsr {
             op: AvxOpcode::Vpinsrb,
-            dst: Writable::from_reg(Xmm::new(xmm13).unwrap()),
-            src1: Xmm::new(xmm14).unwrap(),
-            src2: GprMem::new(RegMem::reg(r15)).unwrap(),
+            dst: Writable::from_reg(Xmm::unwrap_new(xmm13)),
+            src1: Xmm::unwrap_new(xmm14),
+            src2: GprMem::unwrap_new(RegMem::reg(r15)),
             imm: 2,
         },
         "C4430920EF02",
@@ -4901,12 +4840,11 @@ fn test_x64_emit() {
     // ========================================================
     // Pertaining to atomics.
     let am1: SyntheticAmode =
-        Amode::imm_reg_reg_shift(321, Gpr::new(r10).unwrap(), Gpr::new(rdx).unwrap(), 2).into();
+        Amode::imm_reg_reg_shift(321, Gpr::unwrap_new(r10), Gpr::unwrap_new(rdx), 2).into();
     // `am2` doesn't contribute any 1 bits to the rex prefix, so we must use it when testing
     // for retention of the apparently-redundant rex prefix in the 8-bit case.
     let am2: SyntheticAmode =
-        Amode::imm_reg_reg_shift(-12345i32, Gpr::new(rcx).unwrap(), Gpr::new(rsi).unwrap(), 3)
-            .into();
+        Amode::imm_reg_reg_shift(-12345i32, Gpr::unwrap_new(rcx), Gpr::unwrap_new(rsi), 3).into();
     // Use `r9` with a 0 offset.
     let am3: SyntheticAmode = Amode::imm_reg(0, r9).into();
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -215,8 +215,8 @@ impl Inst {
         Self::AluRmiR {
             size,
             op,
-            src1: Gpr::new(dst.to_reg()).unwrap(),
-            src2: GprMemImm::new(src).unwrap(),
+            src1: Gpr::unwrap_new(dst.to_reg()),
+            src2: GprMemImm::unwrap_new(src),
             dst: WritableGpr::from_writable_reg(dst).unwrap(),
         }
     }
@@ -238,7 +238,7 @@ impl Inst {
         Self::UnaryRmR {
             size,
             op,
-            src: GprMem::new(src).unwrap(),
+            src: GprMem::unwrap_new(src),
             dst: WritableGpr::from_writable_reg(dst).unwrap(),
         }
     }
@@ -247,7 +247,7 @@ impl Inst {
         debug_assert_eq!(src.to_reg().class(), RegClass::Int);
         Inst::Not {
             size,
-            src: Gpr::new(src.to_reg()).unwrap(),
+            src: Gpr::unwrap_new(src.to_reg()),
             dst: WritableGpr::from_writable_reg(src).unwrap(),
         }
     }
@@ -267,7 +267,7 @@ impl Inst {
             size,
             sign,
             trap,
-            divisor: GprMem::new(divisor).unwrap(),
+            divisor: GprMem::unwrap_new(divisor),
             dividend_lo,
             dividend_hi,
             dst_quotient,
@@ -286,7 +286,7 @@ impl Inst {
         Inst::Div8 {
             sign,
             trap,
-            divisor: GprMem::new(divisor).unwrap(),
+            divisor: GprMem::unwrap_new(divisor),
             dividend,
             dst,
         }
@@ -312,7 +312,7 @@ impl Inst {
         debug_assert!(size.is_one_of(&[OperandSize::Size32, OperandSize::Size64]));
         debug_assert!(src.class() == RegClass::Int);
         debug_assert!(dst.to_reg().class() == RegClass::Int);
-        let src = Gpr::new(src).unwrap();
+        let src = Gpr::unwrap_new(src);
         let dst = WritableGpr::from_writable_reg(dst).unwrap();
         Inst::MovRR { size, src, dst }
     }
@@ -323,7 +323,7 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmUnaryRmR {
             op,
-            src: XmmMemAligned::new(src).unwrap(),
+            src: XmmMemAligned::unwrap_new(src),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -333,8 +333,8 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmRmR {
             op,
-            src1: Xmm::new(dst.to_reg()).unwrap(),
-            src2: XmmMemAligned::new(src).unwrap(),
+            src1: Xmm::unwrap_new(dst.to_reg()),
+            src2: XmmMemAligned::unwrap_new(src),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -346,9 +346,9 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmRmRVex3 {
             op,
-            src3: XmmMem::new(src3).unwrap(),
-            src2: Xmm::new(src2).unwrap(),
-            src1: Xmm::new(dst.to_reg()).unwrap(),
+            src3: XmmMem::unwrap_new(src3),
+            src2: Xmm::unwrap_new(src2),
+            src1: Xmm::unwrap_new(dst.to_reg()),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -357,7 +357,7 @@ impl Inst {
         debug_assert!(src.class() == RegClass::Float);
         Inst::XmmMovRM {
             op,
-            src: Xmm::new(src).unwrap(),
+            src: Xmm::unwrap_new(src),
             dst: dst.into(),
         }
     }
@@ -373,7 +373,7 @@ impl Inst {
         debug_assert!(dst_size.is_one_of(&[OperandSize::Size32, OperandSize::Size64]));
         Inst::XmmToGpr {
             op,
-            src: Xmm::new(src).unwrap(),
+            src: Xmm::unwrap_new(src),
             dst: WritableGpr::from_writable_reg(dst).unwrap(),
             dst_size,
         }
@@ -390,7 +390,7 @@ impl Inst {
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::GprToXmm {
             op,
-            src: GprMem::new(src).unwrap(),
+            src: GprMem::unwrap_new(src),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
             src_size,
         }
@@ -399,8 +399,8 @@ impl Inst {
     pub(crate) fn xmm_cmp_rm_r(op: SseOpcode, src1: Reg, src2: RegMem) -> Inst {
         src2.assert_regclass_is(RegClass::Float);
         debug_assert!(src1.class() == RegClass::Float);
-        let src2 = XmmMemAligned::new(src2).unwrap();
-        let src1 = Xmm::new(src1).unwrap();
+        let src2 = XmmMemAligned::unwrap_new(src2);
+        let src1 = Xmm::unwrap_new(src1);
         Inst::XmmCmpRmR { op, src1, src2 }
     }
 
@@ -419,8 +419,8 @@ impl Inst {
         Inst::XmmMinMaxSeq {
             size,
             is_min,
-            lhs: Xmm::new(lhs).unwrap(),
-            rhs: Xmm::new(rhs).unwrap(),
+            lhs: Xmm::unwrap_new(lhs),
+            rhs: Xmm::unwrap_new(rhs),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -428,7 +428,7 @@ impl Inst {
     pub(crate) fn movzx_rm_r(ext_mode: ExtMode, src: RegMem, dst: Writable<Reg>) -> Inst {
         src.assert_regclass_is(RegClass::Int);
         debug_assert!(dst.to_reg().class() == RegClass::Int);
-        let src = GprMem::new(src).unwrap();
+        let src = GprMem::unwrap_new(src);
         let dst = WritableGpr::from_writable_reg(dst).unwrap();
         Inst::MovzxRmR { ext_mode, src, dst }
     }
@@ -436,7 +436,7 @@ impl Inst {
     pub(crate) fn movsx_rm_r(ext_mode: ExtMode, src: RegMem, dst: Writable<Reg>) -> Inst {
         src.assert_regclass_is(RegClass::Int);
         debug_assert!(dst.to_reg().class() == RegClass::Int);
-        let src = GprMem::new(src).unwrap();
+        let src = GprMem::unwrap_new(src);
         let dst = WritableGpr::from_writable_reg(dst).unwrap();
         Inst::MovsxRmR { ext_mode, src, dst }
     }
@@ -453,7 +453,7 @@ impl Inst {
         debug_assert!(src.class() == RegClass::Int);
         Inst::MovRM {
             size,
-            src: Gpr::new(src).unwrap(),
+            src: Gpr::unwrap_new(src),
             dst: dst.into(),
         }
     }
@@ -481,7 +481,7 @@ impl Inst {
         Inst::ShiftR {
             size,
             kind,
-            src: Gpr::new(src).unwrap(),
+            src: Gpr::unwrap_new(src),
             num_bits,
             dst: WritableGpr::from_writable_reg(dst).unwrap(),
         }
@@ -494,8 +494,8 @@ impl Inst {
         debug_assert_eq!(src1.class(), RegClass::Int);
         Inst::CmpRmiR {
             size,
-            src1: Gpr::new(src1).unwrap(),
-            src2: GprMemImm::new(src2).unwrap(),
+            src1: Gpr::unwrap_new(src1),
+            src2: GprMemImm::unwrap_new(src2),
             opcode: CmpOpcode::Cmp,
         }
     }
@@ -518,15 +518,15 @@ impl Inst {
         Inst::Cmove {
             size,
             cc,
-            consequent: GprMem::new(src).unwrap(),
-            alternative: Gpr::new(dst.to_reg()).unwrap(),
+            consequent: GprMem::unwrap_new(src),
+            alternative: Gpr::unwrap_new(dst.to_reg()),
             dst: WritableGpr::from_writable_reg(dst).unwrap(),
         }
     }
 
     pub(crate) fn push64(src: RegMemImm) -> Inst {
         src.assert_regclass_is(RegClass::Int);
-        let src = GprMemImm::new(src).unwrap();
+        let src = GprMemImm::unwrap_new(src);
         Inst::Push64 { src }
     }
 

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -291,8 +291,8 @@ fn lower_to_amode(ctx: &mut Lower<Inst>, spec: InsnInput, offset: i32) -> Amode 
 
         return Amode::imm_reg_reg_shift(
             offset,
-            Gpr::new(base).unwrap(),
-            Gpr::new(index).unwrap(),
+            Gpr::unwrap_new(base),
+            Gpr::unwrap_new(index),
             shift,
         )
         .with_flags(flags);

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -161,7 +161,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
         if let Some(c) = inputs.constant {
             let ty = self.lower_ctx.dfg().value_type(val);
             if let Some(imm) = to_simm32(c as i64, ty) {
-                return XmmMemImm::new(imm.to_reg_mem_imm()).unwrap();
+                return XmmMemImm::unwrap_new(imm.to_reg_mem_imm());
             }
         }
 
@@ -170,7 +170,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             RegMem::Mem { addr } => RegMemImm::Mem { addr },
         };
 
-        XmmMemImm::new(res).unwrap()
+        XmmMemImm::unwrap_new(res)
     }
 
     fn put_in_xmm_mem(&mut self, val: Value) -> XmmMem {
@@ -183,11 +183,10 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             // NOTE: this is where behavior differs from `put_in_reg_mem`, as we always force
             // constants to be 16 bytes when a constant will be used in place of an xmm register.
             let vcode_constant = self.emit_u128_le_const(c as u128);
-            return XmmMem::new(RegMem::mem(SyntheticAmode::ConstantOffset(vcode_constant)))
-                .unwrap();
+            return XmmMem::unwrap_new(RegMem::mem(SyntheticAmode::ConstantOffset(vcode_constant)));
         }
 
-        XmmMem::new(self.put_in_reg_mem(val)).unwrap()
+        XmmMem::unwrap_new(self.put_in_reg_mem(val))
     }
 
     fn put_in_reg_mem(&mut self, val: Value) -> RegMem {
@@ -306,10 +305,9 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     #[inline]
     fn const_to_type_masked_imm8(&mut self, c: u64, ty: Type) -> Imm8Gpr {
         let mask = self.shift_mask(ty) as u64;
-        Imm8Gpr::new(Imm8Reg::Imm8 {
+        Imm8Gpr::unwrap_new(Imm8Reg::Imm8 {
             imm: (c & mask) as u8,
         })
-        .unwrap()
     }
 
     #[inline]
@@ -458,7 +456,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
 
     #[inline]
     fn writable_reg_to_xmm(&mut self, r: WritableReg) -> WritableXmm {
-        Writable::from_reg(Xmm::new(r.to_reg()).unwrap())
+        Writable::from_reg(Xmm::unwrap_new(r.to_reg()))
     }
 
     #[inline]
@@ -488,7 +486,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
 
     #[inline]
     fn xmm_mem_to_xmm_mem_imm(&mut self, r: &XmmMem) -> XmmMemImm {
-        XmmMemImm::new(r.clone().to_reg_mem().into()).unwrap()
+        XmmMemImm::unwrap_new(r.clone().to_reg_mem().into())
     }
 
     #[inline]
@@ -508,17 +506,17 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
 
     #[inline]
     fn reg_mem_to_xmm_mem(&mut self, rm: &RegMem) -> XmmMem {
-        XmmMem::new(rm.clone()).unwrap()
+        XmmMem::unwrap_new(rm.clone())
     }
 
     #[inline]
     fn gpr_mem_imm_new(&mut self, rmi: &RegMemImm) -> GprMemImm {
-        GprMemImm::new(rmi.clone()).unwrap()
+        GprMemImm::unwrap_new(rmi.clone())
     }
 
     #[inline]
     fn xmm_mem_imm_new(&mut self, rmi: &RegMemImm) -> XmmMemImm {
-        XmmMemImm::new(rmi.clone()).unwrap()
+        XmmMemImm::unwrap_new(rmi.clone())
     }
 
     #[inline]
@@ -538,27 +536,27 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
 
     #[inline]
     fn xmm_new(&mut self, r: Reg) -> Xmm {
-        Xmm::new(r).unwrap()
+        Xmm::unwrap_new(r)
     }
 
     #[inline]
     fn gpr_new(&mut self, r: Reg) -> Gpr {
-        Gpr::new(r).unwrap()
+        Gpr::unwrap_new(r)
     }
 
     #[inline]
     fn reg_mem_to_gpr_mem(&mut self, rm: &RegMem) -> GprMem {
-        GprMem::new(rm.clone()).unwrap()
+        GprMem::unwrap_new(rm.clone())
     }
 
     #[inline]
     fn reg_to_gpr_mem(&mut self, r: Reg) -> GprMem {
-        GprMem::new(RegMem::reg(r)).unwrap()
+        GprMem::unwrap_new(RegMem::reg(r))
     }
 
     #[inline]
     fn imm8_reg_to_imm8_gpr(&mut self, ir: &Imm8Reg) -> Imm8Gpr {
-        Imm8Gpr::new(ir.clone()).unwrap()
+        Imm8Gpr::unwrap_new(ir.clone())
     }
 
     #[inline]
@@ -578,12 +576,12 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
 
     #[inline]
     fn imm8_to_imm8_gpr(&mut self, imm: u8) -> Imm8Gpr {
-        Imm8Gpr::new(Imm8Reg::Imm8 { imm }).unwrap()
+        Imm8Gpr::unwrap_new(Imm8Reg::Imm8 { imm })
     }
 
     fn gpr_from_imm8_gpr(&mut self, val: &Imm8Gpr) -> Option<Gpr> {
         match val.as_imm8_reg() {
-            &Imm8Reg::Reg { reg } => Some(Gpr::new(reg).unwrap()),
+            &Imm8Reg::Reg { reg } => Some(Gpr::unwrap_new(reg)),
             Imm8Reg::Imm8 { .. } => None,
         }
     }
@@ -986,7 +984,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     fn xmi_imm(&mut self, imm: u32) -> XmmMemImm {
-        XmmMemImm::new(RegMemImm::imm(imm)).unwrap()
+        XmmMemImm::unwrap_new(RegMemImm::imm(imm))
     }
 
     fn insert_i8x16_lane_hole(&mut self, hole_idx: u8) -> VCodeConstant {
@@ -1000,10 +998,10 @@ impl IsleContext<'_, '_, MInst, X64Backend> {
         let tmp = self.lower_ctx.alloc_tmp(types::F32X4).only_reg().unwrap();
         self.lower_ctx.emit(MInst::XmmUnaryRmRUnaligned {
             op: SseOpcode::Movdqu,
-            src: XmmMem::new(RegMem::mem(addr)).unwrap(),
-            dst: Writable::from_reg(Xmm::new(tmp.to_reg()).unwrap()),
+            src: XmmMem::unwrap_new(RegMem::mem(addr)),
+            dst: Writable::from_reg(Xmm::unwrap_new(tmp.to_reg())),
         });
-        Xmm::new(tmp.to_reg()).unwrap()
+        Xmm::unwrap_new(tmp.to_reg())
     }
 }
 
@@ -1041,12 +1039,9 @@ const I8X16_USHR_MASKS: [u8; 128] = [
 #[inline]
 fn to_simm32(constant: i64, ty: Type) -> Option<GprMemImm> {
     if ty.bits() <= 32 || constant == ((constant << 32) >> 32) {
-        Some(
-            GprMemImm::new(RegMemImm::Imm {
-                simm32: constant as u32,
-            })
-            .unwrap(),
-        )
+        Some(GprMemImm::unwrap_new(RegMemImm::Imm {
+            simm32: constant as u32,
+        }))
     } else {
         None
     }

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -59,31 +59,31 @@ impl From<Reg> for WritableXmm {
 
 impl From<Reg> for Gpr {
     fn from(reg: Reg) -> Self {
-        Gpr::new(reg.into()).expect("valid gpr")
+        Gpr::unwrap_new(reg.into())
     }
 }
 
 impl From<Reg> for GprMem {
     fn from(value: Reg) -> Self {
-        GprMem::new(value.into()).expect("valid gpr")
+        GprMem::unwrap_new(value.into())
     }
 }
 
 impl From<Reg> for GprMemImm {
     fn from(reg: Reg) -> Self {
-        GprMemImm::new(reg.into()).expect("valid gpr")
+        GprMemImm::unwrap_new(reg.into())
     }
 }
 
 impl From<Reg> for Imm8Gpr {
     fn from(value: Reg) -> Self {
-        Imm8Gpr::new(Imm8Reg::Reg { reg: value.into() }).expect("valid Imm8Gpr")
+        Imm8Gpr::unwrap_new(Imm8Reg::Reg { reg: value.into() })
     }
 }
 
 impl From<Reg> for Xmm {
     fn from(reg: Reg) -> Self {
-        Xmm::new(reg.into()).expect("valid Xmm register")
+        Xmm::unwrap_new(reg.into())
     }
 }
 
@@ -348,7 +348,7 @@ impl Assembler {
             let reg_mem = RegMem::mem(src);
             self.emit(Inst::MovzxRmR {
                 ext_mode: ext,
-                src: GprMem::new(reg_mem).expect("valid memory address"),
+                src: GprMem::unwrap_new(reg_mem),
                 dst: dst.into(),
             });
         } else {
@@ -378,7 +378,7 @@ impl Assembler {
         let reg_mem = RegMem::mem(src);
         self.emit(Inst::MovsxRmR {
             ext_mode: ext.into(),
-            src: GprMem::new(reg_mem).expect("valid memory address"),
+            src: GprMem::unwrap_new(reg_mem),
             dst: dst.into(),
         })
     }
@@ -426,7 +426,7 @@ impl Assembler {
 
         self.emit(Inst::XmmUnaryRmRUnaligned {
             op,
-            src: XmmMem::new(src.into()).expect("valid xmm unaligned"),
+            src: XmmMem::unwrap_new(src.into()),
             dst: dst.into(),
         });
     }
@@ -452,7 +452,7 @@ impl Assembler {
         );
         self.emit(Inst::XmmUnaryRmRUnaligned {
             op,
-            src: XmmMem::new(RegMem::mem(src)).expect("valid xmm unaligned"),
+            src: XmmMem::unwrap_new(RegMem::mem(src)),
             dst: dst.into(),
         });
     }
@@ -497,7 +497,7 @@ impl Assembler {
         self.emit(Inst::XmmCmove {
             ty,
             cc: cc.into(),
-            consequent: Xmm::new(src.into()).expect("valid Xmm"),
+            consequent: Xmm::unwrap_new(src.into()),
             alternative: dst.into(),
             dst: dst.into(),
         })
@@ -522,7 +522,7 @@ impl Assembler {
             size: size.into(),
             op: AluRmiROpcode::Sub,
             src1: dst.into(),
-            src2: GprMemImm::new(imm).expect("valid immediate"),
+            src2: GprMemImm::unwrap_new(imm),
             dst: dst.into(),
         });
     }
@@ -544,7 +544,7 @@ impl Assembler {
             size: size.into(),
             op: AluRmiROpcode::And,
             src1: dst.into(),
-            src2: GprMemImm::new(imm).expect("valid immediate"),
+            src2: GprMemImm::unwrap_new(imm),
             dst: dst.into(),
         });
     }
@@ -713,7 +713,7 @@ impl Assembler {
 
         self.emit(Inst::XmmRmRUnaligned {
             op,
-            src2: Xmm::new(src.into()).expect("valid xmm unaligned").into(),
+            src2: Xmm::unwrap_new(src.into()).into(),
             src1: dst.into(),
             dst: dst.into(),
         });
@@ -736,7 +736,7 @@ impl Assembler {
             size: size.into(),
             op: AluRmiROpcode::Or,
             src1: dst.into(),
-            src2: GprMemImm::new(imm).expect("valid immediate"),
+            src2: GprMemImm::unwrap_new(imm),
             dst: dst.into(),
         });
     }
@@ -774,7 +774,7 @@ impl Assembler {
             size: size.into(),
             op: AluRmiROpcode::Xor,
             src1: dst.into(),
-            src2: GprMemImm::new(imm).expect("valid immediate"),
+            src2: GprMemImm::unwrap_new(imm),
             dst: dst.into(),
         });
     }
@@ -814,7 +814,7 @@ impl Assembler {
             size: size.into(),
             kind: kind.into(),
             src: dst.into(),
-            num_bits: Imm8Gpr::new(imm).expect("valid immediate"),
+            num_bits: Imm8Gpr::unwrap_new(imm),
             dst: dst.into(),
         });
     }
@@ -835,8 +835,8 @@ impl Assembler {
             DivKind::Signed => {
                 self.emit(Inst::CmpRmiR {
                     size: size.into(),
-                    src1: divisor.into(),
-                    src2: GprMemImm::new(RegMemImm::imm(0)).unwrap(),
+                    src1: divisor.unwrap_into(),
+                    src2: GprMemImm::unwrap_new(RegMemImm::imm(0)),
                     opcode: CmpOpcode::Cmp,
                 });
                 self.emit(Inst::TrapIf {
@@ -871,7 +871,7 @@ impl Assembler {
             sign: kind.into(),
             size: size.into(),
             trap,
-            divisor: GprMem::new(RegMem::reg(divisor.into())).unwrap(),
+            divisor: GprMem::unwrap_new(RegMem::reg(divisor.into())),
             dividend_lo: dst.0.into(),
             dividend_hi: dst.1.into(),
             dst_quotient: dst.0.into(),
@@ -921,7 +921,7 @@ impl Assembler {
                     sign: DivSignedness::Unsigned,
                     trap: TrapCode::IntegerDivisionByZero,
                     size: size.into(),
-                    divisor: GprMem::new(RegMem::reg(divisor.into())).unwrap(),
+                    divisor: GprMem::unwrap_new(RegMem::reg(divisor.into())),
                     dividend_lo: dst.0.into(),
                     dividend_hi: dst.1.into(),
                     dst_quotient: dst.0.into(),
@@ -959,7 +959,7 @@ impl Assembler {
             size: size.into(),
             op: AluRmiROpcode::Add,
             src1: dst.into(),
-            src2: GprMemImm::new(imm).expect("valid immediate"),
+            src2: GprMemImm::unwrap_new(imm),
             dst: dst.into(),
         });
     }
@@ -982,7 +982,7 @@ impl Assembler {
             size: size.into(),
             opcode: CmpOpcode::Cmp,
             src1: src1.into(),
-            src2: GprMemImm::new(imm).expect("valid immediate"),
+            src2: GprMemImm::unwrap_new(imm),
         });
     }
 

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -835,7 +835,7 @@ impl Assembler {
             DivKind::Signed => {
                 self.emit(Inst::CmpRmiR {
                     size: size.into(),
-                    src1: divisor.unwrap_into(),
+                    src1: divisor.into(),
                     src2: GprMemImm::unwrap_new(RegMemImm::imm(0)),
                     opcode: CmpOpcode::Cmp,
                 });


### PR DESCRIPTION
1. Add `Gpr::unwrap_new` and etc... constructors inside the macro that defines all the newtypes. These have better error messages on failure than `Gpr::new(r).unwrap()` would.

2. Use those new constructors everywhere we were otherwise doing `Gpr::new(r).unwrap()` and etc...

Note that (2) is purely mechanical, so whoever is assigned to review this can probably just focus on the changes inside the macro.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
