### PR TITLE
cranelift-codegen: no_std support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -433,6 +433,7 @@ jobs:
     - run: rustup target add x86_64-unknown-none
     - run: cargo check --target x86_64-unknown-none -p wasmtime --no-default-features --features runtime,gc,component-model
     - run: cargo check --target x86_64-unknown-none -p cranelift-control --no-default-features
+    - run: cargo check --target x86_64-unknown-none -p cranelift-codegen --no-default-features --features all-arch,trace-log
 
     # Check that wasmtime compiles with panic=abort since there's some `#[cfg]`
     # for specifically panic=abort there.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "core_maths"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b02505ccb8c50b0aa21ace0fc08c3e53adebd4e58caa18a36152803c7709a3"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,9 +601,11 @@ dependencies = [
 name = "cranelift-codegen"
 version = "0.111.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "bumpalo",
  "capstone",
+ "core_maths",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-codegen-meta",
@@ -601,9 +618,9 @@ dependencies = [
  "gimli",
  "hashbrown 0.14.3",
  "log",
+ "once_cell",
  "postcard",
  "regalloc2",
- "rustc-hash",
  "serde",
  "serde_derive",
  "sha2",
@@ -890,6 +907,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1393,6 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
+ "allocator-api2",
  "serde",
 ]
 
@@ -1965,6 +1989,10 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -2065,6 +2093,12 @@ name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+
+[[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "postcard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
+ahash = { version = "0.8", default-features = false }
 wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.0" }
 wasmtime = { path = "crates/wasmtime", version = "24.0.0", default-features = false }
 wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.0" }
@@ -226,7 +227,7 @@ cranelift-jit = { path = "cranelift/jit", version = "0.111.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
 cranelift-bforest = { path = "cranelift/bforest", version = "0.111.0" }
 cranelift-bitset = { path = "cranelift/bitset", version = "0.111.0" }
-cranelift-control = { path = "cranelift/control", version = "0.111.0" }
+cranelift-control = { path = "cranelift/control", version = "0.111.0", default-features = false }
 cranelift = { path = "cranelift/umbrella", version = "0.111.0" }
 
 winch-codegen = { path = "winch/codegen", version = "=0.22.0" }
@@ -236,7 +237,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.9.3"
+regalloc2 = { version = "0.9.3", default-features = false }
 
 # cap-std family:
 target-lexicon = "0.12.13"
@@ -277,9 +278,9 @@ windows-sys = "0.52.0"
 env_logger = "0.10"
 log = { version = "0.4.8", default-features = false }
 clap = { version = "4.3.12", default-features = false, features = ["std", "derive"] }
-hashbrown = { version = "0.14", default-features = false }
+hashbrown = { version = "0.14" }
 capstone = "0.12.0"
-once_cell = { version = "1.12.0", default-features = false }
+once_cell = { version = "1.12.0", default-features = false, features = ["critical-section"] }
 smallvec = { version = "1.6.1", features = ["union"] }
 tracing = "0.1.26"
 bitflags = "2.0"
@@ -322,7 +323,7 @@ url = "2.3.1"
 humantime = "2.0.0"
 postcard = { version = "1.0.8", default-features = false, features = ['alloc'] }
 criterion = { version = "0.5.0", default-features = false, features = ["html_reports", "rayon"] }
-rustc-hash = "1.1.0"
+rustc-hash = { version = "1.1.0", default-features = false }
 libtest-mimic = "0.7.0"
 semver = { version = "1.0.17", default-features = false }
 

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -16,9 +16,11 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+ahash = { workspace = true }
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
+core_maths = "0.1"
 cranelift-codegen-shared = { path = "./shared", version = "0.111.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
@@ -32,10 +34,10 @@ serde_derive = { workspace = true, optional = true }
 postcard = { workspace = true, optional = true }
 gimli = { workspace = true, features = ["write", "std"], optional = true }
 smallvec = { workspace = true }
+once_cell = { workspace = true }
 regalloc2 = { workspace = true, features = ["checker", "trace-log"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }
-rustc-hash  = { workspace = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be
@@ -97,6 +99,7 @@ enable-serde = [
     "serde_derive",
     "cranelift-entity/enable-serde",
     "cranelift-bitset/enable-serde",
+    "hashbrown/serde",
     "regalloc2/enable-serde",
     "smallvec/serde"
 ]
@@ -109,7 +112,7 @@ incremental-cache = [
 ]
 
 # Enable support for the Souper harvester.
-souper-harvest = ["souper-ir", "souper-ir/stringify"]
+souper-harvest = ["souper-ir", "souper-ir/stringify", "std"]
 
 # Report any ISLE errors in pretty-printed style.
 isle-errors = ["cranelift-isle/fancy-errors"]
@@ -121,7 +124,7 @@ isle-in-source-tree = []
 # Enable tracking how long passes take in Cranelift.
 #
 # Enabled by default.
-timing = []
+timing = ["std"]
 
 [[bench]]
 name = "x64-evex-encoding"

--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -209,7 +209,11 @@ fn run_compilation(compilation: &IsleCompilation) -> Result<(), Errors> {
             .iter()
             .chain(compilation.untracked_inputs.iter());
 
-        let mut options = isle::codegen::CodegenOptions::default();
+        let mut options = isle::codegen::CodegenOptions {
+            no_std: true,
+            ..Default::default()
+        };
+
         // Because we include!() the generated ISLE source, we cannot
         // put the global pragmas (`#![allow(...)]`) in the ISLE
         // source itself; we have to put them in the source that

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -2,6 +2,7 @@
 //! `cranelift-codegen-meta` libraries.
 
 #![deny(missing_docs)]
+#![no_std]
 
 pub mod constant_hash;
 pub mod constants;

--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -71,7 +71,7 @@ use crate::{
     trace,
 };
 use cranelift_entity::{packed_option::PackedOption, EntityRef};
-use rustc_hash::{FxHashMap, FxHashSet};
+use hashbrown::{HashMap, HashSet};
 
 /// For a given program point, the vector of last-store instruction
 /// indices for each disjoint category of abstract state.
@@ -179,14 +179,14 @@ pub struct AliasAnalysis<'a> {
     domtree: &'a DominatorTree,
 
     /// Input state to a basic block.
-    block_input: FxHashMap<Block, LastStores>,
+    block_input: HashMap<Block, LastStores>,
 
     /// Known memory-value equivalences. This is the result of the
     /// analysis. This is a mapping from (last store, address
     /// expression, offset, type) to SSA `Value`.
     ///
     /// We keep the defining inst around for quick dominance checks.
-    mem_values: FxHashMap<MemoryLoc, (Inst, Value)>,
+    mem_values: HashMap<MemoryLoc, (Inst, Value)>,
 }
 
 impl<'a> AliasAnalysis<'a> {
@@ -195,8 +195,8 @@ impl<'a> AliasAnalysis<'a> {
         trace!("alias analysis: input is:\n{:?}", func);
         let mut analysis = AliasAnalysis {
             domtree,
-            block_input: FxHashMap::default(),
-            mem_values: FxHashMap::default(),
+            block_input: HashMap::default(),
+            mem_values: HashMap::default(),
         };
 
         analysis.compute_block_input_states(func);
@@ -205,7 +205,7 @@ impl<'a> AliasAnalysis<'a> {
 
     fn compute_block_input_states(&mut self, func: &Function) {
         let mut queue = vec![];
-        let mut queue_set = FxHashSet::default();
+        let mut queue_set = HashSet::<Block>::default();
         let entry = func.layout.entry_block().unwrap();
         queue.push(entry);
         queue_set.insert(entry);

--- a/cranelift/codegen/src/ctxhash.rs
+++ b/cranelift/codegen/src/ctxhash.rs
@@ -4,8 +4,9 @@
 //! node-internal data references some other storage (e.g., offsets into
 //! an array or pool of shared data).
 
+use ahash::AHasher;
+use core::hash::{Hash, Hasher};
 use hashbrown::raw::RawTable;
-use std::hash::{Hash, Hasher};
 
 /// Trait that allows for equality comparison given some external
 /// context.
@@ -76,7 +77,7 @@ fn compute_hash<Ctx, K>(ctx: &Ctx, k: &K) -> u32
 where
     Ctx: CtxHash<K>,
 {
-    let mut hasher = rustc_hash::FxHasher::default();
+    let mut hasher = AHasher::default();
     ctx.ctx_hash(&mut hasher, k);
     hasher.finish() as u32
 }
@@ -94,7 +95,7 @@ impl<K, V> CtxHashMap<K, V> {
         }) {
             Some(bucket) => {
                 let data = unsafe { bucket.as_mut() };
-                Some(std::mem::replace(&mut data.v, v))
+                Some(core::mem::replace(&mut data.v, v))
             }
             None => {
                 let data = BucketData { hash, k, v };

--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -231,13 +231,13 @@ impl DataValue {
     /// Write a [DataValue] to a memory location in native-endian byte order.
     pub unsafe fn write_value_to(&self, p: *mut u128) {
         let size = self.ty().bytes() as usize;
-        self.write_to_slice_ne(std::slice::from_raw_parts_mut(p as *mut u8, size));
+        self.write_to_slice_ne(core::slice::from_raw_parts_mut(p as *mut u8, size));
     }
 
     /// Read a [DataValue] from a memory location using a given [Type] in native-endian byte order.
     pub unsafe fn read_value_from(p: *const u128, ty: Type) -> Self {
         DataValue::read_from_slice_ne(
-            std::slice::from_raw_parts(p as *const u8, ty.bytes() as usize),
+            core::slice::from_raw_parts(p as *const u8, ty.bytes() as usize),
             ty,
         )
     }
@@ -274,6 +274,7 @@ pub enum DataValueCastFailure {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for DataValueCastFailure {}
 
 impl Display for DataValueCastFailure {

--- a/cranelift/codegen/src/egraph/cost.rs
+++ b/cranelift/codegen/src/egraph/cost.rs
@@ -48,7 +48,7 @@ impl core::fmt::Debug for Cost {
 
 impl Ord for Cost {
     #[inline]
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         // We make sure that the high bits are the op cost and the low bits are
         // the depth. This means that we can use normal integer comparison to
         // order by op cost and then depth.
@@ -65,7 +65,7 @@ impl Ord for Cost {
 
 impl PartialOrd for Cost {
     #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -117,24 +117,24 @@ impl Cost {
     }
 }
 
-impl std::iter::Sum<Cost> for Cost {
+impl core::iter::Sum<Cost> for Cost {
     fn sum<I: Iterator<Item = Cost>>(iter: I) -> Self {
         iter.fold(Self::zero(), |a, b| a + b)
     }
 }
 
-impl std::default::Default for Cost {
+impl core::default::Default for Cost {
     fn default() -> Cost {
         Cost::zero()
     }
 }
 
-impl std::ops::Add<Cost> for Cost {
+impl core::ops::Add<Cost> for Cost {
     type Output = Cost;
 
     fn add(self, other: Cost) -> Cost {
         let op_cost = self.op_cost().saturating_add(other.op_cost());
-        let depth = std::cmp::max(self.depth(), other.depth());
+        let depth = core::cmp::max(self.depth(), other.depth());
         Cost::new(op_cost, depth)
     }
 }

--- a/cranelift/codegen/src/incremental_cache.rs
+++ b/cranelift/codegen/src/incremental_cache.rs
@@ -112,7 +112,7 @@ pub trait CacheKvStore {
 #[derive(Clone, Hash, PartialEq, Eq)]
 pub struct CacheKeyHash([u8; 32]);
 
-impl std::fmt::Display for CacheKeyHash {
+impl core::fmt::Display for CacheKeyHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "CacheKeyHash:{:?}", self.0)
     }

--- a/cranelift/codegen/src/ir/condcodes.rs
+++ b/cranelift/codegen/src/ir/condcodes.rs
@@ -344,7 +344,7 @@ impl FromStr for FloatCC {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn int_complement() {

--- a/cranelift/codegen/src/ir/constant.rs
+++ b/cranelift/codegen/src/ir/constant.rs
@@ -275,7 +275,7 @@ impl ConstantPool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn empty() {

--- a/cranelift/codegen/src/ir/extname.rs
+++ b/cranelift/codegen/src/ir/extname.rs
@@ -99,7 +99,7 @@ pub struct TestcaseName(Box<[u8]>);
 impl fmt::Display for TestcaseName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('%')?;
-        f.write_str(std::str::from_utf8(&self.0).unwrap())
+        f.write_str(core::str::from_utf8(&self.0).unwrap())
     }
 }
 

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -13,6 +13,9 @@ use core::{i32, u32};
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
 
+#[cfg(not(feature = "std"))]
+use core_maths::CoreFloat;
+
 /// Convert a type into a vector of bytes; all implementors in this file must use little-endian
 /// orderings of bytes to match WebAssembly's little-endianness.
 pub trait IntoBytes {
@@ -972,7 +975,8 @@ impl Ieee32 {
     /// Returns the nearest integer to `self`. Rounds half-way cases to the number
     /// with an even least significant digit.
     pub fn round_ties_even(self) -> Self {
-        Self::with_float(self.as_f32().round_ties_even())
+        // TODO: find a suitable alternative to std round_ties_even() in no_std
+        Self::with_float(self.as_f32().round())
     }
 }
 
@@ -1189,7 +1193,8 @@ impl Ieee64 {
     /// Returns the nearest integer to `self`. Rounds half-way cases to the number
     /// with an even least significant digit.
     pub fn round_ties_even(self) -> Self {
-        Self::with_float(self.as_f64().round_ties_even())
+        // TODO: find a suitable alternative to std round_ties_even() in no_std
+        Self::with_float(self.as_f64().round())
     }
 }
 
@@ -1828,7 +1833,7 @@ mod tests {
     fn fcvt_to_sint_negative_overflow_ieee32() {
         for n in &[8, 16] {
             assert_eq!(-((1u32 << (n - 1)) as f32) - 1.0, unsafe {
-                mem::transmute(Ieee32::fcvt_to_sint_negative_overflow(*n))
+                mem::transmute::<_, f32>(Ieee32::fcvt_to_sint_negative_overflow(*n))
             });
         }
     }
@@ -1966,7 +1971,7 @@ mod tests {
     fn fcvt_to_sint_negative_overflow_ieee64() {
         for n in &[8, 16, 32] {
             assert_eq!(-((1u64 << (n - 1)) as f64) - 1.0, unsafe {
-                mem::transmute(Ieee64::fcvt_to_sint_negative_overflow(*n))
+                mem::transmute::<_, f64>(Ieee64::fcvt_to_sint_negative_overflow(*n))
             });
         }
     }

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -301,7 +301,7 @@ impl InstructionData {
         match self {
             Self::Jump {
                 ref destination, ..
-            } => std::slice::from_ref(destination),
+            } => core::slice::from_ref(destination),
             Self::Brif { blocks, .. } => blocks.as_slice(),
             Self::BranchTable { table, .. } => jump_tables.get(*table).unwrap().all_branches(),
             _ => {
@@ -322,7 +322,7 @@ impl InstructionData {
             Self::Jump {
                 ref mut destination,
                 ..
-            } => std::slice::from_mut(destination),
+            } => core::slice::from_mut(destination),
             Self::Brif { blocks, .. } => blocks.as_mut_slice(),
             Self::BranchTable { table, .. } => {
                 jump_tables.get_mut(*table).unwrap().all_branches_mut()
@@ -861,7 +861,7 @@ mod tests {
     fn inst_data_size() {
         // The size of `InstructionData` is performance sensitive, so make sure
         // we don't regress it unintentionally.
-        assert_eq!(std::mem::size_of::<InstructionData>(), 16);
+        assert_eq!(core::mem::size_of::<InstructionData>(), 16);
     }
 
     #[test]

--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -31,7 +31,7 @@ impl JumpTableData {
     /// Create a new jump table with the provided blocks.
     pub fn new(def: BlockCall, table: &[BlockCall]) -> Self {
         Self {
-            table: std::iter::once(def).chain(table.iter().copied()).collect(),
+            table: core::iter::once(def).chain(table.iter().copied()).collect(),
         }
     }
 
@@ -114,7 +114,7 @@ mod tests {
     use crate::entity::EntityRef;
     use crate::ir::instructions::ValueListPool;
     use crate::ir::{Block, BlockCall, Value};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn empty() {

--- a/cranelift/codegen/src/ir/memtype.rs
+++ b/cranelift/codegen/src/ir/memtype.rs
@@ -108,14 +108,14 @@ pub enum MemoryTypeData {
     Empty,
 }
 
-impl std::default::Default for MemoryTypeData {
+impl core::default::Default for MemoryTypeData {
     fn default() -> Self {
         Self::Empty
     }
 }
 
-impl std::fmt::Display for MemoryTypeData {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for MemoryTypeData {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Self::Struct { size, fields } => {
                 write!(f, "struct {size} {{")?;

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -77,14 +77,14 @@ use crate::ir::types::*;
 use crate::isa::TargetIsa;
 use crate::machinst::{BlockIndex, LowerBackend, VCode};
 use crate::trace;
+use core::fmt;
 use regalloc2::Function as _;
-use std::fmt;
 
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
 
 /// The result of checking proof-carrying-code facts.
-pub type PccResult<T> = std::result::Result<T, PccError>;
+pub type PccResult<T> = core::result::Result<T, PccError>;
 
 /// An error or inconsistency discovered when checking proof-carrying
 /// code.
@@ -332,7 +332,7 @@ impl Expr {
         } else {
             Expr {
                 base: BaseExpr::min(&lhs.base, &rhs.base),
-                offset: std::cmp::min(lhs.offset, rhs.offset),
+                offset: core::cmp::min(lhs.offset, rhs.offset),
             }
         }
     }
@@ -347,7 +347,7 @@ impl Expr {
         } else {
             Expr {
                 base: BaseExpr::max(&lhs.base, &rhs.base),
-                offset: std::cmp::max(lhs.offset, rhs.offset),
+                offset: core::cmp::max(lhs.offset, rhs.offset),
             }
         }
     }
@@ -651,8 +651,8 @@ impl Fact {
                 },
             ) if bw_lhs == bw_rhs && max_lhs >= min_rhs && max_rhs >= min_lhs => Fact::Range {
                 bit_width: *bw_lhs,
-                min: std::cmp::max(*min_lhs, *min_rhs),
-                max: std::cmp::min(*max_lhs, *max_rhs),
+                min: core::cmp::max(*min_lhs, *min_rhs),
+                max: core::cmp::min(*max_lhs, *max_rhs),
             },
 
             (
@@ -693,8 +693,8 @@ impl Fact {
             {
                 Fact::Mem {
                     ty: *ty_lhs,
-                    min_offset: std::cmp::max(*min_offset_lhs, *min_offset_rhs),
-                    max_offset: std::cmp::min(*max_offset_lhs, *max_offset_rhs),
+                    min_offset: core::cmp::max(*min_offset_lhs, *min_offset_rhs),
+                    max_offset: core::cmp::min(*max_offset_lhs, *max_offset_rhs),
                     nullable: *nullable_lhs && *nullable_rhs,
                 }
             }
@@ -910,7 +910,7 @@ impl<'a> FactContext<'a> {
             ) if bw_lhs == bw_rhs && add_width >= *bw_lhs => {
                 let computed_min = min_lhs.checked_add(*min_rhs)?;
                 let computed_max = max_lhs.checked_add(*max_rhs)?;
-                let computed_max = std::cmp::min(max_value_for_width(add_width), computed_max);
+                let computed_max = core::cmp::min(max_value_for_width(add_width), computed_max);
                 Some(Fact::Range {
                     bit_width: *bw_lhs,
                     min: computed_min,

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -13,9 +13,9 @@ use crate::settings;
 use crate::{CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use once_cell::sync::OnceCell;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::sync::OnceLock;
 
 // We use a generic implementation that factors out AArch64 and x64 ABI commonalities, because
 // these ABIs are very similar.
@@ -321,7 +321,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             } else {
                 // Every arg takes a minimum slot of 8 bytes. (16-byte stack
                 // alignment happens separately after all args.)
-                std::cmp::max(size, 8)
+                core::cmp::max(size, 8)
             };
 
             // Align the stack slot.
@@ -1126,10 +1126,10 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
     fn get_machine_env(flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
         if flags.enable_pinned_reg() {
-            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            static MACHINE_ENV: OnceCell<MachineEnv> = OnceCell::new();
             MACHINE_ENV.get_or_init(|| create_reg_env(true))
         } else {
-            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            static MACHINE_ENV: OnceCell<MachineEnv> = OnceCell::new();
             MACHINE_ENV.get_or_init(|| create_reg_env(false))
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -4,7 +4,7 @@ use crate::ir::types::*;
 use crate::isa::aarch64::inst::{OperandSize, ScalarSize};
 use crate::machinst::PrettyPrint;
 
-use std::string::String;
+use alloc::string::String;
 
 /// An immediate that represents the NZCV flags.
 #[derive(Clone, Copy, Debug)]

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -8,7 +8,7 @@ use crate::machinst::{Reg, RegClass, Writable};
 use regalloc2::PReg;
 use regalloc2::VReg;
 
-use std::string::{String, ToString};
+use alloc::string::{String, ToString};
 
 //=============================================================================
 // Registers, the Universe thereof, and printing

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -31,9 +31,9 @@ use crate::{
         abi::ArgPair, ty_bits, InstOutput, IsTailCall, MachInst, VCodeConstant, VCodeConstantData,
     },
 };
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use regalloc2::PReg;
-use std::boxed::Box;
-use std::vec::Vec;
 
 type BoxCallInfo = Box<CallInfo>;
 type BoxCallIndInfo = Box<CallIndInfo>;
@@ -206,7 +206,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
     fn lshl_from_u64(&mut self, ty: Type, n: u64) -> Option<ShiftOpAndAmt> {
         let shiftimm = ShiftOpShiftImm::maybe_from_shift(n)?;
         let shiftee_bits = ty_bits(ty);
-        if shiftee_bits <= std::u8::MAX as usize {
+        if shiftee_bits <= core::u8::MAX as usize {
             let shiftimm = shiftimm.mask(shiftee_bits as u8);
             Some(ShiftOpAndAmt::new(ShiftOp::LSL, shiftimm))
         } else {
@@ -217,7 +217,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
     fn ashr_from_u64(&mut self, ty: Type, n: u64) -> Option<ShiftOpAndAmt> {
         let shiftimm = ShiftOpShiftImm::maybe_from_shift(n)?;
         let shiftee_bits = ty_bits(ty);
-        if shiftee_bits <= std::u8::MAX as usize {
+        if shiftee_bits <= core::u8::MAX as usize {
             let shiftimm = shiftimm.mask(shiftee_bits as u8);
             Some(ShiftOpAndAmt::new(ShiftOp::ASR, shiftimm))
         } else {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -23,7 +23,7 @@
 //! # #[macro_use] extern crate target_lexicon;
 //! use cranelift_codegen::isa;
 //! use cranelift_codegen::settings::{self, Configurable};
-//! use std::str::FromStr;
+//! use core::str::FromStr;
 //! use target_lexicon::Triple;
 //!
 //! let shared_builder = settings::builder();
@@ -131,6 +131,7 @@ pub enum LookupError {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for LookupError {}
 
 impl fmt::Display for LookupError {

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -18,10 +18,10 @@ use crate::CodegenError;
 use crate::CodegenResult;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use once_cell::sync::OnceCell;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 
 use smallvec::{smallvec, SmallVec};
-use std::sync::OnceLock;
 
 /// Support for the Riscv64 ABI from the callee side (within a function body).
 pub(crate) type Riscv64Callee = Callee<Riscv64MachineDeps>;
@@ -67,7 +67,7 @@ impl RiscvFlags {
 
             // Due to a limitation in regalloc2, we can't support types
             // larger than 1024 bytes. So limit that here.
-            return std::cmp::min(size, 1024);
+            return core::cmp::min(size, 1024);
         }
 
         return 0;
@@ -151,7 +151,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                     // Compute size and 16-byte stack alignment happens
                     // separately after all args.
                     let size = reg_ty.bits() / 8;
-                    let size = std::cmp::max(size, 8);
+                    let size = core::cmp::max(size, 8);
                     // Align.
                     debug_assert!(size.is_power_of_two());
                     next_stack = align_to(next_stack, size);
@@ -677,7 +677,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     }
 
     fn get_machine_env(_flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
-        static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+        static MACHINE_ENV: OnceCell<MachineEnv> = OnceCell::new();
         MACHINE_ENV.get_or_init(create_reg_enviroment)
     }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -8,7 +8,10 @@ use crate::isa::riscv64::lower::isle::generated_code::{
 };
 use crate::machinst::isle::WritableReg;
 
-use std::fmt::Result;
+use core::fmt::Result;
+
+#[cfg(not(feature = "std"))]
+use core_maths::CoreFloat;
 
 /// A macro for defining a newtype of `Reg` that enforces some invariant about
 /// the wrapped `Reg` (such as that it is of a particular register class).
@@ -57,7 +60,7 @@ macro_rules! newtype_of_reg {
         // NB: We cannot implement `DerefMut` because that would let people do
         // nasty stuff like `*my_xreg.deref_mut() = some_freg`, breaking the
         // invariants that `XReg` provides.
-        impl std::ops::Deref for $newtype_reg {
+        impl core::ops::Deref for $newtype_reg {
             type Target = Reg;
 
             fn deref(&self) -> &Reg {

--- a/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
@@ -1,7 +1,7 @@
 #[allow(unused)]
 use crate::ir::LibCall;
 use crate::isa::riscv64::inst::*;
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 fn fa7() -> Reg {
     f_reg(17)
@@ -42,7 +42,7 @@ fn test_riscv64_binemit() {
         }
     }
 
-    let mut insns = Vec::<TestUnit>::with_capacity(500);
+    let mut insns = alloc::vec::Vec::<TestUnit>::with_capacity(500);
 
     insns.push(TestUnit::new(Inst::Ret {}, "ret", 0x00008067));
 

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -3,7 +3,7 @@
 // Some variants are never constructed, but we still want them as options in the future.
 use super::Inst;
 #[allow(dead_code)]
-use std::fmt::{Debug, Display, Formatter, Result};
+use core::fmt::{Debug, Display, Formatter, Result};
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Imm12 {

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -12,12 +12,12 @@ use crate::{settings, CodegenError, CodegenResult};
 
 pub use crate::ir::condcodes::FloatCC;
 
+use alloc::boxed::Box;
+use alloc::fmt::Write;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use regalloc2::{PRegSet, RegClass};
 use smallvec::{smallvec, SmallVec};
-use std::boxed::Box;
-use std::fmt::Write;
-use std::string::{String, ToString};
 
 pub mod regs;
 pub use self::regs::*;
@@ -38,7 +38,7 @@ use crate::isa::riscv64::abi::Riscv64MachineDeps;
 #[cfg(test)]
 mod emit_tests;
 
-use std::fmt::{Display, Formatter};
+use core::fmt::{Display, Formatter};
 
 pub(crate) type VecU8 = Vec<u8>;
 
@@ -110,7 +110,7 @@ impl CondBrTarget {
 }
 
 impl Display for CondBrTarget {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             CondBrTarget::Label(l) => write!(f, "{}", l.to_string()),
             CondBrTarget::Fallthrough => write!(f, "0"),

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -24,9 +24,9 @@ use crate::{
     machinst::{ArgPair, InstOutput, IsTailCall},
 };
 use crate::{isa, isle_common_prelude_methods};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use regalloc2::PReg;
-use std::boxed::Box;
-use std::vec::Vec;
 
 type BoxCallInfo = Box<CallInfo>;
 type BoxCallIndInfo = Box<CallIndInfo>;

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -79,9 +79,9 @@ use crate::machinst::*;
 use crate::settings;
 use crate::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
+use once_cell::sync::OnceCell;
 use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::sync::OnceLock;
 
 // We use a generic implementation that factors out ABI commonalities.
 
@@ -304,11 +304,11 @@ impl ABIMachineSpec for S390xMachineDeps {
                 // Compute size. Every argument or return value takes a slot of
                 // at least 8 bytes.
                 let size = (ty_bits(param.value_type) / 8) as u32;
-                let slot_size = std::cmp::max(size, 8);
+                let slot_size = core::cmp::max(size, 8);
 
                 // Align the stack slot.
                 debug_assert!(slot_size.is_power_of_two());
-                let slot_align = std::cmp::min(slot_size, 8);
+                let slot_align = core::cmp::min(slot_size, 8);
                 next_stack = align_to(next_stack, slot_align);
 
                 // If the type is actually of smaller size (and the argument
@@ -765,7 +765,7 @@ impl ABIMachineSpec for S390xMachineDeps {
     }
 
     fn get_machine_env(_flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
-        static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+        static MACHINE_ENV: OnceCell<MachineEnv> = OnceCell::new();
         MACHINE_ENV.get_or_init(create_machine_env)
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst/imms.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/imms.rs
@@ -1,7 +1,7 @@
 //! S390x ISA definitions: immediate constants.
 
 use crate::machinst::PrettyPrint;
-use std::string::String;
+use alloc::string::String;
 
 /// An unsigned 12-bit immediate.
 #[derive(Clone, Copy, Debug)]

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -7,11 +7,11 @@ use crate::isa::{CallConv, FunctionAlignment};
 use crate::machinst::*;
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::fmt::Write;
 use regalloc2::{PReg, PRegSet};
 use smallvec::SmallVec;
-use std::fmt::Write;
-use std::string::{String, ToString};
 pub mod regs;
 pub use self::regs::*;
 pub mod imms;
@@ -63,7 +63,7 @@ pub struct CallIndInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(32, std::mem::size_of::<Inst>());
+    assert_eq!(32, core::mem::size_of::<Inst>());
 }
 
 /// A register pair. Enum so it can be destructured in ISLE.

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -28,11 +28,14 @@ use crate::{
         VCodeConstant, VCodeConstantData,
     },
 };
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cell::Cell;
 use regalloc2::PReg;
 use smallvec::smallvec;
-use std::boxed::Box;
-use std::cell::Cell;
-use std::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use core_maths::CoreFloat;
 
 /// Information describing a library call to be emitted.
 pub struct LibCallInfo {
@@ -772,7 +775,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     #[inline]
     fn fcvt_to_sint_lb32(&mut self, size: u8) -> u64 {
         let lb = (-2.0_f32).powi((size - 1).into());
-        std::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits()) as u64
+        core::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits()) as u64
     }
 
     #[inline]
@@ -783,7 +786,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     #[inline]
     fn fcvt_to_sint_lb64(&mut self, size: u8) -> u64 {
         let lb = (-2.0_f64).powi((size - 1).into());
-        std::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits())
+        core::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits())
     }
 
     #[inline]

--- a/cranelift/codegen/src/isa/unwind.rs
+++ b/cranelift/codegen/src/isa/unwind.rs
@@ -12,6 +12,7 @@ pub mod systemv;
 pub mod winx64;
 
 /// CFA-based unwind information used on SystemV.
+#[cfg(feature = "unwind")]
 pub type CfaUnwindInfo = systemv::UnwindInfo;
 
 /// Expected unwind info type.

--- a/cranelift/codegen/src/isa/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/unwind/systemv.rs
@@ -23,10 +23,11 @@ pub enum RegisterMappingError {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for RegisterMappingError {}
 
-impl std::fmt::Display for RegisterMappingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for RegisterMappingError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             RegisterMappingError::MissingBank => write!(f, "unable to find bank for register info"),
             RegisterMappingError::UnsupportedArchitecture => write!(

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -11,9 +11,9 @@ use crate::{CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use args::*;
+use once_cell::sync::OnceCell;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::sync::OnceLock;
 
 /// This is the limit for the size of argument and return-value areas on the
 /// stack. We place a reasonable limit here to avoid integer overflow issues
@@ -313,7 +313,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                     {
                         size
                     } else {
-                        let size = std::cmp::max(size, 8);
+                        let size = core::cmp::max(size, 8);
 
                         // Align.
                         debug_assert!(size.is_power_of_two());
@@ -381,7 +381,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                     for slot in slots.iter_mut() {
                         if let ABIArgSlot::Stack { offset, ty, .. } = slot {
                             let size = if uses_extension {
-                                i64::from(std::cmp::max(ty.bytes(), 8))
+                                i64::from(core::cmp::max(ty.bytes(), 8))
                             } else {
                                 i64::from(ty.bytes())
                             };
@@ -912,10 +912,10 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
     fn get_machine_env(flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
         if flags.enable_pinned_reg() {
-            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            static MACHINE_ENV: OnceCell<MachineEnv> = OnceCell::new();
             MACHINE_ENV.get_or_init(|| create_reg_env_systemv(true))
         } else {
-            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            static MACHINE_ENV: OnceCell<MachineEnv> = OnceCell::new();
             MACHINE_ENV.get_or_init(|| create_reg_env_systemv(false))
         }
     }

--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -477,7 +477,7 @@ mod tests {
     use crate::ir::MemFlags;
     use crate::isa::x64::args::Gpr;
     use crate::isa::x64::inst::regs;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     // As a sanity test, we verify that the output of `xed-asmparse-main 'vpabsq xmm0{k0},
     // xmm1'` matches this EVEX encoding machinery.

--- a/cranelift/codegen/src/isa/x64/encoding/mod.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/mod.rs
@@ -1,6 +1,6 @@
 //! Contains the encoding machinery for the various x64 instruction formats.
 use crate::{isa::x64, machinst::MachBuffer};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 pub mod evex;
 pub mod rex;

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -8,9 +8,9 @@ use crate::ir::MemFlags;
 use crate::isa::x64::inst::regs::pretty_print_reg;
 use crate::isa::x64::inst::Inst;
 use crate::machinst::*;
+use alloc::string::String;
+use core::fmt;
 use smallvec::{smallvec, SmallVec};
-use std::fmt;
-use std::string::String;
 
 pub use crate::isa::x64::lower::isle::generated_code::DivSignedness;
 
@@ -77,7 +77,7 @@ macro_rules! newtype_of_reg {
         // NB: We cannot implement `DerefMut` because that would let people do
         // nasty stuff like `*my_gpr.deref_mut() = some_xmm_reg`, breaking the
         // invariants that `Gpr` provides.
-        impl std::ops::Deref for $newtype_reg {
+        impl core::ops::Deref for $newtype_reg {
             type Target = Reg;
 
             fn deref(&self) -> &Reg {

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1890,7 +1890,7 @@ pub(crate) fn emit(
             // Emit jump table (table of 32-bit offsets).
             sink.bind_label(start_of_jumptable, state.ctrl_plane_mut());
             let jt_off = sink.cur_offset();
-            for &target in targets.iter().chain(std::iter::once(default_target)) {
+            for &target in targets.iter().chain(core::iter::once(default_target)) {
                 let word_off = sink.cur_offset();
                 // off_into_table is an addend here embedded in the label to be later patched at
                 // the end of codegen. The offset is initially relative to this jump table entry;

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -11,10 +11,10 @@ use crate::isa::{CallConv, FunctionAlignment};
 use crate::{machinst::*, trace};
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use core::fmt::{self, Write};
 use regalloc2::PRegSet;
 use smallvec::{smallvec, SmallVec};
-use std::fmt::{self, Write};
-use std::string::{String, ToString};
 
 pub mod args;
 mod emit;
@@ -68,7 +68,7 @@ pub struct ReturnCallInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(40, std::mem::size_of::<Inst>());
+    assert_eq!(40, core::mem::size_of::<Inst>());
 }
 
 pub(crate) fn low32_will_sign_extend_to_64(x: u64) -> bool {
@@ -2617,7 +2617,7 @@ impl MachInst for Inst {
     }
 
     fn gen_nop(preferred_size: usize) -> Inst {
-        Inst::nop(std::cmp::min(preferred_size, 15) as u8)
+        Inst::nop(core::cmp::min(preferred_size, 15) as u8)
     }
 
     fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -6,9 +6,9 @@
 //! Note also that we make use of pinned VRegs to refer to PRegs.
 
 use crate::machinst::{RealReg, Reg};
+use alloc::string::String;
 use alloc::string::ToString;
 use regalloc2::{PReg, RegClass, VReg};
-use std::string::String;
 
 // Hardware encodings (note the special rax, rcx, rdx, rbx order).
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -26,9 +26,9 @@ use crate::{
         VCodeConstant, VCodeConstantData,
     },
 };
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use regalloc2::PReg;
-use std::boxed::Box;
 
 /// Type representing out-of-line data for calls. This type optional because the
 /// call instruction is also used by Winch to emit calls, but the

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -28,6 +28,7 @@ mod lower;
 mod pcc;
 pub mod settings;
 
+#[cfg(feature = "unwind")]
 pub use inst::unwind::systemv::create_cie;
 
 /// An X64 backend.
@@ -184,6 +185,7 @@ impl TargetIsa for X64Backend {
 }
 
 /// Emit unwind info for an x86 target.
+#[cfg(feature = "unwind")]
 pub fn emit_unwind_info(
     buffer: &MachBufferFinalized<Final>,
     kind: crate::isa::unwind::UnwindInfoKind,

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -188,7 +188,7 @@ macro_rules! isle_common_prelude_methods {
 
         #[inline]
         fn i64_sextend_u64(&mut self, ty: Type, x: u64) -> i64 {
-            let shift_amt = std::cmp::max(0, 64 - ty.bits());
+            let shift_amt = core::cmp::max(0, 64 - ty.bits());
             ((x as i64) << shift_amt) >> shift_amt
         }
 
@@ -226,7 +226,7 @@ macro_rules! isle_common_prelude_methods {
 
         #[inline]
         fn ty_bits(&mut self, ty: Type) -> u8 {
-            use std::convert::TryInto;
+            use core::convert::TryInto;
             ty.bits().try_into().unwrap()
         }
 

--- a/cranelift/codegen/src/legalizer/globalvalue.rs
+++ b/cranelift/codegen/src/legalizer/globalvalue.rs
@@ -44,7 +44,7 @@ fn const_vector_scale(inst: ir::Inst, func: &mut ir::Function, ty: ir::Type, isa
     assert!(ty.bytes() <= 16);
 
     // Use a minimum of 128-bits for the base type.
-    let base_bytes = std::cmp::max(ty.bytes(), 16);
+    let base_bytes = core::cmp::max(ty.bytes(), 16);
     let scale = (isa.dynamic_vector_bytes(ty) / base_bytes) as i64;
     assert!(scale > 0);
     let pos = FuncCursor::new(func).at_inst(inst);

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -8,6 +8,10 @@
 // built for one platform we don't have to worry too much about trimming
 // everything down.
 #![cfg_attr(not(feature = "all-arch"), allow(dead_code))]
+// Each architecture has several unwind-specific imports that are unused when
+// the unwind feature is not selected. This is much cleaner to work with than
+// having `use` statements guarded by `#[cfg(feature = "unwind")]`.
+#![cfg_attr(not(feature = "unwind"), allow(unused_imports))]
 
 #[allow(unused_imports)] // #[macro_use] is required for no_std
 #[macro_use]
@@ -17,10 +21,12 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
+// Supports compiling ISLE.
 #[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate core as std;
+
 use hashbrown::{hash_map, HashMap};
-#[cfg(feature = "std")]
-use std::collections::{hash_map, HashMap};
 
 pub use crate::context::Context;
 pub use crate::value_label::{LabelValueLoc, ValueLabelsRanges, ValueLocRange};

--- a/cranelift/codegen/src/loop_analysis.rs
+++ b/cranelift/codegen/src/loop_analysis.rs
@@ -62,13 +62,13 @@ impl LoopLevel {
     /// A clamped loop level from a larger-width (usize) depth.
     pub fn clamped(level: usize) -> Self {
         Self(
-            u8::try_from(std::cmp::min(level, (Self::INVALID as usize) - 1))
+            u8::try_from(core::cmp::min(level, (Self::INVALID as usize) - 1))
                 .expect("Clamped value must always convert"),
         )
     }
 }
 
-impl std::default::Default for LoopLevel {
+impl core::default::Default for LoopLevel {
     fn default() -> Self {
         LoopLevel::invalid()
     }

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -65,7 +65,7 @@ use crate::entity::SecondaryMap;
 use crate::inst_predicates::visit_block_succs;
 use crate::ir::{Block, Function, Inst, Opcode};
 use crate::{machinst::*, trace};
-use rustc_hash::{FxHashMap, FxHashSet};
+use hashbrown::{HashMap, HashSet};
 
 /// Mapping from CLIF BBs to VCode BBs.
 #[derive(Debug)]
@@ -78,16 +78,16 @@ pub struct BlockLoweringOrder {
     lowered_succ_indices: Vec<BlockIndex>,
     /// Ranges in `lowered_succ_indices` giving the successor lists for each lowered
     /// block. Indexed by lowering-order index (`BlockIndex`).
-    lowered_succ_ranges: Vec<(Option<Inst>, std::ops::Range<usize>)>,
+    lowered_succ_ranges: Vec<(Option<Inst>, core::ops::Range<usize>)>,
     /// Cold blocks. These blocks are not reordered in the
     /// `lowered_order` above; the lowered order must respect RPO
     /// (uses after defs) in order for lowering to be
     /// correct. Instead, this set is used to provide `is_cold()`,
     /// which is used by VCode emission to sink the blocks at the last
     /// moment (when we actually emit bytes into the MachBuffer).
-    cold_blocks: FxHashSet<BlockIndex>,
+    cold_blocks: HashSet<BlockIndex>,
     /// Lowered blocks that are indirect branch targets.
-    indirect_branch_targets: FxHashSet<BlockIndex>,
+    indirect_branch_targets: HashSet<BlockIndex>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -160,7 +160,7 @@ impl BlockLoweringOrder {
         let mut block_succs: SmallVec<[LoweredBlock; 128]> = SmallVec::new();
         let mut block_succ_range = SecondaryMap::with_default(0..0);
 
-        let mut indirect_branch_target_clif_blocks = FxHashSet::default();
+        let mut indirect_branch_target_clif_blocks = HashSet::<Block>::default();
 
         for block in f.layout.blocks() {
             let start = block_succs.len();
@@ -221,7 +221,7 @@ impl BlockLoweringOrder {
             }
         }
 
-        let lb_to_bindex = FxHashMap::from_iter(
+        let lb_to_bindex = HashMap::<LoweredBlock, BlockIndex>::from_iter(
             lowered_order
                 .iter()
                 .enumerate()
@@ -232,8 +232,8 @@ impl BlockLoweringOrder {
         // during the creation of `lowering_order`, as we need `lb_to_bindex` to be fully populated
         // first.
         let mut lowered_succ_indices = Vec::new();
-        let mut cold_blocks = FxHashSet::default();
-        let mut indirect_branch_targets = FxHashSet::default();
+        let mut cold_blocks = HashSet::default();
+        let mut indirect_branch_targets = HashSet::default();
         let lowered_succ_ranges =
             Vec::from_iter(lowered_order.iter().enumerate().map(|(ix, lb)| {
                 let bindex = BlockIndex::new(ix);

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -180,14 +180,14 @@ use crate::machinst::{
 use crate::trace;
 use crate::{ir, MachInstEmitState};
 use crate::{timing, VCodeConstantData};
+use alloc::collections::BinaryHeap;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::mem;
 use cranelift_control::ControlPlane;
 use cranelift_entity::{entity_impl, PrimaryMap};
 use smallvec::SmallVec;
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-use std::mem;
-use std::string::String;
-use std::vec::Vec;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -438,7 +438,7 @@ pub struct OpenPatchRegion(usize);
 /// the [`PatchRegion::patch`] function can be used to get a mutable buffer to the instruction
 /// bytes, and the constants uses can be updated directly.
 pub struct PatchRegion {
-    range: std::ops::Range<usize>,
+    range: core::ops::Range<usize>,
 }
 
 impl PatchRegion {
@@ -1722,7 +1722,7 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
     /// Return the code in this mach buffer as a hex string for testing purposes.
     pub fn stringify_code_bytes(&self) -> String {
         // This is pretty lame, but whatever ..
-        use std::fmt::Write;
+        use core::fmt::Write;
         let mut s = String::with_capacity(self.data.len() * 2);
         for b in &self.data {
             write!(&mut s, "{:02X}", b).unwrap();

--- a/cranelift/codegen/src/machinst/helpers.rs
+++ b/cranelift/codegen/src/machinst/helpers.rs
@@ -1,7 +1,7 @@
 //! Miscellaneous helpers for machine backends.
 
 use crate::ir::Type;
-use std::ops::{Add, BitAnd, Not, Sub};
+use core::ops::{Add, BitAnd, Not, Sub};
 
 /// Returns the size (in bits) of a given type.
 pub fn ty_bits(ty: Type) -> usize {

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -1,8 +1,8 @@
 use crate::ir::{BlockCall, Value, ValueList};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::cell::Cell;
 use smallvec::SmallVec;
-use std::cell::Cell;
 
 pub use super::MachLabel;
 use super::RetPair;
@@ -94,7 +94,7 @@ macro_rules! isle_lower_prelude_methods {
 
         #[inline]
         fn output_builder_new(&mut self) -> InstOutputBuilder {
-            std::cell::Cell::new(InstOutput::new())
+            core::cell::Cell::new(InstOutput::new())
         }
 
         #[inline]
@@ -231,7 +231,7 @@ macro_rules! isle_lower_prelude_methods {
                 _ => return None,
             };
             let ty = self.lower_ctx.output_ty(inst, 0);
-            let shift_amt = std::cmp::max(0, 64 - self.ty_bits(ty));
+            let shift_amt = core::cmp::max(0, 64 - self.ty_bits(ty));
             Some((constant << shift_amt) >> shift_amt)
         }
 
@@ -693,7 +693,7 @@ macro_rules! isle_lower_prelude_methods {
             &mut self,
             targets: &MachLabelSlice,
         ) -> Option<(MachLabel, BoxVecMachLabel)> {
-            use std::boxed::Box;
+            use alloc::boxed::Box;
             if targets.is_empty() {
                 return None;
             }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -53,13 +53,13 @@ use crate::result::CodegenResult;
 use crate::settings;
 use crate::settings::Flags;
 use crate::value_label::ValueLabelsRanges;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use cranelift_control::ControlPlane;
 use cranelift_entity::PrimaryMap;
 use regalloc2::VReg;
 use smallvec::{smallvec, SmallVec};
-use std::string::String;
 
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
@@ -395,7 +395,7 @@ impl<T: CompilePhase> CompiledCodeBase<T> {
         params: Option<&crate::ir::function::FunctionParameters>,
         cs: &capstone::Capstone,
     ) -> Result<String, anyhow::Error> {
-        use std::fmt::Write;
+        use core::fmt::Write;
 
         let mut buf = String::new();
 

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -80,8 +80,8 @@ impl Reg {
     }
 }
 
-impl std::fmt::Debug for Reg {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for Reg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         if let Some(rreg) = self.to_real_reg() {
             let preg: PReg = rreg.into();
             write!(f, "{}", preg)
@@ -118,8 +118,8 @@ impl RealReg {
     }
 }
 
-impl std::fmt::Debug for RealReg {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for RealReg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         Reg::from(*self).fmt(f)
     }
 }
@@ -144,8 +144,8 @@ impl VirtualReg {
     }
 }
 
-impl std::fmt::Debug for VirtualReg {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for VirtualReg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         Reg::from(*self).fmt(f)
     }
 }
@@ -188,20 +188,20 @@ impl<T> Writable<T> {
 // Conversions between regalloc2 types (VReg, PReg) and our types
 // (VirtualReg, RealReg, Reg).
 
-impl std::convert::From<regalloc2::VReg> for Reg {
+impl core::convert::From<regalloc2::VReg> for Reg {
     fn from(vreg: regalloc2::VReg) -> Reg {
         Reg(vreg)
     }
 }
 
-impl std::convert::From<regalloc2::VReg> for VirtualReg {
+impl core::convert::From<regalloc2::VReg> for VirtualReg {
     fn from(vreg: regalloc2::VReg) -> VirtualReg {
         debug_assert!(pinned_vreg_to_preg(vreg).is_none());
         VirtualReg(vreg)
     }
 }
 
-impl std::convert::From<Reg> for regalloc2::VReg {
+impl core::convert::From<Reg> for regalloc2::VReg {
     /// Extract the underlying `regalloc2::VReg`. Note that physical
     /// registers also map to particular (special) VRegs, so this
     /// method can be used either on virtual or physical `Reg`s.
@@ -209,19 +209,19 @@ impl std::convert::From<Reg> for regalloc2::VReg {
         reg.0
     }
 }
-impl std::convert::From<&Reg> for regalloc2::VReg {
+impl core::convert::From<&Reg> for regalloc2::VReg {
     fn from(reg: &Reg) -> regalloc2::VReg {
         reg.0
     }
 }
 
-impl std::convert::From<VirtualReg> for regalloc2::VReg {
+impl core::convert::From<VirtualReg> for regalloc2::VReg {
     fn from(reg: VirtualReg) -> regalloc2::VReg {
         reg.0
     }
 }
 
-impl std::convert::From<RealReg> for regalloc2::VReg {
+impl core::convert::From<RealReg> for regalloc2::VReg {
     fn from(reg: RealReg) -> regalloc2::VReg {
         // This representation is redundant: the class is implied in the vreg
         // index as well as being in the vreg class field.
@@ -229,31 +229,31 @@ impl std::convert::From<RealReg> for regalloc2::VReg {
     }
 }
 
-impl std::convert::From<RealReg> for regalloc2::PReg {
+impl core::convert::From<RealReg> for regalloc2::PReg {
     fn from(reg: RealReg) -> regalloc2::PReg {
         reg.0
     }
 }
 
-impl std::convert::From<regalloc2::PReg> for RealReg {
+impl core::convert::From<regalloc2::PReg> for RealReg {
     fn from(preg: regalloc2::PReg) -> RealReg {
         RealReg(preg)
     }
 }
 
-impl std::convert::From<regalloc2::PReg> for Reg {
+impl core::convert::From<regalloc2::PReg> for Reg {
     fn from(preg: regalloc2::PReg) -> Reg {
         RealReg(preg).into()
     }
 }
 
-impl std::convert::From<RealReg> for Reg {
+impl core::convert::From<RealReg> for Reg {
     fn from(reg: RealReg) -> Reg {
         Reg(reg.into())
     }
 }
 
-impl std::convert::From<VirtualReg> for Reg {
+impl core::convert::From<VirtualReg> for Reg {
     fn from(reg: VirtualReg) -> Reg {
         Reg(reg.0)
     }

--- a/cranelift/codegen/src/machinst/valueregs.rs
+++ b/cranelift/codegen/src/machinst/valueregs.rs
@@ -4,7 +4,7 @@
 use regalloc2::{PReg, VReg};
 
 use super::{RealReg, Reg, VirtualReg, Writable};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 const VALUE_REGS_PARTS: usize = 2;
 

--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -13,9 +13,9 @@ pub use crate::ir::{
 use crate::isle_common_prelude_methods;
 use crate::machinst::isle::*;
 use crate::trace;
+use core::marker::PhantomData;
 use cranelift_entity::packed_option::ReservedValue;
 use smallvec::{smallvec, SmallVec};
-use std::marker::PhantomData;
 
 #[allow(dead_code)]
 pub type Unit = ();

--- a/cranelift/codegen/src/result.rs
+++ b/cranelift/codegen/src/result.rs
@@ -4,7 +4,7 @@ use regalloc2::checker::CheckerErrors;
 
 use crate::ir::pcc::PccError;
 use crate::{ir::Function, verifier::VerifierErrors};
-use std::string::String;
+use alloc::string::String;
 
 /// A compilation error.
 ///
@@ -52,6 +52,7 @@ pub type CodegenResult<T> = Result<T, CodegenError>;
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for CodegenError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -67,8 +68,8 @@ impl std::error::Error for CodegenError {
     }
 }
 
-impl std::fmt::Display for CodegenError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             CodegenError::Verifier(_) => write!(f, "Verifier errors"),
             CodegenError::ImplLimitExceeded => write!(f, "Implementation limit exceeded"),

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -290,6 +290,7 @@ pub enum SetError {
     BadValue(String),
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SetError {}
 
 impl fmt::Display for SetError {

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -25,11 +25,11 @@
 //! candidate.
 
 use crate::ir;
+use alloc::string::String;
+use alloc::vec::Vec;
+use hashbrown::{HashMap, HashSet};
 use souper_ir::ast;
-use std::collections::{HashMap, HashSet};
-use std::string::String;
 use std::sync::mpsc;
-use std::vec::Vec;
 
 /// Harvest Souper left-hand side candidates from the given function.
 ///

--- a/cranelift/codegen/src/unionfind.rs
+++ b/cranelift/codegen/src/unionfind.rs
@@ -1,9 +1,9 @@
 //! Simple union-find data structure.
 
 use crate::trace;
+use core::hash::Hash;
+use core::mem::swap;
 use cranelift_entity::{packed_option::ReservedValue, EntityRef, SecondaryMap};
-use std::hash::Hash;
-use std::mem::swap;
 
 /// A union-find data structure. The data structure can allocate
 /// `Idx`s, indicating eclasses, and can merge eclasses together.
@@ -51,7 +51,7 @@ impl<Idx: EntityRef + ReservedValue> Default for Val<Idx> {
     }
 }
 
-impl<Idx: EntityRef + Hash + std::fmt::Display + Ord + ReservedValue> UnionFind<Idx> {
+impl<Idx: EntityRef + Hash + core::fmt::Display + Ord + ReservedValue> UnionFind<Idx> {
     /// Create a new `UnionFind` with the given capacity.
     pub fn with_capacity(cap: usize) -> Self {
         UnionFind {

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -100,6 +100,7 @@ pub struct VerifierError {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for VerifierError {}
 
 impl Display for VerifierError {
@@ -179,6 +180,7 @@ pub struct VerifierErrors(pub Vec<VerifierError>);
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for VerifierErrors {}
 
 impl VerifierErrors {

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -1179,8 +1179,7 @@ mod tests {
     fn create_mock_value_ranges() -> (ValueLabelsRanges, (ValueLabel, ValueLabel, ValueLabel)) {
         use cranelift_codegen::{LabelValueLoc, ValueLocRange};
         use cranelift_entity::EntityRef;
-        use std::collections::HashMap;
-        let mut value_ranges = HashMap::new();
+        let mut value_ranges = ValueLabelsRanges::new();
         let value_0 = ValueLabel::new(0);
         let value_1 = ValueLabel::new(1);
         let value_2 = ValueLabel::new(2);

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ cranelift-filetests = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-fuzzgen = { workspace = true }
 cranelift-native = { workspace = true }
-cranelift-control = { workspace = true }
+cranelift-control = { workspace = true, features = ["fuzz"] }
 libfuzzer-sys = { workspace = true, features = ["arbitrary-derive"] }
 target-lexicon = { workspace = true }
 smallvec = { workspace = true }


### PR DESCRIPTION
Closes #1158, previous context and discussion can be found there. This is a major milestone towards allowing Cranelift to compile code while in embedded or kernel environments.

I do still have a handful of pinch points to work through before this is ready to merge.

First of all, the most major overhaul I've made to the `codegen` crate is to replace `rustc-hash` with `hashbrown` and `ahash`. I'm not a cryptography expert but as far as I can tell, `ahash` does have a security improvement over `FxHash` in terms of improved DOS resistance. More importantly though, `hashbrown` has a feature to use `ahash` by default, which means that replacing `FxHashMap` and `FxHashSet` was as easy as a few invocations of `sed`. However, I believe that this switch in hashing function has caused some of the codegen expected output tests in CI to fail, and the semantics of the codegen have been slightly changed. I could experiment with swapping `rustc-hash` back into `hashbrown` as its hasher implementation locally but I wanted to know if preserving these semantics was important before I undertook another major type substitution throughout the code. Please take a look at the output of the failing CI for more info.

Second of all, on no_std, floating-point arithmetic is not available. To resolve this, I brought in the `core_math` crate, which implements floating-point arithmetic traits for core primitives using libm's implementation of softfloat. However, the function `rounding_ties_even()` is not available in `libm`, and I'm not sure how to go about replacing it. Input would be appreciated. I do know that if the failing codegen output unit tests I discussed are updated to pass with the new output, other tests catch the change in arithmetic semantics and fail.

Finally, there's this `else` block in `src/machinst/vcode.rs` that has some arithmetic with a hard dependency on the `unwind` feature, which is unsupported on `no_std`. I'm not sure what to do with that.

Thank you so much for the help with all of this, I appreciate your time immensely. I'm really happy to answer any questions and update my code as needed.