### PR TITLE
Bump MSRV to 1.78.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -23,7 +23,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2024-06-13" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2024-07-25" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.77.0"
+rust-version = "1.78.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -748,7 +748,7 @@ async fn drop_suspended_async_hook() -> Result<(), Error> {
             assert_eq!(*state, 0);
             *state += 1;
             let _dec = Decrement(state);
-            loop {
+            for _ in 0.. {
                 tokio::task::yield_now().await;
             }
         })

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -690,6 +690,7 @@ fn import_works() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn trap_smoke() -> Result<()> {
     let mut store = Store::<()>::default();
     let f = Func::wrap(&mut store, || -> Result<()> { bail!("test") });

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -454,6 +454,7 @@ fn call_wasm_many_args() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn trap_smoke() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::<()>::new(&engine);

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -125,7 +125,11 @@ fn main() {
                 let engine = Engine::default();
                 let mut store = Store::new(&engine, ());
                 let module = Module::new(&engine, r#"(import "" "" (func)) (start 0)"#).unwrap();
-                let segfault = Func::wrap(&mut store, || segfault());
+                let segfault = Func::wrap(&mut store, || {
+                    if true {
+                        segfault()
+                    }
+                });
                 Instance::new(&mut store, &module, &[segfault.into()]).unwrap();
                 unreachable!();
             },
@@ -140,7 +144,9 @@ fn main() {
                 let mut store = Store::new(&engine, ());
                 let f = Func::wrap_async(&mut store, |_, _: ()| {
                     Box::new(async {
-                        overrun_the_stack();
+                        if true {
+                            overrun_the_stack();
+                        }
                     })
                 });
                 run_future(f.call_async(&mut store, &[], &mut [])).unwrap();
@@ -172,7 +178,9 @@ fn main() {
                 let mut store = Store::new(&engine, ());
                 let f = Func::wrap_async(&mut store, |_, _: ()| {
                     Box::new(async {
-                        overrun_the_stack();
+                        if true {
+                            overrun_the_stack();
+                        }
                     })
                 });
                 run_future(f.call_async(&mut store, &[], &mut [])).unwrap();

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -125,11 +125,7 @@ fn main() {
                 let engine = Engine::default();
                 let mut store = Store::new(&engine, ());
                 let module = Module::new(&engine, r#"(import "" "" (func)) (start 0)"#).unwrap();
-                let segfault = Func::wrap(&mut store, || {
-                    if true {
-                        segfault()
-                    }
-                });
+                let segfault = Func::wrap(&mut store, || -> () { segfault() });
                 Instance::new(&mut store, &module, &[segfault.into()]).unwrap();
                 unreachable!();
             },


### PR DESCRIPTION
This commit updates to use Rust 1.80 in CI as well as updating the minimum-supported-rust-version to 1.78. Additionally the nightly used in testing in CI is updated as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
