### PR TITLE
Enable multiple component model returns in another fuzzer

### DIFF
--- a/crates/fuzzing/src/generators/component_types.rs
+++ b/crates/fuzzing/src/generators/component_types.rs
@@ -127,6 +127,7 @@ where
 
     let mut config = Config::new();
     config.wasm_component_model(true);
+    config.wasm_component_model_multiple_returns(true);
     config.debug_adapter_modules(input.arbitrary()?);
     let engine = Engine::new(&config).unwrap();
     let wat = declarations.make_component();


### PR DESCRIPTION
Fixing another fuzz bug similar to #9004.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
