### PR TITLE
CI: Test Pulley on 32-bit and `no_std` targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -433,6 +433,7 @@ jobs:
     - run: rustup target add x86_64-unknown-none
     - run: cargo check --target x86_64-unknown-none -p wasmtime --no-default-features --features runtime,gc,component-model
     - run: cargo check --target x86_64-unknown-none -p cranelift-control --no-default-features
+    - run: cargo check --target x86_64-unknown-none -p pulley-interpreter --features encode,decode,disas,interp
 
     # Check that wasmtime compiles with panic=abort since there's some `#[cfg]`
     # for specifically panic=abort there.
@@ -817,7 +818,7 @@ jobs:
       if: failure() && github.event_name != 'pull_request'
       env:
         GH_TOKEN: ${{ github.token }}
-  
+
   build-preview1-component-adapter-provider:
     name: Build wasi-preview1-component-adapter-provider
     needs: build-preview1-component-adapter
@@ -830,7 +831,7 @@ jobs:
     - uses: ./.github/actions/build-adapter-provider
       with:
         run-id: ${{ github.run_id }}
-    
+
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -605,22 +605,30 @@ jobs:
 
     - run: cargo fetch --locked
 
-    - uses: actions/cache@v4
-      with:
-        path: ${{ runner.tool_cache }}/qemu
-        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patchcpuinfo
-      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
     - name: Install cross-compilation tools
       run: |
         set -ex
+
         sudo apt-get update
         sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
 
         # Configure Cargo for cross compilation and tell it how it can run
         # cross executables
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
         echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
+      if: matrix.gcc != ''
+
+    - uses: actions/cache@v4
+      with:
+        path: ${{ runner.tool_cache }}/qemu
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patchcpuinfo
+      if: matrix.qemu != ''
+    - name: Install qemu
+      run: |
+        set -ex
+
+        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
+        echo CARGO_TARGET_${upcase}_RUNNER=${{ runner.tool_cache }}/qemu/bin/${{ matrix.qemu }} >> $GITHUB_ENV
 
         # QEMU emulation is not always the speediest, so total testing time
         # goes down if we build the libs in release mode when running tests.
@@ -644,7 +652,7 @@ jobs:
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache}}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
         touch ${{ runner.tool_cache }}/qemu/built
-      if: matrix.gcc != ''
+      if: matrix.qemu != ''
 
     # Record some CPU details; this is helpful information if tests fail due
     # to CPU-specific features.

--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -402,7 +402,7 @@ impl Decoder {
         V: OpVisitor<BytecodeStream = SafeBytecodeStream<'a>> + ExtendedOpVisitor,
     {
         let mut decoder = Decoder::new();
-        let mut results = vec![];
+        let mut results = Vec::new();
 
         while !visitor.bytecode().as_slice().is_empty() {
             results.push(decoder.decode_one(visitor)?);


### PR DESCRIPTION
This PR adds CI testing for Pulley on the following 32-bit targets:

* `i686-unknown-linux-gnu`
* `armv7-unknown-linux-gnueabihf`

It also checks that Pulley builds for `no_std` targets.

Our existing test sharding means that it is already tested on a big-endian
platform (`s390x-unknown-linux-gnu`) as well as on different OSes (Linux,
Windows, and macOS).

So altogether we are now testing a pretty wide range of portability dimensions
for Pulley in CI:

* A variety of different architectures, including 32- vs. 64-bit pointer widths
* `std` vs. `no_std`
* Little- vs. big-endian
* Linux vs. Windows vs. macOS

I think our CI coverage for Pulley is in a pretty good place now!