### PR TITLE
Fix feature combinations in testing

### DIFF
--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -35,4 +35,4 @@ target-lexicon = { workspace = true }
 default = ["std"]
 std = ["cranelift-codegen/std", "cranelift-frontend/std"]
 core = ["hashbrown", "cranelift-codegen/core", "cranelift-frontend/core"]
-enable-serde = ["serde", "serde_derive"]
+enable-serde = ["serde", "serde_derive", "cranelift-codegen/enable-serde"]


### PR DESCRIPTION
I reencountered the issue of feature combinations in this [CI](https://github.com/bytecodealliance/wasmtime/actions/runs/10105639885/job/27946461744?pr=8983), similar to #8997:

```
error[E0277]: the trait bound `cranelift_codegen::ir::GlobalValue: Serialize` is not satisfied
    --> cranelift/wasm/src/heap.rs:67:12
     |
67   |     derive(serde_derive::Serialize, serde_derive::Deserialize)
     |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `cranelift_codegen::ir::GlobalValue`
```

cc @alexcrichton 