### PR TITLE
Winch aarch64 cmp

### DIFF
--- a/tests/disas/winch/aarch64/f32_eq/const.wat
+++ b/tests/disas/winch/aarch64/f32_eq/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f32.const 1)
+        (f32.const 1)
+        (f32.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x3f800000
+;;       fmov    s0, w16
+;;       mov     x16, #0x3f800000
+;;       fmov    s1, w16
+;;       fcmp    s0, s1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f32_eq/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f32)
+        (local $bar f32)
+
+        (f32.const 2)
+        (local.set $foo)
+        (f32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f32.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #0x40000000
+;;       fmov    s0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #0x40400000
+;;       fmov    s0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/params.wat
+++ b/tests/disas/winch/aarch64/f32_eq/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f32) (param f32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f32.eq)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w0, [x28, #4]
+;;       stur    w1, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/const.wat
+++ b/tests/disas/winch/aarch64/f32_ge/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f32.const -1)
+        (f32.const -2)
+        (f32.ge)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       mov     x16, #0xbf800000
+;;       fmov    s1, w16
+;;       fcmp    s0, s1
+;;       cset    x0, ge
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ge/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f32)
+        (local $bar f32)
+
+        (f32.const -2)
+        (local.set $foo)
+        (f32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f32.ge)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #0xc0400000
+;;       fmov    s0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, ge
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/params.wat
+++ b/tests/disas/winch/aarch64/f32_ge/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f32) (param f32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f32.ge)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w0, [x28, #4]
+;;       stur    w1, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, ge
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/const.wat
+++ b/tests/disas/winch/aarch64/f32_gt/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f32.const -1)
+        (f32.const -2)
+        (f32.gt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       mov     x16, #0xbf800000
+;;       fmov    s1, w16
+;;       fcmp    s0, s1
+;;       cset    x0, gt
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_gt/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f32)
+        (local $bar f32)
+
+        (f32.const -2)
+        (local.set $foo)
+        (f32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f32.gt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #0xc0400000
+;;       fmov    s0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, gt
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/params.wat
+++ b/tests/disas/winch/aarch64/f32_gt/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f32) (param f32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f32.gt)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w0, [x28, #4]
+;;       stur    w1, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, gt
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_le/const.wat
+++ b/tests/disas/winch/aarch64/f32_le/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f32.const -1)
+        (f32.const -2)
+        (f32.le)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       mov     x16, #0xbf800000
+;;       fmov    s1, w16
+;;       fcmp    s0, s1
+;;       cset    x0, ls
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_le/locals.wat
+++ b/tests/disas/winch/aarch64/f32_le/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f32)
+        (local $bar f32)
+
+        (f32.const -2)
+        (local.set $foo)
+        (f32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f32.le)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #0xc0400000
+;;       fmov    s0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, ls
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_le/params.wat
+++ b/tests/disas/winch/aarch64/f32_le/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f32) (param f32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f32.le)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w0, [x28, #4]
+;;       stur    w1, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, ls
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/const.wat
+++ b/tests/disas/winch/aarch64/f32_lt/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f32.const -1)
+        (f32.const -2)
+        (f32.lt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       mov     x16, #0xbf800000
+;;       fmov    s1, w16
+;;       fcmp    s0, s1
+;;       cset    x0, mi
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_lt/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f32)
+        (local $bar f32)
+
+        (f32.const -2)
+        (local.set $foo)
+        (f32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f32.lt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #0xc0000000
+;;       fmov    s0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #0xc0400000
+;;       fmov    s0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, mi
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/params.wat
+++ b/tests/disas/winch/aarch64/f32_lt/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f32) (param f32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f32.lt)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w0, [x28, #4]
+;;       stur    w1, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, mi
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/const.wat
+++ b/tests/disas/winch/aarch64/f32_ne/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f32.const 1)
+        (f32.const 2)
+        (f32.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x40000000
+;;       fmov    s0, w16
+;;       mov     x16, #0x3f800000
+;;       fmov    s1, w16
+;;       fcmp    s0, s1
+;;       cset    x0, ne
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ne/locals.wat
@@ -1,0 +1,44 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f32)
+        (local $bar f32)
+
+        (f32.const 2)
+        (local.set $foo)
+        (f32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f32.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #0x40000000
+;;       fmov    s0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #0x40400000
+;;       fmov    s0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, ne
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/params.wat
+++ b/tests/disas/winch/aarch64/f32_ne/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f32) (param f32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f32.ne)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w0, [x28, #4]
+;;       stur    w1, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       fcmp    s0, s1
+;;       cset    x0, ne
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/const.wat
+++ b/tests/disas/winch/aarch64/f64_eq/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f64.const 1)
+        (f64.const 1)
+        (f64.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x3ff0000000000000
+;;       fmov    d0, x16
+;;       mov     x16, #0x3ff0000000000000
+;;       fmov    d1, x16
+;;       fcmp    d0, d1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f64_eq/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f64)
+        (local $bar f64)
+
+        (f64.const 2)
+        (local.set $foo)
+        (f64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f64.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #0x4000000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #0x4008000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/params.wat
+++ b/tests/disas/winch/aarch64/f64_eq/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f64) (param f64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f64.eq)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/const.wat
+++ b/tests/disas/winch/aarch64/f64_ge/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f64.const -1)
+        (f64.const -2)
+        (f64.ge)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       mov     x16, #-0x4010000000000000
+;;       fmov    d1, x16
+;;       fcmp    d0, d1
+;;       cset    x0, ge
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ge/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f64)
+        (local $bar f64)
+
+        (f64.const -2)
+        (local.set $foo)
+        (f64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f64.ge)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-0x3ff8000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, ge
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/params.wat
+++ b/tests/disas/winch/aarch64/f64_ge/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f64) (param f64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f64.ge)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, ge
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/const.wat
+++ b/tests/disas/winch/aarch64/f64_gt/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f64.const -1)
+        (f64.const -2)
+        (f64.gt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       mov     x16, #-0x4010000000000000
+;;       fmov    d1, x16
+;;       fcmp    d0, d1
+;;       cset    x0, gt
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_gt/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f64)
+        (local $bar f64)
+
+        (f64.const -2)
+        (local.set $foo)
+        (f64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f64.gt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-0x3ff8000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, gt
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/params.wat
+++ b/tests/disas/winch/aarch64/f64_gt/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f64) (param f64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f64.gt)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, gt
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_le/const.wat
+++ b/tests/disas/winch/aarch64/f64_le/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f64.const -1)
+        (f64.const -2)
+        (f64.le)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       mov     x16, #-0x4010000000000000
+;;       fmov    d1, x16
+;;       fcmp    d0, d1
+;;       cset    x0, ls
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_le/locals.wat
+++ b/tests/disas/winch/aarch64/f64_le/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f64)
+        (local $bar f64)
+
+        (f64.const -2)
+        (local.set $foo)
+        (f64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f64.le)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-0x3ff8000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, ls
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_le/params.wat
+++ b/tests/disas/winch/aarch64/f64_le/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f64) (param f64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f64.le)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, ls
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/const.wat
+++ b/tests/disas/winch/aarch64/f64_lt/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f64.const -1)
+        (f64.const -2)
+        (f64.lt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       mov     x16, #-0x4010000000000000
+;;       fmov    d1, x16
+;;       fcmp    d0, d1
+;;       cset    x0, mi
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_lt/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f64)
+        (local $bar f64)
+
+        (f64.const -2)
+        (local.set $foo)
+        (f64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f64.lt)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-0x4000000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-0x3ff8000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, mi
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/params.wat
+++ b/tests/disas/winch/aarch64/f64_lt/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f64) (param f64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f64.lt)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, mi
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/const.wat
+++ b/tests/disas/winch/aarch64/f64_ne/const.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f64.const 1)
+        (f64.const 2)
+        (f64.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x4000000000000000
+;;       fmov    d0, x16
+;;       mov     x16, #0x3ff0000000000000
+;;       fmov    d1, x16
+;;       fcmp    d0, d1
+;;       cset    x0, ne
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ne/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo f64)
+        (local $bar f64)
+
+        (f64.const 2)
+        (local.set $foo)
+        (f64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (f64.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #0x4000000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #0x4008000000000000
+;;       fmov    d0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, ne
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/params.wat
+++ b/tests/disas/winch/aarch64/f64_ne/params.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f64) (param f64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (f64.ne)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       fcmp    d0, d1
+;;       cset    x0, ne
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/const.wat
+++ b/tests/disas/winch/aarch64/i32_eq/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 1)
+        (i32.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       cmp     w0, #1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i32_eq/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, eq
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/params.wat
+++ b/tests/disas/winch/aarch64/i32_eq/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.eq)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, eq
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const -1)
+        (i32.const -2)
+        (i32.ge_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0xffffffff
+;;       mov     w0, w16
+;;       orr     x16, xzr, #0xfffffffe
+;;       cmp     w0, w16, uxtx
+;;       cset    x0, ge
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const -2)
+        (local.set $foo)
+        (i32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.ge_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       orr     x16, xzr, #0xfffffffe
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     w16, #-3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, ge
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.ge_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, ge
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.ge_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       cmp     w0, #2
+;;       cset    x0, hs
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.ge_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, hs
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.ge_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, hs
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const -1)
+        (i32.const -2)
+        (i32.gt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0xffffffff
+;;       mov     w0, w16
+;;       orr     x16, xzr, #0xfffffffe
+;;       cmp     w0, w16, uxtx
+;;       cset    x0, gt
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const -2)
+        (local.set $foo)
+        (i32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.gt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       orr     x16, xzr, #0xfffffffe
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     w16, #-3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, gt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.gt_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, gt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.gt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       cmp     w0, #2
+;;       cset    x0, hi
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.gt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, hi
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.gt_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, hi
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const -1)
+        (i32.const -2)
+        (i32.le_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0xffffffff
+;;       mov     w0, w16
+;;       orr     x16, xzr, #0xfffffffe
+;;       cmp     w0, w16, uxtx
+;;       cset    x0, le
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const -2)
+        (local.set $foo)
+        (i32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.le_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       orr     x16, xzr, #0xfffffffe
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     w16, #-3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, le
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.le_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, le
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.le_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       cmp     w0, #2
+;;       cset    x0, ls
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.le_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, ls
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.le_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, ls
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const -1)
+        (i32.const -2)
+        (i32.lt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0xffffffff
+;;       mov     w0, w16
+;;       orr     x16, xzr, #0xfffffffe
+;;       cmp     w0, w16, uxtx
+;;       cset    x0, lt
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const -2)
+        (local.set $foo)
+        (i32.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.lt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       orr     x16, xzr, #0xfffffffe
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     w16, #-3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, lt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.lt_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, lt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.lt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       cmp     w0, #2
+;;       cset    x0, lo
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.lt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, lo
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.lt_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, lo
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/const.wat
+++ b/tests/disas/winch/aarch64/i32_ne/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       cmp     w0, #2
+;;       cset    x0, ne
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ne/locals.wat
@@ -1,0 +1,45 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       stur    w0, [x28, #4]
+;;       mov     x16, #3
+;;       mov     w0, w16
+;;       stur    w0, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, ne
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/params.wat
+++ b/tests/disas/winch/aarch64/i32_ne/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.ne)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cmp     w1, w0, uxtx
+;;       cset    x1, ne
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/const.wat
+++ b/tests/disas/winch/aarch64/i64_eq/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const 1)
+        (i64.const 1)
+        (i64.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       cmp     x0, #1
+;;       cset    x0, eq
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i64_eq/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.eq)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, eq
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/params.wat
+++ b/tests/disas/winch/aarch64/i64_eq/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.eq)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, eq
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const -1)
+        (i64.const -2)
+        (i64.ge_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-1
+;;       mov     x0, x16
+;;       mov     x16, #-2
+;;       cmp     x0, x16, uxtx
+;;       cset    x0, ge
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const -2)
+        (local.set $foo)
+        (i64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.ge_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, ge
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.ge_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, ge
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.ge_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       cmp     x0, #2
+;;       cset    x0, hs
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.ge_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, hs
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.ge_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, hs
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const -1)
+        (i64.const -2)
+        (i64.gt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-1
+;;       mov     x0, x16
+;;       mov     x16, #-2
+;;       cmp     x0, x16, uxtx
+;;       cset    x0, gt
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const -2)
+        (local.set $foo)
+        (i64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.gt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, gt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.gt_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, gt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.gt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       cmp     x0, #2
+;;       cset    x0, hi
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.gt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, hi
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.gt_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, hi
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const -1)
+        (i64.const -2)
+        (i64.le_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-1
+;;       mov     x0, x16
+;;       mov     x16, #-2
+;;       cmp     x0, x16, uxtx
+;;       cset    x0, le
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const -2)
+        (local.set $foo)
+        (i64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.le_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, le
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.le_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, le
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.le_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       cmp     x0, #2
+;;       cset    x0, ls
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.le_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, ls
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.le_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, ls
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/const.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const -1)
+        (i64.const -2)
+        (i64.lt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-1
+;;       mov     x0, x16
+;;       mov     x16, #-2
+;;       cmp     x0, x16, uxtx
+;;       cset    x0, lt
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const -2)
+        (local.set $foo)
+        (i64.const -3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.lt_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #-2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #-3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, lt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.lt_s)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, lt
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.lt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       cmp     x0, #2
+;;       cset    x0, lo
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.lt_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, lo
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.lt_u)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, lo
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/const.wat
+++ b/tests/disas/winch/aarch64/i64_ne/const.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       cmp     x0, #2
+;;       cset    x0, ne
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ne/locals.wat
@@ -1,0 +1,46 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.ne)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       mov     x16, #0
+;;       stur    x16, [x28, #8]
+;;       stur    x16, [x28]
+;;       mov     x16, #2
+;;       mov     x0, x16
+;;       stur    x0, [x28, #8]
+;;       mov     x16, #3
+;;       mov     x0, x16
+;;       stur    x0, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, ne
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/params.wat
+++ b/tests/disas/winch/aarch64/i64_ne/params.wat
@@ -1,0 +1,30 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.ne)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cmp     x1, x0, uxtx
+;;       cset    x1, ne
+;;       mov     w0, w1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -259,19 +259,19 @@ impl Assembler {
     }
 
     /// Subtract with three registers, setting flags.
-    pub fn subs_rrr(&mut self, rm: Reg, rn: Reg, rd: Reg, size: OperandSize) {
-        self.emit_alu_rrr_extend(ALUOp::SubS, rm, rn, rd, size);
+    pub fn subs_rrr(&mut self, rm: Reg, rn: Reg, size: OperandSize) {
+        self.emit_alu_rrr_extend(ALUOp::SubS, rm, rn, regs::zero(), size);
     }
 
     /// Subtract immediate and register, setting flags.
-    pub fn subs_ir(&mut self, imm: u64, rn: Reg, rd: Reg, size: OperandSize) {
+    pub fn subs_ir(&mut self, imm: u64, rn: Reg, size: OperandSize) {
         let alu_op = ALUOp::SubS;
         if let Some(imm) = Imm12::maybe_from_u64(imm) {
-            self.emit_alu_rri(alu_op, imm, rn, rd, size);
+            self.emit_alu_rri(alu_op, imm, rn, regs::zero(), size);
         } else {
             let scratch = regs::scratch();
             self.load_constant(imm, scratch);
-            self.emit_alu_rrr_extend(alu_op, scratch, rn, rd, size);
+            self.emit_alu_rrr_extend(alu_op, scratch, rn, regs::zero(), size);
         }
     }
 

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -1,7 +1,7 @@
 //! Assembler library implementation for Aarch64.
 
 use super::{address::Address, regs};
-use crate::masm::{IntCmpKind, RoundingMode, ShiftKind};
+use crate::masm::{FloatCmpKind, IntCmpKind, RoundingMode, ShiftKind};
 use crate::{masm::OperandSize, reg::Reg};
 use cranelift_codegen::isa::aarch64::inst::FPUOpRI::{UShr32, UShr64};
 use cranelift_codegen::isa::aarch64::inst::{
@@ -42,6 +42,19 @@ impl From<IntCmpKind> for Cond {
             IntCmpKind::LeU => Cond::Ls,
             IntCmpKind::GeS => Cond::Ge,
             IntCmpKind::GeU => Cond::Hs,
+        }
+    }
+}
+
+impl From<FloatCmpKind> for Cond {
+    fn from(value: FloatCmpKind) -> Self {
+        match value {
+            FloatCmpKind::Eq => Cond::Eq,
+            FloatCmpKind::Ne => Cond::Ne,
+            FloatCmpKind::Lt => Cond::Mi,
+            FloatCmpKind::Gt => Cond::Gt,
+            FloatCmpKind::Le => Cond::Ls,
+            FloatCmpKind::Ge => Cond::Ge,
         }
     }
 }
@@ -435,6 +448,15 @@ impl Assembler {
             _ => unreachable!(),
         };
         self.emit_fpu_rri_mod(sli, ri, rn, rd)
+    }
+
+    /// Float compare.
+    pub fn fcmp(&mut self, rm: Reg, rn: Reg, size: OperandSize) {
+        self.emit(Inst::FpuCmp {
+            size: size.into(),
+            rn: rn.into(),
+            rm: rm.into(),
+        })
     }
 
     /// Return instruction.

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -531,13 +531,14 @@ impl Masm for MacroAssembler {
 
     fn float_cmp_with_set(
         &mut self,
-        _src1: Reg,
-        _src2: Reg,
-        _dst: Reg,
-        _kind: FloatCmpKind,
-        _size: OperandSize,
+        src1: Reg,
+        src2: Reg,
+        dst: Reg,
+        kind: FloatCmpKind,
+        size: OperandSize,
     ) {
-        todo!()
+        self.asm.fcmp(src1, src2, size);
+        self.asm.cset(dst, kind.into());
     }
 
     fn clz(&mut self, _src: Reg, _dst: Reg, _size: OperandSize) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -516,7 +516,7 @@ impl Masm for MacroAssembler {
     fn cmp(&mut self, src1: Reg, src2: RegImm, size: OperandSize) {
         match src2 {
             RegImm::Reg(src2) => {
-                self.asm.subs_rrr(src2, src1, regs::zero(), size);
+                self.asm.subs_rrr(src2, src1, size);
             }
             RegImm::Imm(v) => {
                 let imm = match v {
@@ -524,7 +524,7 @@ impl Masm for MacroAssembler {
                     I::I64(v) => v,
                     _ => unreachable!(),
                 };
-                self.asm.subs_ir(imm, src1, regs::zero(), size);
+                self.asm.subs_ir(imm, src1, size);
             }
         }
     }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -508,12 +508,25 @@ impl Masm for MacroAssembler {
         Address::offset(reg, offset as i64)
     }
 
-    fn cmp_with_set(&mut self, _src: RegImm, _dst: Reg, _kind: IntCmpKind, _size: OperandSize) {
-        todo!()
+    fn cmp_with_set(&mut self, src: RegImm, dst: Reg, kind: IntCmpKind, size: OperandSize) {
+        self.cmp(dst, src, size);
+        self.asm.cset(dst, kind.into());
     }
 
-    fn cmp(&mut self, _src1: Reg, _src2: RegImm, _size: OperandSize) {
-        todo!()
+    fn cmp(&mut self, src1: Reg, src2: RegImm, size: OperandSize) {
+        match src2 {
+            RegImm::Reg(src2) => {
+                self.asm.subs_rrr(src2, src1, regs::zero(), size);
+            }
+            RegImm::Imm(v) => {
+                let imm = match v {
+                    I::I32(v) => v as u64,
+                    I::I64(v) => v,
+                    _ => unreachable!(),
+                };
+                self.asm.subs_ir(imm, src1, regs::zero(), size);
+            }
+        }
     }
 
     fn float_cmp_with_set(


### PR DESCRIPTION
This PR implements wasm comparison instructions for winch targeting aarch64.
#8321 