### PR TITLE
Remove `V128Abi` and shrink the size of `Val` from 32 to 24 bytes

### DIFF
--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -964,10 +964,9 @@ mod tests {
             if cfg!(any(
                 target_arch = "x86_64",
                 target_arch = "aarch64",
-                target_arch = "riscv64"
+                target_arch = "riscv64",
+                target_arch = "s390x"
             )) {
-                32
-            } else if cfg!(target_arch = "s390x") {
                 24
             } else {
                 panic!("unsupported architecture")

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -44,7 +44,7 @@ pub mod mpk;
 #[cfg(feature = "debug-builtins")]
 pub use wasmtime_jit_debug::gdb_jit_int::GdbJitImageRegistration;
 
-pub use crate::runtime::vm::arch::{get_stack_pointer, V128Abi};
+pub use crate::runtime::vm::arch::get_stack_pointer;
 pub use crate::runtime::vm::async_yield::*;
 pub use crate::runtime::vm::export::*;
 pub use crate::runtime::vm::gc::*;

--- a/crates/wasmtime/src/runtime/vm/arch/aarch64.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/aarch64.rs
@@ -1,10 +1,5 @@
 //! Arm64-specific definitions of architecture-specific functions in Wasmtime.
 
-/// AArch64 uses vector registered which here is used with a vector type.
-/// Note that the specific type shouldn't matter too much but the choice
-/// of using a vector is the significant part.
-pub type V128Abi = core::arch::aarch64::uint8x16_t;
-
 #[inline]
 #[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {

--- a/crates/wasmtime/src/runtime/vm/arch/riscv64.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/riscv64.rs
@@ -1,12 +1,5 @@
 //! Riscv64-specific definitions of architecture-specific functions in Wasmtime.
 
-/// RISC-V currently always passes all vector arguments indirectly in the
-/// ABI. Currently Rust has no stable means of representing this meaning
-/// that a 128-bit representation is chosen here but it can't be passed
-/// directly to WebAssembly, for example, and must instead be passed
-/// through an array-call trampoline.
-pub type V128Abi = u128;
-
 #[inline]
 #[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {

--- a/crates/wasmtime/src/runtime/vm/arch/s390x.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/s390x.rs
@@ -1,9 +1,5 @@
 //! s390x-specific definitions of architecture-specific functions in Wasmtime.
 
-/// Currently Rust has no stable means of representing vector registers
-/// so like RISC-V at this time this uses a bland 128-bit representation.
-pub type V128Abi = u128;
-
 #[inline]
 #[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {

--- a/crates/wasmtime/src/runtime/vm/arch/x86_64.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/x86_64.rs
@@ -1,10 +1,5 @@
 //! x86_64-specific definitions of architecture-specific functions in Wasmtime.
 
-/// x86 vectors are represented with XMM registers which are represented
-/// with the `__m128i` type. This type is considered a vector type for
-/// ABI purposes which is implemented by Cranelift.
-pub type V128Abi = core::arch::x86_64::__m128i;
-
 #[inline]
 #[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {


### PR DESCRIPTION
This removes `V128Abi`, which is no longer needed since we removed the native calling convention from Wasmtime. For the new internal representation of `V128`, we use an unaligned byte array. This lowers the alignment requirements for `V128` to 1 rather than 16, which means that `Val` no longer requires padding after its discriminant before the storage for its `V128` variant, which in turn allows its size to shrink from 32 to 24 bytes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
