### PR TITLE
Derive `Copy` for `Val`

### DIFF
--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -14,7 +14,7 @@ pub use crate::runtime::vm::ValRaw;
 ///
 /// Note that we inline the `enum Ref { ... }` variants into `enum Val { ... }`
 /// here as a size optimization.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Val {
     // NB: the ordering here is intended to match the ordering in
     // `ValType` to improve codegen when learning the type of a value.


### PR DESCRIPTION
`Val` is just 24 bytes now, and all of its variants are `Copy`, so lets make it `Copy` too.