### PR TITLE
Explorer with clif fix: cache does not emit clif files

### DIFF
--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -55,6 +55,7 @@ impl ExploreCommand {
         let clif_dir = if let Some(Strategy::Cranelift) | None = self.common.codegen.compiler {
             let clif_dir = tempdir()?;
             config.emit_clif(clif_dir.path());
+            config.disable_cache(); // cache does not emit clif
             Some(clif_dir)
         } else {
             None


### PR DESCRIPTION
Hey 👋

I found a bug introduced in [PR#8972](https://github.com/bytecodealliance/wasmtime/pull/8972). When cache is used, no clif files can be emited. I propose to disable the cache when exploring with cranelift

@fitzgen 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
