### PR TITLE
Integrate wasi-keyvalue into wasmtime-cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,6 +360,7 @@ default = [
   "wasi-threads",
   "wasi-http",
   "wasi-runtime-config",
+  "wasi-keyvalue",
 
   # Most features of Wasmtime are enabled by default.
   "wat",
@@ -406,6 +407,7 @@ wasi-nn = ["dep:wasmtime-wasi-nn"]
 wasi-threads = ["dep:wasmtime-wasi-threads", "threads"]
 wasi-http = ["component-model", "dep:wasmtime-wasi-http", "dep:tokio", "dep:hyper"]
 wasi-runtime-config = ["dep:wasmtime-wasi-runtime-config"]
+wasi-keyvalue = ["dep:wasmtime-wasi-keyvalue", "wasmtime-wasi-keyvalue/redis"]
 pooling-allocator = ["wasmtime/pooling-allocator", "wasmtime-cli-flags/pooling-allocator"]
 component-model = [
   "wasmtime/component-model",

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -286,6 +286,8 @@ wasmtime_option_group! {
         pub http: Option<bool>,
         /// Enable support for WASI runtime config API (experimental)
         pub runtime_config: Option<bool>,
+        /// Enable support for WASI key-value API (experimental)
+        pub keyvalue: Option<bool>,
         /// Inherit environment variables and file descriptors following the
         /// systemd listen fd specification (UNIX only)
         pub listenfd: Option<bool>,
@@ -324,7 +326,18 @@ wasmtime_option_group! {
         /// This option can be further overwritten with `--env` flags.
         pub inherit_env: Option<bool>,
         /// Pass a wasi runtime config variable to the program.
-        pub runtime_config_var: Vec<WasiRuntimeConfigVariable>,
+        pub runtime_config_var: Vec<KeyValuePair>,
+        /// Preset data for the In-Memory provider of WASI key-value API.
+        pub keyvalue_in_memory_data: Vec<KeyValuePair>,
+        /// Grant access to the given Redis host for the Redis provider of WASI
+        /// key-value API.
+        pub keyvalue_redis_host: Vec<String>,
+        /// Sets the connection timeout parameter for the Redis provider of WASI
+        /// key-value API.
+        pub keyvalue_redis_connection_timeout: Option<Duration>,
+        /// Sets the response timeout parameter for the Redis provider of WASI
+        /// key-value API.
+        pub keyvalue_redis_response_timeout: Option<Duration>,
     }
 
     enum Wasi {
@@ -339,7 +352,7 @@ pub struct WasiNnGraph {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct WasiRuntimeConfigVariable {
+pub struct KeyValuePair {
     pub key: String,
     pub value: String,
 }

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -5,7 +5,7 @@
 //! specifying options in a struct-like syntax where all other boilerplate about
 //! option parsing is contained exclusively within this module.
 
-use crate::{WasiNnGraph, WasiRuntimeConfigVariable};
+use crate::{KeyValuePair, WasiNnGraph};
 use anyhow::{bail, Result};
 use clap::builder::{StringValueParser, TypedValueParser, ValueParserFactory};
 use clap::error::{Error, ErrorKind};
@@ -397,12 +397,12 @@ impl WasmtimeOptionValue for WasiNnGraph {
     }
 }
 
-impl WasmtimeOptionValue for WasiRuntimeConfigVariable {
+impl WasmtimeOptionValue for KeyValuePair {
     const VAL_HELP: &'static str = "=<name>=<val>";
     fn parse(val: Option<&str>) -> Result<Self> {
         let val = String::parse(val)?;
         let mut parts = val.splitn(2, "=");
-        Ok(WasiRuntimeConfigVariable {
+        Ok(KeyValuePair {
             key: parts.next().unwrap().to_string(),
             value: match parts.next() {
                 Some(part) => part.into(),

--- a/crates/test-programs/src/bin/cli_serve_keyvalue.rs
+++ b/crates/test-programs/src/bin/cli_serve_keyvalue.rs
@@ -1,0 +1,30 @@
+use test_programs::keyvalue::wasi::keyvalue;
+use test_programs::proxy;
+use test_programs::wasi::http::types::{
+    Fields, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+};
+
+struct T;
+
+proxy::export!(T);
+
+impl proxy::exports::wasi::http::incoming_handler::Guest for T {
+    fn handle(_: IncomingRequest, outparam: ResponseOutparam) {
+        let fields = Fields::new();
+        let resp = OutgoingResponse::new(fields);
+        let body = resp.body().expect("outgoing response");
+
+        ResponseOutparam::set(outparam, Ok(resp));
+
+        let out = body.write().expect("outgoing stream");
+        let bucket = keyvalue::store::open("").unwrap();
+        let data = bucket.get("hello").unwrap().unwrap();
+        out.blocking_write_and_flush(&data)
+            .expect("writing response");
+
+        drop(out);
+        OutgoingBody::finish(body, None).expect("outgoing-body.finish");
+    }
+}
+
+fn main() {}

--- a/crates/test-programs/src/bin/keyvalue_main.rs
+++ b/crates/test-programs/src/bin/keyvalue_main.rs
@@ -1,10 +1,7 @@
 use test_programs::keyvalue::wasi::keyvalue::{atomics, batch, store};
 
 fn main() {
-    let identifier = std::env::var_os("IDENTIFIER")
-        .unwrap()
-        .into_string()
-        .unwrap();
+    let identifier = std::env::var("IDENTIFIER").unwrap_or("".to_string());
     let bucket = store::open(&identifier).unwrap();
 
     if identifier != "" {

--- a/crates/wasi-keyvalue/Cargo.toml
+++ b/crates/wasi-keyvalue/Cargo.toml
@@ -13,13 +13,13 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 wasmtime = { workspace = true, features = ["runtime", "async", "component-model"] }
+wasmtime-wasi = { workspace = true }
 async-trait = { workspace = true }
 url = { workspace = true }
 redis = { workspace = true, optional = true, features = ["tokio-comp"] }
 
 [dev-dependencies]
 test-programs-artifacts = { workspace = true }
-wasmtime-wasi = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [features]

--- a/crates/wasi-keyvalue/src/bindings.rs
+++ b/crates/wasi-keyvalue/src/bindings.rs
@@ -1,0 +1,26 @@
+wasmtime::component::bindgen!({
+    path: "wit",
+    world: "wasi:keyvalue/imports",
+    trappable_imports: true,
+    async: true,
+    with: {
+        "wasi:keyvalue/store/bucket": crate::Bucket,
+    },
+    trappable_error_type: {
+        "wasi:keyvalue/store/error" => crate::Error,
+    },
+});
+
+pub(crate) mod sync {
+    wasmtime::component::bindgen!({
+        path: "wit",
+        world: "wasi:keyvalue/imports",
+        trappable_imports: true,
+        with: {
+            "wasi:keyvalue/store/bucket": crate::Bucket,
+        },
+        trappable_error_type: {
+            "wasi:keyvalue/store/error" => crate::Error,
+        },
+    });
+}

--- a/crates/wasi-keyvalue/src/provider/inmemory.rs
+++ b/crates/wasi-keyvalue/src/provider/inmemory.rs
@@ -1,4 +1,4 @@
-use crate::{generated::wasi::keyvalue::store::KeyResponse, to_other_error, Error, Host};
+use crate::{bindings::wasi::keyvalue::store::KeyResponse, to_other_error, Error, Host};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/crates/wasi-keyvalue/src/provider/redis.rs
+++ b/crates/wasi-keyvalue/src/provider/redis.rs
@@ -91,7 +91,7 @@ impl Host for Redis {
         for (key, value) in key_values {
             pipe.set(key, value).ignore();
         }
-        pipe.query_async(&mut self.conn).await?;
+        let _: () = pipe.query_async(&mut self.conn).await?;
         Ok(())
     }
 
@@ -100,7 +100,7 @@ impl Host for Redis {
         for key in keys {
             pipe.del(key).ignore();
         }
-        pipe.query_async(&mut self.conn).await?;
+        let _: () = pipe.query_async(&mut self.conn).await?;
         Ok(())
     }
 }

--- a/crates/wasi-keyvalue/src/provider/redis.rs
+++ b/crates/wasi-keyvalue/src/provider/redis.rs
@@ -1,4 +1,4 @@
-use crate::{generated::wasi::keyvalue::store::KeyResponse, Error, Host};
+use crate::{bindings::wasi::keyvalue::store::KeyResponse, Error, Host};
 use anyhow::Result;
 use async_trait::async_trait;
 use redis::{aio::MultiplexedConnection, AsyncCommands, RedisError};

--- a/crates/wasi-keyvalue/tests/main.rs
+++ b/crates/wasi-keyvalue/tests/main.rs
@@ -32,7 +32,7 @@ async fn run_wasi(path: &str, ctx: Ctx) -> Result<()> {
 
     let mut linker = Linker::new(&engine);
     wasmtime_wasi::add_to_linker_async(&mut linker)?;
-    wasmtime_wasi_keyvalue::add_to_linker(&mut linker, |h: &mut Ctx| {
+    wasmtime_wasi_keyvalue::add_to_linker_async(&mut linker, |h: &mut Ctx| {
         WasiKeyValue::new(&h.wasi_keyvalue_ctx, &mut h.table)
     })?;
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1886,6 +1886,39 @@ stderr [1] :: after empty
         ])?;
         Ok(())
     }
+
+    #[tokio::test]
+    async fn cli_serve_keyvalue() -> Result<()> {
+        let server = WasmtimeServe::new(CLI_SERVE_KEYVALUE_COMPONENT, |cmd| {
+            cmd.arg("-Scli");
+            cmd.arg("-Skeyvalue");
+            cmd.arg("-Skeyvalue-in-memory-data=hello=world");
+        })?;
+
+        let resp = server
+            .send_request(
+                hyper::Request::builder()
+                    .uri("http://localhost/")
+                    .body(String::new())
+                    .context("failed to make request")?,
+            )
+            .await?;
+
+        assert!(resp.status().is_success());
+        assert_eq!(resp.body(), "world");
+        Ok(())
+    }
+
+    #[test]
+    fn cli_keyvalue() -> Result<()> {
+        run_wasmtime(&[
+            "run",
+            "-Skeyvalue",
+            "-Skeyvalue-in-memory-data=atomics_key=5",
+            KEYVALUE_MAIN_COMPONENT,
+        ])?;
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
Continue #8983

This patch adds some new flags:

```
  -S                                keyvalue[=y|n] -- Enable support for WASI key-value API (experimental)
  -S          keyvalue-in-memory-data=<name>=<val> -- Preset data for the In-Memory provider of WASI key-value API.
  -S                       keyvalue-redis-host=val -- Grant access to the given Redis host for the Redis provider of WASI key-value API.
  -S keyvalue-redis-connection-timeout=N|Ns|Nms|.. -- Sets the connection timeout parameter for the Redis provider of WASI key-value API.
  -S   keyvalue-redis-response-timeout=N|Ns|Nms|.. -- Sets the response timeout parameter for the Redis provider of WASI key-value API.
```

cc @alexcrichton 