### PR TITLE
Change `build-test-matrix.js` to run more sometimes

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -286,7 +286,8 @@ async function main() {
     // If any runtest was modified, include all ISA configs as runtests can
     // target any backend.
     if (names.includes(`cranelift/filetests/filetests/runtests`)) {
-      return config.isa !== undefined;
+      if (config.isa !== undefined)
+        return true;
     }
 
     // If any Pulley source file was modified, then run Pulley-specific configs.


### PR DESCRIPTION
This commit updates `build-test-matrix.js` to calculate PR tests to never early-return `false`. The current structure for PR tests will iterate over most matrix entries and filter them out based on whether they're applicable or not given the commit message and modified files. The thinking is that an early-return of `false` might be a false-negative where a later filter enables the test. By only early-returning `true` this enables any passing predicate to cause the tests to be run on a PR. Note that this has no effect on merge queues since those always and unconditionally run everything.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
