### PR TITLE
Enable a few more clippy lints by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,10 @@ unused-lifetimes = 'warn'
 # they're all turned off by default. Selective lints are then enabled below as
 # necessary.
 all = { level = 'allow', priority = -1 }
-clone_on_copy = 'deny'
+clone_on_copy = 'warn'
+map_clone = 'warn'
+unnecessary_to_owned = 'warn'
+manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -63,7 +63,7 @@ pub(crate) fn lower_branch(
     // TODO: reuse the ISLE context across lowerings so we can reuse its
     // internal heap allocations.
     let mut isle_ctx = IsleContext { lower_ctx, backend };
-    generated_code::constructor_lower_branch(&mut isle_ctx, branch, &targets.to_vec())
+    generated_code::constructor_lower_branch(&mut isle_ctx, branch, targets)
 }
 
 pub struct ExtendedValue {

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -647,5 +647,5 @@ pub(crate) fn lower_branch(
     // TODO: reuse the ISLE context across lowerings so we can reuse its
     // internal heap allocations.
     let mut isle_ctx = RV64IsleContext::new(lower_ctx, backend);
-    generated_code::constructor_lower_branch(&mut isle_ctx, branch, &targets.to_vec())
+    generated_code::constructor_lower_branch(&mut isle_ctx, branch, targets)
 }

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -74,7 +74,7 @@ pub(crate) fn lower_branch(
     // TODO: reuse the ISLE context across lowerings so we can reuse its
     // internal heap allocations.
     let mut isle_ctx = IsleContext { lower_ctx, backend };
-    generated_code::constructor_lower_branch(&mut isle_ctx, branch, &targets.to_vec())
+    generated_code::constructor_lower_branch(&mut isle_ctx, branch, targets)
 }
 
 impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -65,7 +65,7 @@ pub(crate) fn lower_branch(
     // TODO: reuse the ISLE context across lowerings so we can reuse its
     // internal heap allocations.
     let mut isle_ctx = IsleContext { lower_ctx, backend };
-    generated_code::constructor_lower_branch(&mut isle_ctx, branch, &targets.to_vec())
+    generated_code::constructor_lower_branch(&mut isle_ctx, branch, &targets)
 }
 
 impl Context for IsleContext<'_, '_, MInst, X64Backend> {

--- a/cranelift/codegen/src/machinst/pcc.rs
+++ b/cranelift/codegen/src/machinst/pcc.rs
@@ -11,7 +11,7 @@ pub(crate) fn get_fact_or_default<I: VCodeInst>(vcode: &VCode<I>, reg: Reg, widt
     );
     vcode
         .vreg_fact(reg.into())
-        .map(|f| f.clone())
+        .cloned()
         .unwrap_or_else(|| Fact::max_range_for_width(width))
 }
 

--- a/cranelift/filetests/src/match_directive.rs
+++ b/cranelift/filetests/src/match_directive.rs
@@ -10,11 +10,7 @@ pub fn match_directive<'a>(comment: &'a str, directive: &str) -> Option<&'a str>
         "Directive must include trailing colon"
     );
     let text = comment.trim_start_matches(';').trim_start();
-    if text.starts_with(directive) {
-        Some(text[directive.len()..].trim())
-    } else {
-        None
-    }
+    text.strip_prefix(directive).map(|s| s.trim())
 }
 
 #[test]

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -788,9 +788,9 @@ impl<'a> Parser<'a> {
         if let Some(Token::Integer(text)) = self.token() {
             self.consume();
             // Lexer just gives us raw text that looks like an integer.
-            if text.starts_with("0x") {
+            if let Some(num) = text.strip_prefix("0x") {
                 // Parse it as a u8 in hexadecimal form.
-                u8::from_str_radix(&text[2..], 16)
+                u8::from_str_radix(num, 16)
                     .map_err(|_| self.error("unable to parse u8 as a hexadecimal immediate"))
             } else {
                 // Parse it as a u8 to check for overflow and other issues.

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -40,7 +40,7 @@ impl ComponentTypesBuilder {
         let results = match self.flatten_types(
             &options.options,
             MAX_FLAT_RESULTS,
-            self[ty.results].types.iter().map(|ty| *ty),
+            self[ty.results].types.iter().copied(),
         ) {
             Some(list) => list,
             None => {

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -432,13 +432,13 @@ impl Compiler<'_, '_> {
         let src_tys = self.types[src_tys]
             .types
             .iter()
-            .map(|ty| *ty)
+            .copied()
             .collect::<Vec<_>>();
         let dst_tys = self.types[adapter.lower.ty].results;
         let dst_tys = self.types[dst_tys]
             .types
             .iter()
-            .map(|ty| *ty)
+            .copied()
             .collect::<Vec<_>>();
         let lift_opts = &adapter.lift.options;
         let lower_opts = &adapter.lower.options;


### PR DESCRIPTION
Also set their default levels to `warn` instead of `deny` to assist with using clippy locally to avoid compilation failures and collecting as many as possible in one run. Note that CI will still deny-by-default through `-Dwarnings`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
