### PR TITLE
Improve unsupported architecture errors in Wasmtime

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -200,7 +200,7 @@ pub struct GcRootIndex {
 const _: () = {
     // NB: these match the C API which should also be updated if this changes
     assert!(mem::size_of::<GcRootIndex>() == 16);
-    assert!(mem::align_of::<GcRootIndex>() == 8);
+    assert!(mem::align_of::<GcRootIndex>() == mem::align_of::<u64>());
 };
 
 impl GcRootIndex {
@@ -1302,9 +1302,9 @@ const _: () = {
 
     // NB: these match the C API which should also be updated if this changes
     assert!(mem::size_of::<ManuallyRooted<AnyRef>>() == 16);
-    assert!(mem::align_of::<ManuallyRooted<AnyRef>>() == 8);
+    assert!(mem::align_of::<ManuallyRooted<AnyRef>>() == mem::align_of::<u64>());
     assert!(mem::size_of::<ManuallyRooted<ExternRef>>() == 16);
-    assert!(mem::align_of::<ManuallyRooted<ExternRef>>() == 8);
+    assert!(mem::align_of::<ManuallyRooted<ExternRef>>() == mem::align_of::<u64>());
 };
 
 impl<T: GcRef> Debug for ManuallyRooted<T> {

--- a/crates/wasmtime/src/runtime/vm/arch/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/mod.rs
@@ -10,23 +10,44 @@
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
         mod x86_64;
-        pub use x86_64::*;
+        use x86_64 as imp;
     } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
-        pub use aarch64::*;
+        use aarch64 as imp;
     } else if #[cfg(target_arch = "s390x")] {
         mod s390x;
-        pub use s390x::*;
+        use s390x as imp;
     } else if #[cfg(target_arch = "riscv64")] {
         mod riscv64;
-        pub use riscv64::*;
+        use riscv64 as imp;
     } else {
-        compile_error!(
-            "Wasmtime is being compiled for an architecture \
-             that it does not support. If this architecture is \
-             one you would like to see supported you may file an \
-             issue on Wasmtime's issue tracker: \
-             https://github.com/bytecodealliance/wasmtime/issues/new\
-        ");
+        mod unsupported;
+        use unsupported as imp;
     }
+}
+
+// Functions defined in this module but all the implementations delegate to each
+// `imp` module. This exists to assert that each module internally provides the
+// same set of functionality with the same types for all architectures.
+
+pub fn get_stack_pointer() -> usize {
+    imp::get_stack_pointer()
+}
+
+pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
+    imp::get_next_older_pc_from_fp(fp)
+}
+
+pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = imp::NEXT_OLDER_FP_FROM_FP_OFFSET;
+
+pub fn reached_entry_sp(fp: usize, entry_sp: usize) -> bool {
+    imp::reached_entry_sp(fp, entry_sp)
+}
+
+pub fn assert_entry_sp_is_aligned(sp: usize) {
+    imp::assert_entry_sp_is_aligned(sp)
+}
+
+pub fn assert_fp_is_aligned(fp: usize) {
+    imp::assert_fp_is_aligned(fp)
 }

--- a/crates/wasmtime/src/runtime/vm/arch/unsupported.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/unsupported.rs
@@ -1,0 +1,44 @@
+compile_error!("Wasmtime's runtime is being compiled for an architecture that it does not support");
+
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "x86")] {
+    compile_error!("\
+the tracking issue for i686 support is https://github.com/bytecodealliance/wasmtime/issues/1980 \
+");
+    } else if #[cfg(target_arch = "arm")] {
+    compile_error!("\
+the tracking issue for arm support is https://github.com/bytecodealliance/wasmtime/issues/1173 \
+");
+    } else if #[cfg(target_arch = "riscv32")] {
+    compile_error!("\
+the tracking issue for riscv32 support is https://github.com/bytecodealliance/wasmtime/issues/8768 \
+");
+    } else {
+    compile_error!("\
+if you'd like feel free to file an issue for platform support at
+https://github.com/bytecodealliance/wasmtime/issues/new
+");
+    }
+}
+
+pub fn get_stack_pointer() -> usize {
+    panic!()
+}
+
+pub unsafe fn get_next_older_pc_from_fp(_fp: usize) -> usize {
+    panic!()
+}
+
+pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = 0;
+
+pub fn reached_entry_sp(_fp: usize, _entry_sp: usize) -> bool {
+    panic!()
+}
+
+pub fn assert_entry_sp_is_aligned(_sp: usize) {
+    panic!()
+}
+
+pub fn assert_fp_is_aligned(_fp: usize) {
+    panic!()
+}

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -28,7 +28,7 @@ use wasmtime_environ::{VMGcKind, VMSharedTypeIndex};
 ///     ty: Option<VMSharedTypeIndex>,
 /// }
 /// ```
-#[repr(transparent)]
+#[repr(align(8))]
 pub struct VMGcHeader(u64);
 
 unsafe impl GcHeapObject for VMGcHeader {

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -166,7 +166,10 @@ impl Default for InstanceLimits {
             // have 10k+ elements.
             table_elements: 20_000,
             max_memories_per_module: 1,
+            #[cfg(target_pointer_width = "64")]
             max_memory_size: 1 << 32, // 4G,
+            #[cfg(target_pointer_width = "32")]
+            max_memory_size: usize::MAX,
             #[cfg(feature = "gc")]
             total_gc_heaps: 1000,
         }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -320,6 +320,7 @@ unsafe fn get_pc_and_fp(cx: *mut libc::c_void, _signum: libc::c_int) -> (*const 
         }
         else {
             compile_error!("unsupported platform");
+            panic!();
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -1018,7 +1018,7 @@ pub union ValRaw {
 // matched in C.
 const _: () = {
     assert!(mem::size_of::<ValRaw>() == 16);
-    assert!(mem::align_of::<ValRaw>() == 8);
+    assert!(mem::align_of::<ValRaw>() == mem::align_of::<u64>());
 };
 
 // This type is just a bag-of-bits so it's up to the caller to figure out how


### PR DESCRIPTION
Don't rely purely on `compile_error!` which doesn't halt compilation. Instead fill out some stubs which won't ever actually get compiled but prevent other compiler errors from cropping up.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
