### PR TITLE
Fix a pulley crash on OSS-Fuzz

### DIFF
--- a/pulley/fuzz/src/interp.rs
+++ b/pulley/fuzz/src/interp.rs
@@ -107,6 +107,6 @@ fn extended_op_is_safe_for_fuzzing(op: &ExtendedOp) -> bool {
     match op {
         ExtendedOp::Trap(_) => true,
         ExtendedOp::Nop(_) => true,
-        ExtendedOp::GetSp(_) => true,
+        ExtendedOp::GetSp(GetSp { dst, .. }) => !dst.is_special(),
     }
 }


### PR DESCRIPTION
This fixes a crash where the `GetSp` opcode was overwriting a special register, so apply a similar filter as to other instructions to ensure that the special registers are not clobbered.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
