### PR TITLE
Bump tokio version to 1.30 to avoid duplicate socket2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,9 +2055,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2262,7 +2262,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
@@ -2615,16 +2615,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
@@ -2882,11 +2872,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -2894,7 +2883,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ tempfile = "3.1.0"
 filecheck = "0.5.0"
 libc = { version = "0.2.112", default-features = true }
 file-per-thread-logger = "0.2.0"
-tokio = { version = "1.26.0", features = [ "rt", "time" ] }
+tokio = { version = "1.30.0", features = [ "rt", "time" ] }
 hyper = "1.0.1"
 http = "1.0.0"
 http-body = "1.0.0"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2226,6 +2226,12 @@ a few `unsafe` blocks related to utf-8 validation which are locally verifiable
 as correct and otherwise this crate is good to go.
 """
 
+[[audits.pin-project-lite]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.13 -> 0.2.14"
+notes = "No substantive changes in this update"
+
 [[audits.pin-utils]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -592,7 +592,7 @@ version = "1.2.1"
 criteria = "safe-to-run"
 
 [[exemptions.tokio]]
-version = "1.29.1"
+version = "1.30.0"
 criteria = "safe-to-deploy"
 notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -4008,6 +4008,13 @@ version = "0.2.9"
 notes = "Reviewed on https://fxrev.dev/824504"
 aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.pin-project-lite]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.9 -> 0.2.13"
+notes = "Audited at https://fxrev.dev/946396"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.socket2]]
 who = "David Koloski <dkoloski@google.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
In #8983, we introduced the `redis` dependency, which relies on `socket2` 0.5. This conflicts with our existing version 0.4, leading to `cargo deny` throwing the following error when trying to merge #9032 (https://github.com/bytecodealliance/wasmtime/actions/runs/10147488558/job/28058006599).

```
error[duplicate]: found 2 duplicate entries for crate 'socket2'
    ┌─ /home/runner/work/wasmtime/wasmtime/Cargo.lock:224:1
    │  
224 │ ╭ socket2 0.4.9 registry+https://github.com/rust-lang/crates.io-index
225 │ │ socket2 0.5.7 registry+https://github.com/rust-lang/crates.io-index
    │ ╰───────────────────────────────────────────────────────────────────^ lock entries
```

Therefore, this patch updates the version of `tokio` from 1.29.1 to 1.30. With this update, we will no longer have duplicate socket2 dependencies, as both will depend on version 0.5.

NOTE: I could also downgrade the `redis` version to 0.25.0, which relies on socket2 0.4, but this version has significant bugs and has been yanked.

<img width="614" alt="Screenshot 2024-07-30 at 10 24 34" src="https://github.com/user-attachments/assets/fd8e82b9-3cb2-4a5b-a88a-6aa6bb8c1952">


