### PR TITLE
Cranelift: Stop sign-extending `Imm64` immediates in builder methods

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -973,7 +973,7 @@ fn gen_format_constructor(format: &InstructionFormat, fmt: &mut Formatter) {
         args.join(", ")
     );
 
-    let imms_need_sign_extension = format
+    let imms_need_masking = format
         .imm_fields
         .iter()
         .any(|f| f.kind.rust_type == "ir::immediates::Imm64");
@@ -986,7 +986,7 @@ fn gen_format_constructor(format: &InstructionFormat, fmt: &mut Formatter) {
         fmtln!(
             fmt,
             "let{} data = ir::InstructionData::{} {{",
-            if imms_need_sign_extension { " mut" } else { "" },
+            if imms_need_masking { " mut" } else { "" },
             format.name
         );
         fmt.indent(|fmt| {
@@ -995,7 +995,7 @@ fn gen_format_constructor(format: &InstructionFormat, fmt: &mut Formatter) {
         });
         fmtln!(fmt, "};");
 
-        if imms_need_sign_extension {
+        if imms_need_masking {
             fmtln!(fmt, "data.mask_immediates(ctrl_typevar);");
         }
 

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -996,7 +996,7 @@ fn gen_format_constructor(format: &InstructionFormat, fmt: &mut Formatter) {
         fmtln!(fmt, "};");
 
         if imms_need_sign_extension {
-            fmtln!(fmt, "data.sign_extend_immediates(ctrl_typevar);");
+            fmtln!(fmt, "data.mask_immediates(ctrl_typevar);");
         }
 
         // Assert that this opcode belongs to this format

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -74,10 +74,27 @@ impl Imm64 {
         self.0
     }
 
+    /// Mask this immediate to the given power-of-two bit width.
+    pub(crate) fn mask_to_width(&mut self, bit_width: u32) {
+        debug_assert!(bit_width.is_power_of_two());
+
+        if bit_width >= 64 {
+            return;
+        }
+
+        let bit_width = i64::from(bit_width);
+        let mask = (1 << bit_width) - 1;
+        let masked = self.0 & mask;
+        *self = Imm64(masked);
+    }
+
     /// Sign extend this immediate as if it were a signed integer of the given
     /// power-of-two width.
-    pub fn sign_extend_from_width(&mut self, bit_width: u32) {
-        debug_assert!(bit_width.is_power_of_two());
+    pub(crate) fn sign_extend_from_width(&mut self, bit_width: u32) {
+        debug_assert!(
+            bit_width.is_power_of_two(),
+            "{bit_width} is not a power of two"
+        );
 
         if bit_width >= 64 {
             return;
@@ -111,8 +128,8 @@ impl From<i64> for Imm64 {
 impl Display for Imm64 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let x = self.0;
-        if -10_000 < x && x < 10_000 {
-            // Use decimal for small numbers.
+        if x < 10_000 {
+            // Use decimal for small and negative numbers.
             write!(f, "{}", x)
         } else {
             write_hex(x as u64, f)

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -1112,7 +1112,7 @@ mod tests {
         assert_eq!(Imm64(9999).to_string(), "9999");
         assert_eq!(Imm64(10000).to_string(), "0x2710");
         assert_eq!(Imm64(-9999).to_string(), "-9999");
-        assert_eq!(Imm64(-10000).to_string(), "0xffff_ffff_ffff_d8f0");
+        assert_eq!(Imm64(-10000).to_string(), "-10000");
         assert_eq!(Imm64(0xffff).to_string(), "0xffff");
         assert_eq!(Imm64(0x10000).to_string(), "0x0001_0000");
     }
@@ -1132,6 +1132,7 @@ mod tests {
     }
 
     // Verify that `text` can be parsed as a `T` into a value that displays as `want`.
+    #[track_caller]
     fn parse_ok<T: FromStr + Display>(text: &str, want: &str)
     where
         <T as FromStr>::Err: Display,
@@ -1165,11 +1166,11 @@ mod tests {
 
         // Probe limits.
         parse_ok::<Imm64>("0xffffffff_ffffffff", "-1");
-        parse_ok::<Imm64>("0x80000000_00000000", "0x8000_0000_0000_0000");
-        parse_ok::<Imm64>("-0x80000000_00000000", "0x8000_0000_0000_0000");
+        parse_ok::<Imm64>("0x80000000_00000000", "-9223372036854775808");
+        parse_ok::<Imm64>("-0x80000000_00000000", "-9223372036854775808");
         parse_err::<Imm64>("-0x80000000_00000001", "Negative number too small");
         parse_ok::<Imm64>("18446744073709551615", "-1");
-        parse_ok::<Imm64>("-9223372036854775808", "0x8000_0000_0000_0000");
+        parse_ok::<Imm64>("-9223372036854775808", "-9223372036854775808");
         // Overflow both the `checked_add` and `checked_mul`.
         parse_err::<Imm64>("18446744073709551616", "Too large decimal number");
         parse_err::<Imm64>("184467440737095516100", "Too large decimal number");

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -75,35 +75,37 @@ impl Imm64 {
     }
 
     /// Mask this immediate to the given power-of-two bit width.
-    pub(crate) fn mask_to_width(&mut self, bit_width: u32) {
+    #[must_use]
+    pub(crate) fn mask_to_width(&self, bit_width: u32) -> Self {
         debug_assert!(bit_width.is_power_of_two());
 
         if bit_width >= 64 {
-            return;
+            return *self;
         }
 
         let bit_width = i64::from(bit_width);
         let mask = (1 << bit_width) - 1;
         let masked = self.0 & mask;
-        *self = Imm64(masked);
+        Imm64(masked)
     }
 
     /// Sign extend this immediate as if it were a signed integer of the given
     /// power-of-two width.
-    pub(crate) fn sign_extend_from_width(&mut self, bit_width: u32) {
+    #[must_use]
+    pub(crate) fn sign_extend_from_width(&self, bit_width: u32) -> Self {
         debug_assert!(
             bit_width.is_power_of_two(),
             "{bit_width} is not a power of two"
         );
 
         if bit_width >= 64 {
-            return;
+            return *self;
         }
 
         let bit_width = i64::from(bit_width);
         let delta = 64 - bit_width;
         let sign_extended = (self.0 << delta) >> delta;
-        *self = Imm64(sign_extended);
+        Imm64(sign_extended)
     }
 }
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -450,7 +450,7 @@ impl InstructionData {
     }
 
     #[inline]
-    pub(crate) fn sign_extend_immediates(&mut self, ctrl_typevar: Type) {
+    pub(crate) fn mask_immediates(&mut self, ctrl_typevar: Type) {
         if ctrl_typevar.is_invalid() {
             return;
         }
@@ -458,13 +458,16 @@ impl InstructionData {
         let bit_width = ctrl_typevar.bits();
 
         match self {
+            Self::UnaryImm { opcode: _, imm } => {
+                imm.mask_to_width(bit_width);
+            }
             Self::BinaryImm64 {
                 opcode,
                 arg: _,
                 imm,
             } => {
                 if *opcode == Opcode::SdivImm || *opcode == Opcode::SremImm {
-                    imm.sign_extend_from_width(bit_width);
+                    imm.mask_to_width(bit_width);
                 }
             }
             Self::IntCompareImm {
@@ -475,7 +478,7 @@ impl InstructionData {
             } => {
                 debug_assert_eq!(*opcode, Opcode::IcmpImm);
                 if cond.unsigned() != *cond {
-                    imm.sign_extend_from_width(bit_width);
+                    imm.mask_to_width(bit_width);
                 }
             }
             _ => {}

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -459,7 +459,7 @@ impl InstructionData {
 
         match self {
             Self::UnaryImm { opcode: _, imm } => {
-                imm.mask_to_width(bit_width);
+                *imm = imm.mask_to_width(bit_width);
             }
             Self::BinaryImm64 {
                 opcode,
@@ -467,7 +467,7 @@ impl InstructionData {
                 imm,
             } => {
                 if *opcode == Opcode::SdivImm || *opcode == Opcode::SremImm {
-                    imm.mask_to_width(bit_width);
+                    *imm = imm.mask_to_width(bit_width);
                 }
             }
             Self::IntCompareImm {
@@ -478,7 +478,7 @@ impl InstructionData {
             } => {
                 debug_assert_eq!(*opcode, Opcode::IcmpImm);
                 if cond.unsigned() != *cond {
-                    imm.mask_to_width(bit_width);
+                    *imm = imm.mask_to_width(bit_width);
                 }
             }
             _ => {}

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -193,9 +193,8 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
-        fn i64_sextend_imm64(&mut self, ty: Type, mut x: Imm64) -> i64 {
-            x.sign_extend_from_width(ty.bits());
-            x.bits()
+        fn i64_sextend_imm64(&mut self, ty: Type, x: Imm64) -> i64 {
+            x.sign_extend_from_width(ty.bits()).bits()
         }
 
         #[inline]

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -390,13 +390,20 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
     let pool = &dfg.value_lists;
     let jump_tables = &dfg.jump_tables;
     use crate::ir::instructions::InstructionData::*;
+    let ctrl_ty = dfg.ctrl_typevar(inst);
     match dfg.insts[inst] {
         AtomicRmw { op, args, .. } => write!(w, " {} {}, {}", op, args[0], args[1]),
         AtomicCas { args, .. } => write!(w, " {}, {}, {}", args[0], args[1], args[2]),
         LoadNoOffset { flags, arg, .. } => write!(w, "{} {}", flags, arg),
         StoreNoOffset { flags, args, .. } => write!(w, "{} {}, {}", flags, args[0], args[1]),
         Unary { arg, .. } => write!(w, " {}", arg),
-        UnaryImm { imm, .. } => write!(w, " {}", imm),
+        UnaryImm { imm, .. } => write!(w, " {}", {
+            let mut imm = imm;
+            if ctrl_ty.bits() != 0 {
+                imm.sign_extend_from_width(ctrl_ty.bits());
+            }
+            imm
+        }),
         UnaryIeee16 { imm, .. } => write!(w, " {}", imm),
         UnaryIeee32 { imm, .. } => write!(w, " {}", imm),
         UnaryIeee64 { imm, .. } => write!(w, " {}", imm),
@@ -406,7 +413,13 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         } => write!(w, " {}", constant_handle),
         Binary { args, .. } => write!(w, " {}, {}", args[0], args[1]),
         BinaryImm8 { arg, imm, .. } => write!(w, " {}, {}", arg, imm),
-        BinaryImm64 { arg, imm, .. } => write!(w, " {}, {}", arg, imm),
+        BinaryImm64 { arg, imm, .. } => write!(w, " {}, {}", arg, {
+            let mut imm = imm;
+            if ctrl_ty.bits() != 0 {
+                imm.sign_extend_from_width(ctrl_ty.bits());
+            }
+            imm
+        }),
         Ternary { args, .. } => write!(w, " {}, {}, {}", args[0], args[1], args[2]),
         MultiAry { ref args, .. } => {
             if args.is_empty() {
@@ -424,7 +437,13 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             write!(w, " {}, {}, {}", args[0], args[1], data)
         }
         IntCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
-        IntCompareImm { cond, arg, imm, .. } => write!(w, " {} {}, {}", cond, arg, imm),
+        IntCompareImm { cond, arg, imm, .. } => write!(w, " {} {}, {}", cond, arg, {
+            let mut imm = imm;
+            if ctrl_ty.bits() != 0 {
+                imm.sign_extend_from_width(ctrl_ty.bits());
+            }
+            imm
+        }),
         IntAddTrap { args, code, .. } => write!(w, " {}, {}, {}", args[0], args[1], code),
         FloatCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
         Jump { destination, .. } => {
@@ -495,7 +514,13 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
     for arg in dfg.inst_values(inst) {
         if let ValueDef::Result(src, _) = dfg.value_def(arg) {
             let imm = match dfg.insts[src] {
-                UnaryImm { imm, .. } => imm.to_string(),
+                UnaryImm { imm, .. } => {
+                    let mut imm = imm;
+                    if dfg.ctrl_typevar(src).bits() != 0 {
+                        imm.sign_extend_from_width(dfg.ctrl_typevar(src).bits());
+                    }
+                    imm.to_string()
+                }
                 UnaryIeee16 { imm, .. } => imm.to_string(),
                 UnaryIeee32 { imm, .. } => imm.to_string(),
                 UnaryIeee64 { imm, .. } => imm.to_string(),

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -400,7 +400,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         UnaryImm { imm, .. } => write!(w, " {}", {
             let mut imm = imm;
             if ctrl_ty.bits() != 0 {
-                imm.sign_extend_from_width(ctrl_ty.bits());
+                imm = imm.sign_extend_from_width(ctrl_ty.bits());
             }
             imm
         }),
@@ -416,7 +416,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         BinaryImm64 { arg, imm, .. } => write!(w, " {}, {}", arg, {
             let mut imm = imm;
             if ctrl_ty.bits() != 0 {
-                imm.sign_extend_from_width(ctrl_ty.bits());
+                imm = imm.sign_extend_from_width(ctrl_ty.bits());
             }
             imm
         }),
@@ -440,7 +440,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         IntCompareImm { cond, arg, imm, .. } => write!(w, " {} {}, {}", cond, arg, {
             let mut imm = imm;
             if ctrl_ty.bits() != 0 {
-                imm.sign_extend_from_width(ctrl_ty.bits());
+                imm = imm.sign_extend_from_width(ctrl_ty.bits());
             }
             imm
         }),
@@ -517,7 +517,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
                 UnaryImm { imm, .. } => {
                     let mut imm = imm;
                     if dfg.ctrl_typevar(src).bits() != 0 {
-                        imm.sign_extend_from_width(dfg.ctrl_typevar(src).bits());
+                        imm = imm.sign_extend_from_width(dfg.ctrl_typevar(src).bits());
                     }
                     imm.to_string()
                 }

--- a/cranelift/filetests/filetests/egraph/cprop.clif
+++ b/cranelift/filetests/filetests/egraph/cprop.clif
@@ -19,7 +19,7 @@ block0:
     return v2
 }
 
-; check: v3 = iconst.i16 0xfffe
+; check: v3 = iconst.i16 -2
 ; nextln: return v3
 
 function %ishl() -> i8 {
@@ -96,7 +96,7 @@ block0:
     return v2
 }
 
-; check: v3 = iconst.i8 252
+; check: v3 = iconst.i8 -4
 ; check: return v3
 
 function %sshr_i8_i16() -> i8 {
@@ -107,7 +107,7 @@ block0:
     return v2
 }
 
-; check: v3 = iconst.i8 252
+; check: v3 = iconst.i8 -4
 ; check: return v3
 
 function %sshr_i16_i8() -> i16 {
@@ -118,7 +118,7 @@ block0:
     return v2
 }
 
-; check: v3 = iconst.i16 0xfffc
+; check: v3 = iconst.i16 -4
 ; check: return v3
 
 function %icmp_eq_i32() -> i8 {
@@ -238,7 +238,7 @@ block0:
     return v2
 }
 
-; check: v3 = iconst.i8 246
+; check: v3 = iconst.i8 -10
 ; nextln: return v3
 
 function %sextend_iconst() -> i32 {
@@ -248,7 +248,7 @@ block0:
     return v2
 }
 
-; check: v3 = iconst.i32 0xffff_fff6
+; check: v3 = iconst.i32 -10
 ; nextln: return v3
 
 function %uextend_iconst() -> i32 {
@@ -310,7 +310,7 @@ block0:
     return v1
 }
 
-; check: v2 = iconst.i64 0xf0de_bc9a_7856_3412
+; check: v2 = iconst.i64 -1090226688147180526
 ; nextln: return v2
 
 function %f16_fmin() -> f16 {

--- a/cranelift/filetests/filetests/egraph/icmp-parameterized.clif
+++ b/cranelift/filetests/filetests/egraph/icmp-parameterized.clif
@@ -180,8 +180,8 @@ block0(v0: i32):
 
 ; function %icmp_eq_umax(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0xffff_ffff
-;     v2 = icmp eq v0, v1  ; v1 = 0xffff_ffff
+;     v1 = iconst.i32 -1
+;     v2 = icmp eq v0, v1  ; v1 = -1
 ;     return v2
 ; }
 
@@ -194,8 +194,8 @@ block0(v0: i32):
 
 ; function %icmp_eq_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v2 = icmp eq v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v2 = icmp eq v0, v1  ; v1 = -2147483648
 ;     return v2
 ; }
 
@@ -236,8 +236,8 @@ block0(v0: i32):
 
 ; function %icmp_ne_umax(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0xffff_ffff
-;     v2 = icmp ne v0, v1  ; v1 = 0xffff_ffff
+;     v1 = iconst.i32 -1
+;     v2 = icmp ne v0, v1  ; v1 = -1
 ;     return v2
 ; }
 
@@ -250,8 +250,8 @@ block0(v0: i32):
 
 ; function %icmp_ne_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v2 = icmp ne v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v2 = icmp ne v0, v1  ; v1 = -2147483648
 ;     return v2
 ; }
 
@@ -291,8 +291,8 @@ block0(v0: i32):
 
 ; function %icmp_ult_umax(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0xffff_ffff
-;     v3 = icmp ne v0, v1  ; v1 = 0xffff_ffff
+;     v1 = iconst.i32 -1
+;     v3 = icmp ne v0, v1  ; v1 = -1
 ;     return v3
 ; }
 
@@ -305,8 +305,8 @@ block0(v0: i32):
 
 ; function %icmp_ult_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v2 = icmp ult v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v2 = icmp ult v0, v1  ; v1 = -2147483648
 ;     return v2
 ; }
 
@@ -360,8 +360,8 @@ block0(v0: i32):
 
 ; function %icmp_ule_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v2 = icmp ule v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v2 = icmp ule v0, v1  ; v1 = -2147483648
 ;     return v2
 ; }
 
@@ -415,8 +415,8 @@ block0(v0: i32):
 
 ; function %icmp_ugt_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v2 = icmp ugt v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v2 = icmp ugt v0, v1  ; v1 = -2147483648
 ;     return v2
 ; }
 
@@ -456,8 +456,8 @@ block0(v0: i32):
 
 ; function %icmp_uge_umax(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0xffff_ffff
-;     v3 = icmp eq v0, v1  ; v1 = 0xffff_ffff
+;     v1 = iconst.i32 -1
+;     v3 = icmp eq v0, v1  ; v1 = -1
 ;     return v3
 ; }
 
@@ -470,8 +470,8 @@ block0(v0: i32):
 
 ; function %icmp_uge_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v2 = icmp uge v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v2 = icmp uge v0, v1  ; v1 = -2147483648
 ;     return v2
 ; }
 
@@ -512,8 +512,8 @@ block0(v0: i32):
 
 ; function %icmp_slt_umax(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0xffff_ffff
-;     v2 = icmp slt v0, v1  ; v1 = 0xffff_ffff
+;     v1 = iconst.i32 -1
+;     v2 = icmp slt v0, v1  ; v1 = -1
 ;     return v2
 ; }
 
@@ -581,8 +581,8 @@ block0(v0: i32):
 
 ; function %icmp_sle_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v3 = icmp eq v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v3 = icmp eq v0, v1  ; v1 = -2147483648
 ;     return v3
 ; }
 
@@ -636,8 +636,8 @@ block0(v0: i32):
 
 ; function %icmp_sgt_smin(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0x8000_0000
-;     v3 = icmp ne v0, v1  ; v1 = 0x8000_0000
+;     v1 = iconst.i32 -2147483648
+;     v3 = icmp ne v0, v1  ; v1 = -2147483648
 ;     return v3
 ; }
 
@@ -677,8 +677,8 @@ block0(v0: i32):
 
 ; function %icmp_sge_umax(i32) -> i8 fast {
 ; block0(v0: i32):
-;     v1 = iconst.i32 0xffff_ffff
-;     v2 = icmp sge v0, v1  ; v1 = 0xffff_ffff
+;     v1 = iconst.i32 -1
+;     v2 = icmp sge v0, v1  ; v1 = -1
 ;     return v2
 ; }
 
@@ -3636,4 +3636,3 @@ block0(v0: i32, v1: i32):
 ;     v2 = icmp sge v0, v1
 ;     return v2
 ; }
-

--- a/cranelift/filetests/filetests/egraph/shifts.clif
+++ b/cranelift/filetests/filetests/egraph/shifts.clif
@@ -8,7 +8,7 @@ block0(v0: i8):
     v2 = ushr v0, v1
     v3 = ishl v2, v1
     return v3
-    ; check: v4 = iconst.i8 224
+    ; check: v4 = iconst.i8 -32
     ; check: v5 = band v0, v4
     ; check: return v5
 }
@@ -19,7 +19,7 @@ block0(v0: i32):
     v2 = ushr v0, v1
     v3 = ishl v2, v1
     return v3
-    ; check: v4 = iconst.i32 0xffff_ffe0
+    ; check: v4 = iconst.i32 -32
     ; check: v5 = band v0, v4
     ; check: return v5
 }
@@ -41,7 +41,7 @@ block0(v0: i8):
     v2 = sshr v0, v1
     v3 = ishl v2, v1
     return v3
-    ; check: v4 = iconst.i8 224
+    ; check: v4 = iconst.i8 -32
     ; check: v5 = band v0, v4
     ; check: return v5
 }
@@ -52,7 +52,7 @@ block0(v0: i32):
     v2 = sshr v0, v1
     v3 = ishl v2, v1
     return v3
-    ; check: v4 = iconst.i32 0xffff_ffe0
+    ; check: v4 = iconst.i32 -32
     ; check: v5 = band v0, v4
     ; check: return v5
 }
@@ -74,7 +74,7 @@ block0(v0: i8):
     v2 = sshr v0, v1
     v3 = ishl v2, v1
     return v3
-    ; check: v7 = iconst.i8 224
+    ; check: v7 = iconst.i8 -32
     ; check: v8 = band v0, v7
     ; check: return v8
 }

--- a/cranelift/filetests/filetests/parser/tiny.clif
+++ b/cranelift/filetests/filetests/parser/tiny.clif
@@ -46,7 +46,7 @@ block0:
 }
 ; sameln: function %bvalues() fast {
 ; nextln: block0:
-; nextln:     v0 = iconst.i32 0xffff_ffff
+; nextln:     v0 = iconst.i32 -1
 ; nextln:     v1 = iconst.i8 0
 ; nextln:     v2 = sextend.i32 v1
 ; nextln:     v3 = bxor v0, v2

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -485,7 +485,7 @@ block12:
             func,
             "block0:
     v0 = iconst.i8 0
-    v1 = icmp_imm eq v0, 128  ; v0 = 0
+    v1 = icmp_imm eq v0, -128  ; v0 = 0
     brif v1, block1, block3
 
 block3:
@@ -517,7 +517,7 @@ block3:
             func,
             "block0:
     v0 = iconst.i8 0
-    v1 = icmp_imm eq v0, 255  ; v0 = 0
+    v1 = icmp_imm eq v0, -1  ; v0 = 0
     brif v1, block1, block4
 
 block4:

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -26,8 +26,8 @@
 ;; @002d                               jump block3(v7)
 ;;
 ;;                                 block4(v8: i32):
-;; @002e                               v9 = iconst.i32 0xffff_fffe
-;; @0030                               v10 = iadd.i32 v4, v9  ; v4 = 1, v9 = 0xffff_fffe
+;; @002e                               v9 = iconst.i32 -2
+;; @0030                               v10 = iadd.i32 v4, v9  ; v4 = 1, v9 = -2
 ;; @0031                               jump block3(v10)
 ;;
 ;;                                 block3(v5: i32):


### PR DESCRIPTION
Originally, we sign-extended `Imm64` immediates from their controlling type var's width to `i64` in the builder methods for `BinaryImm64` and a couple other instruction formats: https://github.com/bytecodealliance/wasmtime/pull/1687

At some point, we decided that the unused bits in the `Imm64` when the controlling type var's width is less than 64 should be zero. And we started asserting that in various places, for example:
https://github.com/bytecodealliance/wasmtime/blob/87817f38a128caa76eaa6a3c3c8ceac81a329a3e/cranelift/codegen/src/machinst/lower.rs#L1237-L1243

However, we never removed or updated the sign-extension code in the builder methods. This commit switches the builder methods over to masking the `Imm64` to just the valid bits, effectively doing a zero extend from the controlling type var's width instead of a sign extend.

To avoid too much churn in tests, I made `display_inst` print the sign-extended-from-the-controlling-type-variable's-width value of `Imm64` immediates. I also made the `Display` implementation for `Imm64` always print in decimal form with a `-` for negative numbers, rather than the hex it would previously print for large negative numbers, so that `iconst.i32 0x8000_0000` doesn't display as `iconst.i32 0xffff_ffff_8000_0000`, which is otherwise pretty confusing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
