### PR TITLE
wasi-nn: track upstream specification

### DIFF
--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -65,10 +65,6 @@ rm -rf $cache_dir
 # Separately (for now), vendor the `wasi-nn` WIT files since their retrieval is
 # slightly different than above.
 repo=https://raw.githubusercontent.com/WebAssembly/wasi-nn
-revision=e2310b
+revision=0.2.0-rc-2024-06-25
 curl -L $repo/$revision/wasi-nn.witx -o crates/wasi-nn/witx/wasi-nn.witx
-# TODO: the in-tree `wasi-nn` implementation does not yet fully support the
-# latest WIT specification on `main`. To create a baseline for moving forward,
-# the in-tree WIT incorporates some but not all of the upstream changes. This
-# TODO can be removed once the implementation catches up with the spec.
-# curl -L $repo/$revision/wit/wasi-nn.wit -o crates/wasi-nn/wit/wasi-nn.wit
+curl -L $repo/$revision/wit/wasi-nn.wit -o crates/wasi-nn/wit/wasi-nn.wit

--- a/crates/wasi-nn/wit/wasi-nn.wit
+++ b/crates/wasi-nn/wit/wasi-nn.wit
@@ -1,4 +1,4 @@
-package wasi:nn;
+package wasi:nn@0.2.0-rc-2024-06-25;
 
 /// `wasi-nn` is a WASI API for performing machine learning (ML) inference. The API is not (yet)
 /// capable of performing ML training. WebAssembly programs that want to use a host's ML
@@ -134,7 +134,7 @@ interface inference {
 
 /// TODO: create function-specific errors (https://github.com/WebAssembly/wasi-nn/issues/42)
 interface errors {
-    enum error {
+    enum error-code {
         // Caller module passed an invalid argument.
         invalid-argument,
         // Invalid encoding.
@@ -148,6 +148,21 @@ interface errors {
         // Graph is too large.
         too-large,
         // Graph not found.
-        not-found
+        not-found,
+        // The operation is insecure or has insufficient privilege to be performed.
+        // e.g., cannot access a hardware feature requested
+        security,
+        // The operation failed for an unspecified reason.
+        unknown
+    }
+
+    resource error {
+        constructor(code: error-code, data: string);
+
+        /// Return the error code.
+        code: func() -> error-code;
+
+        /// Errors can propagated with backend specific status through a string value.
+        data: func() -> string;
     }
 }


### PR DESCRIPTION
In #8873, we stopped tracking the wasi-nn's upstream WIT files temporarily because it was not clear to me at the time how to implement errors as CM resources. This PR fixes that, resuming tracking in the `vendor-wit.sh` and implementing what is needed in the wasi-nn crate.

This leaves several threads unresolved, though:
- it looks like the `vendor-wit.sh` has a new mechanism for retrieving files into `wit/deps`--at some point wasi-nn should migrate to use that (?)
- it's not clear to me that "errors as resources" is even the best approach here; I've opened [#75] to consider the possibility of using "errors as records" instead.
- this PR identifies that the constructor for errors is in fact unnecessary, prompting an upstream change ([#76]) that should eventually be implemented here.

[#75]: https://github.com/WebAssembly/wasi-nn/pull/75
[#76]: https://github.com/WebAssembly/wasi-nn/pull/76

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
