### PR TITLE
Validate import names given to `trappable_imports`

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -397,11 +397,7 @@ impl Parse for Opt {
                 syn::bracketed!(contents in input);
                 let fields: Punctuated<syn::LitStr, Token![,]> =
                     contents.parse_terminated(Parse::parse, Token![,])?;
-                let fields = fields
-                    .iter()
-                    .map(validate_trappable_import)
-                    .collect::<Result<_>>()?;
-                TrappableImports::Only(fields)
+                TrappableImports::Only(fields.iter().map(|s| s.value()).collect())
             };
             Ok(Opt::TrappableImports(config))
         } else if l.peek(kw::additional_derives) {
@@ -448,44 +444,6 @@ impl Parse for Opt {
             Err(l.error())
         }
     }
-}
-
-fn validate_trappable_import(field: &syn::LitStr) -> Result<String> {
-    let val = field.value();
-    let mut chunk = val.as_str();
-
-    let validate = |s| {
-        if wit_parser::validate_id(s).is_err() {
-            return Err(Error::new(
-                field.span(),
-                format!("`{}` is not a valid wit identifier", val),
-            ));
-        }
-        Ok(())
-    };
-
-    if chunk.starts_with("[constructor]") {
-        chunk = &chunk["[constructor]".len()..];
-        validate(chunk)?;
-    } else if chunk.starts_with("[method]") || chunk.starts_with("[static]") {
-        // "[method]" and "[static]" are both 8 characters long
-        chunk = &chunk[8..];
-
-        let dot = chunk.find('.').ok_or_else(|| {
-            Error::new(
-                field.span(),
-                format!("`{}` is not a valid wit identifier", val),
-            )
-        })?;
-
-        let (resource, method) = chunk.split_at(dot);
-        validate(resource)?;
-        validate(&method[1..])?;
-    } else {
-        validate(chunk)?;
-    }
-
-    Ok(val)
 }
 
 fn trappable_error_field_parse(input: ParseStream<'_>) -> Result<TrappableError> {

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -73,8 +73,7 @@ struct Wasmtime {
     // Track the with options that were used. Remapped interfaces provided via `with`
     // are required to be used.
     used_with_opts: HashSet<String>,
-    // Track the with options that were used. Remapped interfaces provided via `with`
-    // are required to be used.
+    // Track the imports that matched the `trappable_imports` spec.
     used_trappable_imports_opts: HashSet<String>,
 }
 

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -2071,9 +2071,15 @@ impl<'a> InterfaceGenerator<'a> {
     }
 
     fn special_case_trappable_error(
-        &self,
-        results: &Results,
+        &mut self,
+        func: &Function,
     ) -> Option<(&'a Result_, TypeId, String)> {
+        let results = &func.results;
+
+        self.gen
+            .used_trappable_imports_opts
+            .insert(func.name.clone());
+
         // We fillin a special trappable error type in the case when a function has just one
         // result, which is itself a `result<a, e>`, and the `e` is *not* a primitive
         // (i.e. defined in std) type, and matches the typename given by the user.
@@ -2138,18 +2144,21 @@ impl<'a> InterfaceGenerator<'a> {
         // into the representation required by Wasmtime's component API.
         let mut required_conversion_traits = IndexSet::new();
         let mut errors_converted = IndexMap::new();
-        let my_error_types = iface
+        let mut my_error_types = iface
             .types
             .iter()
             .filter(|(_, id)| self.gen.trappable_errors.contains_key(*id))
-            .map(|(_, id)| *id);
-        let used_error_types = iface
-            .functions
-            .iter()
-            .filter_map(|(_, func)| self.special_case_trappable_error(&func.results))
-            .map(|(_, id, _)| id);
+            .map(|(_, id)| *id)
+            .collect::<Vec<_>>();
+        my_error_types.extend(
+            iface
+                .functions
+                .iter()
+                .filter_map(|(_, func)| self.special_case_trappable_error(func))
+                .map(|(_, id, _)| id),
+        );
         let root = self.path_to_root();
-        for err_id in my_error_types.chain(used_error_types).collect::<Vec<_>>() {
+        for err_id in my_error_types {
             let custom_name = &self.gen.trappable_errors[&err_id];
             let err = &self.resolve.types[resolve_type_definition_id(self.resolve, err_id)];
             let err_name = err.name.as_ref().unwrap();
@@ -2426,35 +2435,29 @@ impl<'a> InterfaceGenerator<'a> {
             } else {
                 uwrite!(self.src, "Ok(r)\n");
             }
-        } else {
-            self.gen
-                .used_trappable_imports_opts
-                .insert(func.name.clone());
-
-            if let Some((_, err, _)) = self.special_case_trappable_error(&func.results) {
-                let err = &self.resolve.types[resolve_type_definition_id(self.resolve, err)];
-                let err_name = err.name.as_ref().unwrap();
-                let owner = match err.owner {
-                    TypeOwner::Interface(i) => i,
-                    _ => unimplemented!(),
-                };
-                let convert_trait = match self.path_to_interface(owner) {
-                    Some(path) => format!("{path}::Host"),
-                    None => format!("Host"),
-                };
-                let convert = format!("{}::convert_{}", convert_trait, err_name.to_snake_case());
-                uwrite!(
-                    self.src,
-                    "Ok((match r {{
+        } else if let Some((_, err, _)) = self.special_case_trappable_error(func) {
+            let err = &self.resolve.types[resolve_type_definition_id(self.resolve, err)];
+            let err_name = err.name.as_ref().unwrap();
+            let owner = match err.owner {
+                TypeOwner::Interface(i) => i,
+                _ => unimplemented!(),
+            };
+            let convert_trait = match self.path_to_interface(owner) {
+                Some(path) => format!("{path}::Host"),
+                None => format!("Host"),
+            };
+            let convert = format!("{}::convert_{}", convert_trait, err_name.to_snake_case());
+            uwrite!(
+                self.src,
+                "Ok((match r {{
                     Ok(a) => Ok(a),
                     Err(e) => Err({convert}(host, e)?),
                 }},))"
-                );
-            } else if func.results.iter_types().len() == 1 {
-                uwrite!(self.src, "Ok((r?,))\n");
-            } else {
-                uwrite!(self.src, "r\n");
-            }
+            );
+        } else if func.results.iter_types().len() == 1 {
+            uwrite!(self.src, "Ok((r?,))\n");
+        } else {
+            uwrite!(self.src, "r\n");
         }
 
         if self.gen.opts.async_.is_import_async(&func.name) {
@@ -2487,31 +2490,25 @@ impl<'a> InterfaceGenerator<'a> {
 
         if !self.gen.opts.trappable_imports.can_trap(func) {
             self.print_result_ty(&func.results, TypeMode::Owned);
-        } else {
-            self.gen
-                .used_trappable_imports_opts
-                .insert(func.name.clone());
-            if let Some((r, _id, error_typename)) = self.special_case_trappable_error(&func.results)
-            {
-                // Functions which have a single result `result<ok,err>` get special
-                // cased to use the host_wasmtime_rust::Error<err>, making it possible
-                // for them to trap or use `?` to propagate their errors
-                self.push_str("Result<");
-                if let Some(ok) = r.ok {
-                    self.print_ty(&ok, TypeMode::Owned);
-                } else {
-                    self.push_str("()");
-                }
-                self.push_str(",");
-                self.push_str(&error_typename);
-                self.push_str(">");
+        } else if let Some((r, _id, error_typename)) = self.special_case_trappable_error(func) {
+            // Functions which have a single result `result<ok,err>` get special
+            // cased to use the host_wasmtime_rust::Error<err>, making it possible
+            // for them to trap or use `?` to propagate their errors
+            self.push_str("Result<");
+            if let Some(ok) = r.ok {
+                self.print_ty(&ok, TypeMode::Owned);
             } else {
-                // All other functions get their return values wrapped in an wasmtime::Result.
-                // Returning the anyhow::Error case can be used to trap.
-                uwrite!(self.src, "{wt}::Result<");
-                self.print_result_ty(&func.results, TypeMode::Owned);
-                self.push_str(">");
+                self.push_str("()");
             }
+            self.push_str(",");
+            self.push_str(&error_typename);
+            self.push_str(">");
+        } else {
+            // All other functions get their return values wrapped in an wasmtime::Result.
+            // Returning the anyhow::Error case can be used to trap.
+            uwrite!(self.src, "{wt}::Result<");
+            self.print_result_ty(&func.results, TypeMode::Owned);
+            self.push_str(">");
         }
     }
 


### PR DESCRIPTION
It's easy to accidentally use the generated name when passing names to the `trappable_imports` field of the `bindgen!` macro, yielding generated bindings that don't use the expected `trappable_error_type`. This PR adds some validation, ensuring that arguments to `trappable_imports` are used during binding generation and raising an error if any are ignored.

It doesn't appear that we have negative tests for wasmtime-component-macro, but I'm happy to add them if I've missed something there.
