### PR TITLE
Simplify ABI selection and tail call integration

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -60,9 +60,6 @@ pub struct Tunables {
     /// be deterministic.
     pub relaxed_simd_deterministic: bool,
 
-    /// Whether or not Wasm functions can be tail-called or not.
-    pub tail_callable: bool,
-
     /// Whether or not Wasm functions target the winch abi.
     pub winch_callable: bool,
 }
@@ -115,7 +112,6 @@ impl Tunables {
             generate_address_map: true,
             debug_adapter_modules: false,
             relaxed_simd_deterministic: false,
-            tail_callable: false,
             winch_callable: false,
         }
     }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -98,12 +98,7 @@ impl Engine {
             crate::runtime::vm::debug_builtins::ensure_exported();
         }
 
-        let config = {
-            let mut config = config.clone();
-            config.conditionally_enable_defaults();
-            config
-        };
-
+        let config = config.clone();
         let tunables = config.validate()?;
 
         #[cfg(any(feature = "cranelift", feature = "winch"))]

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -366,7 +366,6 @@ impl Metadata<'_> {
             guard_before_linear_memory,
             table_lazy_init,
             relaxed_simd_deterministic,
-            tail_callable,
             winch_callable,
 
             // This doesn't affect compilation, it's just a runtime setting.
@@ -429,7 +428,6 @@ impl Metadata<'_> {
             other.relaxed_simd_deterministic,
             "relaxed simd deterministic semantics",
         )?;
-        Self::check_bool(tail_callable, other.tail_callable, "WebAssembly tail calls")?;
         Self::check_bool(
             winch_callable,
             other.winch_callable,

--- a/tests/all/defaults.rs
+++ b/tests/all/defaults.rs
@@ -3,40 +3,47 @@ use wasmtime::*;
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_tail_call_default() -> Result<()> {
-    for (expected, cfg) in [
+    for (line, expected, cfg) in [
         (
+            line!(),
             true,
             Config::new()
                 .strategy(Strategy::Cranelift)
                 .target("x86_64")?,
         ),
         (
+            line!(),
             true,
             Config::new()
                 .strategy(Strategy::Cranelift)
                 .target("aarch64")?,
         ),
         (
+            line!(),
             true,
             Config::new()
                 .strategy(Strategy::Cranelift)
                 .target("riscv64")?,
         ),
         (
+            line!(),
             true,
             Config::new()
                 .strategy(Strategy::Cranelift)
                 .target("s390x")?,
         ),
         (
+            line!(),
             false,
             Config::new().strategy(Strategy::Winch).target("x86_64")?,
         ),
         (
+            line!(),
             false,
             Config::new().strategy(Strategy::Winch).target("aarch64")?,
         ),
         (
+            line!(),
             false,
             Config::new()
                 .strategy(Strategy::Cranelift)
@@ -54,7 +61,7 @@ fn test_tail_call_default() -> Result<()> {
 
         let result = engine.precompile_module(wat.as_bytes()).map(|_| ());
 
-        eprintln!("for config {cfg:?}, got: {result:?}");
+        eprintln!("for config on line {line}, got: {result:?}");
 
         assert_eq!(expected, result.is_ok());
     }

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -270,10 +270,6 @@ fn tail_call_defaults() -> Result<()> {
             wasm_with_tail_calls,
         );
         assert!(err.is_err());
-
-        // can't enable with winch
-        let err = Engine::new(Config::new().strategy(Strategy::Winch).wasm_tail_call(true));
-        assert!(err.is_err());
     }
     Ok(())
 }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -72,6 +72,10 @@ where
 
     /// Information about the source code location.
     pub source_location: SourceLocation,
+
+    /// Flag indicating whether during translation an unsupported instruction
+    /// was found.
+    pub found_unsupported_instruction: Option<&'static str>,
 }
 
 impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M>
@@ -91,6 +95,7 @@ where
             env,
             source_location: Default::default(),
             control_frames: Default::default(),
+            found_unsupported_instruction: None,
         }
     }
 
@@ -226,6 +231,10 @@ where
                 self,
                 offset,
             ))??;
+
+            if let Some(insn) = self.found_unsupported_instruction {
+                anyhow::bail!("unsupported instruction in Winch: {insn}")
+            }
         }
         validator.finish(body.original_position())?;
         return Ok(());

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -36,7 +36,8 @@ macro_rules! def_unsupported {
 
                 fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
                     $($(let _ = $arg;)*)?
-                        todo!(stringify!($op))
+
+                    self.found_unsupported_instruction = Some(stringify!($op));
                 }
             );
         )*


### PR DESCRIPTION
This commit simplifies the selection of an ABI for wasm functions now that all Cranelift backends implement tail calls. All wasm functions use the `Tail` calling convention except when the `winch_callable` tunable is enabled meaning that Winch-generated functions are being called.

This then additionally simplifies the activation of the tail call proposal. It's not unconditionally active and the same across all compilers. The Winch compiler is updated to return an error for unsupported instructions rather than panicking so the embedder API is suitable for feeding unsupported modules to Winch. This means that tail calls in Winch behaves similarly to GC in Cranelift or other unsupported proposals like SIMD in Winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
