### PR TITLE
Cranelift: Add an `is_safepoint` predicate to `Opcode`

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -587,7 +587,7 @@ impl DataFlowGraph {
     /// Panics if the given instruction is not a (non-tail) call instruction.
     pub fn append_user_stack_map_entry(&mut self, inst: Inst, entry: UserStackMapEntry) {
         let opcode = self.insts[inst].opcode();
-        assert!(opcode.is_call() && !opcode.is_return());
+        assert!(opcode.is_safepoint());
         self.user_stack_maps.entry(inst).or_default().push(entry);
     }
 }

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -193,6 +193,14 @@ impl Opcode {
     pub fn constraints(self) -> OpcodeConstraints {
         OPCODE_CONSTRAINTS[self as usize - 1]
     }
+
+    /// Is this instruction a GC safepoint?
+    ///
+    /// Safepoints are all kinds of calls, except for tail calls.
+    #[inline]
+    pub fn is_safepoint(self) -> bool {
+        self.is_call() && !self.is_return()
+    }
 }
 
 // This trait really belongs in cranelift-reader where it is used by the `.clif` file parser, but since


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
