### PR TITLE
Cranelift: Add a helper for getting a block's successors

### DIFF
--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -313,6 +313,16 @@ impl FunctionStencil {
         Ok(())
     }
 
+    /// Returns an iterator over the blocks succeeding the given block.
+    pub fn block_successors(&self, block: Block) -> impl DoubleEndedIterator<Item = Block> + '_ {
+        self.layout.last_inst(block).into_iter().flat_map(|inst| {
+            self.dfg.insts[inst]
+                .branch_destination(&self.dfg.jump_tables)
+                .iter()
+                .map(|block| block.block(&self.dfg.value_lists))
+        })
+    }
+
     /// Returns true if the function is function that doesn't call any other functions. This is not
     /// to be confused with a "leaf function" in Windows terminology.
     pub fn is_leaf(&self) -> bool {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
