### PR TITLE
`cranelift-entity`: Add a method to pre-reserve capacity to `EntitySet`

### DIFF
--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -45,6 +45,12 @@ where
         }
     }
 
+    /// Ensure that the set has enough capacity to hold `capacity` total
+    /// elements.
+    pub fn ensure_capacity(&mut self, capacity: usize) {
+        self.bitset.ensure_capacity(capacity);
+    }
+
     /// Get the element at `k` if it exists.
     pub fn contains(&self, k: K) -> bool {
         let index = k.index();


### PR DESCRIPTION
Just exposing functionality that already exists in the underlying bitset implementation.

Will be used in a follow-up pull request.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
