### PR TITLE
`cranelift-frontend`: Make `assert_eq_output!` usable in the whole crate

### DIFF
--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -175,6 +175,34 @@ pub use crate::frontend::{FuncInstBuilder, FunctionBuilder, FunctionBuilderConte
 pub use crate::switch::Switch;
 pub use crate::variable::Variable;
 
+#[cfg(test)]
+macro_rules! assert_eq_output {
+    ( $left:expr, $right:expr $(,)? ) => {{
+        let left = $left;
+        let left = left.trim();
+
+        let right = $right;
+        let right = right.trim();
+
+        assert_eq!(
+            left,
+            right,
+            "assertion failed, output not equal:\n\
+             \n\
+             =========== Diff ===========\n\
+             {}\n\
+             =========== Left ===========\n\
+             {left}\n\
+             =========== Right ===========\n\
+             {right}\n\
+             ",
+            similar::TextDiff::from_lines(left, right)
+                .unified_diff()
+                .header("left", "right")
+        )
+    }};
+}
+
 mod frontend;
 mod ssa;
 mod switch;

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -371,19 +371,6 @@ mod tests {
         }};
     }
 
-    macro_rules! assert_eq_output {
-        ($actual:ident, $expected:literal) => {
-            assert_eq!(
-                $actual,
-                $expected,
-                "\n{}",
-                similar::TextDiff::from_lines($expected, &$actual)
-                    .unified_diff()
-                    .header("expected", "actual")
-            )
-        };
-    }
-
     #[test]
     fn switch_empty() {
         let func = setup!(42, []);


### PR DESCRIPTION
This moves the macro to `lib.rs` so that it can be used in all the tests in the whole crate. It also makes it a little more usable by trimming whitespace and printing both the expected and actual values, in addition to the diff.

A follow-up commit will migrate various uses of `assert_eq!` over to it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
