### PR TITLE
ci: check if we need to run cargo vet prune

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,11 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
     - uses: ./.github/actions/install-cargo-vet
+    - name: Check if we need to prune
+      run: |
+        cargo vet prune
+        git diff --exit-code
+      continue-on-error: ${{ github.event_name == 'pull_request' }}
     - id: vet
       run: cargo vet --locked
       continue-on-error: ${{ github.event_name == 'pull_request' }}

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -877,20 +877,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-encoder]]
-version = "0.214.0"
-when = "2024-07-16"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasm-encoder]]
 version = "0.215.0"
 when = "2024-07-31"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasm-metadata]]
-version = "0.214.0"
-when = "2024-07-16"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -901,20 +889,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmparser]]
-version = "0.214.0"
-when = "2024-07-16"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmparser]]
 version = "0.215.0"
 when = "2024-07-31"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmprinter]]
-version = "0.214.0"
-when = "2024-07-16"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1063,20 +1039,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wast]]
-version = "214.0.0"
-when = "2024-07-16"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wast]]
 version = "215.0.0"
 when = "2024-07-31"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wat]]
-version = "1.214.0"
-when = "2024-07-16"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1279,20 +1243,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wit-bindgen]]
-version = "0.28.0"
-when = "2024-07-16"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-bindgen]]
 version = "0.29.0"
 when = "2024-08-02"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-bindgen-core]]
-version = "0.28.0"
-when = "2024-07-16"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1303,20 +1255,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen-rt]]
-version = "0.28.0"
-when = "2024-07-16"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-bindgen-rt]]
 version = "0.29.0"
 when = "2024-08-02"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-bindgen-rust]]
-version = "0.28.0"
-when = "2024-07-16"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1327,32 +1267,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen-rust-macro]]
-version = "0.28.0"
-when = "2024-07-16"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-bindgen-rust-macro]]
 version = "0.29.0"
 when = "2024-08-02"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-component]]
-version = "0.214.0"
-when = "2024-07-16"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-component]]
 version = "0.215.0"
 when = "2024-07-31"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-parser]]
-version = "0.214.0"
-when = "2024-07-16"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
In the context of #9062, I removed a dependency but forgot to remove the corresponding configuration in the `supply-chain`. However, the CI did not alert me about this. It is confusing to see a crate configuration in the `supply-chain` that we no longer depend on. Therefore, I added a step in the CI to check whether we need to execute the prune command.