### PR TITLE
Bump Wasmtime to 25.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "24.0.0"
+version = "25.0.0"
 
 [[package]]
 name = "byteorder"
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -569,14 +569,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -615,25 +615,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.0"
+version = "0.112.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1045,7 +1045,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3089,7 +3089,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3139,7 +3139,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3433,14 +3433,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3456,14 +3456,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3612,11 +3612,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.0"
+version = "25.0.0"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "object",
  "once_cell",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.0"
+version = "25.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "24.0.0"
+version = "25.0.0"
 
 [[package]]
 name = "wast"
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4121,7 +4121,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "24.0.0"
+version = "25.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -183,60 +183,60 @@ manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "24.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=24.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=24.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=24.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=24.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=24.0.0" }
-wasmtime-types = { path = "crates/types", version = "24.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=24.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "24.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.0" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=24.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=24.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=25.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "25.0.0", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=25.0.0" }
+wasmtime-cache = { path = "crates/cache", version = "=25.0.0" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=25.0.0" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=25.0.0" }
+wasmtime-winch = { path = "crates/winch", version = "=25.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=25.0.0" }
+wasmtime-explorer = { path = "crates/explorer", version = "=25.0.0" }
+wasmtime-fiber = { path = "crates/fiber", version = "=25.0.0" }
+wasmtime-types = { path = "crates/types", version = "25.0.0" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=25.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=25.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "25.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=25.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "25.0.0" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "25.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "25.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "25.0.0" }
+wasmtime-component-util = { path = "crates/component-util", version = "=25.0.0" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=25.0.0" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=25.0.0" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=25.0.0" }
+wasmtime-slab = { path = "crates/slab", version = "=25.0.0" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=24.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=24.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=25.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=25.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=25.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=25.0.0", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=25.0.0" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=25.0.0" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.111.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.111.0", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.111.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.111.0" }
-cranelift-native = { path = "cranelift/native", version = "0.111.0" }
-cranelift-module = { path = "cranelift/module", version = "0.111.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.111.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.112.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.112.0", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.112.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.112.0" }
+cranelift-native = { path = "cranelift/native", version = "0.112.0" }
+cranelift-module = { path = "cranelift/module", version = "0.112.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.112.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.112.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.111.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.111.0" }
+cranelift-object = { path = "cranelift/object", version = "0.112.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.112.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.111.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.111.0" }
-cranelift-control = { path = "cranelift/control", version = "0.111.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.111.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.112.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.112.0" }
+cranelift-control = { path = "cranelift/control", version = "0.112.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.112.0" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.22.0" }
+winch-codegen = { path = "winch/codegen", version = "=0.23.0" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 24.0.0
+## 25.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [24.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-24.0.0/RELEASES.md)
 * [23.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-23.0.0/RELEASES.md)
 * [22.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-22.0.0/RELEASES.md)
 * [21.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-21.0.0/RELEASES.md)

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.111.0"
+version = "0.112.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.111.0"
+version = "0.112.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.111.0"
+version = "0.112.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.111.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.112.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.111.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.111.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.112.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.112.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.111.0"
+version = "0.112.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.111.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.112.0" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.111.0"
+version = "0.112.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.111.0"
+version = "0.112.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.111.0"
+version = "0.112.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.111.0"
+version = "0.112.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.111.0"
+version = "0.112.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.111.0"
+version = "0.112.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.111.0"
+version = "0.112.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,11 +206,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "24.0.0"
+#define WASMTIME_VERSION "25.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 24
+#define WASMTIME_VERSION_MAJOR 25
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,180 +5,360 @@
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-control]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-module]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-native]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-object]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.112.0"
+audited_as = "0.110.1"
+
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
+audited_as = "0.110.1"
+
+[[unpublished.cranelift-wasm]]
+version = "0.112.0"
 audited_as = "0.110.1"
 
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasi-common]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-cache]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-cli]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-component-macro]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-component-util]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-cranelift]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-explorer]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-fiber]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-slab]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-types]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-winch]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wiggle]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wiggle]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "25.0.0"
+audited_as = "23.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
+audited_as = "23.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "25.0.0"
 audited_as = "23.0.1"
 
 [[unpublished.wiggle-test]]
@@ -187,6 +367,10 @@ audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
 version = "0.22.0"
+audited_as = "0.21.1"
+
+[[unpublished.winch-codegen]]
+version = "0.23.0"
 audited_as = "0.21.1"
 
 [[publisher.aho-corasick]]

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-24.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 24.0.0 to 25.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 24.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-24.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-24.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-24.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
