### PR TITLE
Cranelift: add stack_switch CLIF instruction

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -962,7 +962,8 @@ pub(crate) fn define(
         .operands_out(vec![Operand::new("out_payload0", iAddr)])
         .other_side_effects()
         .can_load()
-        .can_store(),
+        .can_store()
+        .call(),
     );
 
     let I16x8 = &TypeVar::new(

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -928,8 +928,12 @@ pub(crate) fn define(
         current (i.e., original) stack at ``store_context_ptr``, to
         enabled switching back to the original stack at a later point.
 
-        The size and layout of the information stored at ``load_context_ptr``
-        and ``store_context_ptr`` is platform-dependent.
+        The size, alignment and layout of the information stored at
+        ``load_context_ptr`` and ``store_context_ptr`` is platform-dependent.
+        The instruction assumes that ``load_context_ptr`` and
+        ``store_context_ptr`` are valid pointers to memory with said layout and
+        alignment, and does not perform any checks on these pointers or the data
+        stored there.
 
         The instruction is experimental and only supported on x64 Linux at the
         moment.
@@ -951,6 +955,12 @@ pub(crate) fn define(
         to be equal; the instruction ensures that all data is loaded from the
         former before writing to the latter.
 
+        Stack switching is one-shot in the sense that each ``stack_switch``
+        operation effectively consumes the context identified by
+        ``load_context_ptr``. In other words, performing two ``stack_switches``
+        using the same ``load_context_ptr`` causes undefined behavior, unless
+        the context at ``load_context_ptr`` is overwritten by another
+        `stack_switch` in between.
         "#,
             &formats.ternary,
         )

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -915,6 +915,55 @@ pub(crate) fn define(
         ])
         .can_store(),
     );
+    ig.push(
+        Inst::new(
+            "stack_switch",
+            r#"
+        Suspends execution of the current stack and resumes execution of another
+        one.
+
+        The target stack to switch to is identified by the data stored at
+        ``load_context_ptr``. Before switching, this instruction stores
+        analogous information about the
+        current (i.e., original) stack at ``store_context_ptr``, to
+        enabled switching back to the original stack at a later point.
+
+        The size and layout of the information stored at ``load_context_ptr``
+        and ``store_context_ptr`` is platform-dependent.
+
+        The instruction is experimental and only supported on x64 Linux at the
+        moment.
+
+        When switching from a stack A to a stack B, one of the following cases
+        must apply:
+        1. Stack B was previously suspended using a ``stack_switch`` instruction.
+        2. Stack B is a newly initialized stack. The necessary initialization is
+        platform-dependent and will generally involve running some kind of
+        trampoline to start execution of a function on the new stack.
+
+        In both cases, the ``in_payload`` argument of the ``stack_switch``
+        instruction executed on A is passed to stack B. In the first case above,
+        it will be the result value of the earlier ``stack_switch`` instruction
+        executed on stack B. In the second case, the value will be accessible to
+        the trampoline in a platform-dependent register.
+
+        The pointers ``load_context_ptr`` and ``store_context_ptr`` are allowed
+        to be equal; the instruction ensures that all data is loaded from the
+        former before writing to the latter.
+
+        "#,
+            &formats.ternary,
+        )
+        .operands_in(vec![
+            Operand::new("store_context_ptr", iAddr),
+            Operand::new("load_context_ptr", iAddr),
+            Operand::new("in_payload0", iAddr),
+        ])
+        .operands_out(vec![Operand::new("out_payload0", iAddr)])
+        .other_side_effects()
+        .can_load()
+        .can_store(),
+    );
 
     let I16x8 = &TypeVar::new(
         "I16x8",

--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -155,6 +155,19 @@ pub(crate) fn define() -> SettingGroup {
     );
 
     settings.add_enum(
+        "stack_switch_model",
+        "Defines the model used to performing stack switching.",
+        r#"
+           This determines the compilation of `stack_switch` instructions. If
+           set to `basic`, we simply save all registers, update stack pointer
+           and frame pointer (if needed), and jump to the target IP.
+           If set to `update_windows_tib`, we *additionally* update information
+           about the active stack in Windows' Thread Information Block.
+        "#,
+        vec!["none", "basic", "update_windows_tib"],
+    );
+
+    settings.add_enum(
         "libcall_call_conv",
         "Defines the calling convention to use for LibCalls call expansion.",
         r#"

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -450,6 +450,14 @@ impl InstructionData {
             Self::CallIndirect {
                 sig_ref, ref args, ..
             } => CallInfo::Indirect(sig_ref, &args.as_slice(pool)[1..]),
+            Self::Ternary {
+                opcode: Opcode::StackSwitch,
+                ..
+            } => {
+                // `StackSwitch` is not actually a call, but has the .call() side
+                // effect as it continues execution elsewhere.
+                CallInfo::NotACall
+            }
             _ => {
                 debug_assert!(!self.opcode().is_call());
                 CallInfo::NotACall

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -1257,7 +1257,7 @@ fn compute_clobber_size(clobbers: &[Writable<RealReg>]) -> u32 {
 
 const WINDOWS_CLOBBERS: PRegSet = windows_clobbers();
 const SYSV_CLOBBERS: PRegSet = sysv_clobbers();
-const ALL_CLOBBERS: PRegSet = all_clobbers();
+pub(crate) const ALL_CLOBBERS: PRegSet = all_clobbers();
 
 const fn windows_clobbers() -> PRegSet {
     PRegSet::empty()

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -557,6 +557,12 @@
        ;; Return.
        (Ret (stack_bytes_to_pop u32))
 
+       ;; Stack switching
+       (StackSwitch (store_context_ptr Gpr)
+                    (load_context_ptr Gpr)
+                    (in_payload0 Gpr)
+                    (out_payload0 WritableGpr))
+
        ;; Jump to a known target: jmp simm32.
        (JmpKnown (dst MachLabel))
 
@@ -2287,6 +2293,17 @@
 
 (decl gen_call_indirect (SigRef Value ValueSlice) InstOutput)
 (extern constructor gen_call_indirect gen_call_indirect)
+
+;;;; Helpers for emitting stack switches ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(decl x64_stack_switch (Gpr Gpr Gpr) Gpr)
+(rule (x64_stack_switch store_context_ptr load_context_ptr in_payload0)
+      (let ((out_payload0 WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.StackSwitch store_context_ptr
+                                             load_context_ptr
+                                             in_payload0
+                                             out_payload0))))
+        out_payload0))
 
 ;;;; Helpers for Emitting Loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -558,10 +558,10 @@
        (Ret (stack_bytes_to_pop u32))
 
        ;; Stack switching
-       (StackSwitch (store_context_ptr Gpr)
-                    (load_context_ptr Gpr)
-                    (in_payload0 Gpr)
-                    (out_payload0 WritableGpr))
+       (StackSwitchBasic (store_context_ptr Gpr)
+                         (load_context_ptr Gpr)
+                         (in_payload0 Gpr)
+                         (out_payload0 WritableGpr))
 
        ;; Jump to a known target: jmp simm32.
        (JmpKnown (dst MachLabel))
@@ -2296,13 +2296,13 @@
 
 ;;;; Helpers for emitting stack switches ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl x64_stack_switch (Gpr Gpr Gpr) Gpr)
-(rule (x64_stack_switch store_context_ptr load_context_ptr in_payload0)
+(decl x64_stack_switch_basic (Gpr Gpr Gpr) Gpr)
+(rule (x64_stack_switch_basic store_context_ptr load_context_ptr in_payload0)
       (let ((out_payload0 WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.StackSwitch store_context_ptr
-                                             load_context_ptr
-                                             in_payload0
-                                             out_payload0))))
+            (_ Unit (emit (MInst.StackSwitchBasic store_context_ptr
+                                                  load_context_ptr
+                                                  in_payload0
+                                                  out_payload0))))
         out_payload0))
 
 ;;;; Helpers for Emitting Loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1738,7 +1738,7 @@ pub(crate) fn emit(
             sink.put2(u16::try_from(*stack_bytes_to_pop).unwrap());
         }
 
-        Inst::StackSwitch {
+        Inst::StackSwitchBasic {
             store_context_ptr,
             load_context_ptr,
             in_payload0,

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1747,6 +1747,10 @@ pub(crate) fn emit(
             // Note that we do not emit anything for preserving and restoring
             // ordinary registers here: That's taken care of by regalloc for us,
             // since we marked this instruction as clobbering all registers.
+            //
+            // Also note that we do nothing about passing the single payload
+            // value: We've informed regalloc that it is sent and received via
+            // the fixed register given by [stack_switch::payload_register]
 
             let (tmp1, tmp2) = {
                 // Ideally we would just ask regalloc for two temporary registers.

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1738,6 +1738,119 @@ pub(crate) fn emit(
             sink.put2(u16::try_from(*stack_bytes_to_pop).unwrap());
         }
 
+        Inst::StackSwitch {
+            store_context_ptr,
+            load_context_ptr,
+            in_payload0,
+            out_payload0,
+        } => {
+            // Note that we do not emit anything for preserving and restoring
+            // ordinary registers here: That's taken care of by regalloc for us,
+            // since we marked this instruction as clobbering all registers.
+
+            let (tmp1, tmp2) = {
+                // Ideally we would just ask regalloc for two temporary registers.
+                // However, adding any early defs to the constraints on StackSwitch
+                // causes TooManyLiveRegs. Fortunately, we can manually find tmp
+                // registers without regalloc: Since our instruction clobbers all
+                // registers, we can simply pick any register that is not assigned
+                // to the operands.
+
+                let all = crate::isa::x64::abi::ALL_CLOBBERS;
+
+                let used_regs = [
+                    **load_context_ptr,
+                    **store_context_ptr,
+                    **in_payload0,
+                    *out_payload0.to_reg(),
+                ];
+
+                let mut tmps = all.into_iter().filter_map(|preg| {
+                    let reg: Reg = preg.into();
+                    if !used_regs.contains(&reg) {
+                        WritableGpr::from_writable_reg(isle::WritableReg::from_reg(reg))
+                    } else {
+                        None
+                    }
+                });
+                (tmps.next().unwrap(), tmps.next().unwrap())
+            };
+
+            let layout = stack_switch::control_context_layout();
+            let rsp_offset = layout.stack_pointer_offset as i32;
+            let pc_offset = layout.ip_offset as i32;
+            let rbp_offset = layout.frame_pointer_offset as i32;
+
+            // Location to which someone switch-ing back to this stack will jump
+            // to: Right behind the `StackSwitch` instruction
+            let resume = sink.get_label();
+
+            //
+            // For RBP and RSP we do the following:
+            // - Load new value for register from `load_context_ptr` +
+            // corresponding offset.
+            // - Store previous (!) value of register at `store_context_ptr` +
+            // corresponding offset.
+            //
+            // Since `load_context_ptr` and `store_context_ptr` are allowed to be
+            // equal, we need to use a temporary register here.
+            //
+
+            let mut exchange = |offset, reg| {
+                let inst = Inst::Mov64MR {
+                    src: Amode::imm_reg(offset, **load_context_ptr).into(),
+                    dst: tmp1,
+                };
+                emit(&inst, sink, info, state);
+
+                let inst = Inst::MovRM {
+                    size: OperandSize::Size64,
+                    src: Gpr::new(reg).unwrap(),
+                    dst: Amode::imm_reg(offset, **store_context_ptr).into(),
+                };
+                emit(&inst, sink, info, state);
+
+                let dst = Writable::from_reg(reg.into());
+                let inst = Inst::MovRR {
+                    size: OperandSize::Size64,
+                    src: tmp1.to_reg(),
+                    dst: WritableGpr::from_writable_reg(dst.into()).unwrap(),
+                };
+                emit(&inst, sink, info, state);
+            };
+
+            exchange(rsp_offset, regs::rsp());
+            exchange(rbp_offset, regs::rbp());
+
+            //
+            // Load target PC, store resume PC, jump to target PC
+            //
+
+            let inst = Inst::Mov64MR {
+                src: Amode::imm_reg(pc_offset, **load_context_ptr).into(),
+                dst: tmp1,
+            };
+            emit(&inst, sink, info, state);
+
+            let amode = Amode::RipRelative { target: resume };
+            let inst = Inst::lea(amode, tmp2.map(Reg::from));
+            inst.emit(sink, info, state);
+
+            let inst = Inst::MovRM {
+                size: OperandSize::Size64,
+                src: tmp2.to_reg(),
+                dst: Amode::imm_reg(pc_offset, **store_context_ptr).into(),
+            };
+            emit(&inst, sink, info, state);
+
+            let inst = Inst::JmpUnknown {
+                target: RegMem::reg(tmp1.to_reg().into()),
+            };
+            emit(&inst, sink, info, state);
+
+            sink.bind_label(resume, state.ctrl_plane_mut());
+        }
+
         Inst::JmpKnown { dst } => {
             let br_start = sink.cur_offset();
             let br_disp_off = br_start + 1;

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -138,7 +138,7 @@ impl Inst {
             | Inst::Setcc { .. }
             | Inst::ShiftR { .. }
             | Inst::SignExtendData { .. }
-            | Inst::StackSwitch { .. }
+            | Inst::StackSwitchBasic { .. }
             | Inst::TrapIf { .. }
             | Inst::TrapIfAnd { .. }
             | Inst::TrapIfOr { .. }
@@ -1734,7 +1734,7 @@ impl PrettyPrint for Inst {
                 s
             }
 
-            Inst::StackSwitch {
+            Inst::StackSwitchBasic {
                 store_context_ptr,
                 load_context_ptr,
                 in_payload0,
@@ -1744,7 +1744,7 @@ impl PrettyPrint for Inst {
                 let load_context_ptr = pretty_print_reg(**load_context_ptr, 8);
                 let in_payload0 = pretty_print_reg(**in_payload0, 8);
                 let out_payload0 = pretty_print_reg(*out_payload0.to_reg(), 8);
-                format!("{out_payload0} = stack_switch {store_context_ptr}, {load_context_ptr}, {in_payload0}")
+                format!("{out_payload0} = stack_switch_basic {store_context_ptr}, {load_context_ptr}, {in_payload0}")
             }
 
             Inst::JmpKnown { dst } => {
@@ -2386,7 +2386,7 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             }
             collector.reg_clobbers(*clobbers);
         }
-        Inst::StackSwitch {
+        Inst::StackSwitchBasic {
             store_context_ptr,
             load_context_ptr,
             in_payload0,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -22,6 +22,7 @@ mod emit_state;
 #[cfg(test)]
 mod emit_tests;
 pub mod regs;
+mod stack_switch;
 pub mod unwind;
 
 use args::*;
@@ -137,6 +138,7 @@ impl Inst {
             | Inst::Setcc { .. }
             | Inst::ShiftR { .. }
             | Inst::SignExtendData { .. }
+            | Inst::StackSwitch { .. }
             | Inst::TrapIf { .. }
             | Inst::TrapIfAnd { .. }
             | Inst::TrapIfOr { .. }
@@ -1732,6 +1734,19 @@ impl PrettyPrint for Inst {
                 s
             }
 
+            Inst::StackSwitch {
+                store_context_ptr,
+                load_context_ptr,
+                in_payload0,
+                out_payload0,
+            } => {
+                let store_context_ptr = pretty_print_reg(**store_context_ptr, 8);
+                let load_context_ptr = pretty_print_reg(**load_context_ptr, 8);
+                let in_payload0 = pretty_print_reg(**in_payload0, 8);
+                let out_payload0 = pretty_print_reg(*out_payload0.to_reg(), 8);
+                format!("{out_payload0} = stack_switch {store_context_ptr}, {load_context_ptr}, {in_payload0}")
+            }
+
             Inst::JmpKnown { dst } => {
                 let op = ljustify("jmp".to_string());
                 let dst = dst.to_string();
@@ -2370,6 +2385,27 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
                 collector.reg_fixed_def(vreg, *preg);
             }
             collector.reg_clobbers(*clobbers);
+        }
+        Inst::StackSwitch {
+            store_context_ptr,
+            load_context_ptr,
+            in_payload0,
+            out_payload0,
+        } => {
+            collector.reg_use(load_context_ptr);
+            collector.reg_use(store_context_ptr);
+            collector.reg_fixed_use(in_payload0, stack_switch::payload_register());
+            collector.reg_fixed_def(out_payload0, stack_switch::payload_register());
+
+            let mut clobbers = crate::isa::x64::abi::ALL_CLOBBERS;
+            // The return/payload reg must not be included in the clobber set
+            clobbers.remove(
+                stack_switch::payload_register()
+                    .to_real_reg()
+                    .unwrap()
+                    .into(),
+            );
+            collector.reg_clobbers(clobbers);
         }
 
         Inst::ReturnCallKnown { callee, info } => {

--- a/cranelift/codegen/src/isa/x64/inst/stack_switch.rs
+++ b/cranelift/codegen/src/isa/x64/inst/stack_switch.rs
@@ -1,0 +1,45 @@
+use crate::{isa::x64::inst::regs, machinst::Reg};
+
+/// The `stack_switch` instruction loads information about the stack to switch
+/// to and stores information about the current stack by receiving pointers to
+/// memory laid out as in the struct `ControlContext` below.
+///
+/// The instruction is only supported on x64 Linux at the moment.
+///
+/// ```
+/// #[repr(C)]
+/// pub struct ControlContext {
+///     pub stack_pointer: *mut u8,
+///     pub frame_pointer: *mut u8,
+///     pub instruction_pointer: *mut u8,
+/// }
+/// ```
+///
+/// Note that this layout is deliberately chosen to make frame pointer walking
+/// possible, if desired: The layout enables stack layouts where a
+/// `ControlContext` is part of a frame pointer chain, putting the frame pointer
+/// next to the corresponding IP.
+///
+/// We never actually interact with values of that type in Cranelift, but are
+/// only interested in its layout for the purposes of generating code.
+#[allow(dead_code)]
+pub struct ControlContextLayout {
+    pub size: usize,
+    pub stack_pointer_offset: usize,
+    pub frame_pointer_offset: usize,
+    pub ip_offset: usize,
+}
+
+pub fn control_context_layout() -> ControlContextLayout {
+    ControlContextLayout {
+        size: 24,
+        stack_pointer_offset: 0,
+        frame_pointer_offset: 8,
+        ip_offset: 16,
+    }
+}
+
+/// The register used for handing over the payload when switching stacks.
+pub fn payload_register() -> Reg {
+    regs::rdi()
+}

--- a/cranelift/codegen/src/isa/x64/inst/stack_switch.rs
+++ b/cranelift/codegen/src/isa/x64/inst/stack_switch.rs
@@ -40,6 +40,13 @@ pub fn control_context_layout() -> ControlContextLayout {
 }
 
 /// The register used for handing over the payload when switching stacks.
+///
+/// We must use a fixed register for sending and receiving the payload: When
+/// switching from one stack to another using two matching``stack_switch``
+/// instructions, they must agree on the register where the payload is, similar
+/// to a calling convention. The same holds when `stack_switch`-ing to a newly
+/// initialized stack, where the entry trampoline must know which register the
+/// payload is in.
 pub fn payload_register() -> Reg {
     regs::rdi()
 }

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3356,6 +3356,14 @@
 (rule (lower (return_call_indirect sig_ref callee args))
       (gen_return_call_indirect sig_ref callee args))
 
+;; Rules for `stack_switch` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (stack_switch store_context_ptr load_context_ptr in_payload0))
+       (let ((store_context_ptr Gpr (put_in_gpr store_context_ptr))
+             (load_context_ptr Gpr (put_in_gpr load_context_ptr))
+             (in_payload0 Gpr (put_in_gpr in_payload0)))
+         (x64_stack_switch store_context_ptr load_context_ptr in_payload0)))
+
 ;;;; Rules for `get_{frame,stack}_pointer` and `get_return_address` ;;;;;;;;;;;;
 
 (rule (lower (get_frame_pointer))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3358,11 +3358,13 @@
 
 ;; Rules for `stack_switch` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (stack_switch store_context_ptr load_context_ptr in_payload0))
-       (let ((store_context_ptr Gpr (put_in_gpr store_context_ptr))
-             (load_context_ptr Gpr (put_in_gpr load_context_ptr))
-             (in_payload0 Gpr (put_in_gpr in_payload0)))
-         (x64_stack_switch store_context_ptr load_context_ptr in_payload0)))
+;; currently, only the Basic model is supported
+(rule (lower (has_type (stack_switch_model (StackSwitchModel.Basic))
+                       (stack_switch store_context_ptr load_context_ptr in_payload0)))
+      (let ((store_context_ptr Gpr (put_in_gpr store_context_ptr))
+            (load_context_ptr Gpr (put_in_gpr load_context_ptr))
+            (in_payload0 Gpr (put_in_gpr in_payload0)))
+        (x64_stack_switch_basic store_context_ptr load_context_ptr in_payload0)))
 
 ;;;; Rules for `get_{frame,stack}_pointer` and `get_return_address` ;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3359,9 +3359,6 @@
 ;; Rules for `stack_switch` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (stack_switch store_context_ptr load_context_ptr in_payload0))
-       ;; For the time being, stack switching is only supported on x64 Linux
-       (if (on_linux))
-
        (let ((store_context_ptr Gpr (put_in_gpr store_context_ptr))
              (load_context_ptr Gpr (put_in_gpr load_context_ptr))
              (in_payload0 Gpr (put_in_gpr in_payload0)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3359,6 +3359,9 @@
 ;; Rules for `stack_switch` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (stack_switch store_context_ptr load_context_ptr in_payload0))
+       ;; For the time being, stack switching is only supported on x64 Linux
+       (if (on_linux))
+
        (let ((store_context_ptr Gpr (put_in_gpr store_context_ptr))
              (load_context_ptr Gpr (put_in_gpr load_context_ptr))
              (in_payload0 Gpr (put_in_gpr in_payload0)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3359,8 +3359,8 @@
 ;; Rules for `stack_switch` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; currently, only the Basic model is supported
-(rule (lower (has_type (stack_switch_model (StackSwitchModel.Basic))
-                       (stack_switch store_context_ptr load_context_ptr in_payload0)))
+(rule (lower (stack_switch store_context_ptr load_context_ptr in_payload0))
+      (if-let (StackSwitchModel.Basic) (stack_switch_model))
       (let ((store_context_ptr Gpr (put_in_gpr store_context_ptr))
             (load_context_ptr Gpr (put_in_gpr load_context_ptr))
             (in_payload0 Gpr (put_in_gpr in_payload0)))

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -902,9 +902,7 @@ pub(crate) fn check(
 
         Inst::Unwind { .. } | Inst::DummyUse { .. } => Ok(()),
 
-        Inst::StackSwitch { .. } => {
-            Err(PccError::UnimplementedInst)
-        }
+        Inst::StackSwitch { .. } => Err(PccError::UnimplementedInst),
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -903,7 +903,7 @@ pub(crate) fn check(
         Inst::Unwind { .. } | Inst::DummyUse { .. } => Ok(()),
 
         Inst::StackSwitch { .. } => {
-            todo!("todo")
+            Err(PccError::UnimplementedInst)
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -902,7 +902,7 @@ pub(crate) fn check(
 
         Inst::Unwind { .. } | Inst::DummyUse { .. } => Ok(()),
 
-        Inst::StackSwitch { .. } => Err(PccError::UnimplementedInst),
+        Inst::StackSwitchBasic { .. } => Err(PccError::UnimplementedInst),
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -901,6 +901,10 @@ pub(crate) fn check(
         }
 
         Inst::Unwind { .. } | Inst::DummyUse { .. } => Ok(()),
+
+        Inst::StackSwitch { .. } => {
+            todo!("todo")
+        }
     }
 }
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -112,6 +112,7 @@ use smallvec::smallvec;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::mem;
+use target_lexicon::Triple;
 
 /// A small vector of instructions (with some reasonable size); appropriate for
 /// a small fixed sequence implementing one operation.
@@ -1035,6 +1036,8 @@ pub struct Callee<M: ABIMachineSpec> {
     /// manually register-allocated and carefully only use caller-saved
     /// registers and keep nothing live after this sequence of instructions.
     stack_limit: Option<(Reg, SmallInstVec<M::I>)>,
+    // Target triple
+    triple: Triple,
 
     _mach: PhantomData<M>,
 }
@@ -1160,6 +1163,7 @@ impl<M: ABIMachineSpec> Callee<M> {
             isa_flags: isa_flags.clone(),
             is_leaf: f.is_leaf(),
             stack_limit,
+            triple: isa.triple().clone(),
             _mach: PhantomData,
         })
     }
@@ -1382,6 +1386,10 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// The offsets of all dynamic stack slots (not spill slots) for debuginfo purposes.
     pub fn dynamic_stackslot_offsets(&self) -> &PrimaryMap<DynamicStackSlot, u32> {
         &self.dynamic_stackslots
+    }
+
+    pub fn triple(&self) -> &Triple {
+        &self.triple
     }
 
     /// Generate an instruction which copies an argument to a destination

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -112,7 +112,6 @@ use smallvec::smallvec;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::mem;
-use target_lexicon::Triple;
 
 /// A small vector of instructions (with some reasonable size); appropriate for
 /// a small fixed sequence implementing one operation.
@@ -1036,8 +1035,6 @@ pub struct Callee<M: ABIMachineSpec> {
     /// manually register-allocated and carefully only use caller-saved
     /// registers and keep nothing live after this sequence of instructions.
     stack_limit: Option<(Reg, SmallInstVec<M::I>)>,
-    // Target triple
-    triple: Triple,
 
     _mach: PhantomData<M>,
 }
@@ -1163,7 +1160,6 @@ impl<M: ABIMachineSpec> Callee<M> {
             isa_flags: isa_flags.clone(),
             is_leaf: f.is_leaf(),
             stack_limit,
-            triple: isa.triple().clone(),
             _mach: PhantomData,
         })
     }
@@ -1386,10 +1382,6 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// The offsets of all dynamic stack slots (not spill slots) for debuginfo purposes.
     pub fn dynamic_stackslot_offsets(&self) -> &PrimaryMap<DynamicStackSlot, u32> {
         &self.dynamic_stackslots
-    }
-
-    pub fn triple(&self) -> &Triple {
-        &self.triple
     }
 
     /// Generate an instruction which copies an argument to a destination

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -341,14 +341,6 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         #[inline]
-        fn on_linux(&mut self) -> Option<()> {
-            match self.lower_ctx.abi().triple().operating_system {
-                target_lexicon::OperatingSystem::Linux => Some(()),
-                _ => None,
-            }
-        }
-
-        #[inline]
         fn func_ref_data(&mut self, func_ref: FuncRef) -> (SigRef, ExternalName, RelocDistance) {
             let funcdata = &self.lower_ctx.dfg().ext_funcs[func_ref];
             let reloc_distance = if funcdata.colocated {

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -341,6 +341,14 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         #[inline]
+        fn on_linux(&mut self) -> Option<()> {
+            match self.lower_ctx.abi().triple().operating_system {
+                target_lexicon::OperatingSystem::Linux => Some(()),
+                _ => None,
+            }
+        }
+
+        #[inline]
         fn func_ref_data(&mut self, func_ref: FuncRef) -> (SigRef, ExternalName, RelocDistance) {
             let funcdata = &self.lower_ctx.dfg().ext_funcs[func_ref];
             let reloc_distance = if funcdata.colocated {

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -341,8 +341,8 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         #[inline]
-        fn stack_switch_model(&mut self) -> Option<StackSwitchModel> {
-            Some(self.backend.flags().stack_switch_model())
+        fn stack_switch_model(&mut self) -> StackSwitchModel {
+            self.backend.flags().stack_switch_model()
         }
 
         #[inline]

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -15,7 +15,7 @@ pub use crate::machinst::{
     ABIArg, ABIArgSlot, ABIMachineSpec, CallSite, InputSourceInst, Lower, LowerBackend, RealReg,
     Reg, RelocDistance, Sig, VCodeInst, Writable,
 };
-pub use crate::settings::TlsModel;
+pub use crate::settings::{StackSwitchModel, TlsModel};
 
 pub type Unit = ();
 pub type ValueSlice = (ValueList, usize);
@@ -338,6 +338,11 @@ macro_rules! isle_lower_prelude_methods {
             } else {
                 None
             }
+        }
+
+        #[inline]
+        fn stack_switch_model(&mut self, _: Type) -> StackSwitchModel {
+            self.backend.flags().stack_switch_model()
         }
 
         #[inline]

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -341,8 +341,8 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         #[inline]
-        fn stack_switch_model(&mut self, _: Type) -> StackSwitchModel {
-            self.backend.flags().stack_switch_model()
+        fn stack_switch_model(&mut self) -> Option<StackSwitchModel> {
+            Some(self.backend.flags().stack_switch_model())
         }
 
         #[inline]

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -874,8 +874,8 @@
 ;; cranelift/codegen/meta/src/shared/settings.rs
 (type StackSwitchModel extern (enum (None) (Basic) (UpdateWindowsTib)))
 
-(decl stack_switch_model (StackSwitchModel) Type)
-(extern extractor infallible stack_switch_model stack_switch_model)
+(decl pure partial stack_switch_model () StackSwitchModel)
+(extern constructor stack_switch_model stack_switch_model)
 
 ;;;; Helpers for accessing instruction data ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -870,9 +870,6 @@
 (decl pure partial preserve_frame_pointers () Unit)
 (extern constructor preserve_frame_pointers preserve_frame_pointers)
 
-(decl pure partial on_linux () Unit)
-(extern constructor on_linux on_linux)
-
 ;;;; Helpers for accessing instruction data ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl box_external_name (ExternalName) BoxExternalName)

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -870,6 +870,13 @@
 (decl pure partial preserve_frame_pointers () Unit)
 (extern constructor preserve_frame_pointers preserve_frame_pointers)
 
+;; This definition should be kept up to date with the values defined in
+;; cranelift/codegen/meta/src/shared/settings.rs
+(type StackSwitchModel extern (enum (None) (Basic) (UpdateWindowsTib)))
+
+(decl stack_switch_model (StackSwitchModel) Type)
+(extern extractor infallible stack_switch_model stack_switch_model)
+
 ;;;; Helpers for accessing instruction data ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl box_external_name (ExternalName) BoxExternalName)

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -870,6 +870,9 @@
 (decl pure partial preserve_frame_pointers () Unit)
 (extern constructor preserve_frame_pointers preserve_frame_pointers)
 
+(decl pure partial on_linux () Unit)
+(extern constructor on_linux on_linux)
+
 ;;;; Helpers for accessing instruction data ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl box_external_name (ExternalName) BoxExternalName)

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -874,7 +874,7 @@
 ;; cranelift/codegen/meta/src/shared/settings.rs
 (type StackSwitchModel extern (enum (None) (Basic) (UpdateWindowsTib)))
 
-(decl pure partial stack_switch_model () StackSwitchModel)
+(decl pure stack_switch_model () StackSwitchModel)
 (extern constructor stack_switch_model stack_switch_model)
 
 ;;;; Helpers for accessing instruction data ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -511,6 +511,7 @@ mod tests {
         let expected = r#"[shared]
 opt_level = "none"
 tls_model = "none"
+stack_switch_model = "none"
 libcall_call_conv = "isa_default"
 probestack_size_log2 = 12
 probestack_strategy = "outline"

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set opt_level=speed
-target x86_64-unknown-linux-gnu
+target x86_64
 
 ;; Test code emitted for stack switch itself
 function %switch(i64, i64, i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -2,6 +2,70 @@ test compile precise-output
 set opt_level=speed
 target x86_64-unknown-linux-gnu
 
+;; Test code emitted for stack switch itself
+function %switch(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = stack_switch v0, v1, v2
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $48, %rsp
+;   movq    %rbx, 0(%rsp)
+;   movq    %r12, 8(%rsp)
+;   movq    %r13, 16(%rsp)
+;   movq    %r14, 24(%rsp)
+;   movq    %r15, 32(%rsp)
+; block0:
+;   movq    %rdi, %r10
+;   movq    %rdx, %rdi
+;   %rdi = stack_switch %r10, %rsi, %rdi
+;   movq    %rdi, %rax
+;   movq    0(%rsp), %rbx
+;   movq    8(%rsp), %r12
+;   movq    16(%rsp), %r13
+;   movq    24(%rsp), %r14
+;   movq    32(%rsp), %r15
+;   addq    %rsp, $48, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x30, %rsp
+;   movq %rbx, (%rsp)
+;   movq %r12, 8(%rsp)
+;   movq %r13, 0x10(%rsp)
+;   movq %r14, 0x18(%rsp)
+;   movq %r15, 0x20(%rsp)
+; block1: ; offset 0x20
+;   movq %rdi, %r10
+;   movq %rdx, %rdi
+;   movq (%rsi), %rax
+;   movq %rsp, (%r10)
+;   movq %rax, %rsp
+;   movq 8(%rsi), %rax
+;   movq %rbp, 8(%r10)
+;   movq %rax, %rbp
+;   movq 0x10(%rsi), %rax
+;   leaq 6(%rip), %rcx
+;   movq %rcx, 0x10(%r10)
+;   jmpq *%rax
+;   movq %rdi, %rax
+;   movq (%rsp), %rbx
+;   movq 8(%rsp), %r12
+;   movq 0x10(%rsp), %r13
+;   movq 0x18(%rsp), %r14
+;   movq 0x20(%rsp), %r15
+;   addq $0x30, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 ;; Test clobbering of all 14 GPRs used by Cranelift
 function %switch_int_clobber(i64, i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -1,0 +1,540 @@
+test compile precise-output
+set opt_level=speed
+target x86_64
+
+
+;; Test clobbering of all 14 GPRs used by Cranelift
+function %switch_int_clobber(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = iconst.i64 0
+
+;; We create values v100 to v114 before the stack_switch and want to use them
+;; afterwards. Thus, they must all be spilled on the stack.
+;; Given that they are loads, they cannot be moved behind the stack_switch.
+
+  v100 = load.i64 v0+0
+  v101 = load.i64 v0+8
+  v102 = load.i64 v0+16
+  v103 = load.i64 v0+24
+  v104 = load.i64 v0+32
+  v105 = load.i64 v0+40
+  v106 = load.i64 v0+48
+  v107 = load.i64 v0+56
+  v108 = load.i64 v0+64
+  v109 = load.i64 v0+72
+  v110 = load.i64 v0+80
+  v111 = load.i64 v0+88
+  v112 = load.i64 v0+96
+  v113 = load.i64 v0+104
+  v114 = load.i64 v0+112
+
+  v299 = stack_switch v1, v1, v2
+
+;; We use v100 - v114 after the switch: We load from each v(100+i) into
+;; v(200+i), and use v(300+i) as an accumulator of all values so far.
+;; These are loads and therefore they cannot be moved before the stack_switch.
+
+  v200 = load.i64 v100
+  v300 = iadd.i64 v299, v200
+  v201 = load.i64 v101
+  v301 = iadd.i64 v300, v201
+  v202 = load.i64 v102
+  v302 = iadd.i64 v301, v202
+  v203 = load.i64 v103
+  v303 = iadd.i64 v302, v203
+  v204 = load.i64 v104
+  v304 = iadd.i64 v303, v204
+  v205 = load.i64 v105
+  v305 = iadd.i64 v304, v205
+  v206 = load.i64 v106
+  v306 = iadd.i64 v305, v206
+  v207 = load.i64 v107
+  v307 = iadd.i64 v306, v207
+  v208 = load.i64 v108
+  v308 = iadd.i64 v307, v208
+  v209 = load.i64 v109
+  v309 = iadd.i64 v308, v209
+  v210 = load.i64 v110
+  v310 = iadd.i64 v309, v210
+  v211 = load.i64 v111
+  v311 = iadd.i64 v310, v211
+  v212 = load.i64 v112
+  v312 = iadd.i64 v311, v212
+  v213 = load.i64 v113
+  v313 = iadd.i64 v312, v213
+  v214 = load.i64 v114
+  v314 = iadd.i64 v313, v214
+
+;; Let's also use v0 again
+  v400 = iadd.i64 v314, v0
+
+;; We cannot use v1 again: That causes TooManyLiveRegs, as this usage is an
+;; instance of https://github.com/bytecodealliance/regalloc2/issues/145
+;; v401 = iadd.i64 v400, v1
+
+  return v400
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $192, %rsp
+;   movq    %rbx, 144(%rsp)
+;   movq    %r12, 152(%rsp)
+;   movq    %r13, 160(%rsp)
+;   movq    %r14, 168(%rsp)
+;   movq    %r15, 176(%rsp)
+; block0:
+;   movq    0(%rdi), %rdx
+;   movq    %rdx, rsp(128 + virtual offset)
+;   movq    8(%rdi), %rdx
+;   movq    %rdx, rsp(8 + virtual offset)
+;   movq    16(%rdi), %rdx
+;   movq    %rdx, rsp(120 + virtual offset)
+;   movq    24(%rdi), %rdx
+;   movq    %rdx, rsp(112 + virtual offset)
+;   movq    32(%rdi), %rdx
+;   movq    %rdx, rsp(104 + virtual offset)
+;   movq    40(%rdi), %rdx
+;   movq    %rdx, rsp(96 + virtual offset)
+;   movq    48(%rdi), %rdx
+;   movq    %rdx, rsp(88 + virtual offset)
+;   movq    56(%rdi), %rdx
+;   movq    %rdx, rsp(80 + virtual offset)
+;   movq    64(%rdi), %rdx
+;   movq    %rdx, rsp(72 + virtual offset)
+;   movq    72(%rdi), %rdx
+;   movq    %rdx, rsp(64 + virtual offset)
+;   movq    80(%rdi), %rdx
+;   movq    %rdx, rsp(56 + virtual offset)
+;   movq    88(%rdi), %rdx
+;   movq    %rdx, rsp(48 + virtual offset)
+;   movq    96(%rdi), %rdx
+;   movq    %rdx, rsp(40 + virtual offset)
+;   movq    104(%rdi), %rdx
+;   movq    %rdx, rsp(32 + virtual offset)
+;   movq    112(%rdi), %rdx
+;   movq    %rdi, rsp(0 + virtual offset)
+;   movq    %rdx, rsp(24 + virtual offset)
+;   xorq    %rdi, %rdi, %rdi
+;   %rdi = stack_switch %rsi, %rsi, %rdi
+;   movq    rsp(128 + virtual offset), %rdx
+;   movq    %rdi, rsp(16 + virtual offset)
+;   movq    0(%rdx), %r8
+;   movq    rsp(8 + virtual offset), %rdx
+;   movq    0(%rdx), %r9
+;   movq    rsp(120 + virtual offset), %rdx
+;   movq    %r9, rsp(8 + virtual offset)
+;   movq    0(%rdx), %r10
+;   movq    rsp(112 + virtual offset), %rdx
+;   movq    0(%rdx), %r9
+;   movq    rsp(104 + virtual offset), %rdx
+;   movq    0(%rdx), %rsi
+;   movq    rsp(96 + virtual offset), %rdx
+;   movq    0(%rdx), %rax
+;   movq    rsp(88 + virtual offset), %rdx
+;   movq    0(%rdx), %rcx
+;   movq    rsp(80 + virtual offset), %rdx
+;   movq    0(%rdx), %r15
+;   movq    rsp(72 + virtual offset), %rdx
+;   movq    0(%rdx), %r13
+;   movq    rsp(64 + virtual offset), %rdx
+;   movq    0(%rdx), %rbx
+;   movq    rsp(56 + virtual offset), %rdx
+;   movq    0(%rdx), %r14
+;   movq    rsp(48 + virtual offset), %rdx
+;   movq    0(%rdx), %r12
+;   movq    rsp(40 + virtual offset), %rdx
+;   movq    0(%rdx), %rdx
+;   movq    rsp(32 + virtual offset), %rdi
+;   movq    0(%rdi), %r11
+;   movq    rsp(16 + virtual offset), %rdi
+;   lea     0(%rdi,%r8,1), %r8
+;   movq    rsp(8 + virtual offset), %rdi
+;   lea     0(%rdi,%r10,1), %r10
+;   lea     0(%r8,%r10,1), %r8
+;   lea     0(%r9,%rsi,1), %r9
+;   lea     0(%rax,%rcx,1), %r10
+;   lea     0(%r15,%r13,1), %rsi
+;   lea     0(%r10,%rsi,1), %r10
+;   lea     0(%rbx,%r14,1), %rsi
+;   lea     0(%r10,%rsi,1), %r10
+;   lea     0(%r12,%rdx,1), %rdx
+;   lea     0(%r10,%rdx,1), %rdx
+;   lea     0(%r9,%rdx,1), %rdx
+;   lea     0(%r8,%rdx,1), %rdx
+;   movq    rsp(24 + virtual offset), %r8
+;   addq    %r11, 0(%r8), %r11
+;   movq    rsp(0 + virtual offset), %rdi
+;   lea     0(%r11,%rdi,1), %r8
+;   lea     0(%rdx,%r8,1), %rax
+;   movq    144(%rsp), %rbx
+;   movq    152(%rsp), %r12
+;   movq    160(%rsp), %r13
+;   movq    168(%rsp), %r14
+;   movq    176(%rsp), %r15
+;   addq    %rsp, $192, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0xc0, %rsp
+;   movq %rbx, 0x90(%rsp)
+;   movq %r12, 0x98(%rsp)
+;   movq %r13, 0xa0(%rsp)
+;   movq %r14, 0xa8(%rsp)
+;   movq %r15, 0xb0(%rsp)
+; block1: ; offset 0x33
+;   movq (%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x80(%rsp)
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 8(%rsp)
+;   movq 0x10(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x78(%rsp)
+;   movq 0x18(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x70(%rsp)
+;   movq 0x20(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x68(%rsp)
+;   movq 0x28(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x60(%rsp)
+;   movq 0x30(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x58(%rsp)
+;   movq 0x38(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x50(%rsp)
+;   movq 0x40(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x48(%rsp)
+;   movq 0x48(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x40(%rsp)
+;   movq 0x50(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x38(%rsp)
+;   movq 0x58(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x30(%rsp)
+;   movq 0x60(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x28(%rsp)
+;   movq 0x68(%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, 0x20(%rsp)
+;   movq 0x70(%rdi), %rdx ; trap: heap_oob
+;   movq %rdi, (%rsp)
+;   movq %rdx, 0x18(%rsp)
+;   xorq %rdi, %rdi
+;   movq (%rsi), %rax
+;   movq %rsp, (%rsi)
+;   movq %rax, %rsp
+;   movq 8(%rsi), %rax
+;   movq %rbp, 8(%rsi)
+;   movq %rax, %rbp
+;   movq 0x10(%rsi), %rax
+;   leaq 6(%rip), %rcx
+;   movq %rcx, 0x10(%rsi)
+;   jmpq *%rax
+;   movq 0x80(%rsp), %rdx
+;   movq %rdi, 0x10(%rsp)
+;   movq (%rdx), %r8 ; trap: heap_oob
+;   movq 8(%rsp), %rdx
+;   movq (%rdx), %r9 ; trap: heap_oob
+;   movq 0x78(%rsp), %rdx
+;   movq %r9, 8(%rsp)
+;   movq (%rdx), %r10 ; trap: heap_oob
+;   movq 0x70(%rsp), %rdx
+;   movq (%rdx), %r9 ; trap: heap_oob
+;   movq 0x68(%rsp), %rdx
+;   movq (%rdx), %rsi ; trap: heap_oob
+;   movq 0x60(%rsp), %rdx
+;   movq (%rdx), %rax ; trap: heap_oob
+;   movq 0x58(%rsp), %rdx
+;   movq (%rdx), %rcx ; trap: heap_oob
+;   movq 0x50(%rsp), %rdx
+;   movq (%rdx), %r15 ; trap: heap_oob
+;   movq 0x48(%rsp), %rdx
+;   movq (%rdx), %r13 ; trap: heap_oob
+;   movq 0x40(%rsp), %rdx
+;   movq (%rdx), %rbx ; trap: heap_oob
+;   movq 0x38(%rsp), %rdx
+;   movq (%rdx), %r14 ; trap: heap_oob
+;   movq 0x30(%rsp), %rdx
+;   movq (%rdx), %r12 ; trap: heap_oob
+;   movq 0x28(%rsp), %rdx
+;   movq (%rdx), %rdx ; trap: heap_oob
+;   movq 0x20(%rsp), %rdi
+;   movq (%rdi), %r11 ; trap: heap_oob
+;   movq 0x10(%rsp), %rdi
+;   addq %rdi, %r8
+;   movq 8(%rsp), %rdi
+;   addq %rdi, %r10
+;   addq %r10, %r8
+;   addq %rsi, %r9
+;   leaq (%rax, %rcx), %r10
+;   leaq (%r15, %r13), %rsi
+;   addq %rsi, %r10
+;   leaq (%rbx, %r14), %rsi
+;   addq %rsi, %r10
+;   addq %r12, %rdx
+;   addq %r10, %rdx
+;   addq %r9, %rdx
+;   addq %r8, %rdx
+;   movq 0x18(%rsp), %r8
+;   addq (%r8), %r11 ; trap: heap_oob
+;   movq (%rsp), %rdi
+;   leaq (%r11, %rdi), %r8
+;   leaq (%rdx, %r8), %rax
+;   movq 0x90(%rsp), %rbx
+;   movq 0x98(%rsp), %r12
+;   movq 0xa0(%rsp), %r13
+;   movq 0xa8(%rsp), %r14
+;   movq 0xb0(%rsp), %r15
+;   addq $0xc0, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Test clobbering of all 16 float registers
+function %switch_float_clobber(i64, i64) -> f64 {
+block0(v0: i64, v1: i64):
+  v2 = iconst.i64 0
+
+;; We create values v100 to v115 before the stack_switch and want to use them
+;; afterwards. Thus, they must all be spilled on the stack.
+;; Given that they are loads, they cannot be moved behind the stack_switch.
+
+  v100 = load.f64 v0+0
+  v101 = load.f64 v0+8
+  v102 = load.f64 v0+16
+  v103 = load.f64 v0+24
+  v104 = load.f64 v0+32
+  v105 = load.f64 v0+40
+  v106 = load.f64 v0+48
+  v107 = load.f64 v0+56
+  v108 = load.f64 v0+64
+  v109 = load.f64 v0+72
+  v110 = load.f64 v0+80
+  v111 = load.f64 v0+88
+  v112 = load.f64 v0+96
+  v113 = load.f64 v0+104
+  v114 = load.f64 v0+112
+  v115 = load.f64 v0+120
+
+  v198 = stack_switch v1, v1, v2
+  v199 = fcvt_from_uint.f64 v198
+
+;; We add v100 to v115, using v200 to v215 as an accumulator
+;; We make v199 part of the result to prevent summation of v100 to v115 before
+;; the switch.
+
+  v200 = fadd v199, v100
+  v201 = fadd v200, v101
+  v202 = fadd v201, v102
+  v203 = fadd v202, v103
+  v204 = fadd v203, v104
+  v205 = fadd v204, v105
+  v206 = fadd v205, v106
+  v207 = fadd v206, v107
+  v208 = fadd v207, v108
+  v209 = fadd v208, v109
+  v210 = fadd v209, v110
+  v211 = fadd v210, v111
+  v212 = fadd v211, v112
+  v213 = fadd v212, v113
+  v214 = fadd v213, v114
+  v215 = fadd v214, v115
+
+  return v215
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $304, %rsp
+;   movq    %rbx, 256(%rsp)
+;   movq    %r12, 264(%rsp)
+;   movq    %r13, 272(%rsp)
+;   movq    %r14, 280(%rsp)
+;   movq    %r15, 288(%rsp)
+; block0:
+;   movsd   0(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(240 + virtual offset)
+;   movsd   8(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(224 + virtual offset)
+;   movsd   16(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(208 + virtual offset)
+;   movsd   24(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(192 + virtual offset)
+;   movsd   32(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(176 + virtual offset)
+;   movsd   40(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(160 + virtual offset)
+;   movsd   48(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(144 + virtual offset)
+;   movsd   56(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(128 + virtual offset)
+;   movsd   64(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(112 + virtual offset)
+;   movsd   72(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(96 + virtual offset)
+;   movsd   80(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(80 + virtual offset)
+;   movsd   88(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(64 + virtual offset)
+;   movsd   96(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(48 + virtual offset)
+;   movsd   104(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(32 + virtual offset)
+;   movsd   112(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(16 + virtual offset)
+;   movsd   120(%rdi), %xmm7
+;   movdqu  %xmm7, rsp(0 + virtual offset)
+;   xorq    %rdi, %rdi, %rdi
+;   %rdi = stack_switch %rsi, %rsi, %rdi
+;   u64_to_f64_seq %rdi, %xmm0, %rax, %rcx
+;   movdqu  rsp(240 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(224 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(208 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(192 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(176 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(160 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(144 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(128 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(112 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(96 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(80 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(64 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(48 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(32 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(16 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(0 + virtual offset), %xmm7
+;   addsd   %xmm0, %xmm7, %xmm0
+;   movq    256(%rsp), %rbx
+;   movq    264(%rsp), %r12
+;   movq    272(%rsp), %r13
+;   movq    280(%rsp), %r14
+;   movq    288(%rsp), %r15
+;   addq    %rsp, $304, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x130, %rsp
+;   movq %rbx, 0x100(%rsp)
+;   movq %r12, 0x108(%rsp)
+;   movq %r13, 0x110(%rsp)
+;   movq %r14, 0x118(%rsp)
+;   movq %r15, 0x120(%rsp)
+; block1: ; offset 0x33
+;   movsd (%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0xf0(%rsp)
+;   movsd 8(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0xe0(%rsp)
+;   movsd 0x10(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0xd0(%rsp)
+;   movsd 0x18(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0xc0(%rsp)
+;   movsd 0x20(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0xb0(%rsp)
+;   movsd 0x28(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0xa0(%rsp)
+;   movsd 0x30(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x90(%rsp)
+;   movsd 0x38(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x80(%rsp)
+;   movsd 0x40(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x70(%rsp)
+;   movsd 0x48(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x60(%rsp)
+;   movsd 0x50(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x50(%rsp)
+;   movsd 0x58(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x40(%rsp)
+;   movsd 0x60(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x30(%rsp)
+;   movsd 0x68(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x20(%rsp)
+;   movsd 0x70(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, 0x10(%rsp)
+;   movsd 0x78(%rdi), %xmm7 ; trap: heap_oob
+;   movdqu %xmm7, (%rsp)
+;   xorq %rdi, %rdi
+;   movq (%rsi), %rax
+;   movq %rsp, (%rsi)
+;   movq %rax, %rsp
+;   movq 8(%rsi), %rax
+;   movq %rbp, 8(%rsi)
+;   movq %rax, %rbp
+;   movq 0x10(%rsi), %rax
+;   leaq 6(%rip), %rcx
+;   movq %rcx, 0x10(%rsi)
+;   jmpq *%rax
+;   cmpq $0, %rdi
+;   jl 0x135
+;   cvtsi2sdq %rdi, %xmm0
+;   jmp 0x14f
+;   movq %rdi, %rax
+;   shrq $1, %rax
+;   movq %rdi, %rcx
+;   andq $1, %rcx
+;   orq %rax, %rcx
+;   cvtsi2sdq %rcx, %xmm0
+;   addsd %xmm0, %xmm0
+;   movdqu 0xf0(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0xe0(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0xd0(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0xc0(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0xb0(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0xa0(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x90(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x80(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x70(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x60(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x50(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x40(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x30(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x20(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu 0x10(%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movdqu (%rsp), %xmm7
+;   addsd %xmm7, %xmm0
+;   movq 0x100(%rsp), %rbx
+;   movq 0x108(%rsp), %r12
+;   movq 0x110(%rsp), %r13
+;   movq 0x118(%rsp), %r14
+;   movq 0x120(%rsp), %r15
+;   addq $0x130, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set opt_level=speed
-target x86_64
+target x86_64-unknown-linux-gnu
 
 
 ;; Test clobbering of all 14 GPRs used by Cranelift

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -1,5 +1,6 @@
 test compile precise-output
 set opt_level=speed
+set stack_switch_model=basic
 target x86_64
 
 ;; Test code emitted for stack switch itself
@@ -21,7 +22,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ; block0:
 ;   movq    %rdi, %r10
 ;   movq    %rdx, %rdi
-;   %rdi = stack_switch %r10, %rsi, %rdi
+;   %rdi = stack_switch_basic %r10, %rsi, %rdi
 ;   movq    %rdi, %rax
 ;   movq    0(%rsp), %rbx
 ;   movq    8(%rsp), %r12
@@ -181,7 +182,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rdi, rsp(0 + virtual offset)
 ;   movq    %rdx, rsp(24 + virtual offset)
 ;   xorq    %rdi, %rdi, %rdi
-;   %rdi = stack_switch %rsi, %rsi, %rdi
+;   %rdi = stack_switch_basic %rsi, %rsi, %rdi
 ;   movq    rsp(128 + virtual offset), %rdx
 ;   movq    %rdi, rsp(16 + virtual offset)
 ;   movq    0(%rdx), %r8
@@ -451,7 +452,7 @@ block0(v0: i64, v1: i64):
 ;   movsd   120(%rdi), %xmm7
 ;   movdqu  %xmm7, rsp(0 + virtual offset)
 ;   xorq    %rdi, %rdi, %rdi
-;   %rdi = stack_switch %rsi, %rsi, %rdi
+;   %rdi = stack_switch_basic %rsi, %rsi, %rdi
 ;   u64_to_f64_seq %rdi, %xmm0, %rax, %rcx
 ;   movdqu  rsp(240 + virtual offset), %xmm7
 ;   addsd   %xmm0, %xmm7, %xmm0

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -1286,6 +1286,7 @@ where
         Opcode::X86Pmulhrsw => unimplemented!("X86Pmulhrsw"),
         Opcode::X86Pmaddubsw => unimplemented!("X86Pmaddubsw"),
         Opcode::X86Cvtt2dq => unimplemented!("X86Cvtt2dq"),
+        Opcode::StackSwitch => unimplemented!("StackSwitch"),
     })
 }
 

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -339,6 +339,7 @@ impl Engine {
             | "bb_padding_log2_minus_one"
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now
+            | "stack_switch_model" // wasmtime doesn't use stack switching right now
             | "opt_level" // opt level doesn't change semantics
             | "enable_alias_analysis" // alias analysis-based opts don't change semantics
             | "probestack_size_log2" // probestack above asserted disabled


### PR DESCRIPTION
This PR adds a new CLIF instruction for switching stacks. While the primary motivation is to support the [Wasm stack switching proposal](https://github.com/WebAssembly/stack-switching) currently under development, the CLIF instruction here is lower level and thus intended to be useful for general-purpose stackful context switching (such as implementing coroutines, fibers, etc independently from the Wasm stack switching proposal).
This PR only adds support for the instruction on x64 Linux, but I'm planning to add support for more platforms over time. The design of the instruction should be sufficiently abstract to support all the other platforms.

While work is currently under way to implement Wasm stack switching in Wasmtime [here](https://github.com/wasmfx/wasmfxtime) and indeed uses the CLIF instruction introduced by this PR successfully, it seems worthwhile just upstreaming the CLIF instruction by itself. The proposal is not fully finalized yet, and this CLIF instruction seems useful on its own and independent from the remainder of the Wasm proposal.

Concretely, the CLIF instruction looks as follows:
```
out_payload = stack_switch(store_context_ptr, load_context_ptr, in_payload)
```

This causes the following to happen:
1. The current execution context is saved: The current frame pointer, stack pointer and PC *after* the `stack_switch` instruction are stored at `store_context_ptr`. All other registers are marked as clobbered and thus spilled by regalloc as needed.
2. We load a new `(SP, FP, PC)` triple from `load_context_ptr`, indicating the stack/context to switch to. We assume that we are either switching to a stack that was either previously switched away from by another `stack_switch`, or it's a newly initialized stack.
3. The value `in_payload` is passed over to the other stack. In other words, if the instruction above switches from some stack A to another stack B, then the return value of the `stack_switch` instruction previously executed on B will be `in_payload`.
4. Execution continues on stack B.
5. If we ever switch back to stack A, the value `out_payload` above (i.e., the return value of the `stack_switch` executed when leaving stack `A`) is the payload argument passed to the corresponding switch.


A few additional notes:
- `store_context_ptr` and `load_context_ptr` can be seen as pointers to what is conceptually a three-element struct, containing SP, FP, PC.
- The pointers `store_context_ptr` and `load_context_ptr` are allowed to be equal. In particular, in steps 1 and 2 above, we ensure to actually load all required data from `load_context_ptr` before storing to `store_context_ptr`.
- As mentioned above, there are two cases in step 2: We either switch to code where a matching `stack_switch` was executed, or to a new stack
  + If we switch back to (right behind) a previous `stack_switch` instruction, then regalloc has spilled all subsequently needed SSA values for us, no need to manually restore any context besides SP, FP, PC.
  + If we are executing on a new stack, we assume that execution starts inside a stack-switch aware trampoline
- Payloads are currently hard-coded to be a single, word-sized value. That may seem arbitrary, but it's simply what's needed for our current implementation of Wasm stack switching on top of this CLIF instruction. It could later be extended to more general cases, if necessary.
- The stack switching implemented here is "one-shot": If you execute a `stack_switch` to switch from a stack A to a stack B, we can only switch back to A once (unless we subsequently execute another `stack_switch` on A again).
  This is different from `setjmp`/`longjmp`, where we may store the context once using `setjmp` and then return to it multiple times using `longjmp` without needing to call `setjmp` again.