### PR TITLE
Switch to new "user" stack maps and use `i32` for GC refs in Wasmtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,6 +3629,7 @@ dependencies = [
  "gimli",
  "log",
  "object",
+ "smallvec",
  "target-lexicon",
  "thiserror",
  "wasmparser",

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -70,24 +70,24 @@
 //! SP at function entry ----->  | return address            |
 //!                              +---------------------------+
 //! FP after prologue -------->  | FP (pushed by prologue)   |
-//!                              +---------------------------+   -----
-//!                              |          ...              |     |
-//!                              | clobbered callee-saves    |     |
-//! unwind-frame base -------->  | (pushed by prologue)      |     |
-//!                              +---------------------------+     |
-//!                              |          ...              |     |
-//!                              | spill slots               |     |
-//!                              | (accessed via SP)         |   active
-//!                              |          ...              |    size
-//!                              | stack slots               |     |
-//!                              | (accessed via SP)         |     |
-//!                              | (alloc'd by prologue)     |     |
-//!                              +---------------------------+     |
-//!                              | [alignment as needed]     |     |
-//!                              |          ...              |     |
-//!                              | args for largest call     |     |
-//! SP ----------------------->  | (alloc'd by prologue)     |     |
-//!                              +===========================+   -----
+//!                              +---------------------------+           -----
+//!                              |          ...              |             |
+//!                              | clobbered callee-saves    |             |
+//! unwind-frame base -------->  | (pushed by prologue)      |             |
+//!                              +---------------------------+   -----     |
+//!                              |          ...              |     |       |
+//!                              | spill slots               |     |       |
+//!                              | (accessed via SP)         |   fixed   active
+//!                              |          ...              |   frame    size
+//!                              | stack slots               |  storage    |
+//!                              | (accessed via SP)         |    size     |
+//!                              | (alloc'd by prologue)     |     |       |
+//!                              +---------------------------+   -----     |
+//!                              | [alignment as needed]     |             |
+//!                              |          ...              |             |
+//!                              | args for largest call     |             |
+//! SP ----------------------->  | (alloc'd by prologue)     |             |
+//!                              +===========================+           -----
 //!
 //!   (low address)
 //! ```
@@ -985,6 +985,11 @@ impl FrameLayout {
     /// setup or epilogue tear down).
     pub fn active_size(&self) -> u32 {
         self.outgoing_args_size + self.fixed_frame_storage_size + self.clobber_size
+    }
+
+    /// Get the offset from the SP to the sized stack slots area.
+    pub fn sp_to_sized_stack_slots(&self) -> u32 {
+        self.outgoing_args_size
     }
 }
 

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1688,7 +1688,7 @@ impl<I: VCodeInst> MachBuffer<I> {
         &mut self,
         emit_state: &I::State,
         return_addr: CodeOffset,
-        stack_map: ir::UserStackMap,
+        mut stack_map: ir::UserStackMap,
     ) {
         let span = emit_state.frame_layout().active_size();
         trace!("Adding user stack map @ {return_addr:#x} spanning {span} bytes: {stack_map:?}");
@@ -1702,6 +1702,7 @@ impl<I: VCodeInst> MachBuffer<I> {
             return_addr,
         );
 
+        stack_map.finalize(emit_state.frame_layout().sp_to_sized_stack_slots());
         self.user_stack_maps.push((return_addr, span, stack_map));
     }
 }
@@ -1762,6 +1763,16 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
     /// Take this buffer's stack map metadata.
     pub fn take_stack_maps(&mut self) -> SmallVec<[MachStackMap; 8]> {
         mem::take(&mut self.stack_maps)
+    }
+
+    /// Ge tthe user stack map metadata for this code.
+    pub fn user_stack_maps(&self) -> &[(CodeOffset, u32, ir::UserStackMap)] {
+        &self.user_stack_maps
+    }
+
+    /// Take this buffer's user strack map metadata.
+    pub fn take_user_stack_maps(&mut self) -> SmallVec<[(CodeOffset, u32, ir::UserStackMap); 8]> {
+        mem::take(&mut self.user_stack_maps)
     }
 
     /// Get the list of call sites for this code.

--- a/cranelift/filetests/filetests/isa/aarch64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/user_stack_maps.clif
@@ -52,7 +52,7 @@ block0:
 ;   mov x22, x0
 ;   mov x0, x24
 ;   bl 0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
 ;   mov x12, sp
 ;   mov x0, x19
 ;   str w0, [x12]
@@ -62,13 +62,13 @@ block0:
 ;   mov x22, x0
 ;   mov x0, x24
 ;   bl 0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
 ;   mov x15, sp
 ;   mov x0, x22
 ;   str w0, [x15]
 ;   mov x0, x19
 ;   bl 0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
 ;   mov x0, x22
 ;   bl 0
 ;   add sp, sp, #16
@@ -167,7 +167,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   str d1, [x1]
 ;   str q1, [sp, #112]
 ;   bl 0
-;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})] }
+;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
 ;   mov x0, x23
 ;   mov x1, x20
 ;   mov x2, x21

--- a/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
@@ -52,7 +52,7 @@ block0:
 ;   mv s2,a2
 ;   mv a0,s3
 ;   call userextname0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
 ;   mv a0,s1
 ;   sw a0,0(slot)
 ;   mv a0,s2
@@ -60,12 +60,12 @@ block0:
 ;   mv s2,a0
 ;   mv a0,s3
 ;   call userextname0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
 ;   mv a0,s2
 ;   sw a0,0(slot)
 ;   mv a0,s1
 ;   call userextname0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
 ;   mv a0,s2
 ;   call userextname0
 ;   ld s1,40(sp)
@@ -173,7 +173,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   fsd fa1,32(slot)
 ;   fmv.d fs0,fa1
 ;   call userextname0
-;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})] }
+;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
 ;   mv a2,s2
 ;   mv a4,s10
 ;   sw a2,0(a4)

--- a/cranelift/filetests/filetests/isa/s390x/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/user_stack_maps.clif
@@ -49,19 +49,19 @@ block0:
 ;   mvhi 0(%r4), 2
 ;   lgr %r2, %r11
 ;   brasl %r14, userextname0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
 ;   la %r2, 160(%r15)
 ;   mvhi 0(%r2), 1
 ;   la %r3, 164(%r15)
 ;   mvhi 0(%r3), 2
 ;   lgr %r2, %r11
 ;   brasl %r14, userextname0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
 ;   la %r5, 160(%r15)
 ;   mvhi 0(%r5), 2
 ;   lgr %r2, %r7
 ;   brasl %r14, userextname0
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
 ;   lgr %r2, %r9
 ;   brasl %r14, userextname0
 ;   lmg %r7, %r15, 232(%r15)
@@ -152,7 +152,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   std %f2, 0(%r3)
 ;   vst %v2, 272(%r15)
 ;   brasl %r14, userextname0
-;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})] }
+;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
 ;   lgr %r2, %r11
 ;   lgr %r3, %r9
 ;   lgr %r4, %r7

--- a/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
@@ -53,19 +53,19 @@ block0:
 ;   movl    $2, 0(%rdi)
 ;   movq    %r15, %rdi
 ;   call    User(userextname0)
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
 ;   lea     rsp(0 + virtual offset), %rcx
 ;   movl    $1, 0(%rcx)
 ;   lea     rsp(4 + virtual offset), %rdx
 ;   movl    $2, 0(%rdx)
 ;   movq    %r15, %rdi
 ;   call    User(userextname0)
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
 ;   lea     rsp(0 + virtual offset), %r9
 ;   movl    $2, 0(%r9)
 ;   movq    %rbx, %rdi
 ;   call    User(userextname0)
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})] }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
 ;   movq    %r13, %rdi
 ;   call    User(userextname0)
 ;   movq    16(%rsp), %rbx
@@ -169,7 +169,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   movsd   %xmm1, 0(%rsi)
 ;   movdqu  %xmm1, rsp(112 + virtual offset)
 ;   call    User(userextname0)
-;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})] }
+;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
 ;   movq    %r12, %rdx
 ;   movq    %r13, %r8
 ;   movl    %edx, 0(%r8)

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -438,6 +438,7 @@ impl<'a> FunctionBuilder<'a> {
     /// Panics if the variable's type is larger than 16 bytes or if this
     /// variable has not been declared yet.
     pub fn declare_var_needs_stack_map(&mut self, var: Variable) {
+        log::trace!("declare_var_needs_stack_map({var:?})");
         let ty = self.func_ctx.types[var];
         assert!(ty != types::INVALID);
         assert!(ty.bytes() <= 16);
@@ -560,6 +561,8 @@ impl<'a> FunctionBuilder<'a> {
     ///
     /// Panics if `val` is larger than 16 bytes.
     pub fn declare_value_needs_stack_map(&mut self, val: Value) {
+        log::trace!("declare_value_needs_stack_map({val:?})");
+
         // We rely on these properties in `insert_safepoint_spills`.
         let size = self.func.dfg.value_type(val).bytes();
         assert!(size <= 16);

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -180,10 +180,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                     flags.set_alias_region(Some(ir::AliasRegion::Table));
                     builder.ins().load(ty, flags, addr, offset)
                 }
-                GlobalVariable::Custom => environ.translate_custom_global_get(
-                    builder.cursor(),
-                    GlobalIndex::from_u32(*global_index),
-                )?,
+                GlobalVariable::Custom => environ
+                    .translate_custom_global_get(builder, GlobalIndex::from_u32(*global_index))?,
             };
             state.push1(val);
         }
@@ -207,7 +205,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 GlobalVariable::Custom => {
                     let val = state.pop1();
                     environ.translate_custom_global_set(
-                        builder.cursor(),
+                        builder,
                         GlobalIndex::from_u32(*global_index),
                         val,
                     )?;

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -64,7 +64,11 @@ pub fn block_with_params<PE: TargetEnvironment + ?Sized>(
             }
             wasmparser::ValType::Ref(rt) => {
                 let hty = environ.convert_heap_type(rt.heap_type());
-                builder.append_block_param(block, environ.reference_type(hty));
+                let (ty, needs_stack_map) = environ.reference_type(hty);
+                let val = builder.append_block_param(block, ty);
+                if needs_stack_map {
+                    builder.declare_value_needs_stack_map(val);
+                }
             }
             wasmparser::ValType::V128 => {
                 builder.append_block_param(block, ir::types::I8X16);

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -27,6 +27,7 @@ wasmparser = { workspace = true }
 target-lexicon = { workspace = true }
 gimli = { workspace = true, features = ['std'] }
 object = { workspace = true, features = ['write', 'std'] }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 cfg-if = { workspace = true }
 wasmtime-versioned-export-macros = { workspace = true }

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -4,14 +4,15 @@ use crate::DEBUG_ASSERT_TRAP_CODE;
 use crate::{array_call_signature, CompiledFunction, ModuleTextBuilder};
 use crate::{builder::LinkOptions, wasm_call_signature, BuiltinFunctionSignatures};
 use anyhow::{Context as _, Result};
+use cranelift_codegen::binemit::CodeOffset;
+use cranelift_codegen::bitset::CompoundBitSet;
 use cranelift_codegen::ir::{self, InstBuilder, MemFlags, UserExternalName, UserFuncName, Value};
 use cranelift_codegen::isa::{
     unwind::{UnwindInfo, UnwindInfoKind},
     OwnedTargetIsa, TargetIsa,
 };
 use cranelift_codegen::print_errors::pretty_error;
-use cranelift_codegen::Context;
-use cranelift_codegen::{CompiledCode, MachStackMap};
+use cranelift_codegen::{CompiledCode, Context};
 use cranelift_entity::PrimaryMap;
 use cranelift_frontend::FunctionBuilder;
 use cranelift_wasm::{DefinedFuncIndex, FuncTranslator, WasmFuncType, WasmValType};
@@ -147,8 +148,14 @@ impl wasmtime_environ::Compiler for Compiler {
             context.func.collect_debug_info();
         }
 
-        let mut func_env =
-            FuncEnvironment::new(isa, translation, types, &self.tunables, self.wmemcheck);
+        let mut func_env = FuncEnvironment::new(
+            isa,
+            translation,
+            types,
+            &self.tunables,
+            self.wmemcheck,
+            wasm_func_ty,
+        );
 
         // The `stack_limit` global value below is the implementation of stack
         // overflow checks in Wasmtime.
@@ -866,7 +873,7 @@ impl FunctionCompiler<'_> {
         }
 
         let stack_maps =
-            mach_stack_maps_to_stack_maps(compiled_code.buffer.take_stack_maps().into_iter());
+            clif_to_env_stack_maps(compiled_code.buffer.take_user_stack_maps().into_iter());
         compiled_function
             .set_sized_stack_slots(std::mem::take(&mut context.func.sized_stack_slots));
         self.compiler.contexts.lock().unwrap().push(self.cx);
@@ -881,23 +888,24 @@ impl FunctionCompiler<'_> {
     }
 }
 
-fn mach_stack_maps_to_stack_maps(
-    mach_stack_maps: impl ExactSizeIterator<Item = MachStackMap>,
+/// Convert from Cranelift's representation of a stack map to Wasmtime's
+/// compiler-agnostic representation.
+fn clif_to_env_stack_maps(
+    clif_stack_maps: impl ExactSizeIterator<Item = (CodeOffset, u32, ir::UserStackMap)>,
 ) -> Vec<StackMapInformation> {
-    // This is converting from Cranelift's representation of a stack map to
-    // Wasmtime's representation. They happen to align today but that may
-    // not always be true in the future.
-    let mut stack_maps = Vec::with_capacity(mach_stack_maps.len());
-    for MachStackMap {
-        offset_end,
-        stack_map,
-        ..
-    } in mach_stack_maps
-    {
-        let mapped_words = stack_map.mapped_words();
-        let stack_map = wasmtime_environ::StackMap::new(mapped_words, stack_map.into_bitset());
+    let mut stack_maps = Vec::with_capacity(clif_stack_maps.len());
+    for (code_offset, mapped_bytes, stack_map) in clif_stack_maps {
+        let mut bitset = CompoundBitSet::new();
+        for (ty, offset) in stack_map.entries() {
+            assert_eq!(ty, ir::types::I32);
+            bitset.insert(usize::try_from(offset).unwrap());
+        }
+        if bitset.is_empty() {
+            continue;
+        }
+        let stack_map = wasmtime_environ::StackMap::new(mapped_bytes, bitset);
         stack_maps.push(StackMapInformation {
-            code_offset: offset_end,
+            code_offset,
             stack_map,
         });
     }

--- a/crates/cranelift/src/gc.rs
+++ b/crates/cranelift/src/gc.rs
@@ -25,14 +25,11 @@ pub fn gc_compiler(func_env: &FuncEnvironment<'_>) -> Box<dyn GcCompiler> {
     imp::gc_compiler(func_env)
 }
 
-/// Load a `*mut VMGcRef` into a virtual register of the function environment's
-/// reference type, aka `r{32,64}`, without any GC barriers.
+/// Load a `*mut VMGcRef` into a virtual register, without any GC barriers.
 ///
-/// Note that a `VMGcRef` is always 4-bytes large, even when targeting
-/// 64-bit architectures.
-///
-/// Because Cranelift doesn't support using `r32` with 64-bit targets, this
-/// means that the loaded value may need to be extended.
+/// The resulting value is an instance of the function environment's type for
+/// GC-managed references, aka `i32`. Note that a `VMGcRef` is always 4-bytes
+/// large, even when targeting 64-bit architectures.
 pub fn unbarriered_load_gc_ref(
     func_env: &FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,
@@ -47,15 +44,9 @@ pub fn unbarriered_load_gc_ref(
 ///
 /// `dst` is a `*mut VMGcRef`.
 ///
-/// `gc_ref` is an instance of the function environment's reference type, aka
-/// `r{32,64}`.
-///
-/// Note that a `VMGcRef` is always 4-bytes large, even when targeting
-/// 64-bit architectures.
-///
-/// Because Cranelift doesn't support using `r32` with 64-bit targets, we keep
-/// `VMGcRef`s on the Wasm stack as `r64`s with the top half unset, and this
-/// means that `value` may need to be truncated.
+/// `gc_ref` is an instance of the function environment's type for GC-managed
+/// references, aka `i32`. Note that a `VMGcRef` is always 4-bytes large, even
+/// when targeting 64-bit architectures.
 pub fn unbarriered_store_gc_ref(
     func_env: &FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,
@@ -144,7 +135,7 @@ pub trait GcCompiler {
     /// * `flags`: The memory flags that should be used when accessing `src`.
     ///
     /// This method should return the cloned GC reference (an instance of
-    /// `VMGcRef`) of type `r64`.
+    /// `VMGcRef`) of type `i32`.
     fn translate_read_gc_reference(
         &mut self,
         func_env: &mut FuncEnvironment<'_>,
@@ -183,7 +174,7 @@ pub trait GcCompiler {
     ///   itself or a `*mut VMGcHeader`!
     ///
     /// * `new_val`: The new value that should be written into `dst`. This is a
-    ///   `VMGcRef` of Cranelift type `r64`; not a `*mut VMGcRef`.
+    ///   `VMGcRef` of Cranelift type `i32`; not a `*mut VMGcRef`.
     ///
     /// * `flags`: The memory flags that should be used when accessing `dst`.
     fn translate_write_gc_reference(

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -190,11 +190,7 @@ fn wasm_call_signature(
 fn reference_type(wasm_ht: WasmHeapType, pointer_type: ir::Type) -> ir::Type {
     match wasm_ht.top() {
         WasmHeapTopType::Func => pointer_type,
-        WasmHeapTopType::Any | WasmHeapTopType::Extern => match pointer_type {
-            ir::types::I32 => ir::types::R32,
-            ir::types::I64 => ir::types::R64,
-            _ => panic!("unsupported pointer type"),
-        },
+        WasmHeapTopType::Any | WasmHeapTopType::Extern => ir::types::I32,
     }
 }
 
@@ -354,13 +350,10 @@ impl BuiltinFunctionSignatures {
     fn new(isa: &dyn TargetIsa) -> Self {
         Self {
             pointer_type: isa.pointer_type(),
-            #[cfg(feature = "gc")]
-            reference_type: match isa.pointer_type() {
-                ir::types::I32 => ir::types::R32,
-                ir::types::I64 => ir::types::R64,
-                _ => panic!(),
-            },
             call_conv: CallConv::triple_default(isa.triple()),
+
+            #[cfg(feature = "gc")]
+            reference_type: ir::types::I32,
         }
     }
 

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -67,11 +67,11 @@ macro_rules! foreach_builtin_function {
             update_mem_size(vmctx: vmctx, num_bytes: i32);
 
             // Drop a non-stack GC reference (eg an overwritten table entry)
-            // once it will no longer be used again. (Note: `val` is not a
+            // once it will no longer be used again. (Note: `val` is not of type
             // `reference` because it needn't appear in any stack maps, as it
             // must not be live after this call.)
             #[cfg(feature = "gc")]
-            drop_gc_ref(vmctx: vmctx, val: pointer);
+            drop_gc_ref(vmctx: vmctx, val: i32);
 
             // Do a GC, treating the optional `root` as a GC root and returning
             // the updated `root` (so that, in the case of moving collectors,

--- a/crates/environ/src/stack_map.rs
+++ b/crates/environ/src/stack_map.rs
@@ -9,23 +9,52 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StackMap {
     bits: CompoundBitSet,
-    mapped_words: u32,
+    frame_size: u32,
 }
 
 impl StackMap {
     /// Creates a new `StackMap`, typically from a preexisting
     /// `binemit::StackMap`.
-    pub fn new(mapped_words: u32, bits: CompoundBitSet) -> StackMap {
-        StackMap { bits, mapped_words }
+    pub fn new(frame_size: u32, bits: CompoundBitSet) -> StackMap {
+        StackMap { bits, frame_size }
     }
 
-    /// Returns a specified bit.
-    pub fn get_bit(&self, bit_index: usize) -> bool {
-        self.bits.contains(bit_index)
+    /// Returns the byte size of this stack map's frame.
+    pub fn frame_size(&self) -> u32 {
+        self.frame_size
     }
 
-    /// Returns the number of words represented by this stack map.
-    pub fn mapped_words(&self) -> u32 {
-        self.mapped_words
+    /// Given a frame pointer, get the stack pointer.
+    ///
+    /// # Safety
+    ///
+    /// The `fp` must be the frame pointer at the code offset that this stack
+    /// map is associated with.
+    pub unsafe fn sp(&self, fp: *mut usize) -> *mut usize {
+        let frame_size = usize::try_from(self.frame_size).unwrap();
+        fp.byte_sub(frame_size)
+    }
+
+    /// Given the stack pointer, get a reference to each live GC reference in
+    /// the stack frame.
+    ///
+    /// # Safety
+    ///
+    /// The `sp` must be the stack pointer at the code offset that this stack
+    /// map is associated with.
+    pub unsafe fn live_gc_refs(&self, sp: *mut usize) -> impl Iterator<Item = *mut u32> + '_ {
+        self.bits.iter().map(move |i| {
+            log::trace!("Live GC ref in frame at frame offset {:#x}", i);
+            let ptr_to_gc_ref = sp.byte_add(i);
+
+            // Assert that the pointer is inside this stack map's frame.
+            assert!({
+                let delta = ptr_to_gc_ref as usize - sp as usize;
+                let frame_size = usize::try_from(self.frame_size).unwrap();
+                delta < frame_size
+            });
+
+            ptr_to_gc_ref.cast::<u32>()
+        })
     }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -744,6 +744,11 @@ pub fn table_ops(
 
         {
             let mut scope = RootScope::new(&mut store);
+
+            log::info!(
+                "table_ops: begin allocating {} externref arguments",
+                ops.num_globals
+            );
             let args: Vec<_> = (0..ops.num_params)
                 .map(|_| {
                     Ok(Val::ExternRef(Some(ExternRef::new(
@@ -752,11 +757,16 @@ pub fn table_ops(
                     )?)))
                 })
                 .collect::<Result<_>>()?;
+            log::info!(
+                "table_ops: end allocating {} externref arguments",
+                ops.num_globals
+            );
 
             // The generated function should always return a trap. The only two
             // valid traps are table-out-of-bounds which happens through `table.get`
             // and `table.set` generated or an out-of-fuel trap. Otherwise any other
             // error is unexpected and should fail fuzzing.
+            log::info!("table_ops: calling into Wasm `run` function");
             let trap = run
                 .call(&mut scope, &args, &mut [])
                 .unwrap_err()

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -224,7 +224,7 @@ impl Global {
                 let gc_ref = NonNull::from(gc_ref);
                 let gc_ref = SendSyncPtr::new(gc_ref);
                 unsafe {
-                    gc_roots_list.add_root(gc_ref);
+                    gc_roots_list.add_root(gc_ref, "Wasm global");
                 }
             }
         }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -388,7 +388,7 @@ impl Table {
                 let gc_ref = NonNull::from(gc_ref);
                 let gc_ref = SendSyncPtr::new(gc_ref);
                 unsafe {
-                    gc_roots_list.add_root(gc_ref);
+                    gc_roots_list.add_root(gc_ref, "Wasm table element");
                 }
             }
         }

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -381,7 +381,7 @@ impl RootSet {
         log::trace!("Begin trace user LIFO roots");
         for root in &mut self.lifo_roots {
             unsafe {
-                gc_roots_list.add_root((&mut root.gc_ref).into());
+                gc_roots_list.add_root((&mut root.gc_ref).into(), "user LIFO root");
             }
         }
         log::trace!("End trace user LIFO roots");
@@ -389,7 +389,7 @@ impl RootSet {
         log::trace!("Begin trace user manual roots");
         for (_id, root) in self.manually_rooted.iter_mut() {
             unsafe {
-                gc_roots_list.add_root(root.into());
+                gc_roots_list.add_root(root.into(), "user manual root");
             }
         }
         log::trace!("End trace user manual roots");

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -128,6 +128,7 @@ impl GcStore {
     /// Hook to call whenever a GC reference is about to be exposed to Wasm.
     pub fn expose_gc_ref_to_wasm(&mut self, gc_ref: VMGcRef) {
         if !gc_ref.is_i31() {
+            log::trace!("exposing GC ref to Wasm: {gc_ref:p}");
             self.gc_heap.expose_gc_ref_to_wasm(gc_ref);
         }
     }

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -233,22 +233,6 @@ impl VMGcRef {
         VMGcRef::from_raw_non_zero_u32(non_zero)
     }
 
-    /// Create a new `VMGcRef` from a raw `r64` value from Cranelift.
-    ///
-    /// Returns an error if `raw` cannot be losslessly converted from a `u64`
-    /// into a `u32`.
-    ///
-    /// Returns `Ok(None)` if `raw` is zero (aka a "null" `VMGcRef`).
-    ///
-    /// This method only exists because we can't currently use Cranelift's `r32`
-    /// type on 64-bit platforms. We should instead have a `from_r32` method.
-    pub fn from_r64(raw: u64) -> Result<Option<Self>> {
-        let raw = u32::try_from(raw & (u32::MAX as u64))
-            .err2anyhow()
-            .with_context(|| format!("invalid r64: {raw:#x} cannot be converted into a u32"))?;
-        Ok(Self::from_raw_u32(raw))
-    }
-
     /// Copy this `VMGcRef` without running the GC's clone barriers.
     ///
     /// Prefer calling `clone(&mut GcStore)` instead! This is mostly an internal
@@ -276,24 +260,6 @@ impl VMGcRef {
     /// actually a reference to a GC object or is an `i31ref`.
     pub fn as_raw_u32(&self) -> u32 {
         self.0.get()
-    }
-
-    /// Get this GC reference as a raw `r64` value for passing to Cranelift.
-    ///
-    /// This method only exists because we can't currently use Cranelift's `r32`
-    /// type on 64-bit platforms. We should instead be able to pass `VMGcRef`
-    /// into compiled code directly.
-    pub fn into_r64(self) -> u64 {
-        u64::from(self.0.get())
-    }
-
-    /// Get this GC reference as a raw `r64` value for passing to Cranelift.
-    ///
-    /// This method only exists because we can't currently use Cranelift's `r32`
-    /// type on 64-bit platforms. We should instead be able to pass `VMGcRef`
-    /// into compiled code directly.
-    pub fn as_r64(&self) -> u64 {
-        u64::from(self.0.get())
     }
 
     /// Creates a typed GC reference from `self`, checking that `self` actually

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -732,7 +732,7 @@ macro_rules! define_builtin_array {
 
     (@ty i32) => (u32);
     (@ty i64) => (u64);
-    (@ty reference) => (*mut u8);
+    (@ty reference) => (u32);
     (@ty pointer) => (*mut u8);
     (@ty vmctx) => (*mut VMContext);
 }

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -12,33 +12,33 @@
 	)
 )
 
-;; function u0:0(i64 vmctx, i64) -> r64 tail {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0019                               v3 = null.r64 
-;; @001b                               jump block1(v3)
+;; @0019                               v3 = iconst.i32 0
+;; @001b                               jump block1(v3)  ; v3 = 0
 ;;
-;;                                 block1(v2: r64):
+;;                                 block1(v2: i32):
 ;; @001b                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> r64 tail {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0020                               v4 = null.r64 
-;; @0022                               jump block2(v4)
+;; @0020                               v4 = iconst.i32 0
+;; @0022                               jump block2(v4)  ; v4 = 0
 ;;
-;;                                 block2(v3: r64):
+;;                                 block2(v3: i32):
 ;; @0023                               jump block1(v3)
 ;;
-;;                                 block1(v2: r64):
+;;                                 block1(v2: i32):
 ;; @0023                               return v2
 ;; }

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -13,12 +13,13 @@
   (global (export "funcref-imported") funcref (ref.func $imported))
   (global (export "funcref-local") funcref (ref.func $local)))
 
-;; function u0:1(i64 vmctx, i64) -> r64, r64, i64, i64 tail {
+;; function u0:1(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext) -> r64 system_v
+;;     sig0 = (i64 vmctx, i32 uext) -> i32 system_v
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
@@ -26,15 +27,17 @@
 ;; @008f                               v6 = global_value.i64 gv3
 ;; @008f                               v7 = iconst.i32 0
 ;; @008f                               v8 = call fn0(v6, v7)  ; v7 = 0
+;;                                     stack_store v8, ss0
 ;; @0091                               v9 = global_value.i64 gv3
 ;; @0091                               v10 = iconst.i32 1
-;; @0091                               v11 = call fn0(v9, v10)  ; v10 = 1
+;; @0091                               v11 = call fn0(v9, v10), stack_map=[i32 @ ss0+0]  ; v10 = 1
 ;; @0093                               v12 = global_value.i64 gv3
 ;; @0093                               v13 = load.i64 notrap aligned table v12+144
 ;; @0095                               v14 = global_value.i64 gv3
 ;; @0095                               v15 = load.i64 notrap aligned table v14+160
-;; @0097                               jump block1(v8, v11, v13, v15)
+;;                                     v16 = stack_load.i32 ss0
+;; @0097                               jump block1(v16, v11, v13, v15)
 ;;
-;;                                 block1(v2: r64, v3: r64, v4: i64, v5: i64):
+;;                                 block1(v2: i32, v3: i32, v4: i64, v5: i64):
 ;; @0097                               return v2, v3, v4, v5
 ;; }

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -37,35 +37,35 @@
 ;; @002a                               return v2
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> r64 tail {
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @002d                               v3 = null.r64 
-;; @002f                               v4 = null.r64 
+;; @002d                               v3 = iconst.i32 0
+;; @002f                               v4 = iconst.i32 0
 ;; @0031                               v5 = iconst.i32 1
-;; @0033                               v6 = select v5, v3, v4  ; v5 = 1
+;; @0033                               v6 = select v5, v3, v4  ; v5 = 1, v3 = 0, v4 = 0
 ;; @0036                               jump block1(v6)
 ;;
-;;                                 block1(v2: r64):
+;;                                 block1(v2: i32):
 ;; @0036                               return v2
 ;; }
 ;;
-;; function u0:2(i64 vmctx, i64, r64) -> r64 tail {
+;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     stack_limit = gv2
 ;;
-;;                                 block0(v0: i64, v1: i64, v2: r64):
-;; @0039                               v4 = null.r64 
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0039                               v4 = iconst.i32 0
 ;; @003d                               v5 = iconst.i32 1
-;; @003f                               v6 = select v5, v4, v2  ; v5 = 1
+;; @003f                               v6 = select v5, v4, v2  ; v5 = 1, v4 = 0
 ;; @0042                               jump block1(v6)
 ;;
-;;                                 block1(v3: r64):
+;;                                 block1(v3: i32):
 ;; @0042                               return v3
 ;; }

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -15,13 +15,14 @@
     local.get 0
     table.get 0))
 
-;; function u0:0(i64 vmctx, i64) -> r64 tail {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, r64) -> r64 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 system_v
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -31,83 +32,97 @@
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0054                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v47 = iconst.i64 2
-;; @0054                               v8 = ishl v6, v47  ; v47 = 2
+;;                                     v51 = iconst.i64 2
+;; @0054                               v8 = ishl v6, v51  ; v51 = 2
 ;; @0054                               v9 = iadd v7, v8
 ;; @0054                               v10 = iconst.i64 0
 ;; @0054                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0054                               v12 = load.i32 table_oob aligned table v11
-;; @0054                               v13 = uextend.i64 v12
-;; @0054                               v14 = bitcast.r64 v13
-;; @0054                               v15 = is_null v14
-;; @0054                               brif v15, block5, block2
+;;                                     v52 = stack_addr.i64 ss0
+;;                                     store notrap v12, v52
+;;                                     v53 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v53
+;;                                     v54 = iconst.i32 0
+;; @0054                               v13 = icmp eq v49, v54  ; v54 = 0
+;; @0054                               brif v13, block5, block2
 ;;
 ;;                                 block2:
-;; @0054                               v17 = load.i64 notrap aligned v0+56
-;; @0054                               v18 = load.i64 notrap aligned v17
-;; @0054                               v19 = load.i64 notrap aligned v17+8
-;; @0054                               v20 = icmp eq v18, v19
-;; @0054                               brif v20, block3, block4
+;; @0054                               v15 = load.i64 notrap aligned v0+56
+;; @0054                               v16 = load.i64 notrap aligned v15
+;; @0054                               v17 = load.i64 notrap aligned v15+8
+;; @0054                               v18 = icmp eq v16, v17
+;; @0054                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @0054                               v22 = load.i64 notrap aligned readonly v0+40
-;; @0054                               v23 = load.i64 notrap aligned readonly v0+48
-;; @0054                               v24 = bitcast.i64 v14
+;; @0054                               v20 = load.i64 notrap aligned readonly v0+40
+;; @0054                               v21 = load.i64 notrap aligned readonly v0+48
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v55
+;; @0054                               v22 = uextend.i64 v48
+;; @0054                               v23 = iconst.i64 8
+;; @0054                               v24 = uadd_overflow_trap v22, v23, user65535  ; v23 = 8
 ;; @0054                               v25 = iconst.i64 8
 ;; @0054                               v26 = uadd_overflow_trap v24, v25, user65535  ; v25 = 8
-;; @0054                               v27 = iconst.i64 8
-;; @0054                               v28 = uadd_overflow_trap v26, v27, user65535  ; v27 = 8
-;; @0054                               v29 = icmp ult v28, v23
-;; @0054                               brif v29, block7, block6
+;; @0054                               v27 = icmp ult v26, v21
+;; @0054                               brif v27, block7, block6
 ;;
 ;;                                 block6 cold:
 ;; @0054                               trap user65535
 ;;
 ;;                                 block7:
-;; @0054                               v30 = iadd.i64 v22, v26
-;; @0054                               v31 = load.i64 notrap aligned v30
-;;                                     v48 = iconst.i64 1
-;; @0054                               v32 = iadd v31, v48  ; v48 = 1
-;; @0054                               v34 = load.i64 notrap aligned readonly v0+40
-;; @0054                               v35 = load.i64 notrap aligned readonly v0+48
-;; @0054                               v36 = bitcast.i64 v14
+;; @0054                               v28 = iadd.i64 v20, v24
+;; @0054                               v29 = load.i64 notrap aligned v28
+;;                                     v56 = iconst.i64 1
+;; @0054                               v30 = iadd v29, v56  ; v56 = 1
+;; @0054                               v32 = load.i64 notrap aligned readonly v0+40
+;; @0054                               v33 = load.i64 notrap aligned readonly v0+48
+;;                                     v57 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v57
+;; @0054                               v34 = uextend.i64 v47
+;; @0054                               v35 = iconst.i64 8
+;; @0054                               v36 = uadd_overflow_trap v34, v35, user65535  ; v35 = 8
 ;; @0054                               v37 = iconst.i64 8
 ;; @0054                               v38 = uadd_overflow_trap v36, v37, user65535  ; v37 = 8
-;; @0054                               v39 = iconst.i64 8
-;; @0054                               v40 = uadd_overflow_trap v38, v39, user65535  ; v39 = 8
-;; @0054                               v41 = icmp ult v40, v35
-;; @0054                               brif v41, block9, block8
+;; @0054                               v39 = icmp ult v38, v33
+;; @0054                               brif v39, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @0054                               trap user65535
 ;;
 ;;                                 block9:
-;; @0054                               v42 = iadd.i64 v34, v38
-;; @0054                               store.i64 notrap aligned v32, v42
-;; @0054                               store.r64 notrap aligned v14, v18
-;;                                     v49 = iconst.i64 8
-;; @0054                               v43 = iadd.i64 v18, v49  ; v49 = 8
-;; @0054                               store notrap aligned v43, v17
+;; @0054                               v40 = iadd.i64 v32, v36
+;; @0054                               store.i64 notrap aligned v30, v40
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     v46 = load.i32 notrap v58
+;; @0054                               store notrap aligned v46, v16
+;;                                     v59 = iconst.i64 4
+;; @0054                               v41 = iadd.i64 v16, v59  ; v59 = 4
+;; @0054                               store notrap aligned v41, v15
 ;; @0054                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @0054                               v45 = call fn0(v0, v14)
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     v45 = load.i32 notrap v60
+;; @0054                               v43 = call fn0(v0, v45), stack_map=[i32 @ ss0+0]
 ;; @0054                               jump block5
 ;;
 ;;                                 block5:
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v44 = load.i32 notrap v61
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v14
+;; @0056                               return v44
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> r64 tail {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, r64) -> r64 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 system_v
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -116,72 +131,85 @@
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v47 = iconst.i64 2
-;; @005b                               v8 = ishl v6, v47  ; v47 = 2
+;;                                     v51 = iconst.i64 2
+;; @005b                               v8 = ishl v6, v51  ; v51 = 2
 ;; @005b                               v9 = iadd v7, v8
 ;; @005b                               v10 = iconst.i64 0
 ;; @005b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005b                               v12 = load.i32 table_oob aligned table v11
-;; @005b                               v13 = uextend.i64 v12
-;; @005b                               v14 = bitcast.r64 v13
-;; @005b                               v15 = is_null v14
-;; @005b                               brif v15, block5, block2
+;;                                     v52 = stack_addr.i64 ss0
+;;                                     store notrap v12, v52
+;;                                     v53 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v53
+;;                                     v54 = iconst.i32 0
+;; @005b                               v13 = icmp eq v49, v54  ; v54 = 0
+;; @005b                               brif v13, block5, block2
 ;;
 ;;                                 block2:
-;; @005b                               v17 = load.i64 notrap aligned v0+56
-;; @005b                               v18 = load.i64 notrap aligned v17
-;; @005b                               v19 = load.i64 notrap aligned v17+8
-;; @005b                               v20 = icmp eq v18, v19
-;; @005b                               brif v20, block3, block4
+;; @005b                               v15 = load.i64 notrap aligned v0+56
+;; @005b                               v16 = load.i64 notrap aligned v15
+;; @005b                               v17 = load.i64 notrap aligned v15+8
+;; @005b                               v18 = icmp eq v16, v17
+;; @005b                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @005b                               v22 = load.i64 notrap aligned readonly v0+40
-;; @005b                               v23 = load.i64 notrap aligned readonly v0+48
-;; @005b                               v24 = bitcast.i64 v14
+;; @005b                               v20 = load.i64 notrap aligned readonly v0+40
+;; @005b                               v21 = load.i64 notrap aligned readonly v0+48
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v55
+;; @005b                               v22 = uextend.i64 v48
+;; @005b                               v23 = iconst.i64 8
+;; @005b                               v24 = uadd_overflow_trap v22, v23, user65535  ; v23 = 8
 ;; @005b                               v25 = iconst.i64 8
 ;; @005b                               v26 = uadd_overflow_trap v24, v25, user65535  ; v25 = 8
-;; @005b                               v27 = iconst.i64 8
-;; @005b                               v28 = uadd_overflow_trap v26, v27, user65535  ; v27 = 8
-;; @005b                               v29 = icmp ult v28, v23
-;; @005b                               brif v29, block7, block6
+;; @005b                               v27 = icmp ult v26, v21
+;; @005b                               brif v27, block7, block6
 ;;
 ;;                                 block6 cold:
 ;; @005b                               trap user65535
 ;;
 ;;                                 block7:
-;; @005b                               v30 = iadd.i64 v22, v26
-;; @005b                               v31 = load.i64 notrap aligned v30
-;;                                     v48 = iconst.i64 1
-;; @005b                               v32 = iadd v31, v48  ; v48 = 1
-;; @005b                               v34 = load.i64 notrap aligned readonly v0+40
-;; @005b                               v35 = load.i64 notrap aligned readonly v0+48
-;; @005b                               v36 = bitcast.i64 v14
+;; @005b                               v28 = iadd.i64 v20, v24
+;; @005b                               v29 = load.i64 notrap aligned v28
+;;                                     v56 = iconst.i64 1
+;; @005b                               v30 = iadd v29, v56  ; v56 = 1
+;; @005b                               v32 = load.i64 notrap aligned readonly v0+40
+;; @005b                               v33 = load.i64 notrap aligned readonly v0+48
+;;                                     v57 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v57
+;; @005b                               v34 = uextend.i64 v47
+;; @005b                               v35 = iconst.i64 8
+;; @005b                               v36 = uadd_overflow_trap v34, v35, user65535  ; v35 = 8
 ;; @005b                               v37 = iconst.i64 8
 ;; @005b                               v38 = uadd_overflow_trap v36, v37, user65535  ; v37 = 8
-;; @005b                               v39 = iconst.i64 8
-;; @005b                               v40 = uadd_overflow_trap v38, v39, user65535  ; v39 = 8
-;; @005b                               v41 = icmp ult v40, v35
-;; @005b                               brif v41, block9, block8
+;; @005b                               v39 = icmp ult v38, v33
+;; @005b                               brif v39, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @005b                               trap user65535
 ;;
 ;;                                 block9:
-;; @005b                               v42 = iadd.i64 v34, v38
-;; @005b                               store.i64 notrap aligned v32, v42
-;; @005b                               store.r64 notrap aligned v14, v18
-;;                                     v49 = iconst.i64 8
-;; @005b                               v43 = iadd.i64 v18, v49  ; v49 = 8
-;; @005b                               store notrap aligned v43, v17
+;; @005b                               v40 = iadd.i64 v32, v36
+;; @005b                               store.i64 notrap aligned v30, v40
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     v46 = load.i32 notrap v58
+;; @005b                               store notrap aligned v46, v16
+;;                                     v59 = iconst.i64 4
+;; @005b                               v41 = iadd.i64 v16, v59  ; v59 = 4
+;; @005b                               store notrap aligned v41, v15
 ;; @005b                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @005b                               v45 = call fn0(v0, v14)
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     v45 = load.i32 notrap v60
+;; @005b                               v43 = call fn0(v0, v45), stack_map=[i32 @ ss0+0]
 ;; @005b                               jump block5
 ;;
 ;;                                 block5:
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v44 = load.i32 notrap v61
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:
-;; @005d                               return v14
+;; @005d                               return v44
 ;; }

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -14,14 +14,15 @@
     local.get 0
     table.get 0))
 
-;; function u0:0(i64 vmctx, i64) -> r64 tail {
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i32 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, r64) -> r64 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 system_v
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -31,84 +32,98 @@
 ;; @0053                               v5 = icmp uge v3, v4  ; v3 = 0
 ;; @0053                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0053                               v7 = load.i64 notrap aligned v0+88
-;;                                     v48 = iconst.i64 2
-;; @0053                               v8 = ishl v6, v48  ; v48 = 2
+;;                                     v52 = iconst.i64 2
+;; @0053                               v8 = ishl v6, v52  ; v52 = 2
 ;; @0053                               v9 = iadd v7, v8
 ;; @0053                               v10 = iconst.i64 0
 ;; @0053                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0053                               v12 = load.i32 table_oob aligned table v11
-;; @0053                               v13 = uextend.i64 v12
-;; @0053                               v14 = bitcast.r64 v13
-;; @0053                               v15 = is_null v14
-;; @0053                               brif v15, block5, block2
+;;                                     v53 = stack_addr.i64 ss0
+;;                                     store notrap v12, v53
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v54
+;;                                     v55 = iconst.i32 0
+;; @0053                               v13 = icmp eq v49, v55  ; v55 = 0
+;; @0053                               brif v13, block5, block2
 ;;
 ;;                                 block2:
-;; @0053                               v17 = load.i64 notrap aligned v0+56
-;; @0053                               v18 = load.i64 notrap aligned v17
-;; @0053                               v19 = load.i64 notrap aligned v17+8
-;; @0053                               v20 = icmp eq v18, v19
-;; @0053                               brif v20, block3, block4
+;; @0053                               v15 = load.i64 notrap aligned v0+56
+;; @0053                               v16 = load.i64 notrap aligned v15
+;; @0053                               v17 = load.i64 notrap aligned v15+8
+;; @0053                               v18 = icmp eq v16, v17
+;; @0053                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @0053                               v22 = load.i64 notrap aligned readonly v0+40
-;; @0053                               v23 = load.i64 notrap aligned readonly v0+48
-;; @0053                               v24 = bitcast.i64 v14
+;; @0053                               v20 = load.i64 notrap aligned readonly v0+40
+;; @0053                               v21 = load.i64 notrap aligned readonly v0+48
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v56
+;; @0053                               v22 = uextend.i64 v48
+;; @0053                               v23 = iconst.i64 8
+;; @0053                               v24 = uadd_overflow_trap v22, v23, user65535  ; v23 = 8
 ;; @0053                               v25 = iconst.i64 8
 ;; @0053                               v26 = uadd_overflow_trap v24, v25, user65535  ; v25 = 8
-;; @0053                               v27 = iconst.i64 8
-;; @0053                               v28 = uadd_overflow_trap v26, v27, user65535  ; v27 = 8
-;; @0053                               v29 = icmp ult v28, v23
-;; @0053                               brif v29, block7, block6
+;; @0053                               v27 = icmp ult v26, v21
+;; @0053                               brif v27, block7, block6
 ;;
 ;;                                 block6 cold:
 ;; @0053                               trap user65535
 ;;
 ;;                                 block7:
-;; @0053                               v30 = iadd.i64 v22, v26
-;; @0053                               v31 = load.i64 notrap aligned v30
-;;                                     v49 = iconst.i64 1
-;; @0053                               v32 = iadd v31, v49  ; v49 = 1
-;; @0053                               v34 = load.i64 notrap aligned readonly v0+40
-;; @0053                               v35 = load.i64 notrap aligned readonly v0+48
-;; @0053                               v36 = bitcast.i64 v14
+;; @0053                               v28 = iadd.i64 v20, v24
+;; @0053                               v29 = load.i64 notrap aligned v28
+;;                                     v57 = iconst.i64 1
+;; @0053                               v30 = iadd v29, v57  ; v57 = 1
+;; @0053                               v32 = load.i64 notrap aligned readonly v0+40
+;; @0053                               v33 = load.i64 notrap aligned readonly v0+48
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v58
+;; @0053                               v34 = uextend.i64 v47
+;; @0053                               v35 = iconst.i64 8
+;; @0053                               v36 = uadd_overflow_trap v34, v35, user65535  ; v35 = 8
 ;; @0053                               v37 = iconst.i64 8
 ;; @0053                               v38 = uadd_overflow_trap v36, v37, user65535  ; v37 = 8
-;; @0053                               v39 = iconst.i64 8
-;; @0053                               v40 = uadd_overflow_trap v38, v39, user65535  ; v39 = 8
-;; @0053                               v41 = icmp ult v40, v35
-;; @0053                               brif v41, block9, block8
+;; @0053                               v39 = icmp ult v38, v33
+;; @0053                               brif v39, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @0053                               trap user65535
 ;;
 ;;                                 block9:
-;; @0053                               v42 = iadd.i64 v34, v38
-;; @0053                               store.i64 notrap aligned v32, v42
-;; @0053                               store.r64 notrap aligned v14, v18
-;;                                     v50 = iconst.i64 8
-;; @0053                               v43 = iadd.i64 v18, v50  ; v50 = 8
-;; @0053                               store notrap aligned v43, v17
+;; @0053                               v40 = iadd.i64 v32, v36
+;; @0053                               store.i64 notrap aligned v30, v40
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v46 = load.i32 notrap v59
+;; @0053                               store notrap aligned v46, v16
+;;                                     v60 = iconst.i64 4
+;; @0053                               v41 = iadd.i64 v16, v60  ; v60 = 4
+;; @0053                               store notrap aligned v41, v15
 ;; @0053                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @0053                               v45 = call fn0(v0, v14)
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v45 = load.i32 notrap v61
+;; @0053                               v43 = call fn0(v0, v45), stack_map=[i32 @ ss0+0]
 ;; @0053                               jump block5
 ;;
 ;;                                 block5:
+;;                                     v62 = stack_addr.i64 ss0
+;;                                     v44 = load.i32 notrap v62
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
-;; @0055                               return v14
+;; @0055                               return v44
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> r64 tail {
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i32 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, r64) -> r64 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 system_v
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -117,72 +132,85 @@
 ;; @005a                               v5 = icmp uge v2, v4
 ;; @005a                               v6 = uextend.i64 v2
 ;; @005a                               v7 = load.i64 notrap aligned v0+88
-;;                                     v48 = iconst.i64 2
-;; @005a                               v8 = ishl v6, v48  ; v48 = 2
+;;                                     v52 = iconst.i64 2
+;; @005a                               v8 = ishl v6, v52  ; v52 = 2
 ;; @005a                               v9 = iadd v7, v8
 ;; @005a                               v10 = iconst.i64 0
 ;; @005a                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005a                               v12 = load.i32 table_oob aligned table v11
-;; @005a                               v13 = uextend.i64 v12
-;; @005a                               v14 = bitcast.r64 v13
-;; @005a                               v15 = is_null v14
-;; @005a                               brif v15, block5, block2
+;;                                     v53 = stack_addr.i64 ss0
+;;                                     store notrap v12, v53
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v54
+;;                                     v55 = iconst.i32 0
+;; @005a                               v13 = icmp eq v49, v55  ; v55 = 0
+;; @005a                               brif v13, block5, block2
 ;;
 ;;                                 block2:
-;; @005a                               v17 = load.i64 notrap aligned v0+56
-;; @005a                               v18 = load.i64 notrap aligned v17
-;; @005a                               v19 = load.i64 notrap aligned v17+8
-;; @005a                               v20 = icmp eq v18, v19
-;; @005a                               brif v20, block3, block4
+;; @005a                               v15 = load.i64 notrap aligned v0+56
+;; @005a                               v16 = load.i64 notrap aligned v15
+;; @005a                               v17 = load.i64 notrap aligned v15+8
+;; @005a                               v18 = icmp eq v16, v17
+;; @005a                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @005a                               v22 = load.i64 notrap aligned readonly v0+40
-;; @005a                               v23 = load.i64 notrap aligned readonly v0+48
-;; @005a                               v24 = bitcast.i64 v14
+;; @005a                               v20 = load.i64 notrap aligned readonly v0+40
+;; @005a                               v21 = load.i64 notrap aligned readonly v0+48
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v56
+;; @005a                               v22 = uextend.i64 v48
+;; @005a                               v23 = iconst.i64 8
+;; @005a                               v24 = uadd_overflow_trap v22, v23, user65535  ; v23 = 8
 ;; @005a                               v25 = iconst.i64 8
 ;; @005a                               v26 = uadd_overflow_trap v24, v25, user65535  ; v25 = 8
-;; @005a                               v27 = iconst.i64 8
-;; @005a                               v28 = uadd_overflow_trap v26, v27, user65535  ; v27 = 8
-;; @005a                               v29 = icmp ult v28, v23
-;; @005a                               brif v29, block7, block6
+;; @005a                               v27 = icmp ult v26, v21
+;; @005a                               brif v27, block7, block6
 ;;
 ;;                                 block6 cold:
 ;; @005a                               trap user65535
 ;;
 ;;                                 block7:
-;; @005a                               v30 = iadd.i64 v22, v26
-;; @005a                               v31 = load.i64 notrap aligned v30
-;;                                     v49 = iconst.i64 1
-;; @005a                               v32 = iadd v31, v49  ; v49 = 1
-;; @005a                               v34 = load.i64 notrap aligned readonly v0+40
-;; @005a                               v35 = load.i64 notrap aligned readonly v0+48
-;; @005a                               v36 = bitcast.i64 v14
+;; @005a                               v28 = iadd.i64 v20, v24
+;; @005a                               v29 = load.i64 notrap aligned v28
+;;                                     v57 = iconst.i64 1
+;; @005a                               v30 = iadd v29, v57  ; v57 = 1
+;; @005a                               v32 = load.i64 notrap aligned readonly v0+40
+;; @005a                               v33 = load.i64 notrap aligned readonly v0+48
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v58
+;; @005a                               v34 = uextend.i64 v47
+;; @005a                               v35 = iconst.i64 8
+;; @005a                               v36 = uadd_overflow_trap v34, v35, user65535  ; v35 = 8
 ;; @005a                               v37 = iconst.i64 8
 ;; @005a                               v38 = uadd_overflow_trap v36, v37, user65535  ; v37 = 8
-;; @005a                               v39 = iconst.i64 8
-;; @005a                               v40 = uadd_overflow_trap v38, v39, user65535  ; v39 = 8
-;; @005a                               v41 = icmp ult v40, v35
-;; @005a                               brif v41, block9, block8
+;; @005a                               v39 = icmp ult v38, v33
+;; @005a                               brif v39, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @005a                               trap user65535
 ;;
 ;;                                 block9:
-;; @005a                               v42 = iadd.i64 v34, v38
-;; @005a                               store.i64 notrap aligned v32, v42
-;; @005a                               store.r64 notrap aligned v14, v18
-;;                                     v50 = iconst.i64 8
-;; @005a                               v43 = iadd.i64 v18, v50  ; v50 = 8
-;; @005a                               store notrap aligned v43, v17
+;; @005a                               v40 = iadd.i64 v32, v36
+;; @005a                               store.i64 notrap aligned v30, v40
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v46 = load.i32 notrap v59
+;; @005a                               store notrap aligned v46, v16
+;;                                     v60 = iconst.i64 4
+;; @005a                               v41 = iadd.i64 v16, v60  ; v60 = 4
+;; @005a                               store notrap aligned v41, v15
 ;; @005a                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @005a                               v45 = call fn0(v0, v14)
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v45 = load.i32 notrap v61
+;; @005a                               v43 = call fn0(v0, v45), stack_map=[i32 @ ss0+0]
 ;; @005a                               jump block5
 ;;
 ;;                                 block5:
+;;                                     v62 = stack_addr.i64 ss0
+;;                                     v44 = load.i32 notrap v62
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:
-;; @005c                               return v14
+;; @005c                               return v44
 ;; }

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -16,122 +16,119 @@
     local.get 0
     local.get 1
     table.set 0))
-;; function u0:0(i64 vmctx, i64, r64) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) system_v
+;;     sig0 = (i64 vmctx, i32 uext) system_v
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;
-;;                                 block0(v0: i64, v1: i64, v2: r64):
+;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0052                               v3 = iconst.i32 0
 ;; @0056                               v4 = iconst.i32 7
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0056                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v67 = iconst.i64 2
-;; @0056                               v8 = ishl v6, v67  ; v67 = 2
+;;                                     v62 = iconst.i64 2
+;; @0056                               v8 = ishl v6, v62  ; v62 = 2
 ;; @0056                               v9 = iadd v7, v8
 ;; @0056                               v10 = iconst.i64 0
 ;; @0056                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0056                               v12 = load.i32 table_oob aligned table v11
-;; @0056                               v13 = uextend.i64 v12
-;; @0056                               v14 = bitcast.r64 v13
-;; @0056                               v15 = is_null v2
-;; @0056                               brif v15, block3, block2
+;;                                     v63 = iconst.i32 0
+;; @0056                               v13 = icmp eq v2, v63  ; v63 = 0
+;; @0056                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @0056                               v17 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v18 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v19 = bitcast.i64 v2
+;; @0056                               v15 = load.i64 notrap aligned readonly v0+40
+;; @0056                               v16 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v17 = uextend.i64 v2
+;; @0056                               v18 = iconst.i64 8
+;; @0056                               v19 = uadd_overflow_trap v17, v18, user65535  ; v18 = 8
 ;; @0056                               v20 = iconst.i64 8
 ;; @0056                               v21 = uadd_overflow_trap v19, v20, user65535  ; v20 = 8
-;; @0056                               v22 = iconst.i64 8
-;; @0056                               v23 = uadd_overflow_trap v21, v22, user65535  ; v22 = 8
-;; @0056                               v24 = icmp ult v23, v18
-;; @0056                               brif v24, block9, block8
+;; @0056                               v22 = icmp ult v21, v16
+;; @0056                               brif v22, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @0056                               trap user65535
 ;;
 ;;                                 block9:
-;; @0056                               v25 = iadd.i64 v17, v21
-;; @0056                               v26 = load.i64 notrap aligned v25
-;;                                     v68 = iconst.i64 1
-;; @0056                               v27 = iadd v26, v68  ; v68 = 1
-;; @0056                               v29 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v30 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v31 = bitcast.i64 v2
+;; @0056                               v23 = iadd.i64 v15, v19
+;; @0056                               v24 = load.i64 notrap aligned v23
+;;                                     v64 = iconst.i64 1
+;; @0056                               v25 = iadd v24, v64  ; v64 = 1
+;; @0056                               v27 = load.i64 notrap aligned readonly v0+40
+;; @0056                               v28 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v29 = uextend.i64 v2
+;; @0056                               v30 = iconst.i64 8
+;; @0056                               v31 = uadd_overflow_trap v29, v30, user65535  ; v30 = 8
 ;; @0056                               v32 = iconst.i64 8
 ;; @0056                               v33 = uadd_overflow_trap v31, v32, user65535  ; v32 = 8
-;; @0056                               v34 = iconst.i64 8
-;; @0056                               v35 = uadd_overflow_trap v33, v34, user65535  ; v34 = 8
-;; @0056                               v36 = icmp ult v35, v30
-;; @0056                               brif v36, block11, block10
+;; @0056                               v34 = icmp ult v33, v28
+;; @0056                               brif v34, block11, block10
 ;;
 ;;                                 block10 cold:
 ;; @0056                               trap user65535
 ;;
 ;;                                 block11:
-;; @0056                               v37 = iadd.i64 v29, v33
-;; @0056                               store.i64 notrap aligned v27, v37
+;; @0056                               v35 = iadd.i64 v27, v31
+;; @0056                               store.i64 notrap aligned v25, v35
 ;; @0056                               jump block3
 ;;
 ;;                                 block3:
-;; @0056                               v38 = bitcast.i64 v2
-;; @0056                               v39 = ireduce.i32 v38
-;; @0056                               store table_oob aligned table v39, v11
-;; @0056                               v40 = is_null.r64 v14
-;; @0056                               brif v40, block7, block4
+;; @0056                               store.i32 table_oob aligned table v2, v11
+;;                                     v65 = iconst.i32 0
+;; @0056                               v36 = icmp.i32 eq v12, v65  ; v65 = 0
+;; @0056                               brif v36, block7, block4
 ;;
 ;;                                 block4:
-;; @0056                               v42 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v43 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v44 = bitcast.i64 v14
-;; @0056                               v45 = iconst.i64 8
-;; @0056                               v46 = uadd_overflow_trap v44, v45, user65535  ; v45 = 8
-;; @0056                               v47 = iconst.i64 8
-;; @0056                               v48 = uadd_overflow_trap v46, v47, user65535  ; v47 = 8
-;; @0056                               v49 = icmp ult v48, v43
-;; @0056                               brif v49, block13, block12
+;; @0056                               v38 = load.i64 notrap aligned readonly v0+40
+;; @0056                               v39 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v40 = uextend.i64 v12
+;; @0056                               v41 = iconst.i64 8
+;; @0056                               v42 = uadd_overflow_trap v40, v41, user65535  ; v41 = 8
+;; @0056                               v43 = iconst.i64 8
+;; @0056                               v44 = uadd_overflow_trap v42, v43, user65535  ; v43 = 8
+;; @0056                               v45 = icmp ult v44, v39
+;; @0056                               brif v45, block13, block12
 ;;
 ;;                                 block12 cold:
 ;; @0056                               trap user65535
 ;;
 ;;                                 block13:
-;; @0056                               v50 = iadd.i64 v42, v46
-;; @0056                               v51 = load.i64 notrap aligned v50
-;;                                     v69 = iconst.i64 -1
-;; @0056                               v52 = iadd v51, v69  ; v69 = -1
-;;                                     v70 = iconst.i64 0
-;; @0056                               v53 = icmp eq v52, v70  ; v70 = 0
-;; @0056                               brif v53, block5, block6
+;; @0056                               v46 = iadd.i64 v38, v42
+;; @0056                               v47 = load.i64 notrap aligned v46
+;;                                     v66 = iconst.i64 -1
+;; @0056                               v48 = iadd v47, v66  ; v66 = -1
+;;                                     v67 = iconst.i64 0
+;; @0056                               v49 = icmp eq v48, v67  ; v67 = 0
+;; @0056                               brif v49, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0056                               v55 = bitcast.i64 v14
-;; @0056                               call fn0(v0, v55)
+;; @0056                               call fn0(v0, v12)
 ;; @0056                               jump block7
 ;;
 ;;                                 block6:
-;; @0056                               v57 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v58 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v59 = bitcast.i64 v14
-;; @0056                               v60 = iconst.i64 8
-;; @0056                               v61 = uadd_overflow_trap v59, v60, user65535  ; v60 = 8
-;; @0056                               v62 = iconst.i64 8
-;; @0056                               v63 = uadd_overflow_trap v61, v62, user65535  ; v62 = 8
-;; @0056                               v64 = icmp ult v63, v58
-;; @0056                               brif v64, block15, block14
+;; @0056                               v52 = load.i64 notrap aligned readonly v0+40
+;; @0056                               v53 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v54 = uextend.i64 v12
+;; @0056                               v55 = iconst.i64 8
+;; @0056                               v56 = uadd_overflow_trap v54, v55, user65535  ; v55 = 8
+;; @0056                               v57 = iconst.i64 8
+;; @0056                               v58 = uadd_overflow_trap v56, v57, user65535  ; v57 = 8
+;; @0056                               v59 = icmp ult v58, v53
+;; @0056                               brif v59, block15, block14
 ;;
 ;;                                 block14 cold:
 ;; @0056                               trap user65535
 ;;
 ;;                                 block15:
-;; @0056                               v65 = iadd.i64 v57, v61
-;; @0056                               store.i64 notrap aligned v52, v65
+;; @0056                               v60 = iadd.i64 v52, v56
+;; @0056                               store.i64 notrap aligned v48, v60
 ;; @0056                               jump block7
 ;;
 ;;                                 block7:
@@ -141,121 +138,118 @@
 ;; @0058                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, r64) tail {
+;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i64) system_v
+;;     sig0 = (i64 vmctx, i32 uext) system_v
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;
-;;                                 block0(v0: i64, v1: i64, v2: i32, v3: r64):
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @005f                               v4 = iconst.i32 7
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2
 ;; @005f                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v67 = iconst.i64 2
-;; @005f                               v8 = ishl v6, v67  ; v67 = 2
+;;                                     v62 = iconst.i64 2
+;; @005f                               v8 = ishl v6, v62  ; v62 = 2
 ;; @005f                               v9 = iadd v7, v8
 ;; @005f                               v10 = iconst.i64 0
 ;; @005f                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005f                               v12 = load.i32 table_oob aligned table v11
-;; @005f                               v13 = uextend.i64 v12
-;; @005f                               v14 = bitcast.r64 v13
-;; @005f                               v15 = is_null v3
-;; @005f                               brif v15, block3, block2
+;;                                     v63 = iconst.i32 0
+;; @005f                               v13 = icmp eq v3, v63  ; v63 = 0
+;; @005f                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @005f                               v17 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v18 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v19 = bitcast.i64 v3
+;; @005f                               v15 = load.i64 notrap aligned readonly v0+40
+;; @005f                               v16 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v17 = uextend.i64 v3
+;; @005f                               v18 = iconst.i64 8
+;; @005f                               v19 = uadd_overflow_trap v17, v18, user65535  ; v18 = 8
 ;; @005f                               v20 = iconst.i64 8
 ;; @005f                               v21 = uadd_overflow_trap v19, v20, user65535  ; v20 = 8
-;; @005f                               v22 = iconst.i64 8
-;; @005f                               v23 = uadd_overflow_trap v21, v22, user65535  ; v22 = 8
-;; @005f                               v24 = icmp ult v23, v18
-;; @005f                               brif v24, block9, block8
+;; @005f                               v22 = icmp ult v21, v16
+;; @005f                               brif v22, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @005f                               trap user65535
 ;;
 ;;                                 block9:
-;; @005f                               v25 = iadd.i64 v17, v21
-;; @005f                               v26 = load.i64 notrap aligned v25
-;;                                     v68 = iconst.i64 1
-;; @005f                               v27 = iadd v26, v68  ; v68 = 1
-;; @005f                               v29 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v30 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v31 = bitcast.i64 v3
+;; @005f                               v23 = iadd.i64 v15, v19
+;; @005f                               v24 = load.i64 notrap aligned v23
+;;                                     v64 = iconst.i64 1
+;; @005f                               v25 = iadd v24, v64  ; v64 = 1
+;; @005f                               v27 = load.i64 notrap aligned readonly v0+40
+;; @005f                               v28 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v29 = uextend.i64 v3
+;; @005f                               v30 = iconst.i64 8
+;; @005f                               v31 = uadd_overflow_trap v29, v30, user65535  ; v30 = 8
 ;; @005f                               v32 = iconst.i64 8
 ;; @005f                               v33 = uadd_overflow_trap v31, v32, user65535  ; v32 = 8
-;; @005f                               v34 = iconst.i64 8
-;; @005f                               v35 = uadd_overflow_trap v33, v34, user65535  ; v34 = 8
-;; @005f                               v36 = icmp ult v35, v30
-;; @005f                               brif v36, block11, block10
+;; @005f                               v34 = icmp ult v33, v28
+;; @005f                               brif v34, block11, block10
 ;;
 ;;                                 block10 cold:
 ;; @005f                               trap user65535
 ;;
 ;;                                 block11:
-;; @005f                               v37 = iadd.i64 v29, v33
-;; @005f                               store.i64 notrap aligned v27, v37
+;; @005f                               v35 = iadd.i64 v27, v31
+;; @005f                               store.i64 notrap aligned v25, v35
 ;; @005f                               jump block3
 ;;
 ;;                                 block3:
-;; @005f                               v38 = bitcast.i64 v3
-;; @005f                               v39 = ireduce.i32 v38
-;; @005f                               store table_oob aligned table v39, v11
-;; @005f                               v40 = is_null.r64 v14
-;; @005f                               brif v40, block7, block4
+;; @005f                               store.i32 table_oob aligned table v3, v11
+;;                                     v65 = iconst.i32 0
+;; @005f                               v36 = icmp.i32 eq v12, v65  ; v65 = 0
+;; @005f                               brif v36, block7, block4
 ;;
 ;;                                 block4:
-;; @005f                               v42 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v43 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v44 = bitcast.i64 v14
-;; @005f                               v45 = iconst.i64 8
-;; @005f                               v46 = uadd_overflow_trap v44, v45, user65535  ; v45 = 8
-;; @005f                               v47 = iconst.i64 8
-;; @005f                               v48 = uadd_overflow_trap v46, v47, user65535  ; v47 = 8
-;; @005f                               v49 = icmp ult v48, v43
-;; @005f                               brif v49, block13, block12
+;; @005f                               v38 = load.i64 notrap aligned readonly v0+40
+;; @005f                               v39 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v40 = uextend.i64 v12
+;; @005f                               v41 = iconst.i64 8
+;; @005f                               v42 = uadd_overflow_trap v40, v41, user65535  ; v41 = 8
+;; @005f                               v43 = iconst.i64 8
+;; @005f                               v44 = uadd_overflow_trap v42, v43, user65535  ; v43 = 8
+;; @005f                               v45 = icmp ult v44, v39
+;; @005f                               brif v45, block13, block12
 ;;
 ;;                                 block12 cold:
 ;; @005f                               trap user65535
 ;;
 ;;                                 block13:
-;; @005f                               v50 = iadd.i64 v42, v46
-;; @005f                               v51 = load.i64 notrap aligned v50
-;;                                     v69 = iconst.i64 -1
-;; @005f                               v52 = iadd v51, v69  ; v69 = -1
-;;                                     v70 = iconst.i64 0
-;; @005f                               v53 = icmp eq v52, v70  ; v70 = 0
-;; @005f                               brif v53, block5, block6
+;; @005f                               v46 = iadd.i64 v38, v42
+;; @005f                               v47 = load.i64 notrap aligned v46
+;;                                     v66 = iconst.i64 -1
+;; @005f                               v48 = iadd v47, v66  ; v66 = -1
+;;                                     v67 = iconst.i64 0
+;; @005f                               v49 = icmp eq v48, v67  ; v67 = 0
+;; @005f                               brif v49, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @005f                               v55 = bitcast.i64 v14
-;; @005f                               call fn0(v0, v55)
+;; @005f                               call fn0(v0, v12)
 ;; @005f                               jump block7
 ;;
 ;;                                 block6:
-;; @005f                               v57 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v58 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v59 = bitcast.i64 v14
-;; @005f                               v60 = iconst.i64 8
-;; @005f                               v61 = uadd_overflow_trap v59, v60, user65535  ; v60 = 8
-;; @005f                               v62 = iconst.i64 8
-;; @005f                               v63 = uadd_overflow_trap v61, v62, user65535  ; v62 = 8
-;; @005f                               v64 = icmp ult v63, v58
-;; @005f                               brif v64, block15, block14
+;; @005f                               v52 = load.i64 notrap aligned readonly v0+40
+;; @005f                               v53 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v54 = uextend.i64 v12
+;; @005f                               v55 = iconst.i64 8
+;; @005f                               v56 = uadd_overflow_trap v54, v55, user65535  ; v55 = 8
+;; @005f                               v57 = iconst.i64 8
+;; @005f                               v58 = uadd_overflow_trap v56, v57, user65535  ; v57 = 8
+;; @005f                               v59 = icmp ult v58, v53
+;; @005f                               brif v59, block15, block14
 ;;
 ;;                                 block14 cold:
 ;; @005f                               trap user65535
 ;;
 ;;                                 block15:
-;; @005f                               v65 = iadd.i64 v57, v61
-;; @005f                               store.i64 notrap aligned v52, v65
+;; @005f                               v60 = iadd.i64 v52, v56
+;; @005f                               store.i64 notrap aligned v48, v60
 ;; @005f                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -16,123 +16,120 @@
     local.get 1
     table.set 0))
 
-;; function u0:0(i64 vmctx, i64, r64) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i32 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i64) system_v
+;;     sig0 = (i64 vmctx, i32 uext) system_v
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;
-;;                                 block0(v0: i64, v1: i64, v2: r64):
+;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0051                               v3 = iconst.i32 0
 ;; @0055                               v4 = load.i32 notrap aligned v0+96
 ;; @0055                               v5 = icmp uge v3, v4  ; v3 = 0
 ;; @0055                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0055                               v7 = load.i64 notrap aligned v0+88
-;;                                     v68 = iconst.i64 2
-;; @0055                               v8 = ishl v6, v68  ; v68 = 2
+;;                                     v63 = iconst.i64 2
+;; @0055                               v8 = ishl v6, v63  ; v63 = 2
 ;; @0055                               v9 = iadd v7, v8
 ;; @0055                               v10 = iconst.i64 0
 ;; @0055                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0055                               v12 = load.i32 table_oob aligned table v11
-;; @0055                               v13 = uextend.i64 v12
-;; @0055                               v14 = bitcast.r64 v13
-;; @0055                               v15 = is_null v2
-;; @0055                               brif v15, block3, block2
+;;                                     v64 = iconst.i32 0
+;; @0055                               v13 = icmp eq v2, v64  ; v64 = 0
+;; @0055                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @0055                               v17 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v18 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v19 = bitcast.i64 v2
+;; @0055                               v15 = load.i64 notrap aligned readonly v0+40
+;; @0055                               v16 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v17 = uextend.i64 v2
+;; @0055                               v18 = iconst.i64 8
+;; @0055                               v19 = uadd_overflow_trap v17, v18, user65535  ; v18 = 8
 ;; @0055                               v20 = iconst.i64 8
 ;; @0055                               v21 = uadd_overflow_trap v19, v20, user65535  ; v20 = 8
-;; @0055                               v22 = iconst.i64 8
-;; @0055                               v23 = uadd_overflow_trap v21, v22, user65535  ; v22 = 8
-;; @0055                               v24 = icmp ult v23, v18
-;; @0055                               brif v24, block9, block8
+;; @0055                               v22 = icmp ult v21, v16
+;; @0055                               brif v22, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @0055                               trap user65535
 ;;
 ;;                                 block9:
-;; @0055                               v25 = iadd.i64 v17, v21
-;; @0055                               v26 = load.i64 notrap aligned v25
-;;                                     v69 = iconst.i64 1
-;; @0055                               v27 = iadd v26, v69  ; v69 = 1
-;; @0055                               v29 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v30 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v31 = bitcast.i64 v2
+;; @0055                               v23 = iadd.i64 v15, v19
+;; @0055                               v24 = load.i64 notrap aligned v23
+;;                                     v65 = iconst.i64 1
+;; @0055                               v25 = iadd v24, v65  ; v65 = 1
+;; @0055                               v27 = load.i64 notrap aligned readonly v0+40
+;; @0055                               v28 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v29 = uextend.i64 v2
+;; @0055                               v30 = iconst.i64 8
+;; @0055                               v31 = uadd_overflow_trap v29, v30, user65535  ; v30 = 8
 ;; @0055                               v32 = iconst.i64 8
 ;; @0055                               v33 = uadd_overflow_trap v31, v32, user65535  ; v32 = 8
-;; @0055                               v34 = iconst.i64 8
-;; @0055                               v35 = uadd_overflow_trap v33, v34, user65535  ; v34 = 8
-;; @0055                               v36 = icmp ult v35, v30
-;; @0055                               brif v36, block11, block10
+;; @0055                               v34 = icmp ult v33, v28
+;; @0055                               brif v34, block11, block10
 ;;
 ;;                                 block10 cold:
 ;; @0055                               trap user65535
 ;;
 ;;                                 block11:
-;; @0055                               v37 = iadd.i64 v29, v33
-;; @0055                               store.i64 notrap aligned v27, v37
+;; @0055                               v35 = iadd.i64 v27, v31
+;; @0055                               store.i64 notrap aligned v25, v35
 ;; @0055                               jump block3
 ;;
 ;;                                 block3:
-;; @0055                               v38 = bitcast.i64 v2
-;; @0055                               v39 = ireduce.i32 v38
-;; @0055                               store table_oob aligned table v39, v11
-;; @0055                               v40 = is_null.r64 v14
-;; @0055                               brif v40, block7, block4
+;; @0055                               store.i32 table_oob aligned table v2, v11
+;;                                     v66 = iconst.i32 0
+;; @0055                               v36 = icmp.i32 eq v12, v66  ; v66 = 0
+;; @0055                               brif v36, block7, block4
 ;;
 ;;                                 block4:
-;; @0055                               v42 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v43 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v44 = bitcast.i64 v14
-;; @0055                               v45 = iconst.i64 8
-;; @0055                               v46 = uadd_overflow_trap v44, v45, user65535  ; v45 = 8
-;; @0055                               v47 = iconst.i64 8
-;; @0055                               v48 = uadd_overflow_trap v46, v47, user65535  ; v47 = 8
-;; @0055                               v49 = icmp ult v48, v43
-;; @0055                               brif v49, block13, block12
+;; @0055                               v38 = load.i64 notrap aligned readonly v0+40
+;; @0055                               v39 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v40 = uextend.i64 v12
+;; @0055                               v41 = iconst.i64 8
+;; @0055                               v42 = uadd_overflow_trap v40, v41, user65535  ; v41 = 8
+;; @0055                               v43 = iconst.i64 8
+;; @0055                               v44 = uadd_overflow_trap v42, v43, user65535  ; v43 = 8
+;; @0055                               v45 = icmp ult v44, v39
+;; @0055                               brif v45, block13, block12
 ;;
 ;;                                 block12 cold:
 ;; @0055                               trap user65535
 ;;
 ;;                                 block13:
-;; @0055                               v50 = iadd.i64 v42, v46
-;; @0055                               v51 = load.i64 notrap aligned v50
-;;                                     v70 = iconst.i64 -1
-;; @0055                               v52 = iadd v51, v70  ; v70 = -1
-;;                                     v71 = iconst.i64 0
-;; @0055                               v53 = icmp eq v52, v71  ; v71 = 0
-;; @0055                               brif v53, block5, block6
+;; @0055                               v46 = iadd.i64 v38, v42
+;; @0055                               v47 = load.i64 notrap aligned v46
+;;                                     v67 = iconst.i64 -1
+;; @0055                               v48 = iadd v47, v67  ; v67 = -1
+;;                                     v68 = iconst.i64 0
+;; @0055                               v49 = icmp eq v48, v68  ; v68 = 0
+;; @0055                               brif v49, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @0055                               v55 = bitcast.i64 v14
-;; @0055                               call fn0(v0, v55)
+;; @0055                               call fn0(v0, v12)
 ;; @0055                               jump block7
 ;;
 ;;                                 block6:
-;; @0055                               v57 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v58 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v59 = bitcast.i64 v14
-;; @0055                               v60 = iconst.i64 8
-;; @0055                               v61 = uadd_overflow_trap v59, v60, user65535  ; v60 = 8
-;; @0055                               v62 = iconst.i64 8
-;; @0055                               v63 = uadd_overflow_trap v61, v62, user65535  ; v62 = 8
-;; @0055                               v64 = icmp ult v63, v58
-;; @0055                               brif v64, block15, block14
+;; @0055                               v52 = load.i64 notrap aligned readonly v0+40
+;; @0055                               v53 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v54 = uextend.i64 v12
+;; @0055                               v55 = iconst.i64 8
+;; @0055                               v56 = uadd_overflow_trap v54, v55, user65535  ; v55 = 8
+;; @0055                               v57 = iconst.i64 8
+;; @0055                               v58 = uadd_overflow_trap v56, v57, user65535  ; v57 = 8
+;; @0055                               v59 = icmp ult v58, v53
+;; @0055                               brif v59, block15, block14
 ;;
 ;;                                 block14 cold:
 ;; @0055                               trap user65535
 ;;
 ;;                                 block15:
-;; @0055                               v65 = iadd.i64 v57, v61
-;; @0055                               store.i64 notrap aligned v52, v65
+;; @0055                               v60 = iadd.i64 v52, v56
+;; @0055                               store.i64 notrap aligned v48, v60
 ;; @0055                               jump block7
 ;;
 ;;                                 block7:
@@ -142,122 +139,119 @@
 ;; @0057                               return
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32, r64) tail {
+;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i32 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i64) system_v
+;;     sig0 = (i64 vmctx, i32 uext) system_v
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;
-;;                                 block0(v0: i64, v1: i64, v2: i32, v3: r64):
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @005e                               v4 = load.i32 notrap aligned v0+96
 ;; @005e                               v5 = icmp uge v2, v4
 ;; @005e                               v6 = uextend.i64 v2
 ;; @005e                               v7 = load.i64 notrap aligned v0+88
-;;                                     v68 = iconst.i64 2
-;; @005e                               v8 = ishl v6, v68  ; v68 = 2
+;;                                     v63 = iconst.i64 2
+;; @005e                               v8 = ishl v6, v63  ; v63 = 2
 ;; @005e                               v9 = iadd v7, v8
 ;; @005e                               v10 = iconst.i64 0
 ;; @005e                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005e                               v12 = load.i32 table_oob aligned table v11
-;; @005e                               v13 = uextend.i64 v12
-;; @005e                               v14 = bitcast.r64 v13
-;; @005e                               v15 = is_null v3
-;; @005e                               brif v15, block3, block2
+;;                                     v64 = iconst.i32 0
+;; @005e                               v13 = icmp eq v3, v64  ; v64 = 0
+;; @005e                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @005e                               v17 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v18 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v19 = bitcast.i64 v3
+;; @005e                               v15 = load.i64 notrap aligned readonly v0+40
+;; @005e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v17 = uextend.i64 v3
+;; @005e                               v18 = iconst.i64 8
+;; @005e                               v19 = uadd_overflow_trap v17, v18, user65535  ; v18 = 8
 ;; @005e                               v20 = iconst.i64 8
 ;; @005e                               v21 = uadd_overflow_trap v19, v20, user65535  ; v20 = 8
-;; @005e                               v22 = iconst.i64 8
-;; @005e                               v23 = uadd_overflow_trap v21, v22, user65535  ; v22 = 8
-;; @005e                               v24 = icmp ult v23, v18
-;; @005e                               brif v24, block9, block8
+;; @005e                               v22 = icmp ult v21, v16
+;; @005e                               brif v22, block9, block8
 ;;
 ;;                                 block8 cold:
 ;; @005e                               trap user65535
 ;;
 ;;                                 block9:
-;; @005e                               v25 = iadd.i64 v17, v21
-;; @005e                               v26 = load.i64 notrap aligned v25
-;;                                     v69 = iconst.i64 1
-;; @005e                               v27 = iadd v26, v69  ; v69 = 1
-;; @005e                               v29 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v30 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v31 = bitcast.i64 v3
+;; @005e                               v23 = iadd.i64 v15, v19
+;; @005e                               v24 = load.i64 notrap aligned v23
+;;                                     v65 = iconst.i64 1
+;; @005e                               v25 = iadd v24, v65  ; v65 = 1
+;; @005e                               v27 = load.i64 notrap aligned readonly v0+40
+;; @005e                               v28 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v29 = uextend.i64 v3
+;; @005e                               v30 = iconst.i64 8
+;; @005e                               v31 = uadd_overflow_trap v29, v30, user65535  ; v30 = 8
 ;; @005e                               v32 = iconst.i64 8
 ;; @005e                               v33 = uadd_overflow_trap v31, v32, user65535  ; v32 = 8
-;; @005e                               v34 = iconst.i64 8
-;; @005e                               v35 = uadd_overflow_trap v33, v34, user65535  ; v34 = 8
-;; @005e                               v36 = icmp ult v35, v30
-;; @005e                               brif v36, block11, block10
+;; @005e                               v34 = icmp ult v33, v28
+;; @005e                               brif v34, block11, block10
 ;;
 ;;                                 block10 cold:
 ;; @005e                               trap user65535
 ;;
 ;;                                 block11:
-;; @005e                               v37 = iadd.i64 v29, v33
-;; @005e                               store.i64 notrap aligned v27, v37
+;; @005e                               v35 = iadd.i64 v27, v31
+;; @005e                               store.i64 notrap aligned v25, v35
 ;; @005e                               jump block3
 ;;
 ;;                                 block3:
-;; @005e                               v38 = bitcast.i64 v3
-;; @005e                               v39 = ireduce.i32 v38
-;; @005e                               store table_oob aligned table v39, v11
-;; @005e                               v40 = is_null.r64 v14
-;; @005e                               brif v40, block7, block4
+;; @005e                               store.i32 table_oob aligned table v3, v11
+;;                                     v66 = iconst.i32 0
+;; @005e                               v36 = icmp.i32 eq v12, v66  ; v66 = 0
+;; @005e                               brif v36, block7, block4
 ;;
 ;;                                 block4:
-;; @005e                               v42 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v43 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v44 = bitcast.i64 v14
-;; @005e                               v45 = iconst.i64 8
-;; @005e                               v46 = uadd_overflow_trap v44, v45, user65535  ; v45 = 8
-;; @005e                               v47 = iconst.i64 8
-;; @005e                               v48 = uadd_overflow_trap v46, v47, user65535  ; v47 = 8
-;; @005e                               v49 = icmp ult v48, v43
-;; @005e                               brif v49, block13, block12
+;; @005e                               v38 = load.i64 notrap aligned readonly v0+40
+;; @005e                               v39 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v40 = uextend.i64 v12
+;; @005e                               v41 = iconst.i64 8
+;; @005e                               v42 = uadd_overflow_trap v40, v41, user65535  ; v41 = 8
+;; @005e                               v43 = iconst.i64 8
+;; @005e                               v44 = uadd_overflow_trap v42, v43, user65535  ; v43 = 8
+;; @005e                               v45 = icmp ult v44, v39
+;; @005e                               brif v45, block13, block12
 ;;
 ;;                                 block12 cold:
 ;; @005e                               trap user65535
 ;;
 ;;                                 block13:
-;; @005e                               v50 = iadd.i64 v42, v46
-;; @005e                               v51 = load.i64 notrap aligned v50
-;;                                     v70 = iconst.i64 -1
-;; @005e                               v52 = iadd v51, v70  ; v70 = -1
-;;                                     v71 = iconst.i64 0
-;; @005e                               v53 = icmp eq v52, v71  ; v71 = 0
-;; @005e                               brif v53, block5, block6
+;; @005e                               v46 = iadd.i64 v38, v42
+;; @005e                               v47 = load.i64 notrap aligned v46
+;;                                     v67 = iconst.i64 -1
+;; @005e                               v48 = iadd v47, v67  ; v67 = -1
+;;                                     v68 = iconst.i64 0
+;; @005e                               v49 = icmp eq v48, v68  ; v68 = 0
+;; @005e                               brif v49, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @005e                               v55 = bitcast.i64 v14
-;; @005e                               call fn0(v0, v55)
+;; @005e                               call fn0(v0, v12)
 ;; @005e                               jump block7
 ;;
 ;;                                 block6:
-;; @005e                               v57 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v58 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v59 = bitcast.i64 v14
-;; @005e                               v60 = iconst.i64 8
-;; @005e                               v61 = uadd_overflow_trap v59, v60, user65535  ; v60 = 8
-;; @005e                               v62 = iconst.i64 8
-;; @005e                               v63 = uadd_overflow_trap v61, v62, user65535  ; v62 = 8
-;; @005e                               v64 = icmp ult v63, v58
-;; @005e                               brif v64, block15, block14
+;; @005e                               v52 = load.i64 notrap aligned readonly v0+40
+;; @005e                               v53 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v54 = uextend.i64 v12
+;; @005e                               v55 = iconst.i64 8
+;; @005e                               v56 = uadd_overflow_trap v54, v55, user65535  ; v55 = 8
+;; @005e                               v57 = iconst.i64 8
+;; @005e                               v58 = uadd_overflow_trap v56, v57, user65535  ; v57 = 8
+;; @005e                               v59 = icmp ult v58, v53
+;; @005e                               brif v59, block15, block14
 ;;
 ;;                                 block14 cold:
 ;; @005e                               trap user65535
 ;;
 ;;                                 block15:
-;; @005e                               v65 = iadd.i64 v57, v61
-;; @005e                               store.i64 notrap aligned v52, v65
+;; @005e                               v60 = iadd.i64 v52, v56
+;; @005e                               store.i64 notrap aligned v48, v60
 ;; @005e                               jump block7
 ;;
 ;;                                 block7:


### PR DESCRIPTION
This moves Wasmtime over from the old, regalloc-based stack maps system to the new "user" stack maps system.

Removing the old regalloc-based stack maps system is left for follow-up work.

All tests are passing, and I've been running the `table_ops` fuzz target (which exercises GC refs, passing them between the host and Wasm, and their inline barriers) locally for a while with no more issues found (there was initially one issue found which was fixed in https://github.com/bytecodealliance/wasmtime/pull/9071).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
