### PR TITLE
cranelift-entity: `#[track_caller]` for PackedOption

### DIFF
--- a/cranelift/entity/src/packed_option.rs
+++ b/cranelift/entity/src/packed_option.rs
@@ -55,11 +55,13 @@ impl<T: ReservedValue> PackedOption<T> {
     }
 
     /// Unwrap a packed `Some` value or panic.
+    #[track_caller]
     pub fn unwrap(self) -> T {
         self.expand().unwrap()
     }
 
     /// Unwrap a packed `Some` value or panic.
+    #[track_caller]
     pub fn expect(self, msg: &str) -> T {
         self.expand().expect(msg)
     }


### PR DESCRIPTION
This PR adds the `#[track_caller]` attribute to `PackedOption::unwrap` and `PackedOption::expect`. Using this attribute greatly improves the panic message of any `.expect` or `.unwrap` on a `PackedOption` by using the caller's location, not the location of `packed_option.rs` within `cranelift-entity`.