### PR TITLE
wasmtime: Refactor trap-handling

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -984,8 +984,8 @@ impl Func {
     /// # Panics
     ///
     /// This function will panic if called on a function belonging to an async
-    /// store. Asynchronous stores must always use `call_async`.
-    /// initiates a panic. Also panics if `store` does not own this function.
+    /// store. Asynchronous stores must always use `call_async`. Also panics if
+    /// `store` does not own this function.
     ///
     /// [`WasmBacktrace`]: crate::WasmBacktrace
     pub fn call(

--- a/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
@@ -1,4 +1,4 @@
-use crate::runtime::vm::traphandlers::{tls, TrapTest};
+use crate::runtime::vm::traphandlers::{tls, TrapRegisters, TrapTest};
 use crate::runtime::vm::VMContext;
 use core::mem;
 
@@ -31,7 +31,7 @@ impl TrapHandler {
     pub fn validate_config(&self, _macos_use_mach_ports: bool) {}
 }
 
-extern "C" fn handle_trap(ip: usize, fp: usize, has_faulting_addr: bool, faulting_addr: usize) {
+extern "C" fn handle_trap(pc: usize, fp: usize, has_faulting_addr: bool, faulting_addr: usize) {
     tls::with(|info| {
         let info = match info {
             Some(info) => info,
@@ -42,17 +42,14 @@ extern "C" fn handle_trap(ip: usize, fp: usize, has_faulting_addr: bool, faultin
         } else {
             None
         };
-        let ip = ip as *const u8;
-        let test = info.test_if_trap(ip, |_handler| {
+        let regs = TrapRegisters { pc, fp };
+        let test = info.test_if_trap(regs, faulting_addr, |_handler| {
             panic!("custom signal handlers are not supported on this platform");
         });
         match test {
             TrapTest::NotWasm => {}
             TrapTest::HandledByEmbedder => unreachable!(),
-            TrapTest::Trap { jmp_buf, trap } => {
-                info.set_jit_trap(ip, fp, faulting_addr, trap);
-                unsafe { wasmtime_longjmp(jmp_buf) }
-            }
+            TrapTest::Trap { jmp_buf } => unsafe { wasmtime_longjmp(jmp_buf) },
         }
     })
 }


### PR DESCRIPTION
This commit groups together the registers that have to be collected from a signal handler to correctly report a trap: namely, the program counter and frame pointer, as of the time that the trap occurred.

I also moved the call to set_jit_trap inside test_if_trap for every platform that uses both methods. Only the implementation for Mach ports still needs to call set_jit_trap because it doesn't use test_if_trap.

In addition I'm fixing an unrelated doc comment that I stumbled across while working on this.