### PR TITLE
pulley: pack `dst`, `src1` and `src2` registers into 2 bytes

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst/args.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/args.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::machinst::abi::StackAMode;
+use pulley_interpreter::regs::Reg as _;
 
 /// A macro for defining a newtype of `Reg` that enforces some invariant about
 /// the wrapped `Reg` (such as that it is of a particular register class).

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -9,6 +9,7 @@ use crate::trace;
 use core::marker::PhantomData;
 use cranelift_control::ControlPlane;
 use pulley_interpreter::encode as enc;
+use pulley_interpreter::regs::BinaryOperands;
 use pulley_interpreter::regs::Reg as _;
 
 pub struct EmitInfo {
@@ -334,48 +335,28 @@ fn pulley_emit<P>(
         Inst::Xconst32 { dst, imm } => enc::xconst32(sink, dst, *imm),
         Inst::Xconst64 { dst, imm } => enc::xconst64(sink, dst, *imm),
 
-        Inst::Xadd32 { dst, src1, src2 } => {
-            enc::xadd32(sink, dst, src1, src2);
+        Inst::Xadd32 { dst, src1, src2 } => enc::xadd32(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xadd64 { dst, src1, src2 } => enc::xadd64(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xeq64 { dst, src1, src2 } => enc::xeq64(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xneq64 { dst, src1, src2 } => enc::xneq64(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xslt64 { dst, src1, src2 } => enc::xslt64(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xslteq64 { dst, src1, src2 } => {
+            enc::xslteq64(sink, BinaryOperands::new(dst, src1, src2))
         }
-        Inst::Xadd64 { dst, src1, src2 } => {
-            enc::xadd64(sink, dst, src1, src2);
+        Inst::Xult64 { dst, src1, src2 } => enc::xult64(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xulteq64 { dst, src1, src2 } => {
+            enc::xulteq64(sink, BinaryOperands::new(dst, src1, src2))
         }
 
-        Inst::Xeq64 { dst, src1, src2 } => {
-            enc::xeq64(sink, dst, src1, src2);
-        }
-        Inst::Xneq64 { dst, src1, src2 } => {
-            enc::xneq64(sink, dst, src1, src2);
-        }
-        Inst::Xslt64 { dst, src1, src2 } => {
-            enc::xslt64(sink, dst, src1, src2);
-        }
-        Inst::Xslteq64 { dst, src1, src2 } => {
-            enc::xslteq64(sink, dst, src1, src2);
-        }
-        Inst::Xult64 { dst, src1, src2 } => {
-            enc::xult64(sink, dst, src1, src2);
-        }
-        Inst::Xulteq64 { dst, src1, src2 } => {
-            enc::xulteq64(sink, dst, src1, src2);
-        }
-        Inst::Xeq32 { dst, src1, src2 } => {
-            enc::xeq32(sink, dst, src1, src2);
-        }
-        Inst::Xneq32 { dst, src1, src2 } => {
-            enc::xneq32(sink, dst, src1, src2);
-        }
-        Inst::Xslt32 { dst, src1, src2 } => {
-            enc::xslt32(sink, dst, src1, src2);
-        }
+        Inst::Xeq32 { dst, src1, src2 } => enc::xeq32(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xneq32 { dst, src1, src2 } => enc::xneq32(sink, BinaryOperands::new(dst, src1, src2)),
+        Inst::Xslt32 { dst, src1, src2 } => enc::xslt32(sink, BinaryOperands::new(dst, src1, src2)),
         Inst::Xslteq32 { dst, src1, src2 } => {
-            enc::xslteq32(sink, dst, src1, src2);
+            enc::xslteq32(sink, BinaryOperands::new(dst, src1, src2))
         }
-        Inst::Xult32 { dst, src1, src2 } => {
-            enc::xult32(sink, dst, src1, src2);
-        }
+        Inst::Xult32 { dst, src1, src2 } => enc::xult32(sink, BinaryOperands::new(dst, src1, src2)),
         Inst::Xulteq32 { dst, src1, src2 } => {
-            enc::xulteq32(sink, dst, src1, src2);
+            enc::xulteq32(sink, BinaryOperands::new(dst, src1, src2))
         }
 
         Inst::LoadAddr { dst, mem } => {
@@ -399,8 +380,12 @@ fn pulley_emit<P>(
                     }
 
                     match P::pointer_width() {
-                        PointerWidth::PointerWidth32 => enc::xadd32(sink, dst, base, dst),
-                        PointerWidth::PointerWidth64 => enc::xadd64(sink, dst, base, dst),
+                        PointerWidth::PointerWidth32 => {
+                            enc::xadd32(sink, BinaryOperands::new(dst, base, dst))
+                        }
+                        PointerWidth::PointerWidth64 => {
+                            enc::xadd64(sink, BinaryOperands::new(dst, base, dst))
+                        }
                     }
                 }
             } else {

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -9,6 +9,7 @@ use crate::trace;
 use core::marker::PhantomData;
 use cranelift_control::ControlPlane;
 use pulley_interpreter::encode as enc;
+use pulley_interpreter::regs::Reg as _;
 
 pub struct EmitInfo {
     #[allow(dead_code)] // Will get used as we fill out this backend.

--- a/cranelift/codegen/src/isa/pulley_shared/inst/regs.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/regs.rs
@@ -89,17 +89,12 @@ define_registers! {
     x_reg(24) => x24, writable_x24;
     x_reg(25) => x25, writable_x25;
     x_reg(26) => x26, writable_x26;
-    x_reg(27) => x27, writable_x27;
-    x_reg(28) => x28, writable_x28;
-    x_reg(29) => x29, writable_x29;
-    x_reg(30) => x30, writable_x30;
-    x_reg(31) => x31, writable_x31;
 
-    x_reg(32) => stack_reg, writable_stack_reg;
-    x_reg(33) => link_reg, writable_link_reg;
-    x_reg(34) => fp_reg, writable_fp_reg;
-    x_reg(35) => spilltmp_reg, writable_spilltmp_reg;
-    x_reg(36) => spilltmp2_reg, writable_spilltmp2_reg;
+    x_reg(27) => stack_reg, writable_stack_reg;
+    x_reg(28) => link_reg, writable_link_reg;
+    x_reg(29) => fp_reg, writable_fp_reg;
+    x_reg(30) => spilltmp_reg, writable_spilltmp_reg;
+    x_reg(31) => spilltmp2_reg, writable_spilltmp2_reg;
 
     f_reg(0) => f0, writable_f0;
     f_reg(1) => f1, writable_f1;

--- a/cranelift/filetests/filetests/isa/pulley32/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif.clif
@@ -147,12 +147,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 05 00 01                     xeq32 x5, x0, x1
-;        4: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xe
-;        a: 0e 00 00                        xconst8 x0, 0
-;        d: 00                              ret
-;        e: 0e 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+;        0: 1a 05 04                        xeq32 x5, x0, x1
+;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
+;        9: 0e 00 00                        xconst8 x0, 0
+;        c: 00                              ret
+;        d: 0e 00 01                        xconst8 x0, 1
+;       10: 00                              ret
 
 function %brif_icmp_i16(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -180,12 +180,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 05 00 01                     xneq32 x5, x0, x1
-;        4: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xe
-;        a: 0e 00 00                        xconst8 x0, 0
-;        d: 00                              ret
-;        e: 0e 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+;        0: 1b 05 04                        xneq32 x5, x0, x1
+;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
+;        9: 0e 00 00                        xconst8 x0, 0
+;        c: 00                              ret
+;        d: 0e 00 01                        xconst8 x0, 1
+;       10: 00                              ret
 
 function %brif_icmp_i32(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -244,10 +244,10 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 05 01 00                     xulteq64 x5, x1, x0
-;        4: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xe
-;        a: 0e 00 00                        xconst8 x0, 0
-;        d: 00                              ret
-;        e: 0e 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+;        0: 19 25 00                        xulteq64 x5, x1, x0
+;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
+;        9: 0e 00 00                        xconst8 x0, 0
+;        c: 00                              ret
+;        d: 0e 00 01                        xconst8 x0, 1
+;       10: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -12,34 +12,34 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [1204185006387685820006398, 4294967295] }, callee_pop_size: 0 }
 ;   x0 = xconst8 1
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 0e 00 00                        xconst8 x0, 0
 ;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
 ;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       20: 22 22 20                        load64 fp, sp
-;       23: 0e 23 10                        xconst8 spilltmp0, 16
-;       26: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       20: 22 1d 1b                        load64 fp, sp
+;       23: 0e 1e 10                        xconst8 spilltmp0, 16
+;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       2a: 00                              ret
 
 function %colocated_args_i32_rets_i32() -> i32 {
@@ -53,34 +53,34 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [1204185006387685820006398, 4294967295] }, callee_pop_size: 0 }
 ;   x0 = xconst8 1
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 0e 00 00                        xconst8 x0, 0
 ;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
 ;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       20: 22 22 20                        load64 fp, sp
-;       23: 0e 23 10                        xconst8 spilltmp0, 16
-;       26: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       20: 22 1d 1b                        load64 fp, sp
+;       23: 0e 1e 10                        xconst8 spilltmp0, 16
+;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       2a: 00                              ret
 
 function %colocated_args_i64_i32_i64_i32() {
@@ -96,38 +96,38 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
 ;   x1 = xconst8 1
 ;   x2 = xconst8 2
 ;   x3 = xconst8 3
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [1204185006387685820006399, 4294967295] }, callee_pop_size: 0 }
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 0e 00 00                        xconst8 x0, 0
 ;       14: 0e 01 01                        xconst8 x1, 1
 ;       17: 0e 02 02                        xconst8 x2, 2
 ;       1a: 0e 03 03                        xconst8 x3, 3
 ;       1d: 01 00 00 00 00                  call 0x0    // target = 0x1d
-;       22: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       26: 22 22 20                        load64 fp, sp
-;       29: 0e 23 10                        xconst8 spilltmp0, 16
-;       2c: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       26: 22 1d 1b                        load64 fp, sp
+;       29: 0e 1e 10                        xconst8 spilltmp0, 16
+;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       30: 00                              ret
 
 function %colocated_rets_i64_i64_i64_i64() -> i64 {
@@ -142,36 +142,36 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [1204185006387685820006384, 4294967295] }, callee_pop_size: 0 }
 ;   x4 = xadd64 x0, x2
 ;   x3 = xadd64 x1, x3
 ;   x0 = xadd64 x4, x3
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 01 00 00 00 00                  call 0x0    // target = 0x11
 ;       16: 13 04 00 02                     xadd64 x4, x0, x2
 ;       1a: 13 03 01 03                     xadd64 x3, x1, x3
 ;       1e: 13 00 04 03                     xadd64 x0, x4, x3
-;       22: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       26: 22 22 20                        load64 fp, sp
-;       29: 0e 23 10                        xconst8 spilltmp0, 16
-;       2c: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       26: 22 1d 1b                        load64 fp, sp
+;       29: 0e 1e 10                        xconst8 spilltmp0, 16
+;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       30: 00                              ret
 
 function %colocated_stack_args() {
@@ -184,13 +184,13 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
-;   x35 = xconst8 -48
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
+;   x30 = xconst8 -48
+;   x27 = xadd32 x27, x30
 ; block0:
 ;   x15 = xconst8 0
 ;   store64 OutgoingArg(0), x15 // flags =  notrap aligned
@@ -215,29 +215,29 @@ block0:
 ;   x13 = xmov x15
 ;   x14 = xmov x15
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [1204185006387685820006399, 4294967295] }, callee_pop_size: 0 }
-;   x35 = xconst8 48
-;   x32 = xadd32 x32, x35
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 48
+;   x27 = xadd32 x27, x30
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
-;       11: 0e 23 d0                        xconst8 spilltmp0, -48
-;       14: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
+;       11: 0e 1e d0                        xconst8 spilltmp0, -48
+;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       18: 0e 0f 00                        xconst8 x15, 0
-;       1b: 2a 20 0f                        store64 sp, x15
-;       1e: 2c 20 08 0f                     store64_offset8 sp, 8, x15
-;       22: 2c 20 10 0f                     store64_offset8 sp, 16, x15
-;       26: 2c 20 18 0f                     store64_offset8 sp, 24, x15
-;       2a: 2c 20 20 0f                     store64_offset8 sp, 32, x15
-;       2e: 2c 20 28 0f                     store64_offset8 sp, 40, x15
+;       1b: 2a 1b 0f                        store64 sp, x15
+;       1e: 2c 1b 08 0f                     store64_offset8 sp, 8, x15
+;       22: 2c 1b 10 0f                     store64_offset8 sp, 16, x15
+;       26: 2c 1b 18 0f                     store64_offset8 sp, 24, x15
+;       2a: 2c 1b 20 0f                     store64_offset8 sp, 32, x15
+;       2e: 2c 1b 28 0f                     store64_offset8 sp, 40, x15
 ;       32: 0b 00 0f                        xmov x0, x15
 ;       35: 0b 01 0f                        xmov x1, x15
 ;       38: 0b 02 0f                        xmov x2, x15
@@ -254,12 +254,12 @@ block0:
 ;       59: 0b 0d 0f                        xmov x13, x15
 ;       5c: 0b 0e 0f                        xmov x14, x15
 ;       5f: 01 00 00 00 00                  call 0x0    // target = 0x5f
-;       64: 0e 23 30                        xconst8 spilltmp0, 48
-;       67: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;       6b: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       6f: 22 22 20                        load64 fp, sp
-;       72: 0e 23 10                        xconst8 spilltmp0, 16
-;       75: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       64: 0e 1e 30                        xconst8 spilltmp0, 48
+;       67: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;       6b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       6f: 22 1d 1b                        load64 fp, sp
+;       72: 0e 1e 10                        xconst8 spilltmp0, 16
+;       75: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       79: 00                              ret
 
 function %colocated_stack_rets() -> i64 {
@@ -299,13 +299,13 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
-;   x35 = xconst8 -64
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
+;   x30 = xconst8 -64
+;   x27 = xadd32 x27, x30
 ;   store64 sp+56, x16 // flags =  notrap aligned
 ;   store64 sp+48, x18 // flags =  notrap aligned
 ; block0:
@@ -345,35 +345,35 @@ block0:
 ;   x0 = xadd64 x14, x13
 ;   x16 = load64_u sp+56 // flags = notrap aligned
 ;   x18 = load64_u sp+48 // flags = notrap aligned
-;   x35 = xconst8 64
-;   x32 = xadd32 x32, x35
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 64
+;   x27 = xadd32 x27, x30
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
-;       11: 0e 23 c0                        xconst8 spilltmp0, -64
-;       14: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;       18: 2c 20 38 10                     store64_offset8 sp, 56, x16
-;       1c: 2c 20 30 12                     store64_offset8 sp, 48, x18
-;       20: 0b 00 20                        xmov x0, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
+;       11: 0e 1e c0                        xconst8 spilltmp0, -64
+;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;       18: 2c 1b 38 10                     store64_offset8 sp, 56, x16
+;       1c: 2c 1b 30 12                     store64_offset8 sp, 48, x18
+;       20: 0b 00 1b                        xmov x0, sp
 ;       23: 01 00 00 00 00                  call 0x0    // target = 0x23
 ;       28: 0b 10 0d                        xmov x16, x13
 ;       2b: 0b 12 0b                        xmov x18, x11
-;       2e: 22 19 20                        load64 x25, sp
-;       31: 25 0b 20 08                     load64_offset8 x11, sp, 8
-;       35: 25 0d 20 10                     load64_offset8 x13, sp, 16
-;       39: 25 1f 20 18                     load64_offset8 x31, sp, 24
-;       3d: 25 11 20 20                     load64_offset8 x17, sp, 32
-;       41: 13 1e 00 01                     xadd64 x30, x0, x1
-;       45: 13 1d 02 03                     xadd64 x29, x2, x3
+;       2e: 22 19 1b                        load64 x25, sp
+;       31: 25 0b 1b 08                     load64_offset8 x11, sp, 8
+;       35: 25 0d 1b 10                     load64_offset8 x13, sp, 16
+;       39: 25 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
+;       3d: 25 11 1b 20                     load64_offset8 x17, sp, 32
+;       41: 13 1e 00 01                     xadd64 spilltmp0, x0, x1
+;       45: 13 1d 02 03                     xadd64 fp, x2, x3
 ;       49: 13 05 04 05                     xadd64 x5, x4, x5
 ;       4d: 13 06 06 07                     xadd64 x6, x6, x7
 ;       51: 13 07 08 09                     xadd64 x7, x8, x9
@@ -384,8 +384,8 @@ block0:
 ;       63: 13 0e 0e 0f                     xadd64 x14, x14, x15
 ;       67: 13 0f 19 0b                     xadd64 x15, x25, x11
 ;       6b: 13 0d 0b 0d                     xadd64 x13, x11, x13
-;       6f: 13 00 1f 11                     xadd64 x0, x31, x17
-;       73: 13 01 1e 1d                     xadd64 x1, x30, x29
+;       6f: 13 00 1f 11                     xadd64 x0, spilltmp1, x17
+;       73: 13 01 1e 1d                     xadd64 x1, spilltmp0, fp
 ;       77: 13 02 05 06                     xadd64 x2, x5, x6
 ;       7b: 13 03 07 04                     xadd64 x3, x7, x4
 ;       7f: 13 0e 08 0e                     xadd64 x14, x8, x14
@@ -397,13 +397,13 @@ block0:
 ;       97: 13 0e 00 0e                     xadd64 x14, x0, x14
 ;       9b: 13 0d 0d 0d                     xadd64 x13, x13, x13
 ;       9f: 13 00 0e 0d                     xadd64 x0, x14, x13
-;       a3: 25 10 20 38                     load64_offset8 x16, sp, 56
-;       a7: 25 12 20 30                     load64_offset8 x18, sp, 48
-;       ab: 0e 23 40                        xconst8 spilltmp0, 64
-;       ae: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;       b2: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       b6: 22 22 20                        load64 fp, sp
-;       b9: 0e 23 10                        xconst8 spilltmp0, 16
-;       bc: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       a3: 25 10 1b 38                     load64_offset8 x16, sp, 56
+;       a7: 25 12 1b 30                     load64_offset8 x18, sp, 48
+;       ab: 0e 1e 40                        xconst8 spilltmp0, 64
+;       ae: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;       b2: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       b6: 22 1d 1b                        load64 fp, sp
+;       b9: 0e 1e 10                        xconst8 spilltmp0, 16
+;       bc: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       c0: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -29,18 +29,18 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 00 00                        xconst8 x0, 0
-;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
-;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       20: 22 1d 1b                        load64 fp, sp
-;       23: 0e 1e 10                        xconst8 spilltmp0, 16
-;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       2a: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 00 00                        xconst8 x0, 0
+;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
+;       18: 0e 00 01                        xconst8 x0, 1
+;       1b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       1f: 22 1d 1b                        load64 fp, sp
+;       22: 0e 1e 10                        xconst8 spilltmp0, 16
+;       25: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       28: 00                              ret
 
 function %colocated_args_i32_rets_i32() -> i32 {
     fn0 = colocated %g(i32) -> i32
@@ -70,18 +70,18 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 00 00                        xconst8 x0, 0
-;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
-;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       20: 22 1d 1b                        load64 fp, sp
-;       23: 0e 1e 10                        xconst8 spilltmp0, 16
-;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       2a: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 00 00                        xconst8 x0, 0
+;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
+;       18: 0e 00 01                        xconst8 x0, 1
+;       1b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       1f: 22 1d 1b                        load64 fp, sp
+;       22: 0e 1e 10                        xconst8 spilltmp0, 16
+;       25: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       28: 00                              ret
 
 function %colocated_args_i64_i32_i64_i32() {
     fn0 = colocated %g(i64, i32, i64, i32)
@@ -115,20 +115,20 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 00 00                        xconst8 x0, 0
-;       14: 0e 01 01                        xconst8 x1, 1
-;       17: 0e 02 02                        xconst8 x2, 2
-;       1a: 0e 03 03                        xconst8 x3, 3
-;       1d: 01 00 00 00 00                  call 0x0    // target = 0x1d
-;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       26: 22 1d 1b                        load64 fp, sp
-;       29: 0e 1e 10                        xconst8 spilltmp0, 16
-;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       30: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 00 00                        xconst8 x0, 0
+;       13: 0e 01 01                        xconst8 x1, 1
+;       16: 0e 02 02                        xconst8 x2, 2
+;       19: 0e 03 03                        xconst8 x3, 3
+;       1c: 01 00 00 00 00                  call 0x0    // target = 0x1c
+;       21: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       25: 22 1d 1b                        load64 fp, sp
+;       28: 0e 1e 10                        xconst8 spilltmp0, 16
+;       2b: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       2e: 00                              ret
 
 function %colocated_rets_i64_i64_i64_i64() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64
@@ -160,19 +160,19 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 01 00 00 00 00                  call 0x0    // target = 0x11
-;       16: 13 04 00 02                     xadd64 x4, x0, x2
-;       1a: 13 03 01 03                     xadd64 x3, x1, x3
-;       1e: 13 00 04 03                     xadd64 x0, x4, x3
-;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       26: 22 1d 1b                        load64 fp, sp
-;       29: 0e 1e 10                        xconst8 spilltmp0, 16
-;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       30: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 01 00 00 00 00                  call 0x0    // target = 0x10
+;       15: 13 04 08                        xadd64 x4, x0, x2
+;       18: 13 23 0c                        xadd64 x3, x1, x3
+;       1b: 13 80 0c                        xadd64 x0, x4, x3
+;       1e: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       22: 22 1d 1b                        load64 fp, sp
+;       25: 0e 1e 10                        xconst8 spilltmp0, 16
+;       28: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       2b: 00                              ret
 
 function %colocated_stack_args() {
     fn0 = colocated %g(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64)
@@ -225,42 +225,42 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 1e d0                        xconst8 spilltmp0, -48
-;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       18: 0e 0f 00                        xconst8 x15, 0
-;       1b: 2a 1b 0f                        store64 sp, x15
-;       1e: 2c 1b 08 0f                     store64_offset8 sp, 8, x15
-;       22: 2c 1b 10 0f                     store64_offset8 sp, 16, x15
-;       26: 2c 1b 18 0f                     store64_offset8 sp, 24, x15
-;       2a: 2c 1b 20 0f                     store64_offset8 sp, 32, x15
-;       2e: 2c 1b 28 0f                     store64_offset8 sp, 40, x15
-;       32: 0b 00 0f                        xmov x0, x15
-;       35: 0b 01 0f                        xmov x1, x15
-;       38: 0b 02 0f                        xmov x2, x15
-;       3b: 0b 03 0f                        xmov x3, x15
-;       3e: 0b 04 0f                        xmov x4, x15
-;       41: 0b 05 0f                        xmov x5, x15
-;       44: 0b 06 0f                        xmov x6, x15
-;       47: 0b 07 0f                        xmov x7, x15
-;       4a: 0b 08 0f                        xmov x8, x15
-;       4d: 0b 09 0f                        xmov x9, x15
-;       50: 0b 0a 0f                        xmov x10, x15
-;       53: 0b 0b 0f                        xmov x11, x15
-;       56: 0b 0c 0f                        xmov x12, x15
-;       59: 0b 0d 0f                        xmov x13, x15
-;       5c: 0b 0e 0f                        xmov x14, x15
-;       5f: 01 00 00 00 00                  call 0x0    // target = 0x5f
-;       64: 0e 1e 30                        xconst8 spilltmp0, 48
-;       67: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       6b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       6f: 22 1d 1b                        load64 fp, sp
-;       72: 0e 1e 10                        xconst8 spilltmp0, 16
-;       75: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       79: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 1e d0                        xconst8 spilltmp0, -48
+;       13: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       16: 0e 0f 00                        xconst8 x15, 0
+;       19: 2a 1b 0f                        store64 sp, x15
+;       1c: 2c 1b 08 0f                     store64_offset8 sp, 8, x15
+;       20: 2c 1b 10 0f                     store64_offset8 sp, 16, x15
+;       24: 2c 1b 18 0f                     store64_offset8 sp, 24, x15
+;       28: 2c 1b 20 0f                     store64_offset8 sp, 32, x15
+;       2c: 2c 1b 28 0f                     store64_offset8 sp, 40, x15
+;       30: 0b 00 0f                        xmov x0, x15
+;       33: 0b 01 0f                        xmov x1, x15
+;       36: 0b 02 0f                        xmov x2, x15
+;       39: 0b 03 0f                        xmov x3, x15
+;       3c: 0b 04 0f                        xmov x4, x15
+;       3f: 0b 05 0f                        xmov x5, x15
+;       42: 0b 06 0f                        xmov x6, x15
+;       45: 0b 07 0f                        xmov x7, x15
+;       48: 0b 08 0f                        xmov x8, x15
+;       4b: 0b 09 0f                        xmov x9, x15
+;       4e: 0b 0a 0f                        xmov x10, x15
+;       51: 0b 0b 0f                        xmov x11, x15
+;       54: 0b 0c 0f                        xmov x12, x15
+;       57: 0b 0d 0f                        xmov x13, x15
+;       5a: 0b 0e 0f                        xmov x14, x15
+;       5d: 01 00 00 00 00                  call 0x0    // target = 0x5d
+;       62: 0e 1e 30                        xconst8 spilltmp0, 48
+;       65: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       68: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       6c: 22 1d 1b                        load64 fp, sp
+;       6f: 0e 1e 10                        xconst8 spilltmp0, 16
+;       72: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       75: 00                              ret
 
 function %colocated_stack_rets() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64
@@ -355,55 +355,55 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 1e c0                        xconst8 spilltmp0, -64
-;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       18: 2c 1b 38 10                     store64_offset8 sp, 56, x16
-;       1c: 2c 1b 30 12                     store64_offset8 sp, 48, x18
-;       20: 0b 00 1b                        xmov x0, sp
-;       23: 01 00 00 00 00                  call 0x0    // target = 0x23
-;       28: 0b 10 0d                        xmov x16, x13
-;       2b: 0b 12 0b                        xmov x18, x11
-;       2e: 22 19 1b                        load64 x25, sp
-;       31: 25 0b 1b 08                     load64_offset8 x11, sp, 8
-;       35: 25 0d 1b 10                     load64_offset8 x13, sp, 16
-;       39: 25 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
-;       3d: 25 11 1b 20                     load64_offset8 x17, sp, 32
-;       41: 13 1e 00 01                     xadd64 spilltmp0, x0, x1
-;       45: 13 1d 02 03                     xadd64 fp, x2, x3
-;       49: 13 05 04 05                     xadd64 x5, x4, x5
-;       4d: 13 06 06 07                     xadd64 x6, x6, x7
-;       51: 13 07 08 09                     xadd64 x7, x8, x9
-;       55: 0b 00 12                        xmov x0, x18
-;       58: 13 04 0a 00                     xadd64 x4, x10, x0
-;       5c: 0b 0a 10                        xmov x10, x16
-;       5f: 13 08 0c 0a                     xadd64 x8, x12, x10
-;       63: 13 0e 0e 0f                     xadd64 x14, x14, x15
-;       67: 13 0f 19 0b                     xadd64 x15, x25, x11
-;       6b: 13 0d 0b 0d                     xadd64 x13, x11, x13
-;       6f: 13 00 1f 11                     xadd64 x0, spilltmp1, x17
-;       73: 13 01 1e 1d                     xadd64 x1, spilltmp0, fp
-;       77: 13 02 05 06                     xadd64 x2, x5, x6
-;       7b: 13 03 07 04                     xadd64 x3, x7, x4
-;       7f: 13 0e 08 0e                     xadd64 x14, x8, x14
-;       83: 13 0d 0f 0d                     xadd64 x13, x15, x13
-;       87: 13 0f 00 00                     xadd64 x15, x0, x0
-;       8b: 13 00 01 02                     xadd64 x0, x1, x2
-;       8f: 13 0e 03 0e                     xadd64 x14, x3, x14
-;       93: 13 0d 0d 0f                     xadd64 x13, x13, x15
-;       97: 13 0e 00 0e                     xadd64 x14, x0, x14
-;       9b: 13 0d 0d 0d                     xadd64 x13, x13, x13
-;       9f: 13 00 0e 0d                     xadd64 x0, x14, x13
-;       a3: 25 10 1b 38                     load64_offset8 x16, sp, 56
-;       a7: 25 12 1b 30                     load64_offset8 x18, sp, 48
-;       ab: 0e 1e 40                        xconst8 spilltmp0, 64
-;       ae: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       b2: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       b6: 22 1d 1b                        load64 fp, sp
-;       b9: 0e 1e 10                        xconst8 spilltmp0, 16
-;       bc: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       c0: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 1e c0                        xconst8 spilltmp0, -64
+;       13: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       16: 2c 1b 38 10                     store64_offset8 sp, 56, x16
+;       1a: 2c 1b 30 12                     store64_offset8 sp, 48, x18
+;       1e: 0b 00 1b                        xmov x0, sp
+;       21: 01 00 00 00 00                  call 0x0    // target = 0x21
+;       26: 0b 10 0d                        xmov x16, x13
+;       29: 0b 12 0b                        xmov x18, x11
+;       2c: 22 19 1b                        load64 x25, sp
+;       2f: 25 0b 1b 08                     load64_offset8 x11, sp, 8
+;       33: 25 0d 1b 10                     load64_offset8 x13, sp, 16
+;       37: 25 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
+;       3b: 25 11 1b 20                     load64_offset8 x17, sp, 32
+;       3f: 13 1e 04                        xadd64 spilltmp0, x0, x1
+;       42: 13 5d 0c                        xadd64 fp, x2, x3
+;       45: 13 85 14                        xadd64 x5, x4, x5
+;       48: 13 c6 1c                        xadd64 x6, x6, x7
+;       4b: 13 07 25                        xadd64 x7, x8, x9
+;       4e: 0b 00 12                        xmov x0, x18
+;       51: 13 44 01                        xadd64 x4, x10, x0
+;       54: 0b 0a 10                        xmov x10, x16
+;       57: 13 88 29                        xadd64 x8, x12, x10
+;       5a: 13 ce 3d                        xadd64 x14, x14, x15
+;       5d: 13 2f 2f                        xadd64 x15, x25, x11
+;       60: 13 6d 35                        xadd64 x13, x11, x13
+;       63: 13 e0 47                        xadd64 x0, spilltmp1, x17
+;       66: 13 c1 77                        xadd64 x1, spilltmp0, fp
+;       69: 13 a2 18                        xadd64 x2, x5, x6
+;       6c: 13 e3 10                        xadd64 x3, x7, x4
+;       6f: 13 0e 39                        xadd64 x14, x8, x14
+;       72: 13 ed 35                        xadd64 x13, x15, x13
+;       75: 13 0f 00                        xadd64 x15, x0, x0
+;       78: 13 20 08                        xadd64 x0, x1, x2
+;       7b: 13 6e 38                        xadd64 x14, x3, x14
+;       7e: 13 ad 3d                        xadd64 x13, x13, x15
+;       81: 13 0e 38                        xadd64 x14, x0, x14
+;       84: 13 ad 35                        xadd64 x13, x13, x13
+;       87: 13 c0 35                        xadd64 x0, x14, x13
+;       8a: 25 10 1b 38                     load64_offset8 x16, sp, 56
+;       8e: 25 12 1b 30                     load64_offset8 x18, sp, 48
+;       92: 0e 1e 40                        xconst8 spilltmp0, 64
+;       95: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       98: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       9c: 22 1d 1b                        load64 fp, sp
+;       9f: 0e 1e 10                        xconst8 spilltmp0, 16
+;       a2: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       a5: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/iadd.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/iadd.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 12 00 00 01                     xadd32 x0, x0, x1
-;        4: 00                              ret
+;        0: 12 00 04                        xadd32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 12 00 00 01                     xadd32 x0, x0, x1
-;        4: 00                              ret
+;        0: 12 00 04                        xadd32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 12 00 00 01                     xadd32 x0, x0, x1
-;        4: 00                              ret
+;        0: 12 00 04                        xadd32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -58,6 +58,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 13 00 00 01                     xadd64 x0, x0, x1
-;        4: 00                              ret
+;        0: 13 00 04                        xadd64 x0, x0, x1
+;        3: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/icmp.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 00 01                     xeq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1a 00 04                        xeq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_eq(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 00 01                     xeq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1a 00 04                        xeq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_eq(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 00 01                     xeq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1a 00 04                        xeq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_eq(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -58,8 +58,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 00 00 01                     xeq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 14 00 04                        xeq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ne(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -73,8 +73,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 00 01                     xneq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1b 00 04                        xneq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_ne(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -88,8 +88,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 00 01                     xneq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1b 00 04                        xneq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_ne(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -103,8 +103,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 00 01                     xneq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1b 00 04                        xneq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_ne(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -118,8 +118,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 15 00 00 01                     xneq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 15 00 04                        xneq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ult(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -133,8 +133,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 00 01                     xult32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1e 00 04                        xult32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_ult(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -148,8 +148,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 00 01                     xult32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1e 00 04                        xult32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_ult(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -163,8 +163,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 00 01                     xult32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1e 00 04                        xult32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_ult(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -178,8 +178,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 00 01                     xult64 x0, x0, x1
-;        4: 00                              ret
+;        0: 18 00 04                        xult64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ule(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -193,8 +193,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 00 01                     xulteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1f 00 04                        xulteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_ule(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -208,8 +208,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 00 01                     xulteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1f 00 04                        xulteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_ule(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -223,8 +223,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 00 01                     xulteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1f 00 04                        xulteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_ule(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -238,8 +238,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 00 00 01                     xulteq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 19 00 04                        xulteq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_slt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -253,8 +253,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 00 01                     xslt32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1c 00 04                        xslt32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_slt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -268,8 +268,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 00 01                     xslt32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1c 00 04                        xslt32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_slt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -283,8 +283,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 00 01                     xslt32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1c 00 04                        xslt32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_slt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -298,8 +298,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 00 01                     xslt64 x0, x0, x1
-;        4: 00                              ret
+;        0: 16 00 04                        xslt64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_sle(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -313,8 +313,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 00 01                     xslteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1d 00 04                        xslteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_sle(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -328,8 +328,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 00 01                     xslteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1d 00 04                        xslteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_sle(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -343,8 +343,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 00 01                     xslteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1d 00 04                        xslteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_sle(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -358,8 +358,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 17 00 00 01                     xslteq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 17 00 04                        xslteq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ugt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -373,8 +373,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 01 00                     xult32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1e 20 00                        xult32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_ugt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -388,8 +388,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 01 00                     xult32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1e 20 00                        xult32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_ugt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -403,8 +403,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 01 00                     xult32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1e 20 00                        xult32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_ugt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -418,8 +418,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 01 00                     xult64 x0, x1, x0
-;        4: 00                              ret
+;        0: 18 20 00                        xult64 x0, x1, x0
+;        3: 00                              ret
 
 function %i8_sgt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -433,8 +433,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 01 00                     xslt32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1c 20 00                        xslt32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_sgt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -448,8 +448,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 01 00                     xslt32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1c 20 00                        xslt32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_sgt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -463,8 +463,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 01 00                     xslt32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1c 20 00                        xslt32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_sgt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -478,8 +478,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 01 00                     xslt64 x0, x1, x0
-;        4: 00                              ret
+;        0: 16 20 00                        xslt64 x0, x1, x0
+;        3: 00                              ret
 
 function %i8_uge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -493,8 +493,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 01 00                     xulteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1f 20 00                        xulteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_uge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -508,8 +508,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 01 00                     xulteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1f 20 00                        xulteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_uge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -523,8 +523,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 01 00                     xulteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1f 20 00                        xulteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_uge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -538,8 +538,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 00 01 00                     xulteq64 x0, x1, x0
-;        4: 00                              ret
+;        0: 19 20 00                        xulteq64 x0, x1, x0
+;        3: 00                              ret
 
 function %i8_sge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -553,8 +553,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 01 00                     xslteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1d 20 00                        xslteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_sge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -568,8 +568,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 01 00                     xslteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1d 20 00                        xslteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_sge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -583,8 +583,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 01 00                     xslteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1d 20 00                        xslteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_sge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -598,6 +598,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 17 00 01 00                     xslteq64 x0, x1, x0
-;        4: 00                              ret
+;        0: 17 20 00                        xslteq64 x0, x1, x0
+;        3: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/trap.clif
@@ -33,10 +33,10 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 0e 03 2a                        xconst8 x3, 42
-;        3: 14 03 00 03                     xeq64 x3, x0, x3
-;        7: 03 03 07 00 00 00               br_if x3, 0x7    // target = 0xe
-;        d: 00                              ret
-;        e: 33 00 00                        trap
+;        3: 14 03 0c                        xeq64 x3, x0, x3
+;        6: 03 03 07 00 00 00               br_if x3, 0x7    // target = 0xd
+;        c: 00                              ret
+;        d: 33 00 00                        trap
 
 function %trapz(i64) {
 block0(v0: i64):
@@ -58,8 +58,8 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 0e 03 2a                        xconst8 x3, 42
-;        3: 14 03 00 03                     xeq64 x3, x0, x3
-;        7: 04 03 07 00 00 00               br_if_not x3, 0x7    // target = 0xe
-;        d: 00                              ret
-;        e: 33 00 00                        trap
+;        3: 14 03 0c                        xeq64 x3, x0, x3
+;        6: 04 03 07 00 00 00               br_if_not x3, 0x7    // target = 0xd
+;        c: 00                              ret
+;        d: 33 00 00                        trap
 

--- a/cranelift/filetests/filetests/isa/pulley64/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif.clif
@@ -147,12 +147,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 05 00 01                     xeq32 x5, x0, x1
-;        4: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xe
-;        a: 0e 00 00                        xconst8 x0, 0
-;        d: 00                              ret
-;        e: 0e 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+;        0: 1a 05 04                        xeq32 x5, x0, x1
+;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
+;        9: 0e 00 00                        xconst8 x0, 0
+;        c: 00                              ret
+;        d: 0e 00 01                        xconst8 x0, 1
+;       10: 00                              ret
 
 function %brif_icmp_i16(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -180,12 +180,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 05 00 01                     xneq32 x5, x0, x1
-;        4: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xe
-;        a: 0e 00 00                        xconst8 x0, 0
-;        d: 00                              ret
-;        e: 0e 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+;        0: 1b 05 04                        xneq32 x5, x0, x1
+;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
+;        9: 0e 00 00                        xconst8 x0, 0
+;        c: 00                              ret
+;        d: 0e 00 01                        xconst8 x0, 1
+;       10: 00                              ret
 
 function %brif_icmp_i32(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -244,10 +244,10 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 05 01 00                     xulteq64 x5, x1, x0
-;        4: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xe
-;        a: 0e 00 00                        xconst8 x0, 0
-;        d: 00                              ret
-;        e: 0e 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+;        0: 19 25 00                        xulteq64 x5, x1, x0
+;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
+;        9: 0e 00 00                        xconst8 x0, 0
+;        c: 00                              ret
+;        d: 0e 00 01                        xconst8 x0, 1
+;       10: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -12,34 +12,34 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [1204185006387685820006398, 4294967295] }, callee_pop_size: 0 }
 ;   x0 = xconst8 1
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 0e 00 00                        xconst8 x0, 0
 ;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
 ;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       20: 22 22 20                        load64 fp, sp
-;       23: 0e 23 10                        xconst8 spilltmp0, 16
-;       26: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       20: 22 1d 1b                        load64 fp, sp
+;       23: 0e 1e 10                        xconst8 spilltmp0, 16
+;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       2a: 00                              ret
 
 function %colocated_args_i32_rets_i32() -> i32 {
@@ -53,34 +53,34 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [1204185006387685820006398, 4294967295] }, callee_pop_size: 0 }
 ;   x0 = xconst8 1
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 0e 00 00                        xconst8 x0, 0
 ;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
 ;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       20: 22 22 20                        load64 fp, sp
-;       23: 0e 23 10                        xconst8 spilltmp0, 16
-;       26: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       20: 22 1d 1b                        load64 fp, sp
+;       23: 0e 1e 10                        xconst8 spilltmp0, 16
+;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       2a: 00                              ret
 
 function %colocated_args_i64_i32_i64_i32() {
@@ -96,38 +96,38 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
 ;   x1 = xconst8 1
 ;   x2 = xconst8 2
 ;   x3 = xconst8 3
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [1204185006387685820006399, 4294967295] }, callee_pop_size: 0 }
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 0e 00 00                        xconst8 x0, 0
 ;       14: 0e 01 01                        xconst8 x1, 1
 ;       17: 0e 02 02                        xconst8 x2, 2
 ;       1a: 0e 03 03                        xconst8 x3, 3
 ;       1d: 01 00 00 00 00                  call 0x0    // target = 0x1d
-;       22: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       26: 22 22 20                        load64 fp, sp
-;       29: 0e 23 10                        xconst8 spilltmp0, 16
-;       2c: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       26: 22 1d 1b                        load64 fp, sp
+;       29: 0e 1e 10                        xconst8 spilltmp0, 16
+;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       30: 00                              ret
 
 function %colocated_rets_i64_i64_i64_i64() -> i64 {
@@ -142,36 +142,36 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
 ; block0:
 ;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [1204185006387685820006384, 4294967295] }, callee_pop_size: 0 }
 ;   x4 = xadd64 x0, x2
 ;   x3 = xadd64 x1, x3
 ;   x0 = xadd64 x4, x3
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
 ;       11: 01 00 00 00 00                  call 0x0    // target = 0x11
 ;       16: 13 04 00 02                     xadd64 x4, x0, x2
 ;       1a: 13 03 01 03                     xadd64 x3, x1, x3
 ;       1e: 13 00 04 03                     xadd64 x0, x4, x3
-;       22: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       26: 22 22 20                        load64 fp, sp
-;       29: 0e 23 10                        xconst8 spilltmp0, 16
-;       2c: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       26: 22 1d 1b                        load64 fp, sp
+;       29: 0e 1e 10                        xconst8 spilltmp0, 16
+;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       30: 00                              ret
 
 function %colocated_stack_args() {
@@ -184,13 +184,13 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
-;   x35 = xconst8 -48
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
+;   x30 = xconst8 -48
+;   x27 = xadd32 x27, x30
 ; block0:
 ;   x15 = xconst8 0
 ;   store64 OutgoingArg(0), x15 // flags =  notrap aligned
@@ -215,29 +215,29 @@ block0:
 ;   x13 = xmov x15
 ;   x14 = xmov x15
 ;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [1204185006387685820006399, 4294967295] }, callee_pop_size: 0 }
-;   x35 = xconst8 48
-;   x32 = xadd32 x32, x35
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 48
+;   x27 = xadd32 x27, x30
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
-;       11: 0e 23 d0                        xconst8 spilltmp0, -48
-;       14: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
+;       11: 0e 1e d0                        xconst8 spilltmp0, -48
+;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       18: 0e 0f 00                        xconst8 x15, 0
-;       1b: 2a 20 0f                        store64 sp, x15
-;       1e: 2c 20 08 0f                     store64_offset8 sp, 8, x15
-;       22: 2c 20 10 0f                     store64_offset8 sp, 16, x15
-;       26: 2c 20 18 0f                     store64_offset8 sp, 24, x15
-;       2a: 2c 20 20 0f                     store64_offset8 sp, 32, x15
-;       2e: 2c 20 28 0f                     store64_offset8 sp, 40, x15
+;       1b: 2a 1b 0f                        store64 sp, x15
+;       1e: 2c 1b 08 0f                     store64_offset8 sp, 8, x15
+;       22: 2c 1b 10 0f                     store64_offset8 sp, 16, x15
+;       26: 2c 1b 18 0f                     store64_offset8 sp, 24, x15
+;       2a: 2c 1b 20 0f                     store64_offset8 sp, 32, x15
+;       2e: 2c 1b 28 0f                     store64_offset8 sp, 40, x15
 ;       32: 0b 00 0f                        xmov x0, x15
 ;       35: 0b 01 0f                        xmov x1, x15
 ;       38: 0b 02 0f                        xmov x2, x15
@@ -254,12 +254,12 @@ block0:
 ;       59: 0b 0d 0f                        xmov x13, x15
 ;       5c: 0b 0e 0f                        xmov x14, x15
 ;       5f: 01 00 00 00 00                  call 0x0    // target = 0x5f
-;       64: 0e 23 30                        xconst8 spilltmp0, 48
-;       67: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;       6b: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       6f: 22 22 20                        load64 fp, sp
-;       72: 0e 23 10                        xconst8 spilltmp0, 16
-;       75: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       64: 0e 1e 30                        xconst8 spilltmp0, 48
+;       67: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;       6b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       6f: 22 1d 1b                        load64 fp, sp
+;       72: 0e 1e 10                        xconst8 spilltmp0, 16
+;       75: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       79: 00                              ret
 
 function %colocated_stack_rets() -> i64 {
@@ -299,13 +299,13 @@ block0:
 }
 
 ; VCode:
-;   x35 = xconst8 -16
-;   x32 = xadd32 x32, x35
-;   store64 sp+8, x33 // flags =  notrap aligned
-;   store64 sp+0, x34 // flags =  notrap aligned
-;   x34 = xmov x32
-;   x35 = xconst8 -64
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 -16
+;   x27 = xadd32 x27, x30
+;   store64 sp+8, x28 // flags =  notrap aligned
+;   store64 sp+0, x29 // flags =  notrap aligned
+;   x29 = xmov x27
+;   x30 = xconst8 -64
+;   x27 = xadd32 x27, x30
 ;   store64 sp+56, x16 // flags =  notrap aligned
 ;   store64 sp+48, x18 // flags =  notrap aligned
 ; block0:
@@ -345,35 +345,35 @@ block0:
 ;   x0 = xadd64 x14, x13
 ;   x16 = load64_u sp+56 // flags = notrap aligned
 ;   x18 = load64_u sp+48 // flags = notrap aligned
-;   x35 = xconst8 64
-;   x32 = xadd32 x32, x35
-;   x33 = load64_u sp+8 // flags = notrap aligned
-;   x34 = load64_u sp+0 // flags = notrap aligned
-;   x35 = xconst8 16
-;   x32 = xadd32 x32, x35
+;   x30 = xconst8 64
+;   x27 = xadd32 x27, x30
+;   x28 = load64_u sp+8 // flags = notrap aligned
+;   x29 = load64_u sp+0 // flags = notrap aligned
+;   x30 = xconst8 16
+;   x27 = xadd32 x27, x30
 ;   ret
 ;
 ; Disassembled:
-;        0: 0e 23 f0                        xconst8 spilltmp0, -16
-;        3: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;        7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-;        b: 2a 20 22                        store64 sp, fp
-;        e: 0b 22 20                        xmov fp, sp
-;       11: 0e 23 c0                        xconst8 spilltmp0, -64
-;       14: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;       18: 2c 20 38 10                     store64_offset8 sp, 56, x16
-;       1c: 2c 20 30 12                     store64_offset8 sp, 48, x18
-;       20: 0b 00 20                        xmov x0, sp
+;        0: 0e 1e f0                        xconst8 spilltmp0, -16
+;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        b: 2a 1b 1d                        store64 sp, fp
+;        e: 0b 1d 1b                        xmov fp, sp
+;       11: 0e 1e c0                        xconst8 spilltmp0, -64
+;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;       18: 2c 1b 38 10                     store64_offset8 sp, 56, x16
+;       1c: 2c 1b 30 12                     store64_offset8 sp, 48, x18
+;       20: 0b 00 1b                        xmov x0, sp
 ;       23: 01 00 00 00 00                  call 0x0    // target = 0x23
 ;       28: 0b 10 0d                        xmov x16, x13
 ;       2b: 0b 12 0b                        xmov x18, x11
-;       2e: 22 19 20                        load64 x25, sp
-;       31: 25 0b 20 08                     load64_offset8 x11, sp, 8
-;       35: 25 0d 20 10                     load64_offset8 x13, sp, 16
-;       39: 25 1f 20 18                     load64_offset8 x31, sp, 24
-;       3d: 25 11 20 20                     load64_offset8 x17, sp, 32
-;       41: 13 1e 00 01                     xadd64 x30, x0, x1
-;       45: 13 1d 02 03                     xadd64 x29, x2, x3
+;       2e: 22 19 1b                        load64 x25, sp
+;       31: 25 0b 1b 08                     load64_offset8 x11, sp, 8
+;       35: 25 0d 1b 10                     load64_offset8 x13, sp, 16
+;       39: 25 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
+;       3d: 25 11 1b 20                     load64_offset8 x17, sp, 32
+;       41: 13 1e 00 01                     xadd64 spilltmp0, x0, x1
+;       45: 13 1d 02 03                     xadd64 fp, x2, x3
 ;       49: 13 05 04 05                     xadd64 x5, x4, x5
 ;       4d: 13 06 06 07                     xadd64 x6, x6, x7
 ;       51: 13 07 08 09                     xadd64 x7, x8, x9
@@ -384,8 +384,8 @@ block0:
 ;       63: 13 0e 0e 0f                     xadd64 x14, x14, x15
 ;       67: 13 0f 19 0b                     xadd64 x15, x25, x11
 ;       6b: 13 0d 0b 0d                     xadd64 x13, x11, x13
-;       6f: 13 00 1f 11                     xadd64 x0, x31, x17
-;       73: 13 01 1e 1d                     xadd64 x1, x30, x29
+;       6f: 13 00 1f 11                     xadd64 x0, spilltmp1, x17
+;       73: 13 01 1e 1d                     xadd64 x1, spilltmp0, fp
 ;       77: 13 02 05 06                     xadd64 x2, x5, x6
 ;       7b: 13 03 07 04                     xadd64 x3, x7, x4
 ;       7f: 13 0e 08 0e                     xadd64 x14, x8, x14
@@ -397,13 +397,13 @@ block0:
 ;       97: 13 0e 00 0e                     xadd64 x14, x0, x14
 ;       9b: 13 0d 0d 0d                     xadd64 x13, x13, x13
 ;       9f: 13 00 0e 0d                     xadd64 x0, x14, x13
-;       a3: 25 10 20 38                     load64_offset8 x16, sp, 56
-;       a7: 25 12 20 30                     load64_offset8 x18, sp, 48
-;       ab: 0e 23 40                        xconst8 spilltmp0, 64
-;       ae: 12 20 20 23                     xadd32 sp, sp, spilltmp0
-;       b2: 25 21 20 08                     load64_offset8 lr, sp, 8
-;       b6: 22 22 20                        load64 fp, sp
-;       b9: 0e 23 10                        xconst8 spilltmp0, 16
-;       bc: 12 20 20 23                     xadd32 sp, sp, spilltmp0
+;       a3: 25 10 1b 38                     load64_offset8 x16, sp, 56
+;       a7: 25 12 1b 30                     load64_offset8 x18, sp, 48
+;       ab: 0e 1e 40                        xconst8 spilltmp0, 64
+;       ae: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
+;       b2: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       b6: 22 1d 1b                        load64 fp, sp
+;       b9: 0e 1e 10                        xconst8 spilltmp0, 16
+;       bc: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
 ;       c0: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -29,18 +29,18 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 00 00                        xconst8 x0, 0
-;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
-;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       20: 22 1d 1b                        load64 fp, sp
-;       23: 0e 1e 10                        xconst8 spilltmp0, 16
-;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       2a: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 00 00                        xconst8 x0, 0
+;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
+;       18: 0e 00 01                        xconst8 x0, 1
+;       1b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       1f: 22 1d 1b                        load64 fp, sp
+;       22: 0e 1e 10                        xconst8 spilltmp0, 16
+;       25: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       28: 00                              ret
 
 function %colocated_args_i32_rets_i32() -> i32 {
     fn0 = colocated %g(i32) -> i32
@@ -70,18 +70,18 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 00 00                        xconst8 x0, 0
-;       14: 01 00 00 00 00                  call 0x0    // target = 0x14
-;       19: 0e 00 01                        xconst8 x0, 1
-;       1c: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       20: 22 1d 1b                        load64 fp, sp
-;       23: 0e 1e 10                        xconst8 spilltmp0, 16
-;       26: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       2a: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 00 00                        xconst8 x0, 0
+;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
+;       18: 0e 00 01                        xconst8 x0, 1
+;       1b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       1f: 22 1d 1b                        load64 fp, sp
+;       22: 0e 1e 10                        xconst8 spilltmp0, 16
+;       25: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       28: 00                              ret
 
 function %colocated_args_i64_i32_i64_i32() {
     fn0 = colocated %g(i64, i32, i64, i32)
@@ -115,20 +115,20 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 00 00                        xconst8 x0, 0
-;       14: 0e 01 01                        xconst8 x1, 1
-;       17: 0e 02 02                        xconst8 x2, 2
-;       1a: 0e 03 03                        xconst8 x3, 3
-;       1d: 01 00 00 00 00                  call 0x0    // target = 0x1d
-;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       26: 22 1d 1b                        load64 fp, sp
-;       29: 0e 1e 10                        xconst8 spilltmp0, 16
-;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       30: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 00 00                        xconst8 x0, 0
+;       13: 0e 01 01                        xconst8 x1, 1
+;       16: 0e 02 02                        xconst8 x2, 2
+;       19: 0e 03 03                        xconst8 x3, 3
+;       1c: 01 00 00 00 00                  call 0x0    // target = 0x1c
+;       21: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       25: 22 1d 1b                        load64 fp, sp
+;       28: 0e 1e 10                        xconst8 spilltmp0, 16
+;       2b: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       2e: 00                              ret
 
 function %colocated_rets_i64_i64_i64_i64() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64
@@ -160,19 +160,19 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 01 00 00 00 00                  call 0x0    // target = 0x11
-;       16: 13 04 00 02                     xadd64 x4, x0, x2
-;       1a: 13 03 01 03                     xadd64 x3, x1, x3
-;       1e: 13 00 04 03                     xadd64 x0, x4, x3
-;       22: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       26: 22 1d 1b                        load64 fp, sp
-;       29: 0e 1e 10                        xconst8 spilltmp0, 16
-;       2c: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       30: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 01 00 00 00 00                  call 0x0    // target = 0x10
+;       15: 13 04 08                        xadd64 x4, x0, x2
+;       18: 13 23 0c                        xadd64 x3, x1, x3
+;       1b: 13 80 0c                        xadd64 x0, x4, x3
+;       1e: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       22: 22 1d 1b                        load64 fp, sp
+;       25: 0e 1e 10                        xconst8 spilltmp0, 16
+;       28: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       2b: 00                              ret
 
 function %colocated_stack_args() {
     fn0 = colocated %g(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64)
@@ -225,42 +225,42 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 1e d0                        xconst8 spilltmp0, -48
-;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       18: 0e 0f 00                        xconst8 x15, 0
-;       1b: 2a 1b 0f                        store64 sp, x15
-;       1e: 2c 1b 08 0f                     store64_offset8 sp, 8, x15
-;       22: 2c 1b 10 0f                     store64_offset8 sp, 16, x15
-;       26: 2c 1b 18 0f                     store64_offset8 sp, 24, x15
-;       2a: 2c 1b 20 0f                     store64_offset8 sp, 32, x15
-;       2e: 2c 1b 28 0f                     store64_offset8 sp, 40, x15
-;       32: 0b 00 0f                        xmov x0, x15
-;       35: 0b 01 0f                        xmov x1, x15
-;       38: 0b 02 0f                        xmov x2, x15
-;       3b: 0b 03 0f                        xmov x3, x15
-;       3e: 0b 04 0f                        xmov x4, x15
-;       41: 0b 05 0f                        xmov x5, x15
-;       44: 0b 06 0f                        xmov x6, x15
-;       47: 0b 07 0f                        xmov x7, x15
-;       4a: 0b 08 0f                        xmov x8, x15
-;       4d: 0b 09 0f                        xmov x9, x15
-;       50: 0b 0a 0f                        xmov x10, x15
-;       53: 0b 0b 0f                        xmov x11, x15
-;       56: 0b 0c 0f                        xmov x12, x15
-;       59: 0b 0d 0f                        xmov x13, x15
-;       5c: 0b 0e 0f                        xmov x14, x15
-;       5f: 01 00 00 00 00                  call 0x0    // target = 0x5f
-;       64: 0e 1e 30                        xconst8 spilltmp0, 48
-;       67: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       6b: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       6f: 22 1d 1b                        load64 fp, sp
-;       72: 0e 1e 10                        xconst8 spilltmp0, 16
-;       75: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       79: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 1e d0                        xconst8 spilltmp0, -48
+;       13: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       16: 0e 0f 00                        xconst8 x15, 0
+;       19: 2a 1b 0f                        store64 sp, x15
+;       1c: 2c 1b 08 0f                     store64_offset8 sp, 8, x15
+;       20: 2c 1b 10 0f                     store64_offset8 sp, 16, x15
+;       24: 2c 1b 18 0f                     store64_offset8 sp, 24, x15
+;       28: 2c 1b 20 0f                     store64_offset8 sp, 32, x15
+;       2c: 2c 1b 28 0f                     store64_offset8 sp, 40, x15
+;       30: 0b 00 0f                        xmov x0, x15
+;       33: 0b 01 0f                        xmov x1, x15
+;       36: 0b 02 0f                        xmov x2, x15
+;       39: 0b 03 0f                        xmov x3, x15
+;       3c: 0b 04 0f                        xmov x4, x15
+;       3f: 0b 05 0f                        xmov x5, x15
+;       42: 0b 06 0f                        xmov x6, x15
+;       45: 0b 07 0f                        xmov x7, x15
+;       48: 0b 08 0f                        xmov x8, x15
+;       4b: 0b 09 0f                        xmov x9, x15
+;       4e: 0b 0a 0f                        xmov x10, x15
+;       51: 0b 0b 0f                        xmov x11, x15
+;       54: 0b 0c 0f                        xmov x12, x15
+;       57: 0b 0d 0f                        xmov x13, x15
+;       5a: 0b 0e 0f                        xmov x14, x15
+;       5d: 01 00 00 00 00                  call 0x0    // target = 0x5d
+;       62: 0e 1e 30                        xconst8 spilltmp0, 48
+;       65: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       68: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       6c: 22 1d 1b                        load64 fp, sp
+;       6f: 0e 1e 10                        xconst8 spilltmp0, 16
+;       72: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       75: 00                              ret
 
 function %colocated_stack_rets() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64
@@ -355,55 +355,55 @@ block0:
 ;
 ; Disassembled:
 ;        0: 0e 1e f0                        xconst8 spilltmp0, -16
-;        3: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;        7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-;        b: 2a 1b 1d                        store64 sp, fp
-;        e: 0b 1d 1b                        xmov fp, sp
-;       11: 0e 1e c0                        xconst8 spilltmp0, -64
-;       14: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       18: 2c 1b 38 10                     store64_offset8 sp, 56, x16
-;       1c: 2c 1b 30 12                     store64_offset8 sp, 48, x18
-;       20: 0b 00 1b                        xmov x0, sp
-;       23: 01 00 00 00 00                  call 0x0    // target = 0x23
-;       28: 0b 10 0d                        xmov x16, x13
-;       2b: 0b 12 0b                        xmov x18, x11
-;       2e: 22 19 1b                        load64 x25, sp
-;       31: 25 0b 1b 08                     load64_offset8 x11, sp, 8
-;       35: 25 0d 1b 10                     load64_offset8 x13, sp, 16
-;       39: 25 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
-;       3d: 25 11 1b 20                     load64_offset8 x17, sp, 32
-;       41: 13 1e 00 01                     xadd64 spilltmp0, x0, x1
-;       45: 13 1d 02 03                     xadd64 fp, x2, x3
-;       49: 13 05 04 05                     xadd64 x5, x4, x5
-;       4d: 13 06 06 07                     xadd64 x6, x6, x7
-;       51: 13 07 08 09                     xadd64 x7, x8, x9
-;       55: 0b 00 12                        xmov x0, x18
-;       58: 13 04 0a 00                     xadd64 x4, x10, x0
-;       5c: 0b 0a 10                        xmov x10, x16
-;       5f: 13 08 0c 0a                     xadd64 x8, x12, x10
-;       63: 13 0e 0e 0f                     xadd64 x14, x14, x15
-;       67: 13 0f 19 0b                     xadd64 x15, x25, x11
-;       6b: 13 0d 0b 0d                     xadd64 x13, x11, x13
-;       6f: 13 00 1f 11                     xadd64 x0, spilltmp1, x17
-;       73: 13 01 1e 1d                     xadd64 x1, spilltmp0, fp
-;       77: 13 02 05 06                     xadd64 x2, x5, x6
-;       7b: 13 03 07 04                     xadd64 x3, x7, x4
-;       7f: 13 0e 08 0e                     xadd64 x14, x8, x14
-;       83: 13 0d 0f 0d                     xadd64 x13, x15, x13
-;       87: 13 0f 00 00                     xadd64 x15, x0, x0
-;       8b: 13 00 01 02                     xadd64 x0, x1, x2
-;       8f: 13 0e 03 0e                     xadd64 x14, x3, x14
-;       93: 13 0d 0d 0f                     xadd64 x13, x13, x15
-;       97: 13 0e 00 0e                     xadd64 x14, x0, x14
-;       9b: 13 0d 0d 0d                     xadd64 x13, x13, x13
-;       9f: 13 00 0e 0d                     xadd64 x0, x14, x13
-;       a3: 25 10 1b 38                     load64_offset8 x16, sp, 56
-;       a7: 25 12 1b 30                     load64_offset8 x18, sp, 48
-;       ab: 0e 1e 40                        xconst8 spilltmp0, 64
-;       ae: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       b2: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-;       b6: 22 1d 1b                        load64 fp, sp
-;       b9: 0e 1e 10                        xconst8 spilltmp0, 16
-;       bc: 12 1b 1b 1e                     xadd32 sp, sp, spilltmp0
-;       c0: 00                              ret
+;        3: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;        6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+;        a: 2a 1b 1d                        store64 sp, fp
+;        d: 0b 1d 1b                        xmov fp, sp
+;       10: 0e 1e c0                        xconst8 spilltmp0, -64
+;       13: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       16: 2c 1b 38 10                     store64_offset8 sp, 56, x16
+;       1a: 2c 1b 30 12                     store64_offset8 sp, 48, x18
+;       1e: 0b 00 1b                        xmov x0, sp
+;       21: 01 00 00 00 00                  call 0x0    // target = 0x21
+;       26: 0b 10 0d                        xmov x16, x13
+;       29: 0b 12 0b                        xmov x18, x11
+;       2c: 22 19 1b                        load64 x25, sp
+;       2f: 25 0b 1b 08                     load64_offset8 x11, sp, 8
+;       33: 25 0d 1b 10                     load64_offset8 x13, sp, 16
+;       37: 25 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
+;       3b: 25 11 1b 20                     load64_offset8 x17, sp, 32
+;       3f: 13 1e 04                        xadd64 spilltmp0, x0, x1
+;       42: 13 5d 0c                        xadd64 fp, x2, x3
+;       45: 13 85 14                        xadd64 x5, x4, x5
+;       48: 13 c6 1c                        xadd64 x6, x6, x7
+;       4b: 13 07 25                        xadd64 x7, x8, x9
+;       4e: 0b 00 12                        xmov x0, x18
+;       51: 13 44 01                        xadd64 x4, x10, x0
+;       54: 0b 0a 10                        xmov x10, x16
+;       57: 13 88 29                        xadd64 x8, x12, x10
+;       5a: 13 ce 3d                        xadd64 x14, x14, x15
+;       5d: 13 2f 2f                        xadd64 x15, x25, x11
+;       60: 13 6d 35                        xadd64 x13, x11, x13
+;       63: 13 e0 47                        xadd64 x0, spilltmp1, x17
+;       66: 13 c1 77                        xadd64 x1, spilltmp0, fp
+;       69: 13 a2 18                        xadd64 x2, x5, x6
+;       6c: 13 e3 10                        xadd64 x3, x7, x4
+;       6f: 13 0e 39                        xadd64 x14, x8, x14
+;       72: 13 ed 35                        xadd64 x13, x15, x13
+;       75: 13 0f 00                        xadd64 x15, x0, x0
+;       78: 13 20 08                        xadd64 x0, x1, x2
+;       7b: 13 6e 38                        xadd64 x14, x3, x14
+;       7e: 13 ad 3d                        xadd64 x13, x13, x15
+;       81: 13 0e 38                        xadd64 x14, x0, x14
+;       84: 13 ad 35                        xadd64 x13, x13, x13
+;       87: 13 c0 35                        xadd64 x0, x14, x13
+;       8a: 25 10 1b 38                     load64_offset8 x16, sp, 56
+;       8e: 25 12 1b 30                     load64_offset8 x18, sp, 48
+;       92: 0e 1e 40                        xconst8 spilltmp0, 64
+;       95: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       98: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+;       9c: 22 1d 1b                        load64 fp, sp
+;       9f: 0e 1e 10                        xconst8 spilltmp0, 16
+;       a2: 12 7b 7b                        xadd32 sp, sp, spilltmp0
+;       a5: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/iadd.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/iadd.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 12 00 00 01                     xadd32 x0, x0, x1
-;        4: 00                              ret
+;        0: 12 00 04                        xadd32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 12 00 00 01                     xadd32 x0, x0, x1
-;        4: 00                              ret
+;        0: 12 00 04                        xadd32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 12 00 00 01                     xadd32 x0, x0, x1
-;        4: 00                              ret
+;        0: 12 00 04                        xadd32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -58,6 +58,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 13 00 00 01                     xadd64 x0, x0, x1
-;        4: 00                              ret
+;        0: 13 00 04                        xadd64 x0, x0, x1
+;        3: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/icmp.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 00 01                     xeq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1a 00 04                        xeq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_eq(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 00 01                     xeq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1a 00 04                        xeq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_eq(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 00 01                     xeq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1a 00 04                        xeq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_eq(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -58,8 +58,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 00 00 01                     xeq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 14 00 04                        xeq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ne(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -73,8 +73,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 00 01                     xneq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1b 00 04                        xneq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_ne(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -88,8 +88,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 00 01                     xneq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1b 00 04                        xneq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_ne(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -103,8 +103,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 00 01                     xneq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1b 00 04                        xneq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_ne(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -118,8 +118,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 15 00 00 01                     xneq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 15 00 04                        xneq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ult(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -133,8 +133,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 00 01                     xult32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1e 00 04                        xult32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_ult(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -148,8 +148,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 00 01                     xult32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1e 00 04                        xult32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_ult(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -163,8 +163,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 00 01                     xult32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1e 00 04                        xult32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_ult(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -178,8 +178,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 00 01                     xult64 x0, x0, x1
-;        4: 00                              ret
+;        0: 18 00 04                        xult64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ule(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -193,8 +193,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 00 01                     xulteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1f 00 04                        xulteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_ule(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -208,8 +208,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 00 01                     xulteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1f 00 04                        xulteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_ule(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -223,8 +223,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 00 01                     xulteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1f 00 04                        xulteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_ule(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -238,8 +238,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 00 00 01                     xulteq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 19 00 04                        xulteq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_slt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -253,8 +253,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 00 01                     xslt32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1c 00 04                        xslt32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_slt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -268,8 +268,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 00 01                     xslt32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1c 00 04                        xslt32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_slt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -283,8 +283,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 00 01                     xslt32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1c 00 04                        xslt32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_slt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -298,8 +298,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 00 01                     xslt64 x0, x0, x1
-;        4: 00                              ret
+;        0: 16 00 04                        xslt64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_sle(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -313,8 +313,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 00 01                     xslteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1d 00 04                        xslteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i16_sle(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -328,8 +328,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 00 01                     xslteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1d 00 04                        xslteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i32_sle(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -343,8 +343,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 00 01                     xslteq32 x0, x0, x1
-;        4: 00                              ret
+;        0: 1d 00 04                        xslteq32 x0, x0, x1
+;        3: 00                              ret
 
 function %i64_sle(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -358,8 +358,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 17 00 00 01                     xslteq64 x0, x0, x1
-;        4: 00                              ret
+;        0: 17 00 04                        xslteq64 x0, x0, x1
+;        3: 00                              ret
 
 function %i8_ugt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -373,8 +373,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 01 00                     xult32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1e 20 00                        xult32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_ugt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -388,8 +388,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 01 00                     xult32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1e 20 00                        xult32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_ugt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -403,8 +403,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 01 00                     xult32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1e 20 00                        xult32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_ugt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -418,8 +418,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 01 00                     xult64 x0, x1, x0
-;        4: 00                              ret
+;        0: 18 20 00                        xult64 x0, x1, x0
+;        3: 00                              ret
 
 function %i8_sgt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -433,8 +433,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 01 00                     xslt32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1c 20 00                        xslt32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_sgt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -448,8 +448,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 01 00                     xslt32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1c 20 00                        xslt32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_sgt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -463,8 +463,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 01 00                     xslt32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1c 20 00                        xslt32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_sgt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -478,8 +478,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 01 00                     xslt64 x0, x1, x0
-;        4: 00                              ret
+;        0: 16 20 00                        xslt64 x0, x1, x0
+;        3: 00                              ret
 
 function %i8_uge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -493,8 +493,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 01 00                     xulteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1f 20 00                        xulteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_uge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -508,8 +508,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 01 00                     xulteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1f 20 00                        xulteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_uge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -523,8 +523,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 01 00                     xulteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1f 20 00                        xulteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_uge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -538,8 +538,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 00 01 00                     xulteq64 x0, x1, x0
-;        4: 00                              ret
+;        0: 19 20 00                        xulteq64 x0, x1, x0
+;        3: 00                              ret
 
 function %i8_sge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -553,8 +553,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 01 00                     xslteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1d 20 00                        xslteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i16_sge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -568,8 +568,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 01 00                     xslteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1d 20 00                        xslteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i32_sge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -583,8 +583,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 01 00                     xslteq32 x0, x1, x0
-;        4: 00                              ret
+;        0: 1d 20 00                        xslteq32 x0, x1, x0
+;        3: 00                              ret
 
 function %i64_sge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -598,6 +598,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 17 00 01 00                     xslteq64 x0, x1, x0
-;        4: 00                              ret
+;        0: 17 20 00                        xslteq64 x0, x1, x0
+;        3: 00                              ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/trap.clif
@@ -33,10 +33,10 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 0e 03 2a                        xconst8 x3, 42
-;        3: 14 03 00 03                     xeq64 x3, x0, x3
-;        7: 03 03 07 00 00 00               br_if x3, 0x7    // target = 0xe
-;        d: 00                              ret
-;        e: 33 00 00                        trap
+;        3: 14 03 0c                        xeq64 x3, x0, x3
+;        6: 03 03 07 00 00 00               br_if x3, 0x7    // target = 0xd
+;        c: 00                              ret
+;        d: 33 00 00                        trap
 
 function %trapz(i64) {
 block0(v0: i64):
@@ -58,8 +58,8 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 0e 03 2a                        xconst8 x3, 42
-;        3: 14 03 00 03                     xeq64 x3, x0, x3
-;        7: 04 03 07 00 00 00               br_if_not x3, 0x7    // target = 0xe
-;        d: 00                              ret
-;        e: 33 00 00                        trap
+;        3: 14 03 0c                        xeq64 x3, x0, x3
+;        6: 04 03 07 00 00 00               br_if_not x3, 0x7    // target = 0xd
+;        c: 00                              ret
+;        d: 33 00 00                        trap
 

--- a/pulley/README.md
+++ b/pulley/README.md
@@ -48,17 +48,17 @@ Here is the disassembly of `f(a, b) = a + b` in Pulley today:
 
 ```
        0: 0e 1a f0                        xconst8 x26, -16
-       3: 12 1b 1b 1a                     xadd32 sp, sp, x26
-       7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-       b: 2a 1b 1d                        store64 sp, fp
-       e: 0b 1d 1b                        xmov fp, sp
-      11: 12 00 00 01                     xadd32 x0, x0, x1
-      15: 0b 1b 1d                        xmov sp, fp
-      18: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-      1c: 22 1d 1b                        load64 fp, sp
-      1f: 0e 1a 10                        xconst8 x26, 16
-      22: 12 1b 1b 1a                     xadd32 sp, sp, x26
-      26: 00                              ret
+       3: 12 7b 6b                        xadd32 sp, sp, x26
+       6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+       a: 2a 1b 1d                        store64 sp, fp
+       d: 0b 1d 1b                        xmov fp, sp
+      10: 12 00 04                        xadd32 x0, x0, x1
+      13: 0b 1b 1d                        xmov sp, fp
+      16: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+      1a: 22 1d 1b                        load64 fp, sp
+      1d: 0e 1a 10                        xconst8 x26, 16
+      20: 12 7b 6b                        xadd32 sp, sp, x26
+      23: 00                              ret
 ```
 
 Note that there are a number of things that could be improved here:

--- a/pulley/README.md
+++ b/pulley/README.md
@@ -47,17 +47,17 @@ to change, instructions to appear and disappear, and APIs to be overhauled.
 Here is the disassembly of `f(a, b) = a + b` in Pulley today:
 
 ```
-       0: 0e 1f f0                        xconst8 x31, -16
-       3: 12 20 20 1f                     xadd32 sp, sp, x31
-       7: 29 20 08 21                     store64_offset8 sp, 8, lr
-       b: 27 20 22                        store64 sp, fp
-       e: 0b 22 20                        xmov fp, sp
+       0: 0e 1a f0                        xconst8 x26, -16
+       3: 12 1b 1b 1a                     xadd32 sp, sp, x26
+       7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+       b: 2a 1b 1d                        store64 sp, fp
+       e: 0b 1d 1b                        xmov fp, sp
       11: 12 00 00 01                     xadd32 x0, x0, x1
-      15: 0b 20 22                        xmov sp, fp
-      18: 25 21 20 08                     load64_offset8 lr, sp, 8
-      1c: 22 22 20                        load64 fp, sp
-      1f: 0e 1f 10                        xconst8 x31, 16
-      22: 12 20 20 1f                     xadd32 sp, sp, x31
+      15: 0b 1b 1d                        xmov sp, fp
+      18: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+      1c: 22 1d 1b                        load64 fp, sp
+      1f: 0e 1a 10                        xconst8 x26, 16
+      22: 12 1b 1b 1a                     xadd32 sp, sp, x26
       26: 00                              ret
 ```
 

--- a/pulley/fuzz/src/interp.rs
+++ b/pulley/fuzz/src/interp.rs
@@ -70,8 +70,6 @@ fn op_is_safe_for_fuzzing(op: &Op) -> bool {
         Op::Xconst16(op::Xconst16 { dst, .. }) => !dst.is_special(),
         Op::Xconst32(op::Xconst32 { dst, .. }) => !dst.is_special(),
         Op::Xconst64(op::Xconst64 { dst, .. }) => !dst.is_special(),
-        Op::Xadd32(op::Xadd32 { dst, .. }) => !dst.is_special(),
-        Op::Xadd64(op::Xadd64 { dst, .. }) => !dst.is_special(),
         Op::Load32U(_) => false,
         Op::Load32S(_) => false,
         Op::Load64(_) => false,
@@ -93,18 +91,20 @@ fn op_is_safe_for_fuzzing(op: &Op) -> bool {
         Op::BitcastFloatFromInt64(_) => true,
         Op::ExtendedOp(op) => extended_op_is_safe_for_fuzzing(op),
         Op::Call(_) => false,
-        Op::Xeq64(Xeq64 { dst, .. }) => !dst.is_special(),
-        Op::Xneq64(Xneq64 { dst, .. }) => !dst.is_special(),
-        Op::Xslt64(Xslt64 { dst, .. }) => !dst.is_special(),
-        Op::Xslteq64(Xslteq64 { dst, .. }) => !dst.is_special(),
-        Op::Xult64(Xult64 { dst, .. }) => !dst.is_special(),
-        Op::Xulteq64(Xulteq64 { dst, .. }) => !dst.is_special(),
-        Op::Xeq32(Xeq32 { dst, .. }) => !dst.is_special(),
-        Op::Xneq32(Xneq32 { dst, .. }) => !dst.is_special(),
-        Op::Xslt32(Xslt32 { dst, .. }) => !dst.is_special(),
-        Op::Xslteq32(Xslteq32 { dst, .. }) => !dst.is_special(),
-        Op::Xult32(Xult32 { dst, .. }) => !dst.is_special(),
-        Op::Xulteq32(Xulteq32 { dst, .. }) => !dst.is_special(),
+        Op::Xadd32(Xadd32 { operands, .. })
+        | Op::Xadd64(Xadd64 { operands, .. })
+        | Op::Xeq64(Xeq64 { operands, .. })
+        | Op::Xneq64(Xneq64 { operands, .. })
+        | Op::Xslt64(Xslt64 { operands, .. })
+        | Op::Xslteq64(Xslteq64 { operands, .. })
+        | Op::Xult64(Xult64 { operands, .. })
+        | Op::Xulteq64(Xulteq64 { operands, .. })
+        | Op::Xeq32(Xeq32 { operands, .. })
+        | Op::Xneq32(Xneq32 { operands, .. })
+        | Op::Xslt32(Xslt32 { operands, .. })
+        | Op::Xslteq32(Xslteq32 { operands, .. })
+        | Op::Xult32(Xult32 { operands, .. })
+        | Op::Xulteq32(Xulteq32 { operands, .. }) => !operands.dst.is_special(),
     }
 }
 

--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -375,6 +375,15 @@ impl Decode for PcRelOffset {
     }
 }
 
+impl<R: Reg> Decode for BinaryOperands<R> {
+    fn decode<T>(bytecode: &mut T) -> Result<Self, T::Error>
+    where
+        T: BytecodeStream,
+    {
+        u16::decode(bytecode).map(|bits| Self::from_bits(bits))
+    }
+}
+
 /// A Pulley bytecode decoder.
 ///
 /// Does not materialize bytecode instructions, instead all decoding methods are

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -127,6 +127,16 @@ impl Disas for PcRelOffset {
     }
 }
 
+impl<R: Disas> Disas for BinaryOperands<R> {
+    fn disas(&self, position: usize, disas: &mut String) {
+        self.dst.disas(position, disas);
+        write!(disas, ", ").unwrap();
+        self.src1.disas(position, disas);
+        write!(disas, ", ").unwrap();
+        self.src2.disas(position, disas);
+    }
+}
+
 macro_rules! impl_disas {
     (
         $(

--- a/pulley/src/encode.rs
+++ b/pulley/src/encode.rs
@@ -118,6 +118,15 @@ impl Encode for PcRelOffset {
     }
 }
 
+impl<R: Reg> Encode for BinaryOperands<R> {
+    fn encode<E>(&self, sink: &mut E)
+    where
+        E: Extend<u8>,
+    {
+        self.to_bits().encode(sink);
+    }
+}
+
 macro_rules! impl_encoders {
     (
         $(

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -741,101 +741,101 @@ impl OpVisitor for InterpreterVisitor<'_> {
         Continuation::Continue
     }
 
-    fn xadd32(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u32();
-        let b = self.state[src2].get_u32();
-        self.state[dst].set_u32(a.wrapping_add(b));
+    fn xadd32(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u32();
+        let b = self.state[operands.src2].get_u32();
+        self.state[operands.dst].set_u32(a.wrapping_add(b));
         Continuation::Continue
     }
 
-    fn xadd64(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u64();
-        let b = self.state[src2].get_u64();
-        self.state[dst].set_u64(a.wrapping_add(b));
+    fn xadd64(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u64();
+        let b = self.state[operands.src2].get_u64();
+        self.state[operands.dst].set_u64(a.wrapping_add(b));
         Continuation::Continue
     }
 
-    fn xeq64(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u64();
-        let b = self.state[src2].get_u64();
-        self.state[dst].set_u64(u64::from(a == b));
+    fn xeq64(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u64();
+        let b = self.state[operands.src2].get_u64();
+        self.state[operands.dst].set_u64(u64::from(a == b));
         Continuation::Continue
     }
 
-    fn xneq64(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u64();
-        let b = self.state[src2].get_u64();
-        self.state[dst].set_u64(u64::from(a != b));
+    fn xneq64(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u64();
+        let b = self.state[operands.src2].get_u64();
+        self.state[operands.dst].set_u64(u64::from(a != b));
         Continuation::Continue
     }
 
-    fn xslt64(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_i64();
-        let b = self.state[src2].get_i64();
-        self.state[dst].set_u64(u64::from(a < b));
+    fn xslt64(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_i64();
+        let b = self.state[operands.src2].get_i64();
+        self.state[operands.dst].set_u64(u64::from(a < b));
         Continuation::Continue
     }
 
-    fn xslteq64(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_i64();
-        let b = self.state[src2].get_i64();
-        self.state[dst].set_u64(u64::from(a <= b));
+    fn xslteq64(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_i64();
+        let b = self.state[operands.src2].get_i64();
+        self.state[operands.dst].set_u64(u64::from(a <= b));
         Continuation::Continue
     }
 
-    fn xult64(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u64();
-        let b = self.state[src2].get_u64();
-        self.state[dst].set_u64(u64::from(a < b));
+    fn xult64(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u64();
+        let b = self.state[operands.src2].get_u64();
+        self.state[operands.dst].set_u64(u64::from(a < b));
         Continuation::Continue
     }
 
-    fn xulteq64(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u64();
-        let b = self.state[src2].get_u64();
-        self.state[dst].set_u64(u64::from(a <= b));
+    fn xulteq64(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u64();
+        let b = self.state[operands.src2].get_u64();
+        self.state[operands.dst].set_u64(u64::from(a <= b));
         Continuation::Continue
     }
 
-    fn xeq32(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u32();
-        let b = self.state[src2].get_u32();
-        self.state[dst].set_u64(u64::from(a == b));
+    fn xeq32(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u32();
+        let b = self.state[operands.src2].get_u32();
+        self.state[operands.dst].set_u64(u64::from(a == b));
         Continuation::Continue
     }
 
-    fn xneq32(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u32();
-        let b = self.state[src2].get_u32();
-        self.state[dst].set_u64(u64::from(a != b));
+    fn xneq32(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u32();
+        let b = self.state[operands.src2].get_u32();
+        self.state[operands.dst].set_u64(u64::from(a != b));
         Continuation::Continue
     }
 
-    fn xslt32(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_i32();
-        let b = self.state[src2].get_i32();
-        self.state[dst].set_u64(u64::from(a < b));
+    fn xslt32(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_i32();
+        let b = self.state[operands.src2].get_i32();
+        self.state[operands.dst].set_u64(u64::from(a < b));
         Continuation::Continue
     }
 
-    fn xslteq32(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_i32();
-        let b = self.state[src2].get_i32();
-        self.state[dst].set_u64(u64::from(a <= b));
+    fn xslteq32(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_i32();
+        let b = self.state[operands.src2].get_i32();
+        self.state[operands.dst].set_u64(u64::from(a <= b));
         Continuation::Continue
     }
 
-    fn xult32(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u32();
-        let b = self.state[src2].get_u32();
-        self.state[dst].set_u64(u64::from(a < b));
+    fn xult32(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u32();
+        let b = self.state[operands.src2].get_u32();
+        self.state[operands.dst].set_u64(u64::from(a < b));
         Continuation::Continue
     }
 
-    fn xulteq32(&mut self, dst: XReg, src1: XReg, src2: XReg) -> Self::Return {
-        let a = self.state[src1].get_u32();
-        let b = self.state[src2].get_u32();
-        self.state[dst].set_u64(u64::from(a <= b));
+    fn xulteq32(&mut self, operands: BinaryOperands<XReg>) -> Self::Return {
+        let a = self.state[operands.src1].get_u32();
+        let b = self.state[operands.src2].get_u32();
+        self.state[operands.dst].set_u64(u64::from(a <= b));
         Continuation::Continue
     }
 

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -11,10 +11,6 @@ extern crate std;
 #[allow(unused_extern_crates)] // Some cfg's don't use this.
 extern crate alloc;
 
-// TODO: make `struct BinaryOpRegs<T> { dst: T, src1: T, src2: T }` or something
-// and pack it into 2 bytes (5 bits for each operand; 2**5 = 32 possible
-// registers, and then only special isntructions to access special x registers)
-
 /// Calls the given macro with each opcode.
 macro_rules! for_each_op {
     ( $macro:ident ) => {
@@ -69,35 +65,35 @@ macro_rules! for_each_op {
             /// 32-bit wrapping addition: `low32(dst) = low32(src1) + low32(src2)`.
             ///
             /// The upper 32-bits of `dst` are unmodified.
-            xadd32 = Xadd32 { dst: XReg, src1: XReg, src2: XReg };
+            xadd32 = Xadd32 { operands: BinaryOperands<XReg> };
 
             /// 64-bit wrapping addition: `dst = src1 + src2`.
-            xadd64 = Xadd64 { dst: XReg, src1: XReg, src2: XReg };
+            xadd64 = Xadd64 { operands: BinaryOperands<XReg> };
 
             /// 64-bit equality.
-            xeq64 = Xeq64 { dst: XReg, src1: XReg, src2: XReg };
+            xeq64 = Xeq64 { operands: BinaryOperands<XReg> };
             /// 64-bit inequality.
-            xneq64 = Xneq64 { dst: XReg, src1: XReg, src2: XReg };
+            xneq64 = Xneq64 { operands: BinaryOperands<XReg> };
             /// 64-bit signed less-than.
-            xslt64 = Xslt64 { dst: XReg, src1: XReg, src2: XReg };
+            xslt64 = Xslt64 { operands: BinaryOperands<XReg> };
             /// 64-bit signed less-than-equal.
-            xslteq64 = Xslteq64 { dst: XReg, src1: XReg, src2: XReg };
+            xslteq64 = Xslteq64 { operands: BinaryOperands<XReg> };
             /// 64-bit unsigned less-than.
-            xult64 = Xult64 { dst: XReg, src1: XReg, src2: XReg };
+            xult64 = Xult64 { operands: BinaryOperands<XReg> };
             /// 64-bit unsigned less-than-equal.
-            xulteq64 = Xulteq64 { dst: XReg, src1: XReg, src2: XReg };
+            xulteq64 = Xulteq64 { operands: BinaryOperands<XReg> };
             /// 32-bit equality.
-            xeq32 = Xeq32 { dst: XReg, src1: XReg, src2: XReg };
+            xeq32 = Xeq32 { operands: BinaryOperands<XReg> };
             /// 32-bit inequality.
-            xneq32 = Xneq32 { dst: XReg, src1: XReg, src2: XReg };
+            xneq32 = Xneq32 { operands: BinaryOperands<XReg> };
             /// 32-bit signed less-than.
-            xslt32 = Xslt32 { dst: XReg, src1: XReg, src2: XReg };
+            xslt32 = Xslt32 { operands: BinaryOperands<XReg> };
             /// 32-bit signed less-than-equal.
-            xslteq32 = Xslteq32 { dst: XReg, src1: XReg, src2: XReg };
+            xslteq32 = Xslteq32 { operands: BinaryOperands<XReg> };
             /// 32-bit unsigned less-than.
-            xult32 = Xult32 { dst: XReg, src1: XReg, src2: XReg };
+            xult32 = Xult32 { operands: BinaryOperands<XReg> };
             /// 32-bit unsigned less-than-equal.
-            xulteq32 = Xulteq32 { dst: XReg, src1: XReg, src2: XReg };
+            xulteq32 = Xulteq32 { operands: BinaryOperands<XReg> };
 
             /// `dst = zero_extend(load32(ptr))`
             load32_u = Load32U { dst: XReg, ptr: XReg };

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -166,6 +166,15 @@ pub struct BinaryOperands<R> {
 }
 
 impl<R: Reg> BinaryOperands<R> {
+    /// Convenience constructor for applying `Into`
+    pub fn new(dst: impl Into<R>, src1: impl Into<R>, src2: impl Into<R>) -> Self {
+        Self {
+            dst: dst.into(),
+            src1: src1.into(),
+            src2: src2.into(),
+        }
+    }
+
     /// Convert to dense 16 bit encoding.
     pub fn to_bits(self) -> u16 {
         let dst = self.dst.to_u8();

--- a/pulley/tests/all/disas.rs
+++ b/pulley/tests/all/disas.rs
@@ -34,9 +34,11 @@ fn simple() {
                 imm: -16i8,
             }),
             Op::Xadd32(Xadd32 {
-                dst: XReg::sp,
-                src1: XReg::sp,
-                src2: XReg::x26,
+                operands: BinaryOperands {
+                    dst: XReg::sp,
+                    src1: XReg::sp,
+                    src2: XReg::x26,
+                },
             }),
             Op::Store64Offset8(Store64Offset8 {
                 ptr: XReg::sp,
@@ -53,9 +55,11 @@ fn simple() {
             }),
             // Function body.
             Op::Xadd32(Xadd32 {
-                dst: XReg::x0,
-                src1: XReg::x0,
-                src2: XReg::x1,
+                operands: BinaryOperands {
+                    dst: XReg::x0,
+                    src1: XReg::x0,
+                    src2: XReg::x1,
+                },
             }),
             // Epilogue.
             Op::Xmov(Xmov {
@@ -76,25 +80,27 @@ fn simple() {
                 imm: 16,
             }),
             Op::Xadd32(Xadd32 {
-                dst: XReg::sp,
-                src1: XReg::sp,
-                src2: XReg::x26,
+                operands: BinaryOperands {
+                    dst: XReg::sp,
+                    src1: XReg::sp,
+                    src2: XReg::x26,
+                },
             }),
             Op::Ret(Ret {}),
         ],
         r#"
        0: 0e 1a f0                        xconst8 x26, -16
-       3: 12 1b 1b 1a                     xadd32 sp, sp, x26
-       7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
-       b: 2a 1b 1d                        store64 sp, fp
-       e: 0b 1d 1b                        xmov fp, sp
-      11: 12 00 00 01                     xadd32 x0, x0, x1
-      15: 0b 1b 1d                        xmov sp, fp
-      18: 25 1c 1b 08                     load64_offset8 lr, sp, 8
-      1c: 22 1d 1b                        load64 fp, sp
-      1f: 0e 1a 10                        xconst8 x26, 16
-      22: 12 1b 1b 1a                     xadd32 sp, sp, x26
-      26: 00                              ret
+       3: 12 7b 6b                        xadd32 sp, sp, x26
+       6: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+       a: 2a 1b 1d                        store64 sp, fp
+       d: 0b 1d 1b                        xmov fp, sp
+      10: 12 00 04                        xadd32 x0, x0, x1
+      13: 0b 1b 1d                        xmov sp, fp
+      16: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+      1a: 22 1d 1b                        load64 fp, sp
+      1d: 0e 1a 10                        xconst8 x26, 16
+      20: 12 7b 6b                        xadd32 sp, sp, x26
+      23: 00                              ret
         "#,
     );
 }

--- a/pulley/tests/all/disas.rs
+++ b/pulley/tests/all/disas.rs
@@ -26,75 +26,74 @@ fn assert_disas(ops: &[Op], expected: &str) {
 
 #[test]
 fn simple() {
-    let x0 = XReg::new(0).unwrap();
-    let x1 = XReg::new(1).unwrap();
-    let x31 = XReg::new(31).unwrap();
-
     assert_disas(
         &[
             // Prologue.
             Op::Xconst8(Xconst8 {
-                dst: x31,
+                dst: XReg::x26,
                 imm: -16i8,
             }),
             Op::Xadd32(Xadd32 {
-                dst: XReg::SP,
-                src1: XReg::SP,
-                src2: x31,
+                dst: XReg::sp,
+                src1: XReg::sp,
+                src2: XReg::x26,
             }),
             Op::Store64Offset8(Store64Offset8 {
-                ptr: XReg::SP,
+                ptr: XReg::sp,
                 offset: 8,
-                src: XReg::LR,
+                src: XReg::lr,
             }),
             Op::Store64(Store64 {
-                ptr: XReg::SP,
-                src: XReg::FP,
+                ptr: XReg::sp,
+                src: XReg::fp,
             }),
             Op::Xmov(Xmov {
-                dst: XReg::FP,
-                src: XReg::SP,
+                dst: XReg::fp,
+                src: XReg::sp,
             }),
             // Function body.
             Op::Xadd32(Xadd32 {
-                dst: x0,
-                src1: x0,
-                src2: x1,
+                dst: XReg::x0,
+                src1: XReg::x0,
+                src2: XReg::x1,
             }),
             // Epilogue.
             Op::Xmov(Xmov {
-                dst: XReg::SP,
-                src: XReg::FP,
+                dst: XReg::sp,
+                src: XReg::fp,
             }),
             Op::Load64Offset8(Load64Offset8 {
-                dst: XReg::LR,
-                ptr: XReg::SP,
+                dst: XReg::lr,
+                ptr: XReg::sp,
                 offset: 8,
             }),
             Op::Load64(Load64 {
-                dst: XReg::FP,
-                ptr: XReg::SP,
+                dst: XReg::fp,
+                ptr: XReg::sp,
             }),
-            Op::Xconst8(Xconst8 { dst: x31, imm: 16 }),
+            Op::Xconst8(Xconst8 {
+                dst: XReg::x26,
+                imm: 16,
+            }),
             Op::Xadd32(Xadd32 {
-                dst: XReg::SP,
-                src1: XReg::SP,
-                src2: x31,
+                dst: XReg::sp,
+                src1: XReg::sp,
+                src2: XReg::x26,
             }),
             Op::Ret(Ret {}),
         ],
         r#"
-       0: 0e 1f f0                        xconst8 x31, -16
-       3: 12 20 20 1f                     xadd32 sp, sp, x31
-       7: 2c 20 08 21                     store64_offset8 sp, 8, lr
-       b: 2a 20 22                        store64 sp, fp
-       e: 0b 22 20                        xmov fp, sp
+       0: 0e 1a f0                        xconst8 x26, -16
+       3: 12 1b 1b 1a                     xadd32 sp, sp, x26
+       7: 2c 1b 08 1c                     store64_offset8 sp, 8, lr
+       b: 2a 1b 1d                        store64 sp, fp
+       e: 0b 1d 1b                        xmov fp, sp
       11: 12 00 00 01                     xadd32 x0, x0, x1
-      15: 0b 20 22                        xmov sp, fp
-      18: 25 21 20 08                     load64_offset8 lr, sp, 8
-      1c: 22 22 20                        load64 fp, sp
-      1f: 0e 1f 10                        xconst8 x31, 16
-      22: 12 20 20 1f                     xadd32 sp, sp, x31
+      15: 0b 1b 1d                        xmov sp, fp
+      18: 25 1c 1b 08                     load64_offset8 lr, sp, 8
+      1c: 22 1d 1b                        load64 fp, sp
+      1f: 0e 1a 10                        xconst8 x26, 16
+      22: 12 1b 1b 1a                     xadd32 sp, sp, x26
       26: 00                              ret
         "#,
     );

--- a/pulley/tests/all/interp.rs
+++ b/pulley/tests/all/interp.rs
@@ -136,9 +136,11 @@ fn xadd32() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xadd32 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -154,9 +156,11 @@ fn xadd64() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xadd64 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -177,9 +181,11 @@ fn xeq64() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xeq64 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -200,9 +206,11 @@ fn xneq64() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xneq64 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -230,9 +238,11 @@ fn xslt64() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xslt64 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -260,9 +270,11 @@ fn xslteq64() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xslteq64 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -287,9 +299,11 @@ fn xult64() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xult64 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -314,9 +328,11 @@ fn xulteq64() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xulteq64 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -341,9 +357,11 @@ fn xeq32() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xeq32 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -365,9 +383,11 @@ fn xneq32() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xneq32 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -397,9 +417,11 @@ fn xslt32() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xslt32 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -427,9 +449,11 @@ fn xslteq32() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xslteq32 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -453,9 +477,11 @@ fn xult32() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xult32 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,
@@ -479,9 +505,11 @@ fn xulteq32() {
             assert_one(
                 [(x(0), 0x1234567812345678), (x(1), a), (x(2), b)],
                 Xulteq32 {
-                    dst: x(0),
-                    src1: x(1),
-                    src2: x(2),
+                    operands: BinaryOperands {
+                        dst: x(0),
+                        src1: x(1),
+                        src2: x(2),
+                    },
                 },
                 x(0),
                 expected,


### PR DESCRIPTION
Pack the `dst`, `src1` and `src2` register operands of binary operators into 2 bytes. Solves the `TODO` at the top of `lib.rs`.

~This required moving the special registers into their own register class, and adding `smov` and `spush`/`spop` to interact with SP/FP.~
I held off on splitting special registers into their own `SReg` class because I'm not sure how to integrate it with ISLE/Regalloc