### PR TITLE
Winch aarch64 memory load & store

### DIFF
--- a/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
+++ b/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       ldur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
 ;;       fabs    s0, s0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f32_add/locals.wat
+++ b/tests/disas/winch/aarch64/f32_add/locals.wat
@@ -31,13 +31,13 @@
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x400c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fadd    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_add/params.wat
+++ b/tests/disas/winch/aarch64/f32_add/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fadd    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       ldur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
 ;;       frintp  s0, s0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f32_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/locals.wat
@@ -31,13 +31,13 @@
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0xbf8c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x400c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       ushr    v0.2s, v0.2s, #0x1f
 ;;       sli     v1.2s, v0.2s, #0x1f
 ;;       fmov    s0, s1

--- a/tests/disas/winch/aarch64/f32_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       ushr    v0.2s, v0.2s, #0x1f
 ;;       sli     v1.2s, v0.2s, #0x1f
 ;;       fmov    s0, s1

--- a/tests/disas/winch/aarch64/f32_div/locals.wat
+++ b/tests/disas/winch/aarch64/f32_div/locals.wat
@@ -31,13 +31,13 @@
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x400c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fdiv    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_div/params.wat
+++ b/tests/disas/winch/aarch64/f32_div/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fdiv    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f32_eq/locals.wat
@@ -30,12 +30,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0x40000000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     x16, #0x40400000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, eq
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_eq/params.wat
+++ b/tests/disas/winch/aarch64/f32_eq/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, eq
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
+++ b/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       ldur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
 ;;       frintm  s0, s0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f32_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ge/locals.wat
@@ -30,12 +30,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0xc0000000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     x16, #0xc0400000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ge
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_ge/params.wat
+++ b/tests/disas/winch/aarch64/f32_ge/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ge
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_gt/locals.wat
@@ -30,12 +30,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0xc0000000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     x16, #0xc0400000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, gt
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_gt/params.wat
+++ b/tests/disas/winch/aarch64/f32_gt/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, gt
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_le/locals.wat
+++ b/tests/disas/winch/aarch64/f32_le/locals.wat
@@ -30,12 +30,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0xc0000000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     x16, #0xc0400000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ls
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_le/params.wat
+++ b/tests/disas/winch/aarch64/f32_le/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ls
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_lt/locals.wat
@@ -30,12 +30,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0xc0000000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     x16, #0xc0400000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, mi
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_lt/params.wat
+++ b/tests/disas/winch/aarch64/f32_lt/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, mi
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_max/locals.wat
+++ b/tests/disas/winch/aarch64/f32_max/locals.wat
@@ -31,13 +31,13 @@
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x400c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fmax    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_max/params.wat
+++ b/tests/disas/winch/aarch64/f32_max/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fmax    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_min/locals.wat
+++ b/tests/disas/winch/aarch64/f32_min/locals.wat
@@ -31,13 +31,13 @@
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x400c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fmin    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_min/params.wat
+++ b/tests/disas/winch/aarch64/f32_min/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fmin    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f32_mul/locals.wat
@@ -31,13 +31,13 @@
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x400c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fmul    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_mul/params.wat
+++ b/tests/disas/winch/aarch64/f32_mul/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fmul    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ne/locals.wat
@@ -30,12 +30,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0x40000000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     x16, #0x40400000
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ne
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_ne/params.wat
+++ b/tests/disas/winch/aarch64/f32_ne/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ne
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       ldur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
 ;;       frintn  s0, s0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
+++ b/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       ldur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
 ;;       fneg    s0, s0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       ldur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
 ;;       fsqrt   s0, s0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f32_sub/locals.wat
@@ -31,13 +31,13 @@
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
 ;;       mov     w16, #0xcccd
 ;;       movk    w16, #0x400c, lsl #16
 ;;       fmov    s0, w16
-;;       stur    w0, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fsub    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_sub/params.wat
+++ b/tests/disas/winch/aarch64/f32_sub/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       stur    w1, [x28]
-;;       ldur    w0, [x28]
-;;       ldur    w1, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       stur    s1, [x28]
+;;       ldur    s0, [x28]
+;;       ldur    s1, [x28, #4]
 ;;       fsub    s1, s1, s0
 ;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    w0, [x28, #4]
-;;       ldur    w0, [x28, #4]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
 ;;       frintz  s0, s0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
+++ b/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
 ;;       fabs    d0, d0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f64_add/locals.wat
+++ b/tests/disas/winch/aarch64/f64_add/locals.wat
@@ -34,15 +34,15 @@
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x3ff1, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x999a
 ;;       movk    x16, #0x9999, lsl #16
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x4001, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fadd    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_add/params.wat
+++ b/tests/disas/winch/aarch64/f64_add/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fadd    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
 ;;       frintp  d0, d0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f64_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/locals.wat
@@ -34,15 +34,15 @@
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0xbff1, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x999a
 ;;       movk    x16, #0x9999, lsl #16
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x4001, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       ushr    d0, d0, #0x3f
 ;;       sli     d1, d0, #0x3f
 ;;       fmov    d0, d1

--- a/tests/disas/winch/aarch64/f64_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       ushr    d0, d0, #0x3f
 ;;       sli     d1, d0, #0x3f
 ;;       fmov    d0, d1

--- a/tests/disas/winch/aarch64/f64_div/locals.wat
+++ b/tests/disas/winch/aarch64/f64_div/locals.wat
@@ -34,15 +34,15 @@
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x3ff1, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x999a
 ;;       movk    x16, #0x9999, lsl #16
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x4001, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fdiv    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_div/params.wat
+++ b/tests/disas/winch/aarch64/f64_div/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fdiv    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f64_eq/locals.wat
@@ -31,12 +31,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0x4000000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x4008000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, eq
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_eq/params.wat
+++ b/tests/disas/winch/aarch64/f64_eq/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, eq
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
+++ b/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
 ;;       frintm  d0, d0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f64_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ge/locals.wat
@@ -31,12 +31,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #-0x4000000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #-0x3ff8000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ge
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_ge/params.wat
+++ b/tests/disas/winch/aarch64/f64_ge/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ge
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_gt/locals.wat
@@ -31,12 +31,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #-0x4000000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #-0x3ff8000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, gt
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_gt/params.wat
+++ b/tests/disas/winch/aarch64/f64_gt/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, gt
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_le/locals.wat
+++ b/tests/disas/winch/aarch64/f64_le/locals.wat
@@ -31,12 +31,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #-0x4000000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #-0x3ff8000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ls
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_le/params.wat
+++ b/tests/disas/winch/aarch64/f64_le/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ls
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_lt/locals.wat
@@ -31,12 +31,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #-0x4000000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #-0x3ff8000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, mi
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_lt/params.wat
+++ b/tests/disas/winch/aarch64/f64_lt/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, mi
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_max/locals.wat
+++ b/tests/disas/winch/aarch64/f64_max/locals.wat
@@ -34,15 +34,15 @@
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x3ff1, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x999a
 ;;       movk    x16, #0x9999, lsl #16
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x4001, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fmax    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_max/params.wat
+++ b/tests/disas/winch/aarch64/f64_max/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fmax    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_min/locals.wat
+++ b/tests/disas/winch/aarch64/f64_min/locals.wat
@@ -34,15 +34,15 @@
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x3ff1, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x999a
 ;;       movk    x16, #0x9999, lsl #16
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x4001, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fmin    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_min/params.wat
+++ b/tests/disas/winch/aarch64/f64_min/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fmin    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f64_mul/locals.wat
@@ -34,15 +34,15 @@
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x3ff1, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x999a
 ;;       movk    x16, #0x9999, lsl #16
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x4001, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fmul    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_mul/params.wat
+++ b/tests/disas/winch/aarch64/f64_mul/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fmul    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ne/locals.wat
@@ -31,12 +31,12 @@
 ;;       stur    x16, [x28]
 ;;       mov     x16, #0x4000000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x4008000000000000
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ne
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_ne/params.wat
+++ b/tests/disas/winch/aarch64/f64_ne/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ne
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
 ;;       frintn  d0, d0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
+++ b/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
 ;;       fneg    d0, d0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
 ;;       fsqrt   d0, d0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/f64_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f64_sub/locals.wat
@@ -34,15 +34,15 @@
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x3ff1, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28, #8]
+;;       stur    d0, [x28, #8]
 ;;       mov     x16, #0x999a
 ;;       movk    x16, #0x9999, lsl #16
 ;;       movk    x16, #0x9999, lsl #32
 ;;       movk    x16, #0x4001, lsl #48
 ;;       fmov    d0, x16
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fsub    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_sub/params.wat
+++ b/tests/disas/winch/aarch64/f64_sub/params.wat
@@ -17,10 +17,10 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
-;;       ldur    x0, [x28]
-;;       ldur    x1, [x28, #8]
+;;       stur    d0, [x28, #8]
+;;       stur    d1, [x28]
+;;       ldur    d0, [x28]
+;;       ldur    d1, [x28, #8]
 ;;       fsub    d1, d1, d0
 ;;       fmov    d0, d1
 ;;       add     sp, sp, #0x20

--- a/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
@@ -16,8 +16,8 @@
 ;;       mov     x28, sp
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x0, [x28]
-;;       ldur    x0, [x28]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
 ;;       frintz  d0, d0
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/load/f32.wat
+++ b/tests/disas/winch/aarch64/load/f32.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+  (memory (data "\00\00\a0\7f"))
+
+  (func (export "f32.load") (result f32) (f32.load (i32.const 0)))
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       ldur    x1, [x9, #0x60]
+;;       add     x1, x1, x0, uxtx
+;;       ldur    s0, [x1]
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/load/f64.wat
+++ b/tests/disas/winch/aarch64/load/f64.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+(module
+  (memory (data "\00\00\00\00\00\00\f4\7f"))
+
+  (func (export "f64.load") (result f64) (f64.load (i32.const 0)))
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       ldur    x1, [x9, #0x60]
+;;       add     x1, x1, x0, uxtx
+;;       ldur    d0, [x1]
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/load/i32.wat
+++ b/tests/disas/winch/aarch64/load/i32.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "winch"
+(module
+  (memory 1)
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (i32.load (i32.const 0))))
+  )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       ldur    x1, [x9, #0x60]
+;;       add     x1, x1, x0, uxtx
+;;       ldur    w0, [x1]
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/load/i64.wat
+++ b/tests/disas/winch/aarch64/load/i64.wat
@@ -1,0 +1,34 @@
+;;! target = "aarch64"
+;;! test = "winch"
+(module
+  (memory 1)
+  (func (export "i64_load8_s") (param $i i64) (result i64)
+   (i64.store8 (i32.const 8) (local.get $i))
+   (i64.load8_s (i32.const 8))
+  )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    x2, [x28]
+;;       ldur    x0, [x28]
+;;       mov     x16, #8
+;;       mov     w1, w16
+;;       ldur    x2, [x9, #0x60]
+;;       add     x2, x2, x1, uxtx
+;;       sturb   w0, [x2]
+;;       mov     x16, #8
+;;       mov     w0, w16
+;;       ldur    x1, [x9, #0x60]
+;;       add     x1, x1, x0, uxtx
+;;       ldursb  x0, [x1]
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/store/f32.wat
+++ b/tests/disas/winch/aarch64/store/f32.wat
@@ -1,0 +1,27 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+  (memory (data "\00\00\a0\7f"))
+  (func (export "f32.store") (f32.store (i32.const 0) (f32.const nan:0x200000)))
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x7fa00000
+;;       fmov    s0, w16
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       ldur    x1, [x9, #0x60]
+;;       add     x1, x1, x0, uxtx
+;;       stur    s0, [x1]
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/store/f64.wat
+++ b/tests/disas/winch/aarch64/store/f64.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+  (memory (data "\00\00\00\00\00\00\f4\7f"))
+  (func (export "f64.store") (f64.store (i32.const 0) (f64.const nan:0x4000000000000)))
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x7ff4000000000000
+;;       fmov    d0, x16
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       ldur    x1, [x9, #0x60]
+;;       add     x1, x1, x0, uxtx
+;;       stur    d0, [x1]
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/store/i32.wat
+++ b/tests/disas/winch/aarch64/store/i32.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+(module
+  (memory 1)
+
+  (func (export "as-block-value")
+    (block (i32.store (i32.const 0) (i32.const 1)))
+  )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       ldur    x2, [x9, #0x60]
+;;       add     x2, x2, x1, uxtx
+;;       stur    w0, [x2]
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/store/i64.wat
+++ b/tests/disas/winch/aarch64/store/i64.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+(module
+  (memory 1)
+  (func (export "as-store-both") (result i32)
+    (block (result i32)
+      (i64.store (br 0 (i32.const 32))) (i32.const -1)
+    )
+  )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x20
+;;       mov     w0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -188,8 +188,18 @@ impl Assembler {
         self.emit(inst);
     }
 
+    /// Load a signed register.
+    pub fn sload(&mut self, addr: Address, rd: Reg, size: OperandSize) {
+        self.ldr(addr, rd, size, true);
+    }
+
+    /// Load an unsigned register.
+    pub fn uload(&mut self, addr: Address, rd: Reg, size: OperandSize) {
+        self.ldr(addr, rd, size, false);
+    }
+
     /// Load a register.
-    pub fn ldr(&mut self, addr: Address, rd: Reg, size: OperandSize, signed: bool) {
+    fn ldr(&mut self, addr: Address, rd: Reg, size: OperandSize, signed: bool) {
         use OperandSize::*;
         let writable_reg = Writable::from_reg(rd.into());
         let mem: AMode = addr.try_into().unwrap();

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -147,19 +147,42 @@ impl Assembler {
         let flags = MemFlags::trusted();
 
         use OperandSize::*;
-        let inst = match size {
-            S64 => Inst::Store64 {
+        let inst = match (reg.is_int(), size) {
+            (_, S8) => Inst::Store8 {
                 rd: reg.into(),
                 mem,
                 flags,
             },
-            S32 => Inst::Store32 {
+            (_, S16) => Inst::Store16 {
                 rd: reg.into(),
                 mem,
                 flags,
             },
-
-            _ => unreachable!(),
+            (true, S32) => Inst::Store32 {
+                rd: reg.into(),
+                mem,
+                flags,
+            },
+            (false, S32) => Inst::FpuStore32 {
+                rd: reg.into(),
+                mem,
+                flags,
+            },
+            (true, S64) => Inst::Store64 {
+                rd: reg.into(),
+                mem,
+                flags,
+            },
+            (false, S64) => Inst::FpuStore64 {
+                rd: reg.into(),
+                mem,
+                flags,
+            },
+            (_, S128) => Inst::FpuStore128 {
+                rd: reg.into(),
+                mem,
+                flags,
+            },
         };
 
         self.emit(inst);

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -162,8 +162,8 @@ impl Masm for MacroAssembler {
         self.asm.ldr(src, dst, size, false);
     }
 
-    fn load_ptr(&mut self, _src: Self::Address, _dst: Reg) {
-        todo!()
+    fn load_ptr(&mut self, src: Self::Address, dst: Reg) {
+        self.load(src, dst, self.ptr_size);
     }
 
     fn wasm_load(

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -159,7 +159,7 @@ impl Masm for MacroAssembler {
     }
 
     fn load(&mut self, src: Address, dst: Reg, size: OperandSize) {
-        self.asm.ldr(src, dst, size);
+        self.asm.ldr(src, dst, size, false);
     }
 
     fn load_ptr(&mut self, _src: Self::Address, _dst: Reg) {
@@ -168,12 +168,18 @@ impl Masm for MacroAssembler {
 
     fn wasm_load(
         &mut self,
-        _src: Self::Address,
-        _dst: Reg,
-        _size: OperandSize,
-        _kind: Option<ExtendKind>,
+        src: Self::Address,
+        dst: Reg,
+        size: OperandSize,
+        kind: Option<ExtendKind>,
     ) {
-        todo!()
+        self.asm.ldr(
+            src,
+            dst,
+            size,
+            kind.is_some(), // kind is some if the value is signed
+                            // unlike x64, unused bits are set to zero so we don't need to extend
+        );
     }
 
     fn load_addr(&mut self, _src: Self::Address, _dst: Reg, _size: OperandSize) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -159,7 +159,7 @@ impl Masm for MacroAssembler {
     }
 
     fn load(&mut self, src: Address, dst: Reg, size: OperandSize) {
-        self.asm.ldr(src, dst, size, false);
+        self.asm.uload(src, dst, size);
     }
 
     fn load_ptr(&mut self, src: Self::Address, dst: Reg) {
@@ -173,13 +173,13 @@ impl Masm for MacroAssembler {
         size: OperandSize,
         kind: Option<ExtendKind>,
     ) {
-        self.asm.ldr(
-            src,
-            dst,
-            size,
-            kind.is_some(), // kind is some if the value is signed
-                            // unlike x64, unused bits are set to zero so we don't need to extend
-        );
+        // kind is some if the value is signed
+        // unlike x64, unused bits are set to zero so we don't need to extend
+        if kind.is_some() {
+            self.asm.sload(src, dst, size);
+        } else {
+            self.asm.uload(src, dst, size);
+        }
     }
 
     fn load_addr(&mut self, _src: Self::Address, _dst: Reg, _size: OperandSize) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -146,8 +146,8 @@ impl Masm for MacroAssembler {
         self.asm.str(src, dst, size);
     }
 
-    fn wasm_store(&mut self, _src: Reg, _dst: Self::Address, _size: OperandSize) {
-        todo!()
+    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize) {
+        self.asm.str(src, dst, size);
     }
 
     fn call(


### PR DESCRIPTION
Hey 👋

This PR implements `wasm_load`, `wasm_store` and `load_ptr` instructions for winch targeting aarch64.

#8321

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
