### PR TITLE
Pass `--all-targets` to `cargo clippy` in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -458,7 +458,7 @@ jobs:
 
     # Run clippy configuration
     - run: rustup component add clippy
-    - run: cargo clippy --workspace
+    - run: cargo clippy --workspace --all-targets
 
     # Re-vendor all WIT files and ensure that they're all up-to-date by ensuring
     # that there's no git changes.

--- a/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
@@ -166,7 +166,7 @@ unsafe fn handler_thread() {
             break;
         }
         if kret != KERN_SUCCESS {
-            eprintln!("mach_msg failed with {} ({0:x})", kret);
+            eprintln!("mach_msg failed with {kret} ({kret:x})");
             libc::abort();
         }
         if request.body.Head.msgh_id != EXCEPTION_MSG_ID {

--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -409,14 +409,8 @@ fn assert_or_bless_output(path: &Path, wat: &str, actual: &str) -> Result<()> {
     let mut expected_lines: Vec<_> = wat
         .lines()
         .rev()
-        .take_while(|l| l.starts_with(";;"))
-        .map(|l| {
-            if l.starts_with(";; ") {
-                &l[3..]
-            } else {
-                &l[2..]
-            }
-        })
+        .map_while(|l| l.strip_prefix(";;"))
+        .map(|l| l.strip_prefix(" ").unwrap_or(l))
         .collect();
     expected_lines.reverse();
     let expected = expected_lines.join("\n");


### PR DESCRIPTION
Checks all targets, including tests/benchmarks, in addition to main binaries/libraries.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
