### PR TITLE
add `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]
+profile = "default"


### PR DESCRIPTION
I hit a confusing error trying to build wasmtime on the nightly toolchain (https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/.22failed.20to.20reduce.20input.20adapter.20module.20to.20its.20minimal.20size.22/near/456716867). I thought it would be a good idea to include a `rust-toolchain.toml` file so `cargo build` just works out of the box without any setup required