### PR TITLE
Fix more `clippy::doc_lazy_continuation` lints

### DIFF
--- a/cranelift/codegen/meta/src/shared/mod.rs
+++ b/cranelift/codegen/meta/src/shared/mod.rs
@@ -43,9 +43,9 @@ pub(crate) fn define() -> Definitions {
 /// Verifies certain properties of formats.
 ///
 /// - Formats must be uniquely named: if two formats have the same name, they must refer to the
-/// same data. Otherwise, two format variants in the codegen crate would have the same name.
+///   same data. Otherwise, two format variants in the codegen crate would have the same name.
 /// - Formats must be structurally different from each other. Otherwise, this would lead to
-/// code duplicate in the codegen crate.
+///   code duplicate in the codegen crate.
 ///
 /// Returns a list of all the instruction formats effectively used.
 fn verify_instruction_formats(all_instructions: &AllInstructions) -> Vec<Rc<InstructionFormat>> {

--- a/cranelift/codegen/src/incremental_cache.rs
+++ b/cranelift/codegen/src/incremental_cache.rs
@@ -10,11 +10,11 @@
 //!
 //! The three main primitives are the following:
 //! - `compute_cache_key` is used to compute the cache key associated to a `Function`. This is
-//! basically the content of the function, modulo a few things the caching system is resilient to.
+//!   basically the content of the function, modulo a few things the caching system is resilient to.
 //! - `serialize_compiled` is used to serialize the result of a compilation, so it can be reused
-//! later on by...
+//!   later on by...
 //! - `try_finish_recompile`, which reads binary blobs serialized with `serialize_compiled`,
-//! re-creating the compilation artifact from those.
+//!   re-creating the compilation artifact from those.
 //!
 //! The `CacheStore` trait and `Context::compile_with_cache` method are provided as
 //! high-level, easy-to-use facilities to make use of that cache, and show an example of how to use

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -182,12 +182,12 @@ impl DynamicType {
 /// You can create a `GlobalValue` in the following ways:
 ///
 /// - When compiling to WASM, you can use it to load values from a
-/// [`VmContext`](super::GlobalValueData::VMContext) using
-/// [`FuncEnvironment::make_global`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_global).
+///   [`VmContext`](super::GlobalValueData::VMContext) using
+///   [`FuncEnvironment::make_global`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_global).
 /// - When compiling to native code, you can use it for objects in static memory with
-/// [`Module::declare_data_in_func`](https://docs.rs/cranelift-module/*/cranelift_module/trait.Module.html#method.declare_data_in_func).
+///   [`Module::declare_data_in_func`](https://docs.rs/cranelift-module/*/cranelift_module/trait.Module.html#method.declare_data_in_func).
 /// - For any compilation target, it can be registered with
-/// [`FunctionBuilder::create_global_value`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.create_global_value).
+///   [`FunctionBuilder::create_global_value`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.create_global_value).
 ///
 /// `GlobalValue`s can be retrieved with
 /// [`InstBuilder:global_value`](super::InstBuilder::global_value).
@@ -325,13 +325,13 @@ impl JumpTable {
 /// `FuncRef`s can be created with
 ///
 /// - [`FunctionBuilder::import_function`](https://docs.rs/cranelift-frontend/*/cranelift_frontend/struct.FunctionBuilder.html#method.import_function)
-/// for external functions
+///   for external functions
 /// - [`Module::declare_func_in_func`](https://docs.rs/cranelift-module/*/cranelift_module/trait.Module.html#method.declare_func_in_func)
-/// for functions declared elsewhere in the same native
-/// [`Module`](https://docs.rs/cranelift-module/*/cranelift_module/trait.Module.html)
+///   for functions declared elsewhere in the same native
+///   [`Module`](https://docs.rs/cranelift-module/*/cranelift_module/trait.Module.html)
 /// - [`FuncEnvironment::make_direct_func`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_direct_func)
-/// for functions declared in the same WebAssembly
-/// [`FuncEnvironment`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_direct_func)
+///   for functions declared in the same WebAssembly
+///   [`FuncEnvironment`](https://docs.rs/cranelift-wasm/*/cranelift_wasm/trait.FuncEnvironment.html#tymethod.make_direct_func)
 ///
 /// While the order is stable, it is arbitrary.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -1118,12 +1118,12 @@ pub trait VecInstOverlapInfo {
     ///  * The destination EEW equals the source EEW.
     ///
     ///  * The destination EEW is smaller than the source EEW and the overlap is
-    ///  in the lowest-numbered part of the source register group (e.g., when LMUL=1,
-    ///  vnsrl.wi v0, v0, 3 is legal, but a destination of v1 is not).
+    ///    in the lowest-numbered part of the source register group (e.g., when LMUL=1,
+    ///    vnsrl.wi v0, v0, 3 is legal, but a destination of v1 is not).
     ///
     ///  * The destination EEW is greater than the source EEW, the source EMUL is at
-    ///  least 1, and the overlap is in the highest-numbered part of the destination register
-    ///  group (e.g., when LMUL=8, vzext.vf4 v0, v6 is legal, but a source of v0, v2, or v4 is not).
+    ///    least 1, and the overlap is in the highest-numbered part of the destination register
+    ///    group (e.g., when LMUL=8, vzext.vf4 v0, v6 is legal, but a source of v0, v2, or v4 is not).
     ///
     /// For the purpose of determining register group overlap constraints, mask elements have EEW=1.
     fn forbids_src_dst_overlaps(&self) -> bool;

--- a/cranelift/entity/src/sparse.rs
+++ b/cranelift/entity/src/sparse.rs
@@ -5,7 +5,7 @@
 //! the paper:
 //!
 //! > Briggs, Torczon, *An efficient representation for sparse sets*,
-//!   ACM Letters on Programming Languages and Systems, Volume 2, Issue 1-4, March-Dec. 1993.
+//! > ACM Letters on Programming Languages and Systems, Volume 2, Issue 1-4, March-Dec. 1993.
 
 use crate::map::SecondaryMap;
 use crate::EntityRef;

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -16,10 +16,10 @@ use thiserror::Error;
 /// all of the ways a Cranelift interpreter can interact with its virtual state. This makes it
 /// possible to use the [Interpreter](crate::interpreter::Interpreter) in a range of situations:
 /// - when interpretation needs to happen in a way isolated from the host a state which keeps a
-/// stack and bound checks memory accesses can be used, like
-/// [InterpreterState](crate::interpreter::InterpreterState).
+///   stack and bound checks memory accesses can be used, like
+///   [InterpreterState](crate::interpreter::InterpreterState).
 /// - when interpretation needs to have access to the host a state which allows direct access to the
-/// host memory and native functions can be used.
+///   host memory and native functions can be used.
 pub trait State<'a> {
     /// Retrieve a reference to a [Function].
     fn get_function(&self, func_ref: FuncRef) -> Option<&'a Function>;

--- a/cranelift/isle/isle/src/trie_again.rs
+++ b/cranelift/isle/isle/src/trie_again.rs
@@ -425,6 +425,7 @@ impl RuleSetBuilder {
     /// copy the constraint and push the equality inside it. For example:
     /// - `(term x @ 2 x)` is rewritten to `(term 2 2)`
     /// - `(term x @ (T.A _ _) x)` is rewritten to `(term (T.A y z) (T.A y z))`
+    ///
     /// In the latter case, note that every field of `T.A` has been replaced with a fresh variable
     /// and each of the copies are set equal.
     ///

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -263,7 +263,7 @@ pub trait Compiler: Send + Sync {
     /// 1. First, the index within `funcs` that is being resolved,
     ///
     /// 2. and next the `RelocationTarget` which is the relocation target to
-    /// resolve.
+    ///    resolve.
     ///
     /// The return value is an index within `funcs` that the relocation points
     /// to.

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -55,12 +55,12 @@
 //! get with WasiFile/WasiDir:
 //!
 //! * Timekeeping: `WasiSystemClock` and `WasiMonotonicClock` provide the two
-//! interfaces for a clock. `WasiSystemClock` represents time as a
-//! `cap_std::time::SystemTime`, and `WasiMonotonicClock` represents time as
-//! `cap_std::time::Instant`.  * Randomness: we re-use the `cap_rand::RngCore`
-//! trait to represent a randomness source. A trivial `Deterministic` impl is
-//! provided.  * Scheduling: The `WasiSched` trait abstracts over the
-//! `sched_yield` and `poll_oneoff` functions.
+//!   interfaces for a clock. `WasiSystemClock` represents time as a
+//!   `cap_std::time::SystemTime`, and `WasiMonotonicClock` represents time as
+//!   `cap_std::time::Instant`.  * Randomness: we re-use the `cap_rand::RngCore`
+//!   trait to represent a randomness source. A trivial `Deterministic` impl is
+//!   provided.  * Scheduling: The `WasiSched` trait abstracts over the
+//!   `sched_yield` and `poll_oneoff` functions.
 //!
 //! Users can provide implementations of each of these interfaces to the
 //! `WasiCtx::builder(...)` function. The

--- a/crates/wasi-common/src/snapshots/mod.rs
+++ b/crates/wasi-common/src/snapshots/mod.rs
@@ -9,19 +9,16 @@
 //! The architectural rules for snapshots are:
 //!
 //! * Snapshots are arranged into modules under `crate::snapshots::`.
-//!
 //! * Each snapshot should invoke `wiggle::from_witx!` with `ctx:
-//! crate::WasiCtx` in its module, and impl all of the required traits.
-//!
-//!* Snapshots can be implemented in terms of other snapshots. For example,
-//! snapshot 0 is mostly implemented by calling the snapshot 1 implementation,
-//! and converting its own types back and forth with the snapshot 1 types. In a
-//! few cases, that is not feasible, so snapshot 0 carries its own
-//! implementations in terms of the `WasiFile` and `WasiSched` traits.
-//!
+//!   crate::WasiCtx` in its module, and impl all of the required traits.
+//! * Snapshots can be implemented in terms of other snapshots. For example,
+//!   snapshot 0 is mostly implemented by calling the snapshot 1 implementation,
+//!   and converting its own types back and forth with the snapshot 1 types. In a
+//!   few cases, that is not feasible, so snapshot 0 carries its own
+//!   implementations in terms of the `WasiFile` and `WasiSched` traits.
 //! * Snapshots can be implemented in terms of the `Wasi*` traits given by
-//! `WasiCtx`. No further downcasting via the `as_any` escape hatch is
-//! permitted.
+//!   `WasiCtx`. No further downcasting via the `as_any` escape hatch is
+//!   permitted.
 
 pub mod preview_0;
 pub mod preview_1;

--- a/crates/wasmtime/src/runtime/vm/threads/parking_spot.rs
+++ b/crates/wasmtime/src/runtime/vm/threads/parking_spot.rs
@@ -5,9 +5,9 @@
 //! There are two main operations that can be performed:
 //!
 //! - *Parking* refers to suspending the thread while simultaneously enqueuing it
-//! on a queue keyed by some address.
+//!   on a queue keyed by some address.
 //! - *Unparking* refers to dequeuing a thread from a queue keyed by some address
-//! and resuming it.
+//!   and resuming it.
 
 #![deny(missing_docs)]
 

--- a/winch/codegen/src/abi/local.rs
+++ b/winch/codegen/src/abi/local.rs
@@ -21,6 +21,7 @@ enum Base {
 ///   function defined locals and the param locals.
 /// * Local slots that represent arguments in the stack, are referenced through the
 ///   base pointer register.
+///
 /// A [crate::masm::StackSlot] is a generalized form of a [LocalSlot]: they
 /// represent dynamic chunks of memory that get created throughout the function
 /// compilation lifetime when spilling values (register and locals) into the

--- a/winch/codegen/src/codegen/bounds.rs
+++ b/winch/codegen/src/codegen/bounds.rs
@@ -115,11 +115,11 @@ where
 
 /// This function ensures the following:
 /// * The immediate offset and memory access size fit in a single u64. Given:
-/// that the memory access size is a `u8`, we must guarantee that the immediate
-/// offset will fit in a `u32`, making the result of their addition fit in a u64
-/// and overflow safe.
+///   that the memory access size is a `u8`, we must guarantee that the immediate
+///   offset will fit in a `u32`, making the result of their addition fit in a u64
+///   and overflow safe.
 /// * Adjust the base index to account for the immediate offset via an unsigned
-/// addition and check for overflow in case the previous condition is not met.
+///   addition and check for overflow in case the previous condition is not met.
 #[inline]
 pub(crate) fn ensure_index_and_offset<M: MacroAssembler>(
     masm: &mut M,

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -26,7 +26,7 @@ use wasmtime_environ::{
 /// This macro calls itself recursively;
 /// 1. It no-ops when matching a supported operator.
 /// 2. Defines the visitor function and panics when
-/// matching an unsupported operator.
+///    matching an unsupported operator.
 macro_rules! def_unsupported {
     ($( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
         $(


### PR DESCRIPTION
This fixes all remaining instances of `clippy::doc_lazy_continuation` except for in some generated code.