### PR TITLE
ISLE: lexer simplifications

### DIFF
--- a/cranelift/isle/fuzz/fuzz_targets/compile.rs
+++ b/cranelift/isle/fuzz/fuzz_targets/compile.rs
@@ -1,11 +1,14 @@
 #![no_main]
 
+use std::sync::Arc;
+
+use cranelift_isle::files::Files;
 use libfuzzer_sys::fuzz_target;
 
-fuzz_target!(|s: &str| {
+fuzz_target!(|src: &str| {
     let _ = env_logger::try_init();
 
-    let lexer = cranelift_isle::lexer::Lexer::from_str(s, "fuzz-input.isle");
+    let lexer = cranelift_isle::lexer::Lexer::new(0, src);
     log::debug!("lexer = {:?}", lexer);
     let lexer = match lexer {
         Ok(l) => l,
@@ -19,7 +22,12 @@ fuzz_target!(|s: &str| {
         Err(_) => return,
     };
 
-    let code = cranelift_isle::compile::compile(&defs, &Default::default());
+    let files = Arc::new(Files::from_names_and_contents([(
+        "fuzz-input.isle".to_string(),
+        src.to_string(),
+    )]));
+
+    let code = cranelift_isle::compile::compile(files, &defs, &Default::default());
     log::debug!("code = {:?}", code);
     let code = match code {
         Ok(c) => c,

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -2,6 +2,7 @@
 
 #![allow(missing_docs)]
 
+use crate::files::Files;
 use crate::lexer::Pos;
 use crate::log;
 use std::sync::Arc;
@@ -10,8 +11,7 @@ use std::sync::Arc;
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Defs {
     pub defs: Vec<Def>,
-    pub filenames: Vec<Arc<str>>,
-    pub file_texts: Vec<Arc<str>>,
+    pub files: Arc<Files>,
 }
 
 /// One toplevel form in an ISLE file.

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -2,17 +2,8 @@
 
 #![allow(missing_docs)]
 
-use crate::files::Files;
 use crate::lexer::Pos;
 use crate::log;
-use std::sync::Arc;
-
-/// The parsed form of an ISLE file.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Defs {
-    pub defs: Vec<Def>,
-    pub files: Arc<Files>,
-}
 
 /// One toplevel form in an ISLE file.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -1,11 +1,13 @@
 //! Generate Rust code from a series of Sequences.
 
+use crate::files::Files;
 use crate::sema::{ExternalSig, ReturnKind, Sym, Term, TermEnv, TermId, Type, TypeEnv, TypeId};
 use crate::serialize::{Block, ControlFlow, EvalStep, MatchArm};
 use crate::stablemapset::StableSet;
 use crate::trie_again::{Binding, BindingId, Constraint, RuleSet};
 use std::fmt::Write;
 use std::slice::Iter;
+use std::sync::Arc;
 
 /// Options for code generation.
 #[derive(Clone, Debug, Default)]
@@ -17,16 +19,18 @@ pub struct CodegenOptions {
 
 /// Emit Rust source code for the given type and term environments.
 pub fn codegen(
+    files: Arc<Files>,
     typeenv: &TypeEnv,
     termenv: &TermEnv,
     terms: &[(TermId, RuleSet)],
     options: &CodegenOptions,
 ) -> String {
-    Codegen::compile(typeenv, termenv, terms).generate_rust(options)
+    Codegen::compile(files, typeenv, termenv, terms).generate_rust(options)
 }
 
 #[derive(Clone, Debug)]
 struct Codegen<'a> {
+    files: Arc<Files>,
     typeenv: &'a TypeEnv,
     termenv: &'a TermEnv,
     terms: &'a [(TermId, RuleSet)],
@@ -91,11 +95,13 @@ impl<'a, W: Write> BodyContext<'a, W> {
 
 impl<'a> Codegen<'a> {
     fn compile(
+        files: Arc<Files>,
         typeenv: &'a TypeEnv,
         termenv: &'a TermEnv,
         terms: &'a [(TermId, RuleSet)],
     ) -> Codegen<'a> {
         Codegen {
+            files,
             typeenv,
             termenv,
             terms,
@@ -121,7 +127,7 @@ impl<'a> Codegen<'a> {
             "// Generated automatically from the instruction-selection DSL code in:",
         )
         .unwrap();
-        for file in &self.typeenv.files.file_names {
+        for file in &self.files.file_names {
             writeln!(code, "// - {file}").unwrap();
         }
 
@@ -335,7 +341,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                         code,
                         "\n/// Internal type {}: defined at {}.",
                         name,
-                        pos.pretty_print_line(&self.typeenv.files)
+                        pos.pretty_print_line(&self.files)
                     )
                     .unwrap();
 
@@ -454,7 +460,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                         term_name,
                         termdata
                             .decl_pos
-                            .pretty_print_line(&self.typeenv.files)
+                            .pretty_print_line(&self.files)
                     ),
                 }
             };
@@ -640,7 +646,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                                 ctx.out,
                                 "{}// Rule at {}.",
                                 &ctx.indent,
-                                pos.pretty_print_line(&self.typeenv.files)
+                                pos.pretty_print_line(&self.files)
                             )?;
                             write!(ctx.out, "{}", &ctx.indent)?;
                             match ret_kind {

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -121,7 +121,7 @@ impl<'a> Codegen<'a> {
             "// Generated automatically from the instruction-selection DSL code in:",
         )
         .unwrap();
-        for file in &self.typeenv.filenames {
+        for file in &self.typeenv.files.file_names {
             writeln!(code, "// - {file}").unwrap();
         }
 
@@ -335,7 +335,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                         code,
                         "\n/// Internal type {}: defined at {}.",
                         name,
-                        pos.pretty_print_line(&self.typeenv.filenames[..])
+                        pos.pretty_print_line(&self.typeenv.files)
                     )
                     .unwrap();
 
@@ -454,7 +454,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                         term_name,
                         termdata
                             .decl_pos
-                            .pretty_print_line(&self.typeenv.filenames[..])
+                            .pretty_print_line(&self.typeenv.files)
                     ),
                 }
             };
@@ -640,7 +640,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                                 ctx.out,
                                 "{}// Rule at {}.",
                                 &ctx.indent,
-                                pos.pretty_print_line(&self.typeenv.filenames)
+                                pos.pretty_print_line(&self.typeenv.files)
                             )?;
                             write!(ctx.out, "{}", &ctx.indent)?;
                             match ret_kind {

--- a/cranelift/isle/isle/src/error.rs
+++ b/cranelift/isle/isle/src/error.rs
@@ -138,6 +138,11 @@ pub enum Error {
 }
 
 impl Errors {
+    /// Create new Errors
+    pub fn new(errors: Vec<Error>, files: Arc<Files>) -> Self {
+        Self { errors, files }
+    }
+
     /// Create `isle::Errors` from the given I/O error and context.
     pub fn from_io(error: std::io::Error, context: impl Into<String>) -> Self {
         Errors {

--- a/cranelift/isle/isle/src/error.rs
+++ b/cranelift/isle/isle/src/error.rs
@@ -241,8 +241,6 @@ impl Span {
             to: Pos {
                 file: pos.file,
                 offset: pos.offset + 1,
-                line: pos.line,
-                col: pos.col + 1,
             },
         }
     }

--- a/cranelift/isle/isle/src/files.rs
+++ b/cranelift/isle/isle/src/files.rs
@@ -1,0 +1,118 @@
+#![allow(missing_docs)]
+
+use std::ops::Index;
+
+#[derive(Default, Clone, PartialEq, Eq, Debug)]
+pub struct Files {
+    /// Arena of filenames from the input source.
+    ///
+    /// Indexed via `Pos::file`.
+    pub file_names: Vec<String>,
+
+    /// Arena of file source texts.
+    ///
+    /// Indexed via `Pos::file`.
+    pub file_texts: Vec<String>,
+
+    /// Arena of length of each file
+    ///
+    /// Indexed via `Pos::file`.
+    pub file_starts: Vec<usize>,
+
+    /// Arena of file line maps.
+    ///
+    /// Indexed via `Pos::file`.
+    pub file_line_maps: Vec<LineMap>,
+}
+
+#[derive(Default, Clone, PartialEq, Eq, Debug)]
+pub struct LineMap {
+    /// Mapping from line number to starting byte position.
+    line_ends: Vec<usize>,
+}
+
+impl Index<usize> for LineMap {
+    type Output = usize;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.line_ends[index]
+    }
+}
+
+impl LineMap {
+    pub fn from_str(text: &str) -> Self {
+        let line_ends = text.match_indices('\n').map(|(i, _)| i + 1).collect();
+        Self { line_ends }
+    }
+
+    /// Get the line on which `pos` occurs
+    pub fn line(&self, pos: usize) -> usize {
+        self.line_ends.partition_point(|&end| end <= pos)
+    }
+
+    /// Get the starting byte position of `line`.
+    pub fn get(&self, line: usize) -> Option<&usize> {
+        self.line_ends.get(line)
+    }
+}
+
+impl Files {
+    pub fn from_iter(files: impl IntoIterator<Item = (String, String)>) -> Self {
+        let mut file_names = Vec::new();
+        let mut file_texts = Vec::new();
+        let mut file_starts = Vec::new();
+        let mut file_line_maps = Vec::new();
+
+        let mut len = 0;
+        for (name, contents) in files {
+            file_starts.push(len);
+            len += contents.len();
+
+            file_line_maps.push(LineMap::from_str(&contents));
+            file_names.push(name);
+            file_texts.push(contents);
+        }
+
+        Self {
+            file_names,
+            file_texts,
+            file_starts,
+            file_line_maps,
+        }
+    }
+
+    pub fn file_name(&self, file: usize) -> Option<&str> {
+        self.file_names.get(file).map(|x| x.as_str())
+    }
+
+    pub fn file_text(&self, file: usize) -> Option<&str> {
+        self.file_texts.get(file).map(|x| x.as_str())
+    }
+
+    pub fn file_line_map(&self, file: usize) -> Option<&LineMap> {
+        self.file_line_maps.get(file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_map() {
+        let line_map = LineMap::from_str("");
+        assert_eq!(line_map.line_ends, &[]);
+        assert_eq!(line_map.line(0), 0);
+        assert_eq!(line_map.line(100), 0);
+
+        let line_map = LineMap::from_str("line 0");
+        assert_eq!(line_map.line_ends, &[]);
+        assert_eq!(line_map.line(0), 0);
+        assert_eq!(line_map.line(100), 0);
+
+        let line_map = LineMap::from_str("line 0\nline 1");
+        assert_eq!(line_map.line_ends, &[7]);
+        assert_eq!(line_map.line(0), 0);
+        assert_eq!(line_map.line(100), 1);
+    }
+}

--- a/cranelift/isle/isle/src/lexer.rs
+++ b/cranelift/isle/isle/src/lexer.rs
@@ -366,7 +366,7 @@ mod test {
                 ";; comment\n; another\r\n   \t(one two three 23 -568  )\n",
                 "lexer_basic"
             ),
-            vec![
+            [
                 Token::LParen,
                 Token::Symbol("one".to_string()),
                 Token::Symbol("two".to_string()),
@@ -382,20 +382,20 @@ mod test {
     fn ends_with_sym() {
         assert_eq!(
             lex("asdf", "ends_with_sym"),
-            vec![Token::Symbol("asdf".to_string()),]
+            [Token::Symbol("asdf".to_string())]
         );
     }
 
     #[test]
     fn ends_with_num() {
-        assert_eq!(lex("23", "ends_with_num"), vec![Token::Int(23)],);
+        assert_eq!(lex("23", "ends_with_num"), [Token::Int(23)]);
     }
 
     #[test]
     fn weird_syms() {
         assert_eq!(
             lex("(+ [] => !! _test!;comment\n)", "weird_syms"),
-            vec![
+            [
                 Token::LParen,
                 Token::Symbol("+".to_string()),
                 Token::Symbol("[]".to_string()),

--- a/cranelift/isle/isle/src/lexer.rs
+++ b/cranelift/isle/isle/src/lexer.rs
@@ -266,6 +266,7 @@ impl Token {
 mod test {
     use super::*;
 
+    #[track_caller]
     fn lex(src: &str) -> Vec<Token> {
         let mut toks = vec![];
         let mut lexer = Lexer::new(0, src).unwrap();
@@ -315,5 +316,25 @@ mod test {
                 Token::RParen,
             ]
         );
+    }
+
+    #[test]
+    fn integers() {
+        assert_eq!(
+            lex("0 1 -1"),
+            [Token::Int(0), Token::Int(1), Token::Int(-1)]
+        );
+
+        assert_eq!(
+            lex("340_282_366_920_938_463_463_374_607_431_768_211_455"),
+            [Token::Int(-1)]
+        );
+
+        assert_eq!(
+            lex("170_141_183_460_469_231_731_687_303_715_884_105_727"),
+            [Token::Int(i128::MAX)]
+        );
+
+        assert!(Lexer::new(0, "-170_141_183_460_469_231_731_687_303_715_884_105_728").is_err())
     }
 }

--- a/cranelift/isle/isle/src/lexer.rs
+++ b/cranelift/isle/isle/src/lexer.rs
@@ -33,10 +33,6 @@ pub struct Pos {
     pub file: usize,
     /// This source position's byte offset in the file.
     pub offset: usize,
-    /// This source position's line number in the file.
-    pub line: usize,
-    /// This source position's column number in the file.
-    pub col: usize,
 }
 
 impl Pos {
@@ -72,12 +68,7 @@ impl<'a> Lexer<'a> {
             files: Arc::new(Files::from_iter([(filename.to_string(), s.to_string())])),
 
             buf: Cow::Borrowed(s.as_bytes()),
-            pos: Pos {
-                file: 0,
-                offset: 0,
-                line: 1,
-                col: 0,
-            },
+            pos: Pos { file: 0, offset: 0 },
             lookahead: None,
         };
         l.reload()?;
@@ -112,12 +103,7 @@ impl<'a> Lexer<'a> {
         let mut l = Lexer {
             files: Arc::new(files),
             buf: Cow::Owned(buf.into_bytes()),
-            pos: Pos {
-                file: 0,
-                offset: 0,
-                line: 1,
-                col: 0,
-            },
+            pos: Pos { file: 0, offset: 0 },
             lookahead: None,
         };
         l.reload()?;
@@ -129,24 +115,16 @@ impl<'a> Lexer<'a> {
         Pos {
             file: self.pos.file,
             offset: self.pos.offset - self.files.file_starts[self.pos.file],
-            line: self.pos.line,
-            col: self.pos.col,
         }
     }
 
     fn advance_pos(&mut self) {
-        self.pos.col += 1;
-        if self.buf[self.pos.offset] == b'\n' {
-            self.pos.line += 1;
-            self.pos.col = 0;
-        }
         self.pos.offset += 1;
         if self.pos.file + 1 < self.files.file_starts.len() {
             let next_start = self.files.file_starts[self.pos.file + 1];
             if self.pos.offset >= next_start {
                 assert!(self.pos.offset == next_start);
                 self.pos.file += 1;
-                self.pos.line = 1;
             }
         }
     }

--- a/cranelift/isle/isle/src/lib.rs
+++ b/cranelift/isle/isle/src/lib.rs
@@ -23,6 +23,7 @@ pub mod codegen;
 pub mod compile;
 pub mod disjointsets;
 pub mod error;
+pub mod files;
 pub mod lexer;
 mod log;
 pub mod overlap;

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -3,26 +3,20 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
-use crate::error::{self, Error, Span};
+use crate::error::{Error, Span};
 use crate::lexer::Pos;
-use crate::sema::{TermEnv, TermId, TermKind, TypeEnv};
+use crate::sema::{TermEnv, TermId, TermKind};
 use crate::trie_again;
 
 /// Check for overlap.
-pub fn check(
-    tyenv: &TypeEnv,
-    termenv: &TermEnv,
-) -> Result<Vec<(TermId, trie_again::RuleSet)>, error::Errors> {
+pub fn check(termenv: &TermEnv) -> Result<Vec<(TermId, trie_again::RuleSet)>, Vec<Error>> {
     let (terms, mut errors) = trie_again::build(termenv);
     errors.append(&mut check_overlaps(&terms, termenv).report());
 
     if errors.is_empty() {
         Ok(terms)
     } else {
-        Err(error::Errors {
-            errors,
-            files: tyenv.files.clone(),
-        })
+        Err(errors)
     }
 }
 

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -21,8 +21,7 @@ pub fn check(
     } else {
         Err(error::Errors {
             errors,
-            filenames: tyenv.filenames.clone(),
-            file_texts: tyenv.file_texts.clone(),
+            files: tyenv.files.clone(),
         })
     }
 }

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -40,8 +40,7 @@ impl<'a> Parser<'a> {
                 msg,
                 span: Span::new_single(pos),
             }],
-            filenames: self.lexer.filenames.clone(),
-            file_texts: self.lexer.file_texts.clone(),
+            files: self.lexer.files.clone(),
         }
     }
 
@@ -143,8 +142,7 @@ impl<'a> Parser<'a> {
         }
         Ok(Defs {
             defs,
-            filenames: self.lexer.filenames,
-            file_texts: self.lexer.file_texts,
+            files: self.lexer.files,
         })
     }
 

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -1,13 +1,13 @@
 //! Parser for ISLE language.
 
 use crate::ast::*;
-use crate::error::{Error, Errors, Span};
+use crate::error::{Error, Span};
 use crate::lexer::{Lexer, Pos, Token};
 
-type Result<T> = std::result::Result<T, Errors>;
+type Result<T> = std::result::Result<T, Error>;
 
 /// Parse the top-level ISLE definitions and return their AST.
-pub fn parse(lexer: Lexer) -> Result<Defs> {
+pub fn parse(lexer: Lexer) -> Result<Vec<Def>> {
     let parser = Parser::new(lexer);
     parser.parse_defs()
 }
@@ -34,13 +34,10 @@ impl<'a> Parser<'a> {
         Parser { lexer }
     }
 
-    fn error(&self, pos: Pos, msg: String) -> Errors {
-        Errors {
-            errors: vec![Error::ParseError {
-                msg,
-                span: Span::new_single(pos),
-            }],
-            files: self.lexer.files.clone(),
+    fn error(&self, pos: Pos, msg: String) -> Error {
+        Error::ParseError {
+            msg,
+            span: Span::new_single(pos),
         }
     }
 
@@ -135,15 +132,12 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_defs(mut self) -> Result<Defs> {
+    fn parse_defs(mut self) -> Result<Vec<Def>> {
         let mut defs = vec![];
         while !self.lexer.eof() {
             defs.push(self.parse_def()?);
         }
-        Ok(Defs {
-            defs,
-            files: self.lexer.files,
-        })
+        Ok(defs)
     }
 
     fn parse_def(&mut self) -> Result<Def> {

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -2442,8 +2442,6 @@ mod test {
                 Pos {
                     file: 0,
                     offset: 19,
-                    line: 2,
-                    col: 18,
                 },
             ),
             Type::Enum {
@@ -2483,8 +2481,6 @@ mod test {
                 pos: Pos {
                     file: 0,
                     offset: 58,
-                    line: 3,
-                    col: 18,
                 },
             },
         ];

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -15,7 +15,6 @@
 
 use crate::ast;
 use crate::error::*;
-use crate::files::Files;
 use crate::lexer::Pos;
 use crate::log;
 use crate::stablemapset::{StableMap, StableSet};
@@ -23,7 +22,6 @@ use std::collections::hash_map::Entry;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 declare_id!(
     /// The id of an interned symbol.
@@ -59,11 +57,6 @@ declare_id!(
 /// Keeps track of which symbols and rules have which types.
 #[derive(Debug)]
 pub struct TypeEnv {
-    /// Arena of input ISLE source contents.
-    ///
-    /// We refer to these indirectly through the `Pos::file` indices.
-    pub files: Arc<Files>,
-
     /// Arena of interned symbol names.
     ///
     /// Referred to indirectly via `Sym` indices.
@@ -908,9 +901,8 @@ macro_rules! unwrap_or_continue {
 
 impl TypeEnv {
     /// Construct the type environment from the AST.
-    pub fn from_ast(defs: &ast::Defs) -> Result<TypeEnv, Errors> {
+    pub fn from_ast(defs: &[ast::Def]) -> Result<TypeEnv, Vec<Error>> {
         let mut tyenv = TypeEnv {
-            files: defs.files.clone(),
             syms: vec![],
             sym_map: StableMap::new(),
             types: vec![],
@@ -921,7 +913,7 @@ impl TypeEnv {
 
         // Traverse defs, assigning type IDs to type names. We'll fill
         // in types on a second pass.
-        for def in &defs.defs {
+        for def in defs {
             match def {
                 &ast::Def::Type(ref td) => {
                     let tid = TypeId(tyenv.type_map.len());
@@ -949,7 +941,7 @@ impl TypeEnv {
         // Now lower AST nodes to type definitions, raising errors
         // where typenames of fields are undefined or field names are
         // duplicated.
-        for def in &defs.defs {
+        for def in defs {
             match def {
                 &ast::Def::Type(ref td) => {
                     let tid = tyenv.types.len();
@@ -962,7 +954,7 @@ impl TypeEnv {
         }
 
         // Now collect types for extern constants.
-        for def in &defs.defs {
+        for def in defs {
             if let &ast::Def::Extern(ast::Extern::Const {
                 ref name,
                 ref ty,
@@ -986,14 +978,11 @@ impl TypeEnv {
         Ok(tyenv)
     }
 
-    fn return_errors(&mut self) -> Result<(), Errors> {
+    fn return_errors(&mut self) -> Result<(), Vec<Error>> {
         if self.errors.is_empty() {
             Ok(())
         } else {
-            Err(Errors {
-                errors: std::mem::take(&mut self.errors),
-                files: self.files.clone(),
-            })
+            Err(std::mem::take(&mut self.errors))
         }
     }
 
@@ -1163,7 +1152,7 @@ impl Bindings {
 
 impl TermEnv {
     /// Construct the term environment from the AST and the type environment.
-    pub fn from_ast(tyenv: &mut TypeEnv, defs: &ast::Defs) -> Result<TermEnv, Errors> {
+    pub fn from_ast(tyenv: &mut TypeEnv, defs: &[ast::Def]) -> Result<TermEnv, Vec<Error>> {
         let mut env = TermEnv {
             terms: vec![],
             term_map: StableMap::new(),
@@ -1190,13 +1179,13 @@ impl TermEnv {
         Ok(env)
     }
 
-    fn collect_pragmas(&mut self, _: &ast::Defs) {
+    fn collect_pragmas(&mut self, _: &[ast::Def]) {
         // currently, no pragmas are defined, but the infrastructure is useful to keep around
         return;
     }
 
-    fn collect_term_sigs(&mut self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
-        for def in &defs.defs {
+    fn collect_term_sigs(&mut self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
+        for def in defs {
             match def {
                 &ast::Def::Decl(ref decl) => {
                     let name = tyenv.intern_mut(&decl.term);
@@ -1309,8 +1298,8 @@ impl TermEnv {
         }
     }
 
-    fn collect_constructors(&mut self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
-        for def in &defs.defs {
+    fn collect_constructors(&mut self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
+        for def in defs {
             log!("collect_constructors from def: {:?}", def);
             match def {
                 &ast::Def::Rule(ref rule) => {
@@ -1372,10 +1361,10 @@ impl TermEnv {
         }
     }
 
-    fn collect_extractor_templates(&mut self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
+    fn collect_extractor_templates(&mut self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
         let mut extractor_call_graph = BTreeMap::new();
 
-        for def in &defs.defs {
+        for def in defs {
             if let &ast::Def::Extractor(ref ext) = def {
                 let term = match self.get_term_by_name(tyenv, &ext.term) {
                     Some(x) => x,
@@ -1496,8 +1485,8 @@ impl TermEnv {
         }
     }
 
-    fn collect_converters(&mut self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
-        for def in &defs.defs {
+    fn collect_converters(&mut self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
+        for def in defs {
             match def {
                 &ast::Def::Converter(ast::Converter {
                     ref term,
@@ -1559,8 +1548,8 @@ impl TermEnv {
         }
     }
 
-    fn collect_externs(&mut self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
-        for def in &defs.defs {
+    fn collect_externs(&mut self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
+        for def in defs {
             match def {
                 &ast::Def::Extern(ast::Extern::Constructor {
                     ref term,
@@ -1682,8 +1671,8 @@ impl TermEnv {
         }
     }
 
-    fn collect_rules(&mut self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
-        for def in &defs.defs {
+    fn collect_rules(&mut self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
+        for def in defs {
             match def {
                 &ast::Def::Rule(ref rule) => {
                     let pos = rule.pos;
@@ -1775,8 +1764,8 @@ impl TermEnv {
         }
     }
 
-    fn check_for_undefined_decls(&self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
-        for def in &defs.defs {
+    fn check_for_undefined_decls(&self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
+        for def in defs {
             if let ast::Def::Decl(decl) = def {
                 let term = self.get_term_by_name(tyenv, &decl.term).unwrap();
                 let term = &self.terms[term.index()];
@@ -1793,8 +1782,8 @@ impl TermEnv {
         }
     }
 
-    fn check_for_expr_terms_without_constructors(&self, tyenv: &mut TypeEnv, defs: &ast::Defs) {
-        for def in &defs.defs {
+    fn check_for_expr_terms_without_constructors(&self, tyenv: &mut TypeEnv, defs: &[ast::Def]) {
+        for def in defs {
             if let ast::Def::Rule(rule) = def {
                 rule.expr.terms(&mut |pos, ident| {
                     let term = match self.get_term_by_name(tyenv, ident) {
@@ -2404,7 +2393,7 @@ mod test {
             (type u32 (primitive u32))
             (type A extern (enum (B (f1 u32) (f2 u32)) (C (f1 u32))))
         ";
-        let ast = parse(Lexer::from_str(text, "file.isle").unwrap()).expect("should parse");
+        let ast = parse(Lexer::new(0, text).unwrap()).expect("should parse");
         let tyenv = TypeEnv::from_ast(&ast).expect("should not have type-definition errors");
 
         let sym_a = tyenv

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -15,6 +15,7 @@
 
 use crate::ast;
 use crate::error::*;
+use crate::files::Files;
 use crate::lexer::Pos;
 use crate::log;
 use crate::stablemapset::{StableMap, StableSet};
@@ -58,15 +59,10 @@ declare_id!(
 /// Keeps track of which symbols and rules have which types.
 #[derive(Debug)]
 pub struct TypeEnv {
-    /// Arena of input ISLE source filenames.
-    ///
-    /// We refer to these indirectly through the `Pos::file` indices.
-    pub filenames: Vec<Arc<str>>,
-
     /// Arena of input ISLE source contents.
     ///
     /// We refer to these indirectly through the `Pos::file` indices.
-    pub file_texts: Vec<Arc<str>>,
+    pub files: Arc<Files>,
 
     /// Arena of interned symbol names.
     ///
@@ -914,8 +910,7 @@ impl TypeEnv {
     /// Construct the type environment from the AST.
     pub fn from_ast(defs: &ast::Defs) -> Result<TypeEnv, Errors> {
         let mut tyenv = TypeEnv {
-            filenames: defs.filenames.clone(),
-            file_texts: defs.file_texts.clone(),
+            files: defs.files.clone(),
             syms: vec![],
             sym_map: StableMap::new(),
             types: vec![],
@@ -997,8 +992,7 @@ impl TypeEnv {
         } else {
             Err(Errors {
                 errors: std::mem::take(&mut self.errors),
-                filenames: self.filenames.clone(),
-                file_texts: self.file_texts.clone(),
+                files: self.files.clone(),
             })
         }
     }


### PR DESCRIPTION
* Instead of pushing every byte in a lexed integer into a `Vec<u8>`, use a slice of the original buffer, and only reallocate if there are underscores that need to be removed
* Don't track line/column in `Pos`, so don't need to update line/column in `advance_pos()`
* Store text being lexed as `&str` rather than `&[u8]` to avoid checking substrings for UTF-8 validity
* Don't try to parse integers twice
