### PR TITLE
Support DWARF packages for `wasmtime compile`

### DIFF
--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -109,7 +109,9 @@ impl CompileCommand {
                 bail!("component model support was disabled at compile time")
             }
         } else {
-            engine.precompile_module(&input)?
+            wasmtime::CodeBuilder::new(&engine)
+                .wasm(&input, Some(&self.module))?
+                .compile_module_serialized()?
         };
         fs::write(&output, output_bytes)
             .with_context(|| format!("failed to write output: {}", output.display()))?;

--- a/tests/all/debug/obj.rs
+++ b/tests/all/debug/obj.rs
@@ -3,10 +3,11 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use target_lexicon::Triple;
-use wasmtime::{Config, Engine, Module};
+use wasmtime::{CodeBuilder, Config, Engine};
 
 pub fn compile_cranelift(
     wasm: &[u8],
+    path: Option<&Path>,
     target: Option<Triple>,
     output: impl AsRef<Path>,
 ) -> Result<()> {
@@ -16,7 +17,9 @@ pub fn compile_cranelift(
         config.target(&target.to_string())?;
     }
     let engine = Engine::new(&config)?;
-    let module = Module::new(&engine, wasm)?;
+    let module = CodeBuilder::new(&engine)
+        .wasm(wasm, path)?
+        .compile_module()?;
     let bytes = module.serialize()?;
 
     let mut file = File::create(output).context("failed to create object file")?;

--- a/tests/all/debug/simulate.rs
+++ b/tests/all/debug/simulate.rs
@@ -10,7 +10,7 @@ fn check_wat(wat: &str) -> Result<()> {
     let wasm = parse_str(wat)?;
     let obj_file = NamedTempFile::new()?;
     let obj_path = obj_file.path().to_str().unwrap();
-    compile_cranelift(&wasm, None, obj_path)?;
+    compile_cranelift(&wasm, None, None, obj_path)?;
     let dump = get_dwarfdump(obj_path, DwarfDumpSection::DebugInfo)?;
     let mut builder = CheckerBuilder::new();
     builder

--- a/tests/all/debug/translate.rs
+++ b/tests/all/debug/translate.rs
@@ -10,7 +10,7 @@ fn check_wasm(wasm_path: &str, directives: &str) -> Result<()> {
     let wasm = read(wasm_path)?;
     let obj_file = NamedTempFile::new()?;
     let obj_path = obj_file.path().to_str().unwrap();
-    compile_cranelift(&wasm, None, obj_path)?;
+    compile_cranelift(&wasm, Some(wasm_path.as_ref()), None, obj_path)?;
     let dump = get_dwarfdump(obj_path, DwarfDumpSection::DebugInfo)?;
     let mut builder = CheckerBuilder::new();
     builder
@@ -29,7 +29,7 @@ fn check_line_program(wasm_path: &str, directives: &str) -> Result<()> {
     let wasm = read(wasm_path)?;
     let obj_file = NamedTempFile::new()?;
     let obj_path = obj_file.path().to_str().unwrap();
-    compile_cranelift(&wasm, None, obj_path)?;
+    compile_cranelift(&wasm, Some(wasm_path.as_ref()), None, obj_path)?;
     let dump = get_dwarfdump(obj_path, DwarfDumpSection::DebugLine)?;
     let mut builder = CheckerBuilder::new();
     builder
@@ -152,6 +152,24 @@ check:   DW_TAG_subprogram
 check:     DW_AT_name	("__wasm_call_ctors")
 check:     DW_AT_decl_file	("/<wasm-module>/<gen-$(=\d+)>.wasm")
 check:     DW_AT_decl_line	(124)
+    "##,
+    )
+}
+
+#[test]
+#[ignore]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    target_pointer_width = "64"
+))]
+fn test_debug_dwarf_translate_fission() -> Result<()> {
+    check_wasm(
+        "tests/all/debug/testsuite/dwarf_fission.wasm",
+        r##"
+check: DW_TAG_compile_unit
+check:   DW_AT_producer	("clang version 19.0.0git (https:/github.com/llvm/llvm-project ccdebbae4d77d3efc236af92c22941de5d437e01)")
+check:   DW_AT_language	(DW_LANG_C11)
+check:   DW_AT_name	("dwarf_fission.c")
     "##,
     )
 }


### PR DESCRIPTION
Previously we didn't pass the path to the Wasm file, so we didn't find the associated DWARF package.

I'm not sure if this is the right fix. Maybe `Engine` needs a new method instead?

I've also added a test for a similar problem in the tests. This doesn't actually test `wasmtime compile` though.