### PR TITLE
test-programs: use the wasi:http/imports world

### DIFF
--- a/crates/test-programs/src/lib.rs
+++ b/crates/test-programs/src/lib.rs
@@ -9,10 +9,9 @@ wit_bindgen::generate!({
 
         world test {
             include wasi:cli/imports@0.2.1;
+            include wasi:http/imports@0.2.1;
             include wasi:config/imports@0.2.0-draft;
             include wasi:keyvalue/imports@0.2.0-draft;
-            import wasi:http/types@0.2.1;
-            import wasi:http/outgoing-handler@0.2.1;
         }
     ",
     path: [


### PR DESCRIPTION
In version 0.2.1 of `wasi-http`, a new `imports` world was introduced, this allows us to manage our `test` world in `test-programs` with a simpler and more consistent style.