### PR TITLE
Add `rust-version.workspace = true` to all crates

### DIFF
--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://github.com/bytecodealliance/wasmtime/blob/main/cranelif
 repository = "https://github.com/bytecodealliance/wasmtime"
 publish = false
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["no-std"]
 readme = "README.md"
 keywords = ["btree", "forest", "set", "map"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["compile", "compiler", "jit"]
 build = "build.rs"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 # Since this is a shared dependency of several packages, please strive to keep this dependency-free

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 keywords = ["fuzz", "test"]
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["no-std"]
 readme = "README.md"
 keywords = ["entity", "set", "map"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/cranelift-filetests"
 repository = "https://github.com/bytecodealliance/wasmtime"
 publish = false
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["no-std"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/fuzzgen/Cargo.toml
+++ b/cranelift/fuzzgen/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lints]

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["no-std"]
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/isle/fuzz/Cargo.toml
+++ b/cranelift/isle/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata]
 cargo-fuzz = true

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Cranelift Project Developers"]
 description = "ISLE: Instruction Selection and Lowering Expressions. A domain-specific language for instruction selection in Cranelift."
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"

--- a/cranelift/isle/islec/Cargo.toml
+++ b/cranelift/isle/islec/Cargo.toml
@@ -3,6 +3,7 @@ name = "islec"
 version = "0.0.0"
 authors = ["The Cranelift Project Developers"]
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 publish = false
 

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/cranelift-jit"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["no-std"]
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["no-std"]
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 cranelift-codegen = { workspace = true }

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/cranelift-object"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/cranelift-reader"
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 keywords = ["webassembly", "serde"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["no-std"]
 readme = "README.md"
 keywords = ["compile", "compiler", "jit"]
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 cranelift-codegen = { workspace = true }

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["no-std", "wasm"]
 readme = "README.md"
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/asm-macros/Cargo.toml
+++ b/crates/asm-macros/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Wasmtime Project Developers"]
 description = "Macros for defining asm functions in Wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wasmtime-asm-macros"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lints]

--- a/crates/c-api-macros/Cargo.toml
+++ b/crates/c-api-macros/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
+rust-version.workspace = true
 description = "Support macros for `wasmtime-c-api`"
 repository = "https://github.com/bytecodealliance/wasmtime"
 

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 links = "wasmtime-c-api"
 include = ["include", "src", "build.rs", "CMakeLists.txt", "cmake", "doxygen.conf.in"]
 

--- a/crates/c-api/artifact/Cargo.toml
+++ b/crates/c-api/artifact/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lib]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cache/"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cache/"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/wasmtime-component-macro/"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/component-macro/test-helpers/Cargo.toml
+++ b/crates/component-macro/test-helpers/Cargo.toml
@@ -2,6 +2,7 @@
 name = "component-macro-test-helpers"
 version = "0.0.0"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/crates/component-util/Cargo.toml
+++ b/crates/component-util/Cargo.toml
@@ -9,3 +9,4 @@ documentation = "https://docs.rs/wasmtime-component-util/"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
+rust-version.workspace = true

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/wasmtime-cranelift/"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/wasmtime-environ/"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/environ/fuzz/Cargo.toml
+++ b/crates/environ/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -4,6 +4,7 @@ authors.workspace = true
 description = "Compiler explorer for Wasmtime and Cranelift"
 documentation = "https://docs.rs/wasmtime-explorer/"
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 version.workspace = true

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -6,6 +6,7 @@ description = "Fiber support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -2,6 +2,7 @@
 authors.workspace = true
 description = "Fuzzing infrastructure for Wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 name = "wasmtime-fuzzing"
 publish = false
 version = "0.0.0"

--- a/crates/fuzzing/wasm-spec-interpreter/Cargo.toml
+++ b/crates/fuzzing/wasm-spec-interpreter/Cargo.toml
@@ -5,6 +5,7 @@ name = "wasm-spec-interpreter"
 version = "0.0.0"
 publish = false
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 
 [lints]

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["gdb", "jit"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/jit-icache-coherence"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/misc/component-fuzz-util/Cargo.toml
+++ b/crates/misc/component-fuzz-util/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 version = "0.0.0"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lints]

--- a/crates/misc/component-macro-test/Cargo.toml
+++ b/crates/misc/component-macro-test/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 version = "0.0.0"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lib]

--- a/crates/misc/component-test-util/Cargo.toml
+++ b/crates/misc/component-test-util/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 version = "0.0.0"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/slab/Cargo.toml
+++ b/crates/slab/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Wasmtime Project Developers"]
 description = "Uni-typed slab with a free list for use in Wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wasmtime-slab"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-programs"
 version = "0.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/crates/test-programs/artifacts/Cargo.toml
+++ b/crates/test-programs/artifacts/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-programs-artifacts"
 version = "0.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 license = "Apache-2.0 WITH LLVM-exception"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-types"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/versioned-export-macros/Cargo.toml
+++ b/crates/versioned-export-macros/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Wasmtime Project Developers"]
 description = "Macros for defining versioned exports in Wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wasmtime-versioned-export-macros"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "tests/**/*", "witx", "README.md", "LICENSE", "build.rs"]
 
 [lints]

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasmtime-wasi-http"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository = "https://github.com/bytecodealliance/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Experimental HTTP library for WebAssembly in Wasmtime"

--- a/crates/wasi-keyvalue/Cargo.toml
+++ b/crates/wasi-keyvalue/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasmtime-wasi-keyvalue"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository = "https://github.com/bytecodealliance/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Wasmtime implementation of the wasi-keyvalue API"

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["webassembly", "wasm", "neural-network"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/wasi-preview1-component-adapter/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasi-preview1-component-adapter"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lints]

--- a/crates/wasi-preview1-component-adapter/byte-array-literals/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/byte-array-literals/Cargo.toml
@@ -3,6 +3,7 @@ name = "byte-array-literals"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lib]

--- a/crates/wasi-preview1-component-adapter/provider/Cargo.toml.in
+++ b/crates/wasi-preview1-component-adapter/provider/Cargo.toml.in
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/wasi-preview1-component-adapter-provider/"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/wasi-preview1-component-adapter/verify/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/verify/Cargo.toml
@@ -2,6 +2,7 @@
 name = "verify-component-adapter"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 publish = false
 

--- a/crates/wasi-runtime-config/Cargo.toml
+++ b/crates/wasi-runtime-config/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasmtime-wasi-runtime-config"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository = "https://github.com/bytecodealliance/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Wasmtime implementation of the wasi-runtime-config API"

--- a/crates/wasi-threads/Cargo.toml
+++ b/crates/wasi-threads/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["webassembly", "wasm", "neural-network"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "README.md", "LICENSE", "witx/*", "wit/**/*", "tests/*"]
 
 [lints]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -8,6 +8,7 @@ categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -3,6 +3,7 @@ name = "wiggle"
 version.workspace = true
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Runtime components of wiggle code generator"
 categories = ["wasm"]

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
+rust-version.workspace = true
 description = "Library crate for wiggle code generator."
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -3,6 +3,7 @@ name = "wiggle-macro"
 version.workspace = true
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Wiggle code generator"
 categories = ["wasm"]

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
+rust-version.workspace = true
 description = "Reusable testing components for wiggle code generator. Only intended to be used by tests in `wiggle` crate."
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]

--- a/crates/winch/Cargo.toml
+++ b/crates/winch/Cargo.toml
@@ -4,6 +4,7 @@ description = "Integration between Wasmtime and Winch"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 

--- a/crates/wit-bindgen/Cargo.toml
+++ b/crates/wit-bindgen/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-wit-bindgen/"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/wmemcheck/Cargo.toml
+++ b/crates/wmemcheck/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cranelift/"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasmtime-fuzz"
 version = "0.0.0"
 edition.workspace = true
+rust-version.workspace = true
 publish = false
 
 [lints]

--- a/pulley/Cargo.toml
+++ b/pulley/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Pulley Project Developers"]
 description = "The Pulley interpreter, its bytecode definition, encoder, decoder, and etc..."
 edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "pulley-interpreter"
 readme = "./README.md"

--- a/pulley/fuzz/Cargo.toml
+++ b/pulley/fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "pulley-interpreter-fuzz"
 version = "0.0.0"
 publish = false
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 version = "0.23.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Right now this is only on some crates such as `wasmtime` itself and `wasmtime-cli`, but by applying it to all crates it helps with version selection of those using just Cranelift for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
