### PR TITLE
Clean up dist build configuration

### DIFF
--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -47,7 +47,7 @@ if (process.env.CENTOS !== undefined) {
   // is mounted below.
   args.push('bash');
   args.push('-c');
-  args.push('export PATH=$PATH:/rust/bin; exec "$@"');
+  args.push('export PATH=$PATH:/rust/bin; export RUSTFLAGS="$RUSTFLAGS $EXTRA_RUSTFLAGS"; exec "$@"');
   args.push('bash');
 
   // Add in whatever we're running which will get executed in the sub-shell with

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -33,7 +33,7 @@ if (process.env.INPUT_NAME && process.env.INPUT_NAME.indexOf("android") >= 0) {
 
 if (process.env.CENTOS !== undefined) {
   const args = ['exec', '--workdir', process.cwd(), '--interactive'];
-  // forward any rust-looking env vars from the environment into the container
+  // Forward any rust-looking env vars from the environment into the container
   // itself.
   for (let key in process.env) {
     if (key.startsWith('CARGO') || key.startsWith('RUST')) {

--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -7,6 +7,4 @@ RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certifi
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
 
-ENV PATH=$PATH:/rust/bin
-ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/ci/docker/riscv64gc-linux/Dockerfile
+++ b/ci/docker/riscv64gc-linux/Dockerfile
@@ -2,6 +2,4 @@ FROM ubuntu:22.04
 
 RUN apt-get update -y && apt-get install -y gcc gcc-riscv64-linux-gnu ca-certificates cmake
 
-ENV PATH=$PATH:/rust/bin
-ENV CARGO_BUILD_TARGET=riscv64gc-unknown-linux-gnu
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc

--- a/ci/docker/s390x-linux/Dockerfile
+++ b/ci/docker/s390x-linux/Dockerfile
@@ -7,6 +7,4 @@ RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certifica
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
 
-ENV PATH=$PATH:/rust/bin
-ENV CARGO_BUILD_TARGET=s390x-unknown-linux-gnu
 ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,5 +1,3 @@
 FROM almalinux:8
 
 RUN dnf install -y git gcc make cmake
-
-ENV PATH=$PATH:/rust/bin

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -11,5 +11,5 @@ COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
 
 # Note that `-crt-feature` is passed here to specifically disable static linking
 # with musl. We want a `*.so` to pop out so static linking isn't what we want.
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV EXTRA_RUSTFLAGS=-Ctarget-feature=-crt-static
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -9,8 +9,6 @@ FROM ubuntu:24.04
 RUN apt-get update -y && apt-get install -y cmake musl-tools
 COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
 
-ENV PATH=$PATH:/rust/bin
-
 # Note that `-crt-feature` is passed here to specifically disable static linking
 # with musl. We want a `*.so` to pop out so static linking isn't what we want.
 ENV RUSTFLAGS=-Ctarget-feature=-crt-static

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -11,5 +11,5 @@ COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
 
 # Note that `-crt-feature` is passed here to specifically disable static linking
 # with musl. We want a `*.so` to pop out so static linking isn't what we want.
-ENV RUSTFLAGS=-Ctarget-feature=-crt-static
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS=-Ctarget-feature=-crt-static
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc


### PR DESCRIPTION
* Move updating `$PATH` to the `main.js` script which is the one that mounts `/rust/bin` so that knowledge isn't spread around.
* Remove some unused env vars in docker containers.
* Forward cargo/rust-specific env vars to the build from outside of containers to the build itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
