### PR TITLE
[23.0.0] Fix `cargo audit` for `cranelift-bitset`

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -32,6 +32,13 @@ start = "2021-10-29"
 end = "2024-06-26"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.cranelift-bitset]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-07-22"
+end = "2025-08-12"
+
 [[wildcard-audits.cranelift-codegen]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -28,6 +28,9 @@ audit-as-crates-io = true
 [policy.cranelift-bforest]
 audit-as-crates-io = true
 
+[policy.cranelift-bitset]
+audit-as-crates-io = true
+
 [policy.cranelift-codegen]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1140,6 +1140,12 @@ when = "2024-05-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-bitset]]
+version = "0.110.1"
+when = "2024-07-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen]]
 version = "0.105.2"
 when = "2024-02-28"


### PR DESCRIPTION
Backport some config changes from `main`. This is intended to help fix https://github.com/bytecodealliance/wasmtime/actions/runs/10354082634/job/28658496843

