### PR TITLE
Add a CI check to vet version bumps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,6 +147,11 @@ jobs:
       run: cargo vet --locked
       continue-on-error: ${{ github.event_name == 'pull_request' }}
 
+    # Double-check that if versions are bumped that `cargo vet` still works.
+    # This is intended to weed out mistakes such as #9115 from happening again.
+    - run: rustc scripts/publish.rs && ./publish bump-patch && cargo vet
+      name: Ensure `cargo vet` works if versions are bumped
+
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}
       if: failure() && github.event_name != 'pull_request'


### PR DESCRIPTION
This commit adds a CI check that if versions are bumped that `cargo vet` still works. It's hoped that #9115 won't happen again in the future with this by ensuring we get all the various entries right in our vet configuration.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
