### PR TITLE
Refactor use of `CodeBuilder` on the CLI

### DIFF
--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -41,7 +41,7 @@ use wasmtime_environ::{
 };
 
 mod code_builder;
-pub use self::code_builder::{CodeBuilder, HashedEngineCompileEnv};
+pub use self::code_builder::{CodeBuilder, CodeHint, HashedEngineCompileEnv};
 
 #[cfg(feature = "runtime")]
 mod runtime;

--- a/crates/wasmtime/src/compile/code_builder.rs
+++ b/crates/wasmtime/src/compile/code_builder.rs
@@ -164,9 +164,15 @@ impl<'a> CodeBuilder<'a> {
     /// In addition to the errors returned by [`CodeBuilder::wasm_binary_file`]
     /// this may also fail if the text format is read and the syntax is invalid.
     pub fn wasm_binary_or_text_file(&mut self, file: &'a Path) -> Result<&mut Self> {
-        let wasm = std::fs::read(file)
-            .with_context(|| format!("failed to read input file: {}", file.display()))?;
-        self.wasm_binary_or_text(wasm, Some(file))
+        #[cfg(feature = "wat")]
+        {
+            let wasm = wat::parse_file(file)?;
+            self.wasm_binary(wasm, Some(file))
+        }
+        #[cfg(not(feature = "wat"))]
+        {
+            self.wasm_binary_file(file)
+        }
     }
 
     pub(super) fn get_wasm(&self) -> Result<&[u8]> {

--- a/crates/wasmtime/src/compile/runtime.rs
+++ b/crates/wasmtime/src/compile/runtime.rs
@@ -13,8 +13,8 @@ impl<'a> CodeBuilder<'a> {
         &self,
         build_artifacts: fn(&Engine, &[u8], Option<&[u8]>) -> Result<(MmapVecWrapper, Option<T>)>,
     ) -> Result<(Arc<CodeMemory>, Option<T>)> {
-        let wasm = self.wasm_binary()?;
-        let dwarf_package = self.dwarf_package_binary();
+        let wasm = self.get_wasm()?;
+        let dwarf_package = self.get_dwarf_package();
 
         self.engine
             .check_compatible_with_native_host()

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -494,7 +494,7 @@ impl Engine {
     /// [text]: https://webassembly.github.io/spec/core/text/index.html
     pub fn precompile_module(&self, bytes: &[u8]) -> Result<Vec<u8>> {
         crate::CodeBuilder::new(self)
-            .wasm(bytes, None)?
+            .wasm_binary_or_text(bytes, None)?
             .compile_module_serialized()
     }
 
@@ -503,7 +503,7 @@ impl Engine {
     #[cfg(feature = "component-model")]
     pub fn precompile_component(&self, bytes: &[u8]) -> Result<Vec<u8>> {
         crate::CodeBuilder::new(self)
-            .wasm(bytes, None)?
+            .wasm_binary_or_text(bytes, None)?
             .compile_component_serialized()
     }
 

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -363,7 +363,7 @@ pub use runtime::*;
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 mod compile;
 #[cfg(any(feature = "cranelift", feature = "winch"))]
-pub use compile::CodeBuilder;
+pub use compile::{CodeBuilder, CodeHint};
 
 mod config;
 mod engine;

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -161,7 +161,7 @@ impl Component {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn new(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Component> {
         crate::CodeBuilder::new(engine)
-            .wasm(bytes.as_ref(), None)?
+            .wasm_binary_or_text(bytes.as_ref(), None)?
             .compile_component()
     }
 
@@ -173,7 +173,7 @@ impl Component {
     #[cfg(all(feature = "std", any(feature = "cranelift", feature = "winch")))]
     pub fn from_file(engine: &Engine, file: impl AsRef<Path>) -> Result<Component> {
         crate::CodeBuilder::new(engine)
-            .wasm_file(file.as_ref())?
+            .wasm_binary_or_text_file(file.as_ref())?
             .compile_component()
     }
 
@@ -189,8 +189,7 @@ impl Component {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn from_binary(engine: &Engine, binary: &[u8]) -> Result<Component> {
         crate::CodeBuilder::new(engine)
-            .wasm(binary, None)?
-            .wat(false)?
+            .wasm_binary(binary, None)?
             .compile_component()
     }
 

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -243,7 +243,7 @@ impl Module {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn new(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Module> {
         crate::CodeBuilder::new(engine)
-            .wasm(bytes.as_ref(), None)?
+            .wasm_binary_or_text(bytes.as_ref(), None)?
             .compile_module()
     }
 
@@ -278,7 +278,7 @@ impl Module {
     #[cfg(all(feature = "std", any(feature = "cranelift", feature = "winch")))]
     pub fn from_file(engine: &Engine, file: impl AsRef<Path>) -> Result<Module> {
         crate::CodeBuilder::new(engine)
-            .wasm_file(file.as_ref())?
+            .wasm_binary_or_text_file(file.as_ref())?
             .compile_module()
     }
 
@@ -316,8 +316,7 @@ impl Module {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn from_binary(engine: &Engine, binary: &[u8]) -> Result<Module> {
         crate::CodeBuilder::new(engine)
-            .wasm(binary, None)?
-            .wat(false)?
+            .wasm_binary(binary, None)?
             .compile_module()
     }
 
@@ -351,7 +350,7 @@ impl Module {
         }
 
         crate::CodeBuilder::new(engine)
-            .wasm(&mmap, Some(file.as_ref()))?
+            .wasm_binary_or_text(&mmap[..], Some(file.as_ref()))?
             .compile_module()
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,9 +4,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use std::net::TcpListener;
 use std::{path::Path, time::Duration};
-use wasmtime::{
-    CodeBuilder, CodeHint, Engine, Module, Precompiled, StoreLimits, StoreLimitsBuilder,
-};
+use wasmtime::{Engine, Module, Precompiled, StoreLimits, StoreLimitsBuilder};
 use wasmtime_cli_flags::{opt::WasmtimeOptionValue, CommonOptions};
 use wasmtime_wasi::WasiCtxBuilder;
 
@@ -229,10 +227,10 @@ impl RunCommon {
             }
             #[cfg(any(feature = "cranelift", feature = "winch"))]
             None => {
-                let mut code = CodeBuilder::new(engine);
+                let mut code = wasmtime::CodeBuilder::new(engine);
                 code.wasm_binary_or_text(bytes, Some(path))?;
                 match code.hint() {
-                    Some(CodeHint::Component) => {
+                    Some(wasmtime::CodeHint::Component) => {
                         #[cfg(feature = "component-model")]
                         {
                             self.ensure_allow_components()?;
@@ -243,7 +241,9 @@ impl RunCommon {
                             bail!("support for components was not enabled at compile time");
                         }
                     }
-                    Some(CodeHint::Module) | None => RunTarget::Core(code.compile_module()?),
+                    Some(wasmtime::CodeHint::Module) | None => {
+                        RunTarget::Core(code.compile_module()?)
+                    }
                 }
             }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,9 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use std::net::TcpListener;
 use std::{path::Path, time::Duration};
-use wasmtime::{Engine, Module, Precompiled, StoreLimits, StoreLimitsBuilder};
+use wasmtime::{
+    CodeBuilder, CodeHint, Engine, Module, Precompiled, StoreLimits, StoreLimitsBuilder,
+};
 use wasmtime_cli_flags::{opt::WasmtimeOptionValue, CommonOptions};
 use wasmtime_wasi::WasiCtxBuilder;
 
@@ -227,33 +229,24 @@ impl RunCommon {
             }
             #[cfg(any(feature = "cranelift", feature = "winch"))]
             None => {
-                // Parse the text format here specifically to add the `path` to
-                // the error message if there's a syntax error.
-                #[cfg(feature = "wat")]
-                let bytes = wat::parse_bytes(bytes).map_err(|mut e| {
-                    e.set_path(path);
-                    e
-                })?;
-                if wasmparser::Parser::is_component(&bytes) {
-                    #[cfg(feature = "component-model")]
-                    {
-                        self.ensure_allow_components()?;
-                        let component = wasmtime::CodeBuilder::new(engine)
-                            .wasm(&bytes, Some(path))?
-                            .compile_component()?;
-                        RunTarget::Component(component)
+                let mut code = CodeBuilder::new(engine);
+                code.wasm_binary_or_text(bytes, Some(path))?;
+                match code.hint() {
+                    Some(CodeHint::Component) => {
+                        #[cfg(feature = "component-model")]
+                        {
+                            self.ensure_allow_components()?;
+                            RunTarget::Component(code.compile_component()?)
+                        }
+                        #[cfg(not(feature = "component-model"))]
+                        {
+                            bail!("support for components was not enabled at compile time");
+                        }
                     }
-                    #[cfg(not(feature = "component-model"))]
-                    {
-                        bail!("support for components was not enabled at compile time");
-                    }
-                } else {
-                    let module = wasmtime::CodeBuilder::new(engine)
-                        .wasm(&bytes, Some(path))?
-                        .compile_module()?;
-                    RunTarget::Core(module)
+                    Some(CodeHint::Module) | None => RunTarget::Core(code.compile_module()?),
                 }
             }
+
             #[cfg(not(any(feature = "cranelift", feature = "winch")))]
             None => {
                 let _ = path;

--- a/tests/all/debug/obj.rs
+++ b/tests/all/debug/obj.rs
@@ -18,7 +18,7 @@ pub fn compile_cranelift(
     }
     let engine = Engine::new(&config)?;
     let module = CodeBuilder::new(&engine)
-        .wasm(wasm, path)?
+        .wasm_binary_or_text(wasm, path)?
         .compile_module()?;
     let bytes = module.serialize()?;
 


### PR DESCRIPTION
This commit refactors `wasmtime run` and `wasmtime compile` to unconditionally use `CodeBuilder` internally. This will in theory help out in the future if more debug-related options are added to `CodeBuilder` for example. This refactoring required some changes to `CodeBuilder` to be able to support a query about whether the internal bytes were a component or a module. The text format is now converted to binary immediately when supplied rather than during the compilation phase. This in turn required some API changes to make the selection of supporting the text format a compile-time choice of method rather than a runtime value.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
