### PR TITLE
Disable the trace-log feature of regalloc2 by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
 cranelift-wasm = { path = "cranelift/wasm", version = "0.112.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.112.0", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.112.0", default-features = false, features = ["std", "unwind"] }
 cranelift-frontend = { path = "cranelift/frontend", version = "0.112.0" }
 cranelift-entity = { path = "cranelift/entity", version = "0.112.0" }
 cranelift-native = { path = "cranelift/native", version = "0.112.0" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -33,7 +33,7 @@ serde_derive = { workspace = true, optional = true }
 postcard = { workspace = true, optional = true }
 gimli = { workspace = true, features = ["write", "std"], optional = true }
 smallvec = { workspace = true }
-regalloc2 = { workspace = true, features = ["checker", "trace-log"] }
+regalloc2 = { workspace = true, features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 rustc-hash  = { workspace = true }
@@ -70,7 +70,7 @@ core = []
 disas = ["anyhow", "capstone"]
 
 # Enables detailed logging which can be somewhat expensive.
-trace-log = []
+trace-log = ["regalloc2/trace-log"]
 
 # This enables unwind info generation functionality.
 unwind = ["gimli"]


### PR DESCRIPTION
This makes register allocation a bit faster when these logs are not used.