### PR TITLE
Add NEWLINE_STYLE to cmake install

### DIFF
--- a/crates/c-api/cmake/install-headers.cmake
+++ b/crates/c-api/cmake/install-headers.cmake
@@ -11,7 +11,8 @@ set(include_src "${CMAKE_CURRENT_LIST_DIR}/../include")
 
 message(STATUS "Installing: ${dst}/wasmtime/conf.h")
 file(READ "${include_src}/wasmtime/conf.h.in" conf_h)
-file(CONFIGURE OUTPUT "${dst}/wasmtime/conf.h" CONTENT "${conf_h}")
+file(CONFIGURE OUTPUT "${dst}/wasmtime/conf.h" CONTENT "${conf_h}"
+     NEWLINE_STYLE CRLF)
 file(INSTALL "${include_src}/"
      DESTINATION "${dst}"
      FILES_MATCHING REGEX "\\.hh?$")


### PR DESCRIPTION
Looks like CMake before 3.20.0 doesn't generate newlines at all without this configuration option. CMake 3.20.0 and prior, however, generates newlines by default which is why this didn't show up in CI or development.

Closes #9126

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
