### PR TITLE
Use the correct DWARF sections and unit for parsing split DWARF

### DIFF
--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -5,10 +5,7 @@ use crate::debug::gc::build_dependencies;
 use crate::debug::Compilation;
 use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
-use gimli::{
-    write, DebugAddr, DebugLine, DebugStr, Dwarf, DwarfPackage, LittleEndian, LocationLists,
-    RangeLists, Section, Unit, UnitSectionOffset,
-};
+use gimli::{write, Dwarf, DwarfPackage, LittleEndian, Section, Unit, UnitSectionOffset};
 use std::{collections::HashSet, fmt::Debug};
 use thiserror::Error;
 use wasmtime_environ::{
@@ -53,15 +50,7 @@ impl<'input, Endian> Reader for gimli::EndianSlice<'input, Endian> where
 #[error("Debug info transform error: {0}")]
 pub struct TransformError(&'static str);
 
-pub(crate) struct DebugInputContext<'a, R>
-where
-    R: Reader,
-{
-    debug_str: &'a DebugStr<R>,
-    debug_line: &'a DebugLine<R>,
-    debug_addr: &'a DebugAddr<R>,
-    rnglists: &'a RangeLists<R>,
-    loclists: &'a LocationLists<R>,
+pub(crate) struct DebugInputContext<'a> {
     reachable: &'a HashSet<UnitSectionOffset>,
 }
 
@@ -190,11 +179,6 @@ pub fn transform_dwarf(
         let addr_tr = &transforms[module];
         let di = &translation.debuginfo;
         let context = DebugInputContext {
-            debug_str: &di.dwarf.debug_str,
-            debug_line: &di.dwarf.debug_line,
-            debug_addr: &di.dwarf.debug_addr,
-            rnglists: &di.dwarf.ranges,
-            loclists: &di.dwarf.locations,
             reachable: &reachable,
         };
         let mut iter = di.dwarf.debug_info.units();
@@ -266,8 +250,7 @@ fn replace_unit_from_split_dwarf<'a>(
     let dwo_id = unit.dwo_id?;
     let split_unit_dwarf = dwp.find_cu(dwo_id, parent).ok()??;
     let unit_header = split_unit_dwarf.debug_info.units().next().ok()??;
-    Some((
-        split_unit_dwarf.unit(unit_header).unwrap(),
-        split_unit_dwarf,
-    ))
+    let mut split_unit = split_unit_dwarf.unit(unit_header).ok()?;
+    split_unit.copy_relocated_attributes(unit);
+    Some((split_unit, split_unit_dwarf))
 }


### PR DESCRIPTION
The DWARF sections in `DebugInputContext` were always set to the DWARF sections from the .wasm file. However, when parsing split DWARF, most of the time we want to be using the sections from the .dwp file instead. We were already passing `gimli::Dwarf` to most places already so having the sections in `DebugInputContext` was no benefit. So a lot of this commit is replacing `context` with `dwarf`.

Next, sometimes we were using the wrong `gimli::Dwarf`. In general, we want to use the skeleton unit for parsing line info, and the split unit for everything else. `clone_unit` was wrongly using the DWARF associated with the skeleton unit in many places. Instead of changing all of those places, I've kept the variable names `dwarf` and `unit`, but changed which DWARF they refer to. This also fits better with the non-split operation. So some of the changes in this commit are updating places that were already correct to use the new variable meanings.

Finally, this commit adds a call to `copy_relocated_attributes`. This copies some info from the skeleton unit that is needed when parsing the split unit.

For testing, the existing `dwarf_fission.dwp` is too simple for this to make any difference. I've been testing with one of my own C projects, but that's not something I want to add to wasmtime. Additionally, further fixes are required. I'm open to suggestions for a suitable small but non-trivial project to use for testing purposes.