### PR TITLE
Implement a few minor optimizations around 128-bit integers

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -101,15 +101,27 @@
 (rule 1 (lower (has_type $I128 (iadd x y)))
       ;; Get the high/low registers for `x`.
       (let ((x_regs ValueRegs x)
-            (x_lo Gpr (value_regs_get_gpr x_regs 0))
-            (x_hi Gpr (value_regs_get_gpr x_regs 1)))
-        ;; Get the high/low registers for `y`.
-        (let ((y_regs ValueRegs y)
-              (y_lo Gpr (value_regs_get_gpr y_regs 0))
-              (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-          ;; Do an add followed by an add-with-carry.
-          (with_flags (x64_add_with_flags_paired $I64 x_lo y_lo)
-                      (x64_adc_paired $I64 x_hi y_hi)))))
+            (y_regs ValueRegs y))
+        (iadd128
+          (value_regs_get_gpr x_regs 0)
+          (value_regs_get_gpr x_regs 1)
+          (value_regs_get_gpr y_regs 0)
+          (value_regs_get_gpr y_regs 1))))
+(rule 2 (lower (has_type $I128 (iadd x (iconcat y_lo y_hi))))
+        (let ((x_regs ValueRegs x))
+          (iadd128 (value_regs_get_gpr x 0) (value_regs_get_gpr x 1) y_lo y_hi)))
+(rule 3 (lower (has_type $I128 (iadd x (uextend y @ (value_type $I64)))))
+        (let ((x_regs ValueRegs x))
+          (iadd128 (value_regs_get_gpr x 0) (value_regs_get_gpr x 1)
+                   y (RegMemImm.Imm 0))))
+
+;; Helper for lowering 128-bit addition with the 64-bit halves of the lhs/rhs
+;; already split. The first two arguments are lo/hi for the lhs and the second
+;; two are lo/hi for the rhs.
+(decl iadd128 (Gpr Gpr GprMemImm GprMemImm) ValueRegs)
+(rule (iadd128 x_lo x_hi y_lo y_hi)
+      (with_flags (x64_add_with_flags_paired $I64 x_lo y_lo)
+                  (x64_adc_paired $I64 x_hi y_hi)))
 
 ;;;; Helpers for `*_overflow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -245,15 +257,22 @@
 (rule 1 (lower (has_type $I128 (isub x y)))
       ;; Get the high/low registers for `x`.
       (let ((x_regs ValueRegs x)
-            (x_lo Gpr (value_regs_get_gpr x_regs 0))
-            (x_hi Gpr (value_regs_get_gpr x_regs 1)))
-        ;; Get the high/low registers for `y`.
-        (let ((y_regs ValueRegs y)
-              (y_lo Gpr (value_regs_get_gpr y_regs 0))
-              (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-          ;; Do a sub followed by an sub-with-borrow.
-          (with_flags (x64_sub_with_flags_paired $I64 x_lo y_lo)
-                      (x64_sbb_paired $I64 x_hi y_hi)))))
+            (y_regs ValueRegs y))
+        (isub128
+          (value_regs_get_gpr x_regs 0)
+          (value_regs_get_gpr x_regs 1)
+          (value_regs_get_gpr y_regs 0)
+          (value_regs_get_gpr y_regs 1))))
+(rule 2 (lower (has_type $I128 (isub (iconcat x_lo x_hi) (iconcat y_lo y_hi))))
+        (isub128 x_lo x_hi y_lo y_hi))
+
+;; Helper for lowering 128-bit subtraction with the 64-bit halves of the lhs/rhs
+;; already split. The first two arguments are lo/hi for the lhs and the second
+;; two are lo/hi for the rhs.
+(decl isub128 (Gpr Gpr GprMemImm GprMemImm) ValueRegs)
+(rule (isub128 x_lo x_hi y_lo y_hi)
+      (with_flags (x64_sub_with_flags_paired $I64 x_lo y_lo)
+                  (x64_sbb_paired $I64 x_hi y_hi)))
 
 ;;;; Rules for `ssub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -999,6 +1018,22 @@
 
 ;; `i128`.
 
+(rule 2 (lower (has_type $I128 (imul x y)))
+      (let ((x_regs ValueRegs x)
+            (y_regs ValueRegs y))
+        (imul128
+          (value_regs_get_gpr x_regs 0)
+          (value_regs_get_gpr x_regs 1)
+          (value_regs_get_gpr y_regs 0)
+          (value_regs_get_gpr y_regs 1))))
+
+(rule 4 (lower (has_type $I128 (imul (iconcat x_lo x_hi) (iconcat y_lo y_hi))))
+        (imul128 x_lo x_hi y_lo y_hi))
+
+;; Helper for lowering 128-bit multiplication with the 64-bit halves of the
+;; lhs/rhs already split. The first two arguments are lo/hi for the lhs and the
+;; second two are lo/hi for the rhs.
+;;
 ;; mul:
 ;;   dst_lo = lhs_lo * rhs_lo
 ;;   dst_hi = umulhi(lhs_lo, rhs_lo) +
@@ -1012,16 +1047,10 @@
 ;;   dst_lo:hi_lolo = mulhi_u x_lo, y_lo
 ;;   dst_hi = add hilo_hilo, hi_lolo
 ;;   return (dst_lo, dst_hi)
-(rule 2 (lower (has_type $I128 (imul x y)))
+(decl imul128 (Gpr Gpr GprMem GprMem) ValueRegs)
+(rule (imul128 x_lo x_hi y_lo y_hi)
       ;; Put `x` into registers and unpack its hi/lo halves.
-      (let ((x_regs ValueRegs x)
-            (x_lo Gpr (value_regs_get_gpr x_regs 0))
-            (x_hi Gpr (value_regs_get_gpr x_regs 1))
-            ;; Put `y` into registers and unpack its hi/lo halves.
-            (y_regs ValueRegs y)
-            (y_lo Gpr (value_regs_get_gpr y_regs 0))
-            (y_hi Gpr (value_regs_get_gpr y_regs 1))
-            ;; lo_hi = mul x_lo, y_hi
+      (let (;; lo_hi = mul x_lo, y_hi
             (lo_hi Gpr (x64_imul $I64 x_lo y_hi))
             ;; hi_lo = mul x_hi, y_lo
             (hi_lo Gpr (x64_imul $I64 x_hi y_lo))
@@ -1034,6 +1063,17 @@
             ;; dst_hi = add hilo_hilo, hi_lolo
             (dst_hi Gpr (x64_add $I64 hilo_hilo hi_lolo)))
         (value_gprs dst_lo dst_hi)))
+
+;; The `mul` and `imul` instructions on x64 are defined as taking 64-bit
+;; operands and producing a 128-bit result, which exactly matches the semantics
+;; of widening 64-bit inputs to 128-bit and then multiplying them. That means
+;; that these cases can get some some simpler codegen.
+(rule 5 (lower (has_type $I128 (imul (uextend x @ (value_type $I64))
+                                     (uextend y @ (value_type $I64)))))
+        (x64_mul $I64 $false x y))
+(rule 5 (lower (has_type $I128 (imul (sextend x @ (value_type $I64))
+                                     (sextend y @ (value_type $I64)))))
+        (x64_mul $I64 $true x y))
 
 ;; SSE.
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -263,8 +263,13 @@
           (value_regs_get_gpr x_regs 1)
           (value_regs_get_gpr y_regs 0)
           (value_regs_get_gpr y_regs 1))))
-(rule 2 (lower (has_type $I128 (isub (iconcat x_lo x_hi) (iconcat y_lo y_hi))))
-        (isub128 x_lo x_hi y_lo y_hi))
+(rule 2 (lower (has_type $I128 (isub x (iconcat y_lo y_hi))))
+        (let ((x_regs ValueRegs x))
+          (isub128 (value_regs_get_gpr x 0) (value_regs_get_gpr x 1) y_lo y_hi)))
+(rule 3 (lower (has_type $I128 (isub x (uextend y @ (value_type $I64)))))
+        (let ((x_regs ValueRegs x))
+          (isub128 (value_regs_get_gpr x 0) (value_regs_get_gpr x 1)
+                   y (RegMemImm.Imm 0))))
 
 ;; Helper for lowering 128-bit subtraction with the 64-bit halves of the lhs/rhs
 ;; already split. The first two arguments are lo/hi for the lhs and the second

--- a/cranelift/codegen/src/opts/extends.isle
+++ b/cranelift/codegen/src/opts/extends.isle
@@ -89,3 +89,7 @@
 (rule (simplify (ireduce ty (bor  _ x y))) (bor  ty (ireduce ty x) (ireduce ty y)))
 (rule (simplify (ireduce ty (bxor _ x y))) (bxor ty (ireduce ty x) (ireduce ty y)))
 (rule (simplify (ireduce ty (band _ x y))) (band ty (ireduce ty x) (ireduce ty y)))
+
+;; Try to transform an `iconcat` into an i128 into either an sextend or uextend
+(rule (simplify (iconcat $I128 x (iconst_u _ 0))) (uextend $I128 x))
+(rule (simplify (iconcat $I128 x (sshr _ x (iconst_u _ 63)))) (sextend $I128 x))

--- a/cranelift/filetests/filetests/egraph/extends.clif
+++ b/cranelift/filetests/filetests/egraph/extends.clif
@@ -227,3 +227,23 @@ block0(v0: i16):
 
 ; check: v5 = bnot v0
 ; check: return v5
+
+function %concat_zero(i64) -> i128 {
+block0(v0: i64):
+    v1 = iconst.i64 0
+    v2 = iconcat v0, v1
+    return v2
+}
+
+; check: v3 = uextend.i128 v0
+; check: return v3
+
+function %sext128(i64) -> i128 {
+block0(v0: i64):
+    v1 = sshr_imm v0, 63
+    v2 = iconcat v0, v1
+    return v2
+}
+
+; check: v4 = sextend.i128 v0
+; check: return v4

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1878,7 +1878,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1895,3 +1895,125 @@ block0(v0: i128):
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+
+function %mul_wide_i64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = imul v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   mulq    %rax, %rsi, %rax, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   mulq %rsi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_concat_64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v10 = iconst.i64 0
+    v2 = iconcat v0, v10
+    v3 = iconcat v1, v10
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   xorq    %rdx, %rdx, %rdx
+;   movq    %rdi, %rax
+;   addq    %rax, %rsi, %rax
+;   adcq    %rdx, $0, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   xorq %rdx, %rdx
+;   movq %rdi, %rax
+;   addq %rsi, %rax
+;   adcq $0, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %mul_uextend_i64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = imul v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   mulq    %rax, %rsi, %rax, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   mulq %rsi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %mul_sextend_i64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = sextend.i128 v0
+    v3 = sextend.i128 v1
+    v4 = imul v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   imulq   %rax, %rsi, %rax, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   imulq %rsi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1112,24 +1112,19 @@ block2(v8: i128):
 ; block0:
 ;   xorq    %rax, %rax, %rax
 ;   xorq    %r8, %r8, %r8
-;   movq    %r8, %rcx
 ;   testb   %dl, %dl
 ;   jnz     label2; j label1
 ; block1:
-;   movl    $2, %r8d
-;   xorq    %r9, %r9, %r9
-;   addq    %rax, %r8, %rax
-;   movq    %rcx, %rdx
-;   adcq    %rdx, %r9, %rdx
+;   addq    %rax, $2, %rax
+;   movq    %r8, %rdx
+;   adcq    %rdx, $0, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movq    %rcx, %rdx
-;   movl    $1, %r8d
-;   xorq    %r9, %r9, %r9
-;   addq    %rax, %r8, %rax
-;   adcq    %rdx, %r9, %rdx
+;   movq    %r8, %rdx
+;   addq    %rax, $1, %rax
+;   adcq    %rdx, $0, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1141,24 +1136,19 @@ block2(v8: i128):
 ; block1: ; offset 0x4
 ;   xorq %rax, %rax
 ;   xorq %r8, %r8
-;   movq %r8, %rcx
 ;   testb %dl, %dl
-;   jne 0x2c
-; block2: ; offset 0x15
-;   movl $2, %r8d
-;   xorq %r9, %r9
-;   addq %r8, %rax
-;   movq %rcx, %rdx
-;   adcq %r9, %rdx
+;   jne 0x22
+; block2: ; offset 0x12
+;   addq $2, %rax
+;   movq %r8, %rdx
+;   adcq $0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x2c
-;   movq %rcx, %rdx
-;   movl $1, %r8d
-;   xorq %r9, %r9
-;   addq %r8, %rax
-;   adcq %r9, %rdx
+; block3: ; offset 0x22
+;   movq %r8, %rdx
+;   addq $1, %rax
+;   adcq $0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1179,34 +1169,31 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $32, %rsp
-;   movq    %rbx, 0(%rsp)
-;   movq    %r13, 8(%rsp)
-;   movq    %r14, 16(%rsp)
-;   movq    %r15, 24(%rsp)
+;   movq    %r13, 0(%rsp)
+;   movq    %r14, 8(%rsp)
+;   movq    %r15, 16(%rsp)
 ; block0:
-;   movq    %rdx, %rbx
-;   movq    %rcx, %r14
+;   movq    %rcx, %r13
+;   movq    %rdx, %r15
 ;   movq    rbp(stack args max - 48), %rcx
 ;   movq    rbp(stack args max - 40), %rax
 ;   movq    rbp(stack args max - 32), %rdx
 ;   movq    rbp(stack args max - 24), %r11
 ;   movq    rbp(stack args max - 16), %r10
-;   addq    %rdi, %rbx, %rdi
-;   movq    %r14, %r15
-;   adcq    %rsi, %r15, %rsi
-;   xorq    %r13, %r13, %r13
+;   addq    %rdi, %r15, %rdi
+;   movq    %r13, %r14
+;   adcq    %rsi, %r14, %rsi
 ;   addq    %r9, %r8, %r9
-;   adcq    %rcx, %r13, %rcx
+;   adcq    %rcx, $0, %rcx
 ;   addq    %rax, %r11, %rax
 ;   adcq    %rdx, %r10, %rdx
 ;   addq    %rdi, %r9, %rdi
 ;   adcq    %rsi, %rcx, %rsi
 ;   addq    %rax, %rdi, %rax
 ;   adcq    %rdx, %rsi, %rdx
-;   movq    0(%rsp), %rbx
-;   movq    8(%rsp), %r13
-;   movq    16(%rsp), %r14
-;   movq    24(%rsp), %r15
+;   movq    0(%rsp), %r13
+;   movq    8(%rsp), %r14
+;   movq    16(%rsp), %r15
 ;   addq    %rsp, $32, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1217,34 +1204,31 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x20, %rsp
-;   movq %rbx, (%rsp)
-;   movq %r13, 8(%rsp)
-;   movq %r14, 0x10(%rsp)
-;   movq %r15, 0x18(%rsp)
-; block1: ; offset 0x1b
-;   movq %rdx, %rbx
-;   movq %rcx, %r14
+;   movq %r13, (%rsp)
+;   movq %r14, 8(%rsp)
+;   movq %r15, 0x10(%rsp)
+; block1: ; offset 0x16
+;   movq %rcx, %r13
+;   movq %rdx, %r15
 ;   movq 0x10(%rbp), %rcx
 ;   movq 0x18(%rbp), %rax
 ;   movq 0x20(%rbp), %rdx
 ;   movq 0x28(%rbp), %r11
 ;   movq 0x30(%rbp), %r10
-;   addq %rbx, %rdi
-;   movq %r14, %r15
-;   adcq %r15, %rsi
-;   xorq %r13, %r13
+;   addq %r15, %rdi
+;   movq %r13, %r14
+;   adcq %r14, %rsi
 ;   addq %r8, %r9
-;   adcq %r13, %rcx
+;   adcq $0, %rcx
 ;   addq %r11, %rax
 ;   adcq %r10, %rdx
 ;   addq %r9, %rdi
 ;   adcq %rcx, %rsi
 ;   addq %rdi, %rax
 ;   adcq %rsi, %rdx
-;   movq (%rsp), %rbx
-;   movq 8(%rsp), %r13
-;   movq 0x10(%rsp), %r14
-;   movq 0x18(%rsp), %r15
+;   movq (%rsp), %r13
+;   movq 8(%rsp), %r14
+;   movq 0x10(%rsp), %r15
 ;   addq $0x20, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -2001,3 +2001,36 @@ block0(v0: i64, v1: i64):
 ;   popq %rbp
 ;   retq
 
+function %sub_uextend_64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   xorq    %rdx, %rdx, %rdx
+;   movq    %rdi, %rax
+;   subq    %rax, %rsi, %rax
+;   sbbq    %rdx, $0, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   xorq %rdx, %rdx
+;   movq %rdi, %rax
+;   subq %rsi, %rax
+;   sbbq $0, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
@@ -23,6 +23,18 @@ block0(v0: i128,v1: i128):
 ; run: %add_i128(0x06060606_06060606_A00A00A0_0A00A00A, 0x30303030_30303030_0BB0BB0B_B0BB0BB0) == 0x36363636_36363636_ABBABBAB_BABBABBA
 ; run: %add_i128(0xC0FFEEEE_C0FFEEEE_C0FFEEEE_C0FFEEEE, 0x1DCB1111_1DCB1111_1DCB1111_1DCB1111) == 0xDECAFFFF_DECAFFFF_DECAFFFF_DECAFFFF
 
+function %add_i128_splats(i64, i64, i64, i64) -> i128 {
+block0(v0: i64, v1: i64, v2: i64, v3: i64):
+    v4 = iconcat v0, v1
+    v5 = iconcat v2, v3
+    v6 = iadd v4, v5
+    return v6
+}
+; run: %add_i128_splats(0, 0, 0, 0) == 0
+; run: %add_i128_splats(1, 0, 0, 0) == 1
+; run: %add_i128_splats(1, 0, 1, 0) == 2
+; run: %add_i128_splats(1, 0, -1, -1) == 0
+
 
 function %sub_i128(i128, i128) -> i128 {
 block0(v0: i128,v1: i128):
@@ -38,6 +50,18 @@ block0(v0: i128,v1: i128):
 ; run: %sub_i128(-1, 0xFEDCBA98_76543210_FEDCBA98_76543210) == 0x01234567_89ABCDEF_01234567_89ABCDEF
 ; run: %sub_i128(0x36363636_36363636_ABBABBAB_BABBABBA, 0x30303030_30303030_0BB0BB0B_B0BB0BB0) == 0x06060606_06060606_A00A00A0_0A00A00A
 ; run: %sub_i128(0xDECAFFFF_DECAFFFF_DECAFFFF_DECAFFFF, 0x1DCB1111_1DCB1111_1DCB1111_1DCB1111) == 0xC0FFEEEE_C0FFEEEE_C0FFEEEE_C0FFEEEE
+
+function %sub_i128_splats(i64, i64, i64, i64) -> i128 {
+block0(v0: i64, v1: i64, v2: i64, v3: i64):
+    v4 = iconcat v0, v1
+    v5 = iconcat v2, v3
+    v6 = isub v4, v5
+    return v6
+}
+; run: %sub_i128_splats(0, 0, 0, 0) == 0
+; run: %sub_i128_splats(1, 0, 0, 0) == 1
+; run: %sub_i128_splats(1, 0, 1, 0) == 0
+; run: %sub_i128_splats(1, 0, -1, -1) == 2
 
 
 function %mul_i128(i128, i128) -> i128 {
@@ -59,6 +83,17 @@ block0(v0: i128,v1: i128):
 ; run: %mul_i128(0x00000000_01234567_89ABCDEF_00000000, 0x00000000_FEDCBA98_76543210_00000000) == 0x2236D88F_E5618CF0_00000000_00000000
 ; run: %mul_i128(0xC0FFEEEE_C0FFEEEE_C0FFEEEE_C0FFEEEE, 0xDECAFFFF_DECAFFFF_DECAFFFF_DECAFFFF) == 0x5ECD38B5_9D1C2B7E_DB6B1E48_19BA1112
 
+function %mul_i128_splats(i64, i64, i64, i64) -> i128 {
+block0(v0: i64, v1: i64, v2: i64, v3: i64):
+    v4 = iconcat v0, v1
+    v5 = iconcat v2, v3
+    v6 = imul v4, v5
+    return v6
+}
+; run: %mul_i128_splats(0, 0, 0, 0) == 0
+; run: %mul_i128_splats(1, 0, 0, 0) == 0
+; run: %mul_i128_splats(1, 0, 1, 0) == 1
+; run: %mul_i128_splats(1, 0, -1, -1) == -1
 
 ; Tests that imm's are sign extended on i128's
 ; See: https://github.com/bytecodealliance/wasmtime/issues/4568
@@ -68,3 +103,27 @@ block0(v0: i128):
     return v1
 }
 ; run: %iadd_imm_neg(1) == 0
+
+function %mul_uextend_i64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = imul v2, v3
+    return v4
+}
+; run: %mul_uextend_i64(0, 0) == 0
+; run: %mul_uextend_i64(1, 2) == 2
+; run: %mul_uextend_i64(0x10000000_00000000, 0x10000000_00000000) == 0x1000000000000000000000000000000
+
+function %mul_sextend_i64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = sextend.i128 v0
+    v3 = sextend.i128 v1
+    v4 = imul v2, v3
+    return v4
+}
+; run: %mul_sextend_i64(0, 0) == 0
+; run: %mul_sextend_i64(1, 2) == 2
+; run: %mul_sextend_i64(0x10000000_00000000, 0x10000000_00000000) == 0x1000000000000000000000000000000
+; run: %mul_sextend_i64(-2, 200) == -400
+; run: %mul_sextend_i64(300, -4) == -1200


### PR DESCRIPTION
This commit implements a few minor changes for `i128` in both the egraph optimizations and lowerings for x64. The optimization pass will now transform `iconcat` into a `uextend` or `sextend` where appropriate. The x64 backend then pattern-matches this to produce slightly more optimal machine code. Additionally the x64 backend now handles memory/immediate operands a bit better when the argument to a 128-bit operation is an `iconcat`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
