### PR TITLE
add more pooling allocator options to CLI

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -115,6 +115,14 @@ wasmtime_option_group! {
         /// The maximum runtime size of each linear memory in the pooling
         /// allocator, in bytes.
         pub pooling_max_memory_size: Option<usize>,
+
+        /// The maximum table elements for any table defined in a module when
+        /// using the pooling allocator.
+        pub pooling_table_elements: Option<u32>,
+
+        /// The maximum size, in bytes, allocated for a core instance's metadata
+        /// when using the pooling allocator.
+        pub pooling_max_core_instance_size: Option<usize>,
     }
 
     enum Optimize {
@@ -608,6 +616,12 @@ impl CommonOptions {
                     }
                     if let Some(limit) = self.opts.pooling_total_tables {
                         cfg.total_tables(limit);
+                    }
+                    if let Some(limit) = self.opts.pooling_table_elements {
+                        cfg.table_elements(limit);
+                    }
+                    if let Some(limit) = self.opts.pooling_max_core_instance_size {
+                        cfg.max_core_instance_size(limit);
                     }
                     match_feature! {
                         ["async" : self.opts.pooling_total_stacks]


### PR DESCRIPTION
This adds `pooling-table-elements` and `pooling-max-core-instance-size` options to the CLI, allowing the user to override the defaults.

I found myself needing to override both of these settings when running a ASP.NET Core application built using the Native AOT feature of the .NET runtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
