### PR TITLE
wasi-nn: bump to next snapshot

### DIFF
--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -64,6 +64,6 @@ rm -rf $cache_dir
 # Separately (for now), vendor the `wasi-nn` WIT files since their retrieval is
 # slightly different than above.
 repo=https://raw.githubusercontent.com/WebAssembly/wasi-nn
-revision=0.2.0-rc-2024-06-25
+revision=0.2.0-rc-2024-08-19
 curl -L $repo/$revision/wasi-nn.witx -o crates/wasi-nn/witx/wasi-nn.witx
 curl -L $repo/$revision/wit/wasi-nn.wit -o crates/wasi-nn/wit/wasi-nn.wit

--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -329,14 +329,6 @@ impl gen::tensor::HostTensor for WasiNnView<'_> {
 }
 
 impl gen::errors::HostError for WasiNnView<'_> {
-    fn new(
-        &mut self,
-        _code: gen::errors::ErrorCode,
-        _data: String,
-    ) -> wasmtime::Result<Resource<Error>> {
-        unimplemented!("this should be removed; see https://github.com/WebAssembly/wasi-nn/pull/76")
-    }
-
     fn code(&mut self, error: Resource<Error>) -> wasmtime::Result<gen::errors::ErrorCode> {
         let error = self.table.get(&error)?;
         match error.code {

--- a/crates/wasi-nn/wit/wasi-nn.wit
+++ b/crates/wasi-nn/wit/wasi-nn.wit
@@ -1,4 +1,4 @@
-package wasi:nn@0.2.0-rc-2024-06-25;
+package wasi:nn@0.2.0-rc-2024-08-19;
 
 /// `wasi-nn` is a WASI API for performing machine learning (ML) inference. The API is not (yet)
 /// capable of performing ML training. WebAssembly programs that want to use a host's ML
@@ -157,8 +157,6 @@ interface errors {
     }
 
     resource error {
-        constructor(code: error-code, data: string);
-
         /// Return the error code.
         code: func() -> error-code;
 


### PR DESCRIPTION
This change removes an unnecessary constructor for error resources.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
