### PR TITLE
Adding an --emit-opt-clif CLI option

### DIFF
--- a/crates/cranelift/src/builder.rs
+++ b/crates/cranelift/src/builder.rs
@@ -21,6 +21,7 @@ struct Builder {
     linkopts: LinkOptions,
     cache_store: Option<Arc<dyn CacheStore>>,
     clif_dir: Option<path::PathBuf>,
+    opt_clif_dir: Option<path::PathBuf>,
     wmemcheck: bool,
 }
 
@@ -44,6 +45,7 @@ pub fn builder(triple: Option<Triple>) -> Result<Box<dyn CompilerBuilder>> {
         linkopts: LinkOptions::default(),
         cache_store: None,
         clif_dir: None,
+        opt_clif_dir: None,
         wmemcheck: false,
     }))
 }
@@ -55,6 +57,11 @@ impl CompilerBuilder for Builder {
 
     fn clif_dir(&mut self, path: &path::Path) -> Result<()> {
         self.clif_dir = Some(path.to_path_buf());
+        Ok(())
+    }
+
+    fn opt_clif_dir(&mut self, path: &path::Path) -> Result<()> {
+        self.opt_clif_dir = Some(path.to_path_buf());
         Ok(())
     }
 
@@ -97,6 +104,7 @@ impl CompilerBuilder for Builder {
             self.cache_store.clone(),
             self.linkopts.clone(),
             self.clif_dir.clone(),
+            self.opt_clif_dir.clone(),
             self.wmemcheck,
         )))
     }

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -111,6 +111,11 @@ pub trait CompilerBuilder: Send + Sync + fmt::Debug {
         anyhow::bail!("clif output not supported");
     }
 
+    /// Enables optimized clif output in the directory specified.
+    fn opt_clif_dir(&mut self, _path: &path::Path) -> Result<()> {
+        anyhow::bail!("optimized clif output not supported");
+    }
+
     /// Returns the currently configured target triple that compilation will
     /// produce artifacts for.
     fn triple(&self) -> &target_lexicon::Triple;

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -163,6 +163,7 @@ struct CompilerConfig {
     #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
     cache_store: Option<Arc<dyn CacheStore>>,
     clif_dir: Option<std::path::PathBuf>,
+    opt_clif_dir: Option<std::path::PathBuf>,
     wmemcheck: bool,
 }
 
@@ -177,6 +178,7 @@ impl CompilerConfig {
             #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
             cache_store: None,
             clif_dir: None,
+            opt_clif_dir: None,
             wmemcheck: false,
         }
     }
@@ -1897,6 +1899,10 @@ impl Config {
             compiler.clif_dir(path)?;
         }
 
+        if let Some(path) = &self.compiler_config.opt_clif_dir {
+            compiler.opt_clif_dir(path)?;
+        }
+
         // If probestack is enabled for a target, Wasmtime will always use the
         // inline strategy which doesn't require us to define a `__probestack`
         // function or similar.
@@ -1996,6 +2002,13 @@ impl Config {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn emit_clif(&mut self, path: &Path) -> &mut Self {
         self.compiler_config.clif_dir = Some(path.to_path_buf());
+        self
+    }
+
+    /// Enables optimized clif output when compiling a WebAssembly module.
+    #[cfg(any(feature = "cranelift", feature = "winch"))]
+    pub fn emit_opt_clif(&mut self, path: &Path) -> &mut Self {
+        self.compiler_config.opt_clif_dir = Some(path.to_path_buf());
         self
     }
 

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -51,6 +51,10 @@ pub struct CompileCommand {
     #[arg(long = "emit-clif", value_name = "PATH")]
     pub emit_clif: Option<PathBuf>,
 
+    /// The directory path to write optimized clif files into, one clif file per wasm function.
+    #[arg(long = "emit-opt-clif", value_name = "PATH")]
+    pub emit_opt_clif: Option<PathBuf>,
+
     /// The path of the WebAssembly to compile
     #[arg(index = 1, value_name = "MODULE")]
     pub module: PathBuf,
@@ -76,6 +80,21 @@ impl CompileCommand {
             }
 
             config.emit_clif(&path);
+        }
+
+        if let Some(path) = self.emit_opt_clif {
+            if !path.exists() {
+                std::fs::create_dir(&path)?;
+            }
+
+            if !path.is_dir() {
+                bail!(
+                    "the path passed for '--emit-opt-clif' ({}) must be a directory",
+                    path.display()
+                );
+            }
+
+            config.emit_opt_clif(&path);
         }
 
         let engine = Engine::new(&config)?;


### PR DESCRIPTION
The option `--emit-opt-clif` follows the `--emit-clif` implementation from wasmtime's CLI, but the output comes with the egraph optimizations applied. It has been helpful for work on #6260. From discussions in zulip, it seemed more generally desirable.

* I consider some small changes in `crates/cranelift/src/compiler.rs` to be a bit "hacky", probably due to my inexperience with the borrow checker...
* Maybe there are some CLI error messages you would like introduced (e.g. if the paths for `--emit-clif` and `--emit-opt-clif` are the same) — I haven't created any since I'm not even sure about the CLI interface you would prefer.
* The current state does not include support for the wasmtime explorer.