### PR TITLE
Copy skeleton unit attributes for split DWARF

### DIFF
--- a/crates/cranelift/src/debug/transform/line_program.rs
+++ b/crates/cranelift/src/debug/transform/line_program.rs
@@ -61,7 +61,7 @@ where
         let out_comp_dir = match header.directory(0) {
             Some(comp_dir) => clone_line_string(
                 dwarf.attr_string(unit, comp_dir)?,
-                gimli::DW_FORM_strp,
+                gimli::DW_FORM_string,
                 out_strings,
             )?,
             None => write::LineString::String(Vec::new()),

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -305,6 +305,26 @@ pub(crate) fn clone_unit(
                     FileAttributeContext::Root(Some(debug_line_offset)),
                     isa,
                 )?;
+                if split_unit.is_some() {
+                    if let Some((_, skeleton_entry)) = skeleton_unit.entries().next_dfs()? {
+                        clone_die_attributes(
+                            skeleton_dwarf,
+                            skeleton_unit,
+                            skeleton_entry,
+                            addr_tr,
+                            None,
+                            comp_unit,
+                            root_id,
+                            None,
+                            None,
+                            out_strings,
+                            &mut pending_die_refs,
+                            &mut pending_di_refs,
+                            FileAttributeContext::Root(Some(debug_line_offset)),
+                            isa,
+                        )?;
+                    }
+                }
 
                 let (wp_die_id, vmctx_die_id) =
                     add_internal_types(comp_unit, root_id, out_strings, memory_offset);

--- a/tests/all/debug/translate.rs
+++ b/tests/all/debug/translate.rs
@@ -203,6 +203,9 @@ check: DW_TAG_compile_unit
 check:   DW_AT_producer	("clang version 19.0.0git (https:/github.com/llvm/llvm-project ccdebbae4d77d3efc236af92c22941de5d437e01)")
 check:   DW_AT_language	(DW_LANG_C11)
 check:   DW_AT_name	("dwarf_fission.c")
+check:   DW_AT_ranges	(0x00000000
+check:   DW_AT_stmt_list	(0x00000000)
+check:   DW_AT_comp_dir	("C:\\tmp\\dwarfc")
     "##,
     )
 }


### PR DESCRIPTION
The skeleton unit may contain attributes that don't appear in the split unit. In particular, this includes DW_AT_ranges and DW_AT_comp_dir.

Also, set the correct form for the default directory in the line program. Previously, the different form meant that we emitted the directory again when a file used it. Copying the DW_AT_comp_dir attribute is required for use of the default directory to work successfully.