### PR TITLE
Install `git` executable in container builds

### DIFF
--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates curl make
+RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates curl make git
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.

--- a/ci/docker/riscv64gc-linux/Dockerfile
+++ b/ci/docker/riscv64gc-linux/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
 
-RUN apt-get update -y && apt-get install -y gcc gcc-riscv64-linux-gnu ca-certificates cmake
+RUN apt-get update -y && apt-get install -y gcc gcc-riscv64-linux-gnu ca-certificates cmake git
 
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc

--- a/ci/docker/s390x-linux/Dockerfile
+++ b/ci/docker/s390x-linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certificates curl make
+RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certificates curl make git
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,3 +1,3 @@
 FROM almalinux:8
 
-RUN dnf install -y git gcc make cmake
+RUN dnf install -y git gcc make cmake git

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add libgcc
 # Use something glibc-based for the actual compile because the Rust toolchain
 # we're using is glibc-based in CI.
 FROM ubuntu:24.04
-RUN apt-get update -y && apt-get install -y cmake musl-tools
+RUN apt-get update -y && apt-get install -y cmake musl-tools git
 COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
 
 # Note that `-crt-feature` is passed here to specifically disable static linking


### PR DESCRIPTION
Precompiled artifacts for macOS show this for `wasmtime --version`

    wasmtime-cli 24.0.0 (6fc3d274c 2024-08-20)

whereas for Linux they show

    wasmtime-cli 24.0.0

and this is due to `git` not being available in the build environment on Linux.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
