### PR TITLE
Change the CLI's name to `wasmtime`

### DIFF
--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 /// Wasmtime WebAssembly Runtime
 #[derive(Parser, PartialEq)]
 #[command(
+    name = "wasmtime",
     version = version(),
     after_help = "If a subcommand is not provided, the `run` subcommand will be used.\n\
                   \n\


### PR DESCRIPTION
Currently `wasmtime --version` prints `wasmtime-cli ...` which is the package name but this changes it to just `wasmtime` to match the executable.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
