### PR TITLE
Try again to fix version info in CI builds

### DIFF
--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates curl make git
+RUN git config --global --add safe.directory '*'
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.

--- a/ci/docker/riscv64gc-linux/Dockerfile
+++ b/ci/docker/riscv64gc-linux/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:22.04
 
 RUN apt-get update -y && apt-get install -y gcc gcc-riscv64-linux-gnu ca-certificates cmake git
+RUN git config --global --add safe.directory '*'
 
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc

--- a/ci/docker/s390x-linux/Dockerfile
+++ b/ci/docker/s390x-linux/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certificates curl make git
+RUN git config --global --add safe.directory '*'
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,3 +1,4 @@
 FROM almalinux:8
 
 RUN dnf install -y git gcc make cmake git
+RUN git config --global --add safe.directory '*'

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add libgcc
 FROM ubuntu:24.04
 RUN apt-get update -y && apt-get install -y cmake musl-tools git
 COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
+RUN git config --global --add safe.directory '*'
 
 # Note that `-crt-feature` is passed here to specifically disable static linking
 # with musl. We want a `*.so` to pop out so static linking isn't what we want.


### PR DESCRIPTION
Turns out just having `git` wasn't enough. In the containers things are running as `root` and `git` doesn't like that so try to convince git that it should like it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
