### PR TITLE
Use a smaller default GC heap under MIRI

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled.rs
@@ -21,4 +21,9 @@ pub fn default_gc_runtime() -> impl GcRuntime {
 }
 
 /// The default GC heap capacity: 512KiB.
+#[cfg(not(miri))]
 const DEFAULT_GC_HEAP_CAPACITY: usize = 1 << 19;
+
+/// The default GC heap capacity for miri: 64KiB.
+#[cfg(miri)]
+const DEFAULT_GC_HEAP_CAPACITY: usize = 1 << 16;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
