### PR TITLE
Bump wasm-tools dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmtime-types",
  "wat",
 ]
@@ -2786,7 +2786,7 @@ dependencies = [
  "cargo_metadata",
  "heck 0.4.0",
  "wasmtime",
- "wit-component",
+ "wit-component 0.216.0",
 ]
 
 [[package]]
@@ -3114,7 +3114,7 @@ name = "verify-component-adapter"
 version = "25.0.0"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wat",
 ]
 
@@ -3207,7 +3207,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi",
- "wasm-encoder",
+ "wasm-encoder 0.216.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3272,7 +3272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb56df3e06b8e6b77e37d2969a50ba51281029a9aeb3855e76b7f49b6418847"
 dependencies = [
  "leb128",
- "wasmparser",
+ "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+dependencies = [
+ "leb128",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
@@ -3287,36 +3296,49 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.215.0",
+ "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d8899223f9e1365f851a960f864f4f2c9b631dbf8dceb86174e36295415d4"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa72e06e213eca343cd3ce71eb78edd6fde947a22fc2288249ff64ef8197988"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder",
+ "wasm-encoder 0.216.0",
 ]
 
 [[package]]
@@ -3370,6 +3392,18 @@ dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+dependencies = [
+ "ahash",
+ "bitflags 2.4.1",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.6",
+ "semver",
  "serde",
 ]
 
@@ -3384,13 +3418,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e9a325d85053408209b3d2ce5eaddd0dd6864d1cff7a007147ba073157defc"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
@@ -3434,8 +3467,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3577,7 +3610,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3593,10 +3626,10 @@ dependencies = [
  "wasmtime-wasi-runtime-config",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 215.0.0",
+ "wast 216.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component",
+ "wit-component 0.216.0",
 ]
 
 [[package]]
@@ -3629,7 +3662,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
@@ -3654,7 +3687,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3679,8 +3712,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3695,7 +3728,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3755,7 +3788,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3776,12 +3809,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder",
+ "wasm-encoder 0.216.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3831,7 +3864,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
@@ -3962,7 +3995,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 215.0.0",
+ "wast 216.0.0",
 ]
 
 [[package]]
@@ -3974,7 +4007,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3987,7 +4020,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.0",
  "indexmap 2.2.6",
- "wit-parser",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
@@ -4005,24 +4038,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "215.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff1d00d893593249e60720be04a7c1f42f1c4dc3806a2869f4e66ab61eb54cb"
+version = "216.0.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.216.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670bf4d9c8cf76ae242d70ded47c546525b6dafaa6871f9bcb065344bf2b4e3d"
+version = "1.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
 dependencies = [
- "wast 215.0.0",
+ "wast 216.0.0",
 ]
 
 [[package]]
@@ -4152,7 +4183,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.216.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4369,7 +4400,7 @@ checksum = "bb7e3df01cd43cfa1cb52602e4fc05cb2b62217655f6705639b6953eb0a3fed2"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.215.0",
 ]
 
 [[package]]
@@ -4392,9 +4423,9 @@ dependencies = [
  "indexmap 2.2.6",
  "prettyplease",
  "syn 2.0.60",
- "wasm-metadata",
+ "wasm-metadata 0.215.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.215.0",
 ]
 
 [[package]]
@@ -4425,10 +4456,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.215.0",
+ "wasm-metadata 0.215.0",
+ "wasmparser 0.215.0",
+ "wit-parser 0.215.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "indexmap 2.2.6",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.216.0",
+ "wasm-metadata 0.216.0",
+ "wasmparser 0.216.0",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
@@ -4446,7 +4495,24 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.216.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,7 +3278,8 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
 dependencies = [
  "leb128",
  "wasmparser 0.216.0",
@@ -3303,7 +3304,8 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8154d703a6b0e45acf6bd172fa002fc3c7058a9f7615e517220aeca27c638"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3318,7 +3320,8 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17002e0f291e0c330a81b9285cf0e4e316e10e75b00d4f5c625d325f14582d11"
 dependencies = [
  "egg",
  "log",
@@ -3331,7 +3334,8 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25e5a09d7934b471fb84ea864cc91ed1a4467ea8aaa32c09f60f3fb262e070e"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3397,7 +3401,8 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcdee6bea3619d311fb4b299721e89a986c3470f804b6d534340e412589028e3"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -3419,7 +3424,8 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f82916f3892e53620639217d6ec78fe15c678352a3fbf3f3745b6417d0bd70f"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -4039,7 +4045,8 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "216.0.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7eb1f2eecd913fdde0dc6c3439d0f24530a98ac6db6cb3d14d92a5328554a08"
 dependencies = [
  "bumpalo",
  "leb128",
@@ -4051,7 +4058,8 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0409090fb5154f95fb5ba3235675fd9e579e731524d63b6a2f653e1280c82a"
 dependencies = [
  "wast 216.0.0",
 ]
@@ -4465,7 +4473,8 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2ca3ece38ea2447a9069b43074ba73d96dde1944cba276c54e41371745f9dc"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4501,7 +4510,8 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.216.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools#28c8962b1484bf150a0fcf7848db160d67e6573c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d108165c1167a4ccc8a803dcf5c28e0a51d6739fd228cc7adce768632c764c"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -504,14 +504,3 @@ opt-level = 's'
 inherits = "release"
 codegen-units = 1
 lto = true
-
-[patch.crates-io]
-wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wat = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
-wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,15 +266,15 @@ wit-bindgen = { version = "0.30.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.30.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.215.0", default-features = false }
-wat = "1.215.0"
-wast = "215.0.0"
-wasmprinter = "0.215.0"
-wasm-encoder = "0.215.0"
-wasm-smith = "0.215.0"
-wasm-mutate = "0.215.0"
-wit-parser = "0.215.0"
-wit-component = "0.215.0"
+wasmparser = { version = "0.216.0", default-features = false }
+wat = "1.216.0"
+wast = "216.0.0"
+wasmprinter = "0.216.0"
+wasm-encoder = "0.216.0"
+wasm-smith = "0.216.0"
+wasm-mutate = "0.216.0"
+wit-parser = "0.216.0"
+wit-component = "0.216.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
@@ -504,3 +504,14 @@ opt-level = 's'
 inherits = "release"
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wat = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1791,6 +1791,7 @@ impl Config {
         // subject to the criteria at
         // https://docs.wasmtime.dev/contributing-implementing-wasm-proposals.html
         features |= WasmFeatures::FLOATS;
+        features |= WasmFeatures::GC_TYPES;
         features |= WasmFeatures::MULTI_VALUE;
         features |= WasmFeatures::BULK_MEMORY;
         features |= WasmFeatures::SIGN_EXTENSION;

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -204,6 +204,7 @@ struct WasmFeatures {
     custom_page_sizes: bool,
     component_model_more_flags: bool,
     component_model_multiple_returns: bool,
+    gc_types: bool,
 }
 
 impl Metadata<'_> {
@@ -232,6 +233,7 @@ impl Metadata<'_> {
             component_model_more_flags,
             component_model_multiple_returns,
             legacy_exceptions,
+            gc_types,
 
             // Always on; we don't currently have knobs for these.
             mutable_global: _,
@@ -272,6 +274,7 @@ impl Metadata<'_> {
                 custom_page_sizes,
                 component_model_more_flags,
                 component_model_multiple_returns,
+                gc_types,
             },
         }
     }
@@ -477,6 +480,7 @@ impl Metadata<'_> {
             custom_page_sizes,
             component_model_more_flags,
             component_model_multiple_returns,
+            gc_types,
         } = self.features;
 
         use wasmparser::WasmFeatures as F;
@@ -567,6 +571,11 @@ impl Metadata<'_> {
             component_model_multiple_returns,
             other.contains(F::COMPONENT_MODEL_MULTIPLE_RETURNS),
             "WebAssembly component model support for multiple returns",
+        )?;
+        Self::check_bool(
+            gc_types,
+            other.contains(F::GC_TYPES),
+            "support for WebAssembly gc types",
         )?;
 
         Ok(())

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1781,12 +1781,12 @@ impl<'a> InterfaceGenerator<'a> {
         uwriteln!(
             self.src,
             "assert!({} == <{name} as {wt}::component::ComponentType>::SIZE32);",
-            self.gen.sizes.size(&Type::Id(id)),
+            self.gen.sizes.size(&Type::Id(id)).size_wasm32(),
         );
         uwriteln!(
             self.src,
             "assert!({} == <{name} as {wt}::component::ComponentType>::ALIGN32);",
-            self.gen.sizes.align(&Type::Id(id)),
+            self.gen.sizes.align(&Type::Id(id)).align_wasm32(),
         );
         self.push_str("};\n");
     }

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1098,6 +1098,12 @@ when = "2024-07-31"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-encoder]]
+version = "0.216.0"
+when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-metadata]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1107,6 +1113,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasm-metadata]]
 version = "0.215.0"
 when = "2024-07-31"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasm-metadata]]
+version = "0.216.0"
+when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1122,6 +1134,12 @@ when = "2024-07-31"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmparser]]
+version = "0.216.0"
+when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmprinter]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1131,6 +1149,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmprinter]]
 version = "0.215.0"
 when = "2024-07-31"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmprinter]]
+version = "0.216.0"
+when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1296,6 +1320,12 @@ when = "2024-07-31"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wast]]
+version = "216.0.0"
+when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wat]]
 version = "1.214.0"
 when = "2024-07-16"
@@ -1305,6 +1335,12 @@ user-login = "wasmtime-publish"
 [[publisher.wat]]
 version = "1.215.0"
 when = "2024-07-31"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wat]]
+version = "1.216.0"
+when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1609,6 +1645,12 @@ when = "2024-07-31"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-component]]
+version = "0.216.0"
+when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-parser]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1618,6 +1660,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-parser]]
 version = "0.215.0"
 when = "2024-07-31"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-parser]]
+version = "0.216.0"
+when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This commit updates the wasm-tools dependencies to their 216 track of versions. This will be followed-up with some updates to how some features are managed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
