### PR TITLE
Make `i31.get_{s.u}` instructions trap on null `i31ref`s

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1734,6 +1734,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         mut pos: FuncCursor,
         i31ref: ir::Value,
     ) -> WasmResult<ir::Value> {
+        pos.ins().trapz(i31ref, ir::TrapCode::NullI31Ref);
         Ok(pos.ins().sshr_imm(i31ref, 1))
     }
 
@@ -1742,6 +1743,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         mut pos: FuncCursor,
         i31ref: ir::Value,
     ) -> WasmResult<ir::Value> {
+        pos.ins().trapz(i31ref, ir::TrapCode::NullI31Ref);
         Ok(pos.ins().ushr_imm(i31ref, 1))
     }
 

--- a/tests/misc_testsuite/gc/null-i31ref.wast
+++ b/tests/misc_testsuite/gc/null-i31ref.wast
@@ -1,0 +1,11 @@
+(module
+  (func (export "get_u-null") (result i32)
+    (i31.get_u (ref.null i31))
+  )
+  (func (export "get_s-null") (result i32)
+    (i31.get_u (ref.null i31))
+  )
+)
+
+(assert_trap (invoke "get_u-null") "null i31 reference")
+(assert_trap (invoke "get_s-null") "null i31 reference")


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
