### PR TITLE
Fix assertions for `VMGcRef` table builtin functions

### DIFF
--- a/crates/cranelift/src/gc.rs
+++ b/crates/cranelift/src/gc.rs
@@ -65,7 +65,7 @@ pub fn gc_ref_table_grow_builtin(
     func_env: &mut FuncEnvironment<'_>,
     func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {
-    debug_assert!(ty.is_vmgcref_type_and_not_i31());
+    debug_assert!(ty.is_vmgcref_type());
     imp::gc_ref_table_grow_builtin(ty, func_env, func)
 }
 
@@ -76,7 +76,7 @@ pub fn gc_ref_table_fill_builtin(
     func_env: &mut FuncEnvironment<'_>,
     func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {
-    debug_assert!(ty.is_vmgcref_type_and_not_i31());
+    debug_assert!(ty.is_vmgcref_type());
     imp::gc_ref_table_fill_builtin(ty, func_env, func)
 }
 

--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -49,7 +49,7 @@ pub fn gc_ref_table_grow_builtin(
     func_env: &mut FuncEnvironment<'_>,
     func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {
-    debug_assert!(ty.is_vmgcref_type_and_not_i31());
+    debug_assert!(ty.is_vmgcref_type());
     Ok(func_env.builtin_functions.table_grow_gc_ref(func))
 }
 
@@ -58,7 +58,7 @@ pub fn gc_ref_table_fill_builtin(
     func_env: &mut FuncEnvironment<'_>,
     func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {
-    debug_assert!(ty.is_vmgcref_type_and_not_i31());
+    debug_assert!(ty.is_vmgcref_type());
     Ok(func_env.builtin_functions.table_fill_gc_ref(func))
 }
 

--- a/tests/misc_testsuite/gc/i31ref-tables.wast
+++ b/tests/misc_testsuite/gc/i31ref-tables.wast
@@ -1,0 +1,61 @@
+(module $tables_of_i31ref
+  (table $table 3 10 i31ref)
+  (elem (table $table) (i32.const 0) i31ref (item (ref.i31 (i32.const 999)))
+                                            (item (ref.i31 (i32.const 888)))
+                                            (item (ref.i31 (i32.const 777))))
+
+  (func (export "size") (result i32)
+    table.size $table
+  )
+
+  (func (export "get") (param i32) (result i32)
+    (i31.get_u (table.get $table (local.get 0)))
+  )
+
+  (func (export "grow") (param i32 i32) (result i32)
+    (table.grow $table (ref.i31 (local.get 1)) (local.get 0))
+  )
+
+  (func (export "fill") (param i32 i32 i32)
+    (table.fill $table (local.get 0) (ref.i31 (local.get 1)) (local.get 2))
+  )
+
+  (func (export "copy") (param i32 i32 i32)
+    (table.copy $table $table (local.get 0) (local.get 1) (local.get 2))
+  )
+
+  (elem $elem i31ref (item (ref.i31 (i32.const 123)))
+                     (item (ref.i31 (i32.const 456)))
+                     (item (ref.i31 (i32.const 789))))
+  (func (export "init") (param i32 i32 i32)
+    (table.init $table $elem (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+
+;; Initial state.
+(assert_return (invoke "size") (i32.const 3))
+(assert_return (invoke "get" (i32.const 0)) (i32.const 999))
+(assert_return (invoke "get" (i32.const 1)) (i32.const 888))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 777))
+
+;; Grow from size 3 to size 5.
+(assert_return (invoke "grow" (i32.const 2) (i32.const 333)) (i32.const 3))
+(assert_return (invoke "size") (i32.const 5))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 333))
+(assert_return (invoke "get" (i32.const 4)) (i32.const 333))
+
+;; Fill table[2..4] = 111.
+(invoke "fill" (i32.const 2) (i32.const 111) (i32.const 2))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 111))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 111))
+
+;; Copy from table[0..2] to table[3..5].
+(invoke "copy" (i32.const 3) (i32.const 0) (i32.const 2))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 999))
+(assert_return (invoke "get" (i32.const 4)) (i32.const 888))
+
+;; Initialize the passive element at table[1..4].
+(invoke "init" (i32.const 1) (i32.const 0) (i32.const 3))
+(assert_return (invoke "get" (i32.const 1)) (i32.const 123))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 456))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 789))


### PR DESCRIPTION
These are used for all GC refs, not just non-`i31ref` ones.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
