### PR TITLE
Fix `cranelift-codegen` build script for Pulley backends

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -384,9 +384,10 @@ jobs:
               -p wasmtime-cli --all-features
               -p wasmtime-cli --features component-model
 
-          - name: cranelift-codegen benches
+          - name: cranelift-codegen
             checks: |
-              --benches -p cranelift-codegen
+              -p cranelift-codegen --benches
+              -p cranelift-codegen --no-default-features --features std,unwind,pulley
 
           - name: wasmtime-bench-api
             checks: |

--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -36,7 +36,12 @@ fn main() {
         .iter()
         .cloned()
         .filter(|isa| {
-            let env_key = format!("CARGO_FEATURE_{}", isa.to_string().to_uppercase());
+            let env_key = match isa {
+                meta::isa::Isa::Pulley32 | meta::isa::Isa::Pulley64 => {
+                    "CARGO_FEATURE_PULLEY".to_string()
+                }
+                _ => format!("CARGO_FEATURE_{}", isa.to_string().to_uppercase()),
+            };
             all_arch || env::var(env_key).is_ok()
         })
         .collect::<Vec<_>>();

--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -122,7 +122,7 @@ where
         let emit_info = EmitInfo::new(self.flags.clone(), self.isa_flags.clone());
         let sigs = SigSet::new::<abi::PulleyMachineDeps<P>>(func, &self.flags)?;
         let abi = abi::PulleyCallee::new(func, self, &self.isa_flags, &sigs)?;
-        machinst::compile::compile::<Self>(func, domtree, self, abi, emit_info, sigs, ctrl_plane)
+        machinst::compile::<Self>(func, domtree, self, abi, emit_info, sigs, ctrl_plane)
     }
 }
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -6,10 +6,7 @@ use std::cell::Cell;
 
 pub use super::MachLabel;
 use super::RetPair;
-pub use crate::ir::{
-    condcodes::CondCode, dynamic_to_fixed, Constant, DynamicStackSlot, ExternalName, FuncRef,
-    GlobalValue, Immediate, SigRef, StackSlot,
-};
+pub use crate::ir::{condcodes::CondCode, *};
 pub use crate::isa::{unwind::UnwindInst, TargetIsa};
 pub use crate::machinst::{
     ABIArg, ABIArgSlot, ABIMachineSpec, CallSite, InputSourceInst, Lower, LowerBackend, RealReg,


### PR DESCRIPTION
The cargo feature is called "pulley" for both the pulley32 and pulley64 backends, since they are the same code, but the build script was checking for cargo features named "pulley32" and "pulley64" instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
