### PR TITLE
Improve support for `Module` trait objects

### DIFF
--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -1094,7 +1094,7 @@ impl<M: Module + ?Sized> Module for &mut M {
     }
 }
 
-impl Module for Box<dyn Module> {
+impl<M: Module + ?Sized> Module for Box<M> {
     fn isa(&self) -> &dyn isa::TargetIsa {
         (**self).isa()
     }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Removes the implicit `Sized` requirement on the implementation for `&mut M where M: Module` and adds an implementation for `Box<dyn Module>`.