### PR TITLE
Expand the set of constructors of `bindgen!`-generated bindings

### DIFF
--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::chars::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::chars::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::chars::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::chars::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::chars::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::chars::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -178,15 +264,20 @@ pub mod exports {
                     return_char: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     take_char: wasmtime::component::ComponentExportIndex,
                     return_char: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/chars")
                             .ok_or_else(|| {
@@ -194,10 +285,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/chars")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/chars`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/chars` does \
@@ -205,9 +320,13 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let take_char = _lookup("take-char")?;
-                        let return_char = _lookup("return-char")?;
-                        Ok(GuestPre { take_char, return_char })
+                        let _ = &mut lookup;
+                        let take_char = lookup("take-char")?;
+                        let return_char = lookup("return-char")?;
+                        Ok(GuestIndices {
+                            take_char,
+                            return_char,
+                        })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::chars::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::chars::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::chars::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::chars::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::chars::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::chars::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -191,15 +277,20 @@ pub mod exports {
                     return_char: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     take_char: wasmtime::component::ComponentExportIndex,
                     return_char: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/chars")
                             .ok_or_else(|| {
@@ -207,10 +298,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/chars")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/chars`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/chars` does \
@@ -218,9 +333,13 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let take_char = _lookup("take-char")?;
-                        let return_char = _lookup("return-char")?;
-                        Ok(GuestPre { take_char, return_char })
+                        let _ = &mut lookup;
+                        let take_char = lookup("take-char")?;
+                        let return_char = lookup("return-char")?;
+                        Ok(GuestIndices {
+                            take_char,
+                            return_char,
+                        })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -4,68 +4,147 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::conventions::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::conventions::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::conventions::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::conventions::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::conventions::GuestIndices::new(
+                _component,
+            )?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::conventions::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +157,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -386,7 +474,7 @@ pub mod exports {
                     bool: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     kebab_case: wasmtime::component::ComponentExportIndex,
                     foo: wasmtime::component::ComponentExportIndex,
                     function_with_dashes: wasmtime::component::ComponentExportIndex,
@@ -400,11 +488,16 @@ pub mod exports {
                     explicit_kebab: wasmtime::component::ComponentExportIndex,
                     bool: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/conventions")
                             .ok_or_else(|| {
@@ -412,10 +505,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/conventions")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/conventions`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/conventions` does \
@@ -423,21 +540,22 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let kebab_case = _lookup("kebab-case")?;
-                        let foo = _lookup("foo")?;
-                        let function_with_dashes = _lookup("function-with-dashes")?;
-                        let function_with_no_weird_characters = _lookup(
+                        let _ = &mut lookup;
+                        let kebab_case = lookup("kebab-case")?;
+                        let foo = lookup("foo")?;
+                        let function_with_dashes = lookup("function-with-dashes")?;
+                        let function_with_no_weird_characters = lookup(
                             "function-with-no-weird-characters",
                         )?;
-                        let apple = _lookup("apple")?;
-                        let apple_pear = _lookup("apple-pear")?;
-                        let apple_pear_grape = _lookup("apple-pear-grape")?;
-                        let a0 = _lookup("a0")?;
-                        let is_xml = _lookup("is-XML")?;
-                        let explicit = _lookup("explicit")?;
-                        let explicit_kebab = _lookup("explicit-kebab")?;
-                        let bool = _lookup("bool")?;
-                        Ok(GuestPre {
+                        let apple = lookup("apple")?;
+                        let apple_pear = lookup("apple-pear")?;
+                        let apple_pear_grape = lookup("apple-pear-grape")?;
+                        let a0 = lookup("a0")?;
+                        let is_xml = lookup("is-XML")?;
+                        let explicit = lookup("explicit")?;
+                        let explicit_kebab = lookup("explicit-kebab")?;
+                        let bool = lookup("bool")?;
+                        Ok(GuestIndices {
                             kebab_case,
                             foo,
                             function_with_dashes,

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -4,71 +4,150 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::conventions::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::conventions::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::conventions::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::conventions::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::conventions::GuestIndices::new(
+                _component,
+            )?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::conventions::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +163,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -399,7 +487,7 @@ pub mod exports {
                     bool: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     kebab_case: wasmtime::component::ComponentExportIndex,
                     foo: wasmtime::component::ComponentExportIndex,
                     function_with_dashes: wasmtime::component::ComponentExportIndex,
@@ -413,11 +501,16 @@ pub mod exports {
                     explicit_kebab: wasmtime::component::ComponentExportIndex,
                     bool: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/conventions")
                             .ok_or_else(|| {
@@ -425,10 +518,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/conventions")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/conventions`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/conventions` does \
@@ -436,21 +553,22 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let kebab_case = _lookup("kebab-case")?;
-                        let foo = _lookup("foo")?;
-                        let function_with_dashes = _lookup("function-with-dashes")?;
-                        let function_with_no_weird_characters = _lookup(
+                        let _ = &mut lookup;
+                        let kebab_case = lookup("kebab-case")?;
+                        let foo = lookup("foo")?;
+                        let function_with_dashes = lookup("function-with-dashes")?;
+                        let function_with_no_weird_characters = lookup(
                             "function-with-no-weird-characters",
                         )?;
-                        let apple = _lookup("apple")?;
-                        let apple_pear = _lookup("apple-pear")?;
-                        let apple_pear_grape = _lookup("apple-pear-grape")?;
-                        let a0 = _lookup("a0")?;
-                        let is_xml = _lookup("is-XML")?;
-                        let explicit = _lookup("explicit")?;
-                        let explicit_kebab = _lookup("explicit-kebab")?;
-                        let bool = _lookup("bool")?;
-                        Ok(GuestPre {
+                        let apple = lookup("apple")?;
+                        let apple_pear = lookup("apple-pear")?;
+                        let apple_pear_grape = lookup("apple-pear-grape")?;
+                        let a0 = lookup("a0")?;
+                        let is_xml = lookup("is-XML")?;
+                        let explicit = lookup("explicit")?;
+                        let explicit_kebab = lookup("explicit-kebab")?;
+                        let bool = lookup("bool")?;
+                        Ok(GuestIndices {
                             kebab_case,
                             foo,
                             function_with_dashes,

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -78,7 +78,7 @@ pub struct ImportsIndices {}
 ///   create a [`Imports`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Imports::new_instance`]
+///   then you can use [`Imports::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`ImportsIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -4,59 +4,135 @@
 /// This structure is created through [`ImportsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Imports`] as well.
 pub struct ImportsPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: ImportsIndices,
 }
 impl<T> Clone for ImportsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> ImportsPre<_T> {
+    /// Creates a new copy of `ImportsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = ImportsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Imports`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Imports> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `imports`.
+///
+/// This is an implementation detail of [`ImportsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Imports`] as well.
+#[derive(Clone)]
+pub struct ImportsIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `imports`.
 ///
-/// This structure is created through either
-/// [`Imports::instantiate`] or by first creating
-/// a [`ImportsPre`] followed by using
-/// [`ImportsPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Imports::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`ImportsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`ImportsPre::instantiate`] to
+///   create a [`Imports`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Imports::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`ImportsIndices::new_instance`] followed
+///   by [`ImportsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Imports {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> ImportsPre<_T> {
-        /// Creates a new copy of `ImportsPre` bindings which can then
+    impl ImportsIndices {
+        /// Creates a new copy of `ImportsIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(ImportsPre { instance_pre })
+            let _component = component;
+            Ok(ImportsIndices {})
         }
-        /// Instantiates a new instance of [`Imports`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`ImportsIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Imports`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Imports`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(ImportsIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Imports`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Imports> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(Imports {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Imports {
@@ -69,6 +145,15 @@ const _: () = {
         ) -> wasmtime::Result<Imports> {
             let pre = linker.instantiate_pre(component)?;
             ImportsPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`ImportsIndices::new_instance`] and
+        /// [`ImportsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Imports> {
+            let indices = ImportsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -81,7 +81,7 @@ pub struct ImportsIndices {}
 ///   create a [`Imports`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Imports::new_instance`]
+///   then you can use [`Imports::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`ImportsIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -4,62 +4,138 @@
 /// This structure is created through [`ImportsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Imports`] as well.
 pub struct ImportsPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: ImportsIndices,
 }
 impl<T> Clone for ImportsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> ImportsPre<_T> {
+    /// Creates a new copy of `ImportsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = ImportsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Imports`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Imports>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `imports`.
+///
+/// This is an implementation detail of [`ImportsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Imports`] as well.
+#[derive(Clone)]
+pub struct ImportsIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `imports`.
 ///
-/// This structure is created through either
-/// [`Imports::instantiate_async`] or by first creating
-/// a [`ImportsPre`] followed by using
-/// [`ImportsPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Imports::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`ImportsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`ImportsPre::instantiate_async`] to
+///   create a [`Imports`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Imports::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`ImportsIndices::new_instance`] followed
+///   by [`ImportsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Imports {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> ImportsPre<_T> {
-        /// Creates a new copy of `ImportsPre` bindings which can then
+    impl ImportsIndices {
+        /// Creates a new copy of `ImportsIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(ImportsPre { instance_pre })
+            let _component = component;
+            Ok(ImportsIndices {})
         }
-        /// Instantiates a new instance of [`Imports`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`ImportsIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Imports`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Imports`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(ImportsIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Imports`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Imports>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Imports> {
+            let _instance = instance;
             Ok(Imports {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Imports {
@@ -75,6 +151,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             ImportsPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`ImportsIndices::new_instance`] and
+        /// [`ImportsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Imports> {
+            let indices = ImportsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -4,23 +4,93 @@
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {}
 pub trait FooImports {
     fn foo(&mut self) -> ();
@@ -45,38 +115,44 @@ impl<_T: FooImports + ?Sized> FooImports for &mut _T {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(FooPre { instance_pre })
+            let _component = component;
+            Ok(FooIndices {})
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(FooIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Foo> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(Foo {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -89,6 +165,15 @@ const _: () = {
         ) -> wasmtime::Result<Foo> {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker_imports_get_host<T>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -78,7 +78,7 @@ pub struct FooIndices {}
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -81,7 +81,7 @@ pub struct FooIndices {}
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -4,23 +4,96 @@
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate_async`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {}
 #[wasmtime::component::__internal::async_trait]
 pub trait FooImports: Send {
@@ -47,41 +120,44 @@ impl<_T: FooImports + ?Sized + Send> FooImports for &mut _T {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(FooPre { instance_pre })
+            let _component = component;
+            Ok(FooIndices {})
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(FooIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Foo>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
             Ok(Foo {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -97,6 +173,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker_imports_get_host<T>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/empty.rs
+++ b/crates/component-macro/tests/expanded/empty.rs
@@ -78,7 +78,7 @@ pub struct EmptyIndices {}
 ///   create a [`Empty`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Empty::new_instance`]
+///   then you can use [`Empty::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`EmptyIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/empty.rs
+++ b/crates/component-macro/tests/expanded/empty.rs
@@ -4,59 +4,135 @@
 /// This structure is created through [`EmptyPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Empty`] as well.
 pub struct EmptyPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: EmptyIndices,
 }
 impl<T> Clone for EmptyPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> EmptyPre<_T> {
+    /// Creates a new copy of `EmptyPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = EmptyIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Empty`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Empty> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `empty`.
+///
+/// This is an implementation detail of [`EmptyPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Empty`] as well.
+#[derive(Clone)]
+pub struct EmptyIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `empty`.
 ///
-/// This structure is created through either
-/// [`Empty::instantiate`] or by first creating
-/// a [`EmptyPre`] followed by using
-/// [`EmptyPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Empty::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`EmptyPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`EmptyPre::instantiate`] to
+///   create a [`Empty`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Empty::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`EmptyIndices::new_instance`] followed
+///   by [`EmptyIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Empty {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> EmptyPre<_T> {
-        /// Creates a new copy of `EmptyPre` bindings which can then
+    impl EmptyIndices {
+        /// Creates a new copy of `EmptyIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(EmptyPre { instance_pre })
+            let _component = component;
+            Ok(EmptyIndices {})
         }
-        /// Instantiates a new instance of [`Empty`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`EmptyIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Empty`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Empty`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(EmptyIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Empty`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Empty> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(Empty {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Empty {
@@ -69,6 +145,15 @@ const _: () = {
         ) -> wasmtime::Result<Empty> {
             let pre = linker.instantiate_pre(component)?;
             EmptyPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`EmptyIndices::new_instance`] and
+        /// [`EmptyIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Empty> {
+            let indices = EmptyIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
     }
 };

--- a/crates/component-macro/tests/expanded/empty_async.rs
+++ b/crates/component-macro/tests/expanded/empty_async.rs
@@ -81,7 +81,7 @@ pub struct EmptyIndices {}
 ///   create a [`Empty`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Empty::new_instance`]
+///   then you can use [`Empty::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`EmptyIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/empty_async.rs
+++ b/crates/component-macro/tests/expanded/empty_async.rs
@@ -4,62 +4,138 @@
 /// This structure is created through [`EmptyPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Empty`] as well.
 pub struct EmptyPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: EmptyIndices,
 }
 impl<T> Clone for EmptyPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> EmptyPre<_T> {
+    /// Creates a new copy of `EmptyPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = EmptyIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Empty`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Empty>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `empty`.
+///
+/// This is an implementation detail of [`EmptyPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Empty`] as well.
+#[derive(Clone)]
+pub struct EmptyIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `empty`.
 ///
-/// This structure is created through either
-/// [`Empty::instantiate_async`] or by first creating
-/// a [`EmptyPre`] followed by using
-/// [`EmptyPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Empty::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`EmptyPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`EmptyPre::instantiate_async`] to
+///   create a [`Empty`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Empty::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`EmptyIndices::new_instance`] followed
+///   by [`EmptyIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Empty {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> EmptyPre<_T> {
-        /// Creates a new copy of `EmptyPre` bindings which can then
+    impl EmptyIndices {
+        /// Creates a new copy of `EmptyIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(EmptyPre { instance_pre })
+            let _component = component;
+            Ok(EmptyIndices {})
         }
-        /// Instantiates a new instance of [`Empty`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`EmptyIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Empty`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Empty`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(EmptyIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Empty`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Empty>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Empty> {
+            let _instance = instance;
             Ok(Empty {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Empty {
@@ -75,6 +151,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             EmptyPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`EmptyIndices::new_instance`] and
+        /// [`EmptyIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Empty> {
+            let indices = EmptyIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
     }
 };

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -80,7 +80,7 @@ pub struct TheFlagsIndices {
 ///   create a [`TheFlags`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheFlags::new_instance`]
+///   then you can use [`TheFlags::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheFlagsIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheFlagsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheFlags`] as well.
 pub struct TheFlagsPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::flegs::GuestPre,
+    indices: TheFlagsIndices,
 }
 impl<T> Clone for TheFlagsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheFlagsPre<_T> {
+    /// Creates a new copy of `TheFlagsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheFlagsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheFlags`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheFlags> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-flags`.
+///
+/// This is an implementation detail of [`TheFlagsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheFlags`] as well.
+#[derive(Clone)]
+pub struct TheFlagsIndices {
+    interface0: exports::foo::foo::flegs::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-flags`.
 ///
-/// This structure is created through either
-/// [`TheFlags::instantiate`] or by first creating
-/// a [`TheFlagsPre`] followed by using
-/// [`TheFlagsPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheFlags::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheFlagsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheFlagsPre::instantiate`] to
+///   create a [`TheFlags`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheFlags::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheFlagsIndices::new_instance`] followed
+///   by [`TheFlagsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheFlags {
     interface0: exports::foo::foo::flegs::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheFlagsPre<_T> {
-        /// Creates a new copy of `TheFlagsPre` bindings which can then
+    impl TheFlagsIndices {
+        /// Creates a new copy of `TheFlagsIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::flegs::GuestPre::new(_component)?;
-            Ok(TheFlagsPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::flegs::GuestIndices::new(_component)?;
+            Ok(TheFlagsIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheFlags`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheFlagsIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheFlags`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheFlags`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::flegs::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheFlagsIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheFlags`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheFlags> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheFlags { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheFlags {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheFlags> {
             let pre = linker.instantiate_pre(component)?;
             TheFlagsPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheFlagsIndices::new_instance`] and
+        /// [`TheFlagsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheFlags> {
+            let indices = TheFlagsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -520,7 +606,7 @@ pub mod exports {
                     roundtrip_flag64: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     roundtrip_flag1: wasmtime::component::ComponentExportIndex,
                     roundtrip_flag2: wasmtime::component::ComponentExportIndex,
                     roundtrip_flag4: wasmtime::component::ComponentExportIndex,
@@ -529,11 +615,16 @@ pub mod exports {
                     roundtrip_flag32: wasmtime::component::ComponentExportIndex,
                     roundtrip_flag64: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/flegs")
                             .ok_or_else(|| {
@@ -541,10 +632,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/flegs")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/flegs`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/flegs` does \
@@ -552,14 +667,15 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let roundtrip_flag1 = _lookup("roundtrip-flag1")?;
-                        let roundtrip_flag2 = _lookup("roundtrip-flag2")?;
-                        let roundtrip_flag4 = _lookup("roundtrip-flag4")?;
-                        let roundtrip_flag8 = _lookup("roundtrip-flag8")?;
-                        let roundtrip_flag16 = _lookup("roundtrip-flag16")?;
-                        let roundtrip_flag32 = _lookup("roundtrip-flag32")?;
-                        let roundtrip_flag64 = _lookup("roundtrip-flag64")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let roundtrip_flag1 = lookup("roundtrip-flag1")?;
+                        let roundtrip_flag2 = lookup("roundtrip-flag2")?;
+                        let roundtrip_flag4 = lookup("roundtrip-flag4")?;
+                        let roundtrip_flag8 = lookup("roundtrip-flag8")?;
+                        let roundtrip_flag16 = lookup("roundtrip-flag16")?;
+                        let roundtrip_flag32 = lookup("roundtrip-flag32")?;
+                        let roundtrip_flag64 = lookup("roundtrip-flag64")?;
+                        Ok(GuestIndices {
                             roundtrip_flag1,
                             roundtrip_flag2,
                             roundtrip_flag4,

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -83,7 +83,7 @@ pub struct TheFlagsIndices {
 ///   create a [`TheFlags`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheFlags::new_instance`]
+///   then you can use [`TheFlags::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheFlagsIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheFlagsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheFlags`] as well.
 pub struct TheFlagsPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::flegs::GuestPre,
+    indices: TheFlagsIndices,
 }
 impl<T> Clone for TheFlagsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheFlagsPre<_T> {
+    /// Creates a new copy of `TheFlagsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheFlagsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheFlags`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheFlags>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-flags`.
+///
+/// This is an implementation detail of [`TheFlagsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheFlags`] as well.
+#[derive(Clone)]
+pub struct TheFlagsIndices {
+    interface0: exports::foo::foo::flegs::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-flags`.
 ///
-/// This structure is created through either
-/// [`TheFlags::instantiate_async`] or by first creating
-/// a [`TheFlagsPre`] followed by using
-/// [`TheFlagsPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheFlags::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheFlagsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheFlagsPre::instantiate_async`] to
+///   create a [`TheFlags`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheFlags::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheFlagsIndices::new_instance`] followed
+///   by [`TheFlagsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheFlags {
     interface0: exports::foo::foo::flegs::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheFlagsPre<_T> {
-        /// Creates a new copy of `TheFlagsPre` bindings which can then
+    impl TheFlagsIndices {
+        /// Creates a new copy of `TheFlagsIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::flegs::GuestPre::new(_component)?;
-            Ok(TheFlagsPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::flegs::GuestIndices::new(_component)?;
+            Ok(TheFlagsIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheFlags`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheFlagsIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheFlags`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheFlags`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::flegs::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheFlagsIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheFlags`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheFlags>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheFlags> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheFlags { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheFlags {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheFlagsPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheFlagsIndices::new_instance`] and
+        /// [`TheFlagsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheFlags> {
+            let indices = TheFlagsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -533,7 +619,7 @@ pub mod exports {
                     roundtrip_flag64: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     roundtrip_flag1: wasmtime::component::ComponentExportIndex,
                     roundtrip_flag2: wasmtime::component::ComponentExportIndex,
                     roundtrip_flag4: wasmtime::component::ComponentExportIndex,
@@ -542,11 +628,16 @@ pub mod exports {
                     roundtrip_flag32: wasmtime::component::ComponentExportIndex,
                     roundtrip_flag64: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/flegs")
                             .ok_or_else(|| {
@@ -554,10 +645,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/flegs")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/flegs`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/flegs` does \
@@ -565,14 +680,15 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let roundtrip_flag1 = _lookup("roundtrip-flag1")?;
-                        let roundtrip_flag2 = _lookup("roundtrip-flag2")?;
-                        let roundtrip_flag4 = _lookup("roundtrip-flag4")?;
-                        let roundtrip_flag8 = _lookup("roundtrip-flag8")?;
-                        let roundtrip_flag16 = _lookup("roundtrip-flag16")?;
-                        let roundtrip_flag32 = _lookup("roundtrip-flag32")?;
-                        let roundtrip_flag64 = _lookup("roundtrip-flag64")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let roundtrip_flag1 = lookup("roundtrip-flag1")?;
+                        let roundtrip_flag2 = lookup("roundtrip-flag2")?;
+                        let roundtrip_flag4 = lookup("roundtrip-flag4")?;
+                        let roundtrip_flag8 = lookup("roundtrip-flag8")?;
+                        let roundtrip_flag16 = lookup("roundtrip-flag16")?;
+                        let roundtrip_flag32 = lookup("roundtrip-flag32")?;
+                        let roundtrip_flag64 = lookup("roundtrip-flag64")?;
+                        Ok(GuestIndices {
                             roundtrip_flag1,
                             roundtrip_flag2,
                             roundtrip_flag4,

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::floats::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::floats::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::floats::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::floats::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::floats::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::floats::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -197,17 +283,22 @@ pub mod exports {
                     float64_result: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     float32_param: wasmtime::component::ComponentExportIndex,
                     float64_param: wasmtime::component::ComponentExportIndex,
                     float32_result: wasmtime::component::ComponentExportIndex,
                     float64_result: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/floats")
                             .ok_or_else(|| {
@@ -215,10 +306,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/floats")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/floats`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/floats` does \
@@ -226,11 +341,12 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let float32_param = _lookup("float32-param")?;
-                        let float64_param = _lookup("float64-param")?;
-                        let float32_result = _lookup("float32-result")?;
-                        let float64_result = _lookup("float64-result")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let float32_param = lookup("float32-param")?;
+                        let float64_param = lookup("float64-param")?;
+                        let float32_result = lookup("float32-result")?;
+                        let float64_result = lookup("float64-result")?;
+                        Ok(GuestIndices {
                             float32_param,
                             float64_param,
                             float32_result,

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::floats::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::floats::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::floats::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::floats::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::floats::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::floats::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -210,17 +296,22 @@ pub mod exports {
                     float64_result: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     float32_param: wasmtime::component::ComponentExportIndex,
                     float64_param: wasmtime::component::ComponentExportIndex,
                     float32_result: wasmtime::component::ComponentExportIndex,
                     float64_result: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/floats")
                             .ok_or_else(|| {
@@ -228,10 +319,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/floats")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/floats`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/floats` does \
@@ -239,11 +354,12 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let float32_param = _lookup("float32-param")?;
-                        let float64_param = _lookup("float64-param")?;
-                        let float32_result = _lookup("float32-result")?;
-                        let float64_result = _lookup("float64-result")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let float32_param = lookup("float32-param")?;
+                        let float64_param = lookup("float64-param")?;
+                        let float32_result = lookup("float32-result")?;
+                        let float64_result = lookup("float64-result")?;
+                        Ok(GuestIndices {
                             float32_param,
                             float64_param,
                             float32_result,

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -80,7 +80,7 @@ pub struct FooIndices {
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -4,68 +4,147 @@
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    new: wasmtime::component::ComponentExportIndex,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            new: self.new.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    new: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {
     new: wasmtime::component::Func,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
+            let _component = component;
             let new = _component
                 .export_index(None, "new")
                 .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?
                 .1;
-            Ok(FooPre { instance_pre, new })
+            Ok(FooIndices { new })
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let new = _instance
+                .get_export(&mut store, None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
+            Ok(FooIndices { new })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Foo> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let new = *_instance.get_typed_func::<(), ()>(&mut store, &self.new)?.func();
             Ok(Foo { new })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -78,6 +157,15 @@ const _: () = {
         ) -> wasmtime::Result<Foo> {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn call_new<S: wasmtime::AsContextMut>(
             &self,

--- a/crates/component-macro/tests/expanded/function-new_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_async.rs
@@ -83,7 +83,7 @@ pub struct FooIndices {
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/function-new_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_async.rs
@@ -4,71 +4,150 @@
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    new: wasmtime::component::ComponentExportIndex,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            new: self.new.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    new: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate_async`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {
     new: wasmtime::component::Func,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
+            let _component = component;
             let new = _component
                 .export_index(None, "new")
                 .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?
                 .1;
-            Ok(FooPre { instance_pre, new })
+            Ok(FooIndices { new })
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let new = _instance
+                .get_export(&mut store, None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
+            Ok(FooIndices { new })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Foo>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
             let new = *_instance.get_typed_func::<(), ()>(&mut store, &self.new)?.func();
             Ok(Foo { new })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -84,6 +163,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub async fn call_new<S: wasmtime::AsContextMut>(
             &self,

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::integers::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::integers::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::integers::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::integers::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::integers::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::integers::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -421,7 +507,7 @@ pub mod exports {
                     pair_ret: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     a1: wasmtime::component::ComponentExportIndex,
                     a2: wasmtime::component::ComponentExportIndex,
                     a3: wasmtime::component::ComponentExportIndex,
@@ -441,11 +527,16 @@ pub mod exports {
                     r8: wasmtime::component::ComponentExportIndex,
                     pair_ret: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/integers")
                             .ok_or_else(|| {
@@ -453,10 +544,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/integers")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/integers`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/integers` does \
@@ -464,25 +579,26 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let a1 = _lookup("a1")?;
-                        let a2 = _lookup("a2")?;
-                        let a3 = _lookup("a3")?;
-                        let a4 = _lookup("a4")?;
-                        let a5 = _lookup("a5")?;
-                        let a6 = _lookup("a6")?;
-                        let a7 = _lookup("a7")?;
-                        let a8 = _lookup("a8")?;
-                        let a9 = _lookup("a9")?;
-                        let r1 = _lookup("r1")?;
-                        let r2 = _lookup("r2")?;
-                        let r3 = _lookup("r3")?;
-                        let r4 = _lookup("r4")?;
-                        let r5 = _lookup("r5")?;
-                        let r6 = _lookup("r6")?;
-                        let r7 = _lookup("r7")?;
-                        let r8 = _lookup("r8")?;
-                        let pair_ret = _lookup("pair-ret")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let a1 = lookup("a1")?;
+                        let a2 = lookup("a2")?;
+                        let a3 = lookup("a3")?;
+                        let a4 = lookup("a4")?;
+                        let a5 = lookup("a5")?;
+                        let a6 = lookup("a6")?;
+                        let a7 = lookup("a7")?;
+                        let a8 = lookup("a8")?;
+                        let a9 = lookup("a9")?;
+                        let r1 = lookup("r1")?;
+                        let r2 = lookup("r2")?;
+                        let r3 = lookup("r3")?;
+                        let r4 = lookup("r4")?;
+                        let r5 = lookup("r5")?;
+                        let r6 = lookup("r6")?;
+                        let r7 = lookup("r7")?;
+                        let r8 = lookup("r8")?;
+                        let pair_ret = lookup("pair-ret")?;
+                        Ok(GuestIndices {
                             a1,
                             a2,
                             a3,

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::integers::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::integers::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::integers::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::integers::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::integers::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::integers::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -435,7 +521,7 @@ pub mod exports {
                     pair_ret: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     a1: wasmtime::component::ComponentExportIndex,
                     a2: wasmtime::component::ComponentExportIndex,
                     a3: wasmtime::component::ComponentExportIndex,
@@ -455,11 +541,16 @@ pub mod exports {
                     r8: wasmtime::component::ComponentExportIndex,
                     pair_ret: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/integers")
                             .ok_or_else(|| {
@@ -467,10 +558,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/integers")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/integers`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/integers` does \
@@ -478,25 +593,26 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let a1 = _lookup("a1")?;
-                        let a2 = _lookup("a2")?;
-                        let a3 = _lookup("a3")?;
-                        let a4 = _lookup("a4")?;
-                        let a5 = _lookup("a5")?;
-                        let a6 = _lookup("a6")?;
-                        let a7 = _lookup("a7")?;
-                        let a8 = _lookup("a8")?;
-                        let a9 = _lookup("a9")?;
-                        let r1 = _lookup("r1")?;
-                        let r2 = _lookup("r2")?;
-                        let r3 = _lookup("r3")?;
-                        let r4 = _lookup("r4")?;
-                        let r5 = _lookup("r5")?;
-                        let r6 = _lookup("r6")?;
-                        let r7 = _lookup("r7")?;
-                        let r8 = _lookup("r8")?;
-                        let pair_ret = _lookup("pair-ret")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let a1 = lookup("a1")?;
+                        let a2 = lookup("a2")?;
+                        let a3 = lookup("a3")?;
+                        let a4 = lookup("a4")?;
+                        let a5 = lookup("a5")?;
+                        let a6 = lookup("a6")?;
+                        let a7 = lookup("a7")?;
+                        let a8 = lookup("a8")?;
+                        let a9 = lookup("a9")?;
+                        let r1 = lookup("r1")?;
+                        let r2 = lookup("r2")?;
+                        let r3 = lookup("r3")?;
+                        let r4 = lookup("r4")?;
+                        let r5 = lookup("r5")?;
+                        let r6 = lookup("r6")?;
+                        let r7 = lookup("r7")?;
+                        let r8 = lookup("r8")?;
+                        let pair_ret = lookup("pair-ret")?;
+                        Ok(GuestIndices {
                             a1,
                             a2,
                             a3,

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheListsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheLists`] as well.
 pub struct TheListsPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::lists::GuestPre,
+    indices: TheListsIndices,
 }
 impl<T> Clone for TheListsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheListsPre<_T> {
+    /// Creates a new copy of `TheListsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheListsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheLists`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheLists> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-lists`.
+///
+/// This is an implementation detail of [`TheListsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheLists`] as well.
+#[derive(Clone)]
+pub struct TheListsIndices {
+    interface0: exports::foo::foo::lists::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-lists`.
 ///
-/// This structure is created through either
-/// [`TheLists::instantiate`] or by first creating
-/// a [`TheListsPre`] followed by using
-/// [`TheListsPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheLists::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheListsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheListsPre::instantiate`] to
+///   create a [`TheLists`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheLists::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheListsIndices::new_instance`] followed
+///   by [`TheListsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheLists {
     interface0: exports::foo::foo::lists::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheListsPre<_T> {
-        /// Creates a new copy of `TheListsPre` bindings which can then
+    impl TheListsIndices {
+        /// Creates a new copy of `TheListsIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::lists::GuestPre::new(_component)?;
-            Ok(TheListsPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::lists::GuestIndices::new(_component)?;
+            Ok(TheListsIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheLists`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheListsIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheLists`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheLists`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::lists::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheListsIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheLists`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheLists> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheLists { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheLists {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheLists> {
             let pre = linker.instantiate_pre(component)?;
             TheListsPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheListsIndices::new_instance`] and
+        /// [`TheListsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheLists> {
+            let indices = TheListsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -1118,7 +1204,7 @@ pub mod exports {
                     load_store_everything: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     list_u8_param: wasmtime::component::ComponentExportIndex,
                     list_u16_param: wasmtime::component::ComponentExportIndex,
                     list_u32_param: wasmtime::component::ComponentExportIndex,
@@ -1149,11 +1235,16 @@ pub mod exports {
                     variant_list: wasmtime::component::ComponentExportIndex,
                     load_store_everything: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/lists")
                             .ok_or_else(|| {
@@ -1161,10 +1252,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/lists` does \
@@ -1172,36 +1287,37 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let list_u8_param = _lookup("list-u8-param")?;
-                        let list_u16_param = _lookup("list-u16-param")?;
-                        let list_u32_param = _lookup("list-u32-param")?;
-                        let list_u64_param = _lookup("list-u64-param")?;
-                        let list_s8_param = _lookup("list-s8-param")?;
-                        let list_s16_param = _lookup("list-s16-param")?;
-                        let list_s32_param = _lookup("list-s32-param")?;
-                        let list_s64_param = _lookup("list-s64-param")?;
-                        let list_float32_param = _lookup("list-float32-param")?;
-                        let list_float64_param = _lookup("list-float64-param")?;
-                        let list_u8_ret = _lookup("list-u8-ret")?;
-                        let list_u16_ret = _lookup("list-u16-ret")?;
-                        let list_u32_ret = _lookup("list-u32-ret")?;
-                        let list_u64_ret = _lookup("list-u64-ret")?;
-                        let list_s8_ret = _lookup("list-s8-ret")?;
-                        let list_s16_ret = _lookup("list-s16-ret")?;
-                        let list_s32_ret = _lookup("list-s32-ret")?;
-                        let list_s64_ret = _lookup("list-s64-ret")?;
-                        let list_float32_ret = _lookup("list-float32-ret")?;
-                        let list_float64_ret = _lookup("list-float64-ret")?;
-                        let tuple_list = _lookup("tuple-list")?;
-                        let string_list_arg = _lookup("string-list-arg")?;
-                        let string_list_ret = _lookup("string-list-ret")?;
-                        let tuple_string_list = _lookup("tuple-string-list")?;
-                        let string_list = _lookup("string-list")?;
-                        let record_list = _lookup("record-list")?;
-                        let record_list_reverse = _lookup("record-list-reverse")?;
-                        let variant_list = _lookup("variant-list")?;
-                        let load_store_everything = _lookup("load-store-everything")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let list_u8_param = lookup("list-u8-param")?;
+                        let list_u16_param = lookup("list-u16-param")?;
+                        let list_u32_param = lookup("list-u32-param")?;
+                        let list_u64_param = lookup("list-u64-param")?;
+                        let list_s8_param = lookup("list-s8-param")?;
+                        let list_s16_param = lookup("list-s16-param")?;
+                        let list_s32_param = lookup("list-s32-param")?;
+                        let list_s64_param = lookup("list-s64-param")?;
+                        let list_float32_param = lookup("list-float32-param")?;
+                        let list_float64_param = lookup("list-float64-param")?;
+                        let list_u8_ret = lookup("list-u8-ret")?;
+                        let list_u16_ret = lookup("list-u16-ret")?;
+                        let list_u32_ret = lookup("list-u32-ret")?;
+                        let list_u64_ret = lookup("list-u64-ret")?;
+                        let list_s8_ret = lookup("list-s8-ret")?;
+                        let list_s16_ret = lookup("list-s16-ret")?;
+                        let list_s32_ret = lookup("list-s32-ret")?;
+                        let list_s64_ret = lookup("list-s64-ret")?;
+                        let list_float32_ret = lookup("list-float32-ret")?;
+                        let list_float64_ret = lookup("list-float64-ret")?;
+                        let tuple_list = lookup("tuple-list")?;
+                        let string_list_arg = lookup("string-list-arg")?;
+                        let string_list_ret = lookup("string-list-ret")?;
+                        let tuple_string_list = lookup("tuple-string-list")?;
+                        let string_list = lookup("string-list")?;
+                        let record_list = lookup("record-list")?;
+                        let record_list_reverse = lookup("record-list-reverse")?;
+                        let variant_list = lookup("variant-list")?;
+                        let load_store_everything = lookup("load-store-everything")?;
+                        Ok(GuestIndices {
                             list_u8_param,
                             list_u16_param,
                             list_u32_param,

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -80,7 +80,7 @@ pub struct TheListsIndices {
 ///   create a [`TheLists`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheLists::new_instance`]
+///   then you can use [`TheLists::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheListsIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -83,7 +83,7 @@ pub struct TheListsIndices {
 ///   create a [`TheLists`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheLists::new_instance`]
+///   then you can use [`TheLists::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheListsIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheListsPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheLists`] as well.
 pub struct TheListsPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::lists::GuestPre,
+    indices: TheListsIndices,
 }
 impl<T> Clone for TheListsPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheListsPre<_T> {
+    /// Creates a new copy of `TheListsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheListsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheLists`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheLists>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-lists`.
+///
+/// This is an implementation detail of [`TheListsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheLists`] as well.
+#[derive(Clone)]
+pub struct TheListsIndices {
+    interface0: exports::foo::foo::lists::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-lists`.
 ///
-/// This structure is created through either
-/// [`TheLists::instantiate_async`] or by first creating
-/// a [`TheListsPre`] followed by using
-/// [`TheListsPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheLists::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheListsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheListsPre::instantiate_async`] to
+///   create a [`TheLists`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheLists::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheListsIndices::new_instance`] followed
+///   by [`TheListsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheLists {
     interface0: exports::foo::foo::lists::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheListsPre<_T> {
-        /// Creates a new copy of `TheListsPre` bindings which can then
+    impl TheListsIndices {
+        /// Creates a new copy of `TheListsIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::lists::GuestPre::new(_component)?;
-            Ok(TheListsPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::lists::GuestIndices::new(_component)?;
+            Ok(TheListsIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheLists`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheListsIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheLists`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheLists`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::lists::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheListsIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheLists`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheLists>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheLists> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheLists { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheLists {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheListsPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheListsIndices::new_instance`] and
+        /// [`TheListsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheLists> {
+            let indices = TheListsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -1163,7 +1249,7 @@ pub mod exports {
                     load_store_everything: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     list_u8_param: wasmtime::component::ComponentExportIndex,
                     list_u16_param: wasmtime::component::ComponentExportIndex,
                     list_u32_param: wasmtime::component::ComponentExportIndex,
@@ -1194,11 +1280,16 @@ pub mod exports {
                     variant_list: wasmtime::component::ComponentExportIndex,
                     load_store_everything: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/lists")
                             .ok_or_else(|| {
@@ -1206,10 +1297,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/lists` does \
@@ -1217,36 +1332,37 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let list_u8_param = _lookup("list-u8-param")?;
-                        let list_u16_param = _lookup("list-u16-param")?;
-                        let list_u32_param = _lookup("list-u32-param")?;
-                        let list_u64_param = _lookup("list-u64-param")?;
-                        let list_s8_param = _lookup("list-s8-param")?;
-                        let list_s16_param = _lookup("list-s16-param")?;
-                        let list_s32_param = _lookup("list-s32-param")?;
-                        let list_s64_param = _lookup("list-s64-param")?;
-                        let list_float32_param = _lookup("list-float32-param")?;
-                        let list_float64_param = _lookup("list-float64-param")?;
-                        let list_u8_ret = _lookup("list-u8-ret")?;
-                        let list_u16_ret = _lookup("list-u16-ret")?;
-                        let list_u32_ret = _lookup("list-u32-ret")?;
-                        let list_u64_ret = _lookup("list-u64-ret")?;
-                        let list_s8_ret = _lookup("list-s8-ret")?;
-                        let list_s16_ret = _lookup("list-s16-ret")?;
-                        let list_s32_ret = _lookup("list-s32-ret")?;
-                        let list_s64_ret = _lookup("list-s64-ret")?;
-                        let list_float32_ret = _lookup("list-float32-ret")?;
-                        let list_float64_ret = _lookup("list-float64-ret")?;
-                        let tuple_list = _lookup("tuple-list")?;
-                        let string_list_arg = _lookup("string-list-arg")?;
-                        let string_list_ret = _lookup("string-list-ret")?;
-                        let tuple_string_list = _lookup("tuple-string-list")?;
-                        let string_list = _lookup("string-list")?;
-                        let record_list = _lookup("record-list")?;
-                        let record_list_reverse = _lookup("record-list-reverse")?;
-                        let variant_list = _lookup("variant-list")?;
-                        let load_store_everything = _lookup("load-store-everything")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let list_u8_param = lookup("list-u8-param")?;
+                        let list_u16_param = lookup("list-u16-param")?;
+                        let list_u32_param = lookup("list-u32-param")?;
+                        let list_u64_param = lookup("list-u64-param")?;
+                        let list_s8_param = lookup("list-s8-param")?;
+                        let list_s16_param = lookup("list-s16-param")?;
+                        let list_s32_param = lookup("list-s32-param")?;
+                        let list_s64_param = lookup("list-s64-param")?;
+                        let list_float32_param = lookup("list-float32-param")?;
+                        let list_float64_param = lookup("list-float64-param")?;
+                        let list_u8_ret = lookup("list-u8-ret")?;
+                        let list_u16_ret = lookup("list-u16-ret")?;
+                        let list_u32_ret = lookup("list-u32-ret")?;
+                        let list_u64_ret = lookup("list-u64-ret")?;
+                        let list_s8_ret = lookup("list-s8-ret")?;
+                        let list_s16_ret = lookup("list-s16-ret")?;
+                        let list_s32_ret = lookup("list-s32-ret")?;
+                        let list_s64_ret = lookup("list-s64-ret")?;
+                        let list_float32_ret = lookup("list-float32-ret")?;
+                        let list_float64_ret = lookup("list-float64-ret")?;
+                        let tuple_list = lookup("tuple-list")?;
+                        let string_list_arg = lookup("string-list-arg")?;
+                        let string_list_ret = lookup("string-list-ret")?;
+                        let tuple_string_list = lookup("tuple-string-list")?;
+                        let string_list = lookup("string-list")?;
+                        let record_list = lookup("record-list")?;
+                        let record_list_reverse = lookup("record-list-reverse")?;
+                        let variant_list = lookup("variant-list")?;
+                        let load_store_everything = lookup("load-store-everything")?;
+                        Ok(GuestIndices {
                             list_u8_param,
                             list_u16_param,
                             list_u32_param,

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::manyarg::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::manyarg::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::manyarg::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::manyarg::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::manyarg::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::manyarg::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -449,15 +535,20 @@ pub mod exports {
                     big_argument: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     many_args: wasmtime::component::ComponentExportIndex,
                     big_argument: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/manyarg")
                             .ok_or_else(|| {
@@ -465,10 +556,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/manyarg")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/manyarg`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/manyarg` does \
@@ -476,9 +591,10 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let many_args = _lookup("many-args")?;
-                        let big_argument = _lookup("big-argument")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let many_args = lookup("many-args")?;
+                        let big_argument = lookup("big-argument")?;
+                        Ok(GuestIndices {
                             many_args,
                             big_argument,
                         })

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::manyarg::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::manyarg::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::manyarg::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::manyarg::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::manyarg::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::manyarg::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -464,15 +550,20 @@ pub mod exports {
                     big_argument: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     many_args: wasmtime::component::ComponentExportIndex,
                     big_argument: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/manyarg")
                             .ok_or_else(|| {
@@ -480,10 +571,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/manyarg")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/manyarg`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/manyarg` does \
@@ -491,9 +606,10 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let many_args = _lookup("many-args")?;
-                        let big_argument = _lookup("big-argument")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let many_args = lookup("many-args")?;
+                        let big_argument = lookup("big-argument")?;
+                        Ok(GuestIndices {
                             many_args,
                             big_argument,
                         })

--- a/crates/component-macro/tests/expanded/multi-return.rs
+++ b/crates/component-macro/tests/expanded/multi-return.rs
@@ -4,68 +4,147 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::multi_return::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::multi_return::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::multi_return::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::multi_return::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::multi_return::GuestIndices::new(
+                _component,
+            )?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::multi_return::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +157,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -210,18 +298,23 @@ pub mod exports {
                     mre: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     mra: wasmtime::component::ComponentExportIndex,
                     mrb: wasmtime::component::ComponentExportIndex,
                     mrc: wasmtime::component::ComponentExportIndex,
                     mrd: wasmtime::component::ComponentExportIndex,
                     mre: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/multi-return")
                             .ok_or_else(|| {
@@ -229,10 +322,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/multi-return`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/multi-return")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/multi-return`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/multi-return` does \
@@ -240,12 +357,13 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let mra = _lookup("mra")?;
-                        let mrb = _lookup("mrb")?;
-                        let mrc = _lookup("mrc")?;
-                        let mrd = _lookup("mrd")?;
-                        let mre = _lookup("mre")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let mra = lookup("mra")?;
+                        let mrb = lookup("mrb")?;
+                        let mrc = lookup("mrc")?;
+                        let mrd = lookup("mrd")?;
+                        let mre = lookup("mre")?;
+                        Ok(GuestIndices {
                             mra,
                             mrb,
                             mrc,

--- a/crates/component-macro/tests/expanded/multi-return.rs
+++ b/crates/component-macro/tests/expanded/multi-return.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/multi-return_async.rs
+++ b/crates/component-macro/tests/expanded/multi-return_async.rs
@@ -4,71 +4,150 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::multi_return::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::multi_return::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::multi_return::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::multi_return::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::multi_return::GuestIndices::new(
+                _component,
+            )?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::multi_return::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +163,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -223,18 +311,23 @@ pub mod exports {
                     mre: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     mra: wasmtime::component::ComponentExportIndex,
                     mrb: wasmtime::component::ComponentExportIndex,
                     mrc: wasmtime::component::ComponentExportIndex,
                     mrd: wasmtime::component::ComponentExportIndex,
                     mre: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/multi-return")
                             .ok_or_else(|| {
@@ -242,10 +335,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/multi-return`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/multi-return")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/multi-return`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/multi-return` does \
@@ -253,12 +370,13 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let mra = _lookup("mra")?;
-                        let mrb = _lookup("mrb")?;
-                        let mrc = _lookup("mrc")?;
-                        let mrd = _lookup("mrd")?;
-                        let mre = _lookup("mre")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let mra = lookup("mra")?;
+                        let mrb = lookup("mrb")?;
+                        let mrc = lookup("mrc")?;
+                        let mrd = lookup("mrd")?;
+                        let mre = lookup("mre")?;
+                        Ok(GuestIndices {
                             mra,
                             mrb,
                             mrc,

--- a/crates/component-macro/tests/expanded/multi-return_async.rs
+++ b/crates/component-macro/tests/expanded/multi-return_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -4,27 +4,96 @@
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::my::dep0_1_0::a::GuestPre,
-    interface1: exports::my::dep0_2_0::a::GuestPre,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
-            interface1: self.interface1.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    interface0: exports::my::dep0_1_0::a::GuestIndices,
+    interface1: exports::my::dep0_2_0::a::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {
     interface0: exports::my::dep0_1_0::a::Guest,
     interface1: exports::my::dep0_2_0::a::Guest,
@@ -32,46 +101,62 @@ pub struct Foo {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::my::dep0_1_0::a::GuestPre::new(_component)?;
-            let interface1 = exports::my::dep0_2_0::a::GuestPre::new(_component)?;
-            Ok(FooPre {
-                instance_pre,
+            let _component = component;
+            let interface0 = exports::my::dep0_1_0::a::GuestIndices::new(_component)?;
+            let interface1 = exports::my::dep0_2_0::a::GuestIndices::new(_component)?;
+            Ok(FooIndices {
                 interface0,
                 interface1,
             })
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::my::dep0_1_0::a::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface1 = exports::my::dep0_2_0::a::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(FooIndices {
+                interface0,
+                interface1,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Foo> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             let interface1 = self.interface1.load(&mut store, &_instance)?;
             Ok(Foo { interface0, interface1 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -84,6 +169,15 @@ const _: () = {
         ) -> wasmtime::Result<Foo> {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -219,14 +313,19 @@ pub mod exports {
                     x: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     x: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
@@ -234,10 +333,34 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "my:dep/a@0.1.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.1.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `my:dep/a@0.1.0` does \
@@ -245,8 +368,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let x = _lookup("x")?;
-                        Ok(GuestPre { x })
+                        let _ = &mut lookup;
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
                     }
                     pub fn load(
                         &self,
@@ -289,14 +413,19 @@ pub mod exports {
                     x: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     x: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
@@ -304,10 +433,34 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "my:dep/a@0.2.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.2.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `my:dep/a@0.2.0` does \
@@ -315,8 +468,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let x = _lookup("x")?;
-                        Ok(GuestPre { x })
+                        let _ = &mut lookup;
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -81,7 +81,7 @@ pub struct FooIndices {
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -4,27 +4,99 @@
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::my::dep0_1_0::a::GuestPre,
-    interface1: exports::my::dep0_2_0::a::GuestPre,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
-            interface1: self.interface1.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    interface0: exports::my::dep0_1_0::a::GuestIndices,
+    interface1: exports::my::dep0_2_0::a::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate_async`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {
     interface0: exports::my::dep0_1_0::a::Guest,
     interface1: exports::my::dep0_2_0::a::Guest,
@@ -32,49 +104,62 @@ pub struct Foo {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::my::dep0_1_0::a::GuestPre::new(_component)?;
-            let interface1 = exports::my::dep0_2_0::a::GuestPre::new(_component)?;
-            Ok(FooPre {
-                instance_pre,
+            let _component = component;
+            let interface0 = exports::my::dep0_1_0::a::GuestIndices::new(_component)?;
+            let interface1 = exports::my::dep0_2_0::a::GuestIndices::new(_component)?;
+            Ok(FooIndices {
                 interface0,
                 interface1,
             })
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::my::dep0_1_0::a::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface1 = exports::my::dep0_2_0::a::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(FooIndices {
+                interface0,
+                interface1,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Foo>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             let interface1 = self.interface1.load(&mut store, &_instance)?;
             Ok(Foo { interface0, interface1 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -90,6 +175,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -238,14 +332,19 @@ pub mod exports {
                     x: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     x: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
@@ -253,10 +352,34 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "my:dep/a@0.1.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.1.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `my:dep/a@0.1.0` does \
@@ -264,8 +387,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let x = _lookup("x")?;
-                        Ok(GuestPre { x })
+                        let _ = &mut lookup;
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
                     }
                     pub fn load(
                         &self,
@@ -311,14 +435,19 @@ pub mod exports {
                     x: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     x: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
@@ -326,10 +455,34 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "my:dep/a@0.2.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.2.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `my:dep/a@0.2.0` does \
@@ -337,8 +490,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let x = _lookup("x")?;
-                        Ok(GuestPre { x })
+                        let _ = &mut lookup;
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -84,7 +84,7 @@ pub struct FooIndices {
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::records::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::records::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::records::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::records::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::records::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::records::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -625,7 +711,7 @@ pub mod exports {
                     typedef_inout: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     tuple_arg: wasmtime::component::ComponentExportIndex,
                     tuple_result: wasmtime::component::ComponentExportIndex,
                     empty_arg: wasmtime::component::ComponentExportIndex,
@@ -638,11 +724,16 @@ pub mod exports {
                     aggregate_result: wasmtime::component::ComponentExportIndex,
                     typedef_inout: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/records")
                             .ok_or_else(|| {
@@ -650,10 +741,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/records")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/records`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/records` does \
@@ -661,18 +776,19 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let tuple_arg = _lookup("tuple-arg")?;
-                        let tuple_result = _lookup("tuple-result")?;
-                        let empty_arg = _lookup("empty-arg")?;
-                        let empty_result = _lookup("empty-result")?;
-                        let scalar_arg = _lookup("scalar-arg")?;
-                        let scalar_result = _lookup("scalar-result")?;
-                        let flags_arg = _lookup("flags-arg")?;
-                        let flags_result = _lookup("flags-result")?;
-                        let aggregate_arg = _lookup("aggregate-arg")?;
-                        let aggregate_result = _lookup("aggregate-result")?;
-                        let typedef_inout = _lookup("typedef-inout")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let tuple_arg = lookup("tuple-arg")?;
+                        let tuple_result = lookup("tuple-result")?;
+                        let empty_arg = lookup("empty-arg")?;
+                        let empty_result = lookup("empty-result")?;
+                        let scalar_arg = lookup("scalar-arg")?;
+                        let scalar_result = lookup("scalar-result")?;
+                        let flags_arg = lookup("flags-arg")?;
+                        let flags_result = lookup("flags-result")?;
+                        let aggregate_arg = lookup("aggregate-arg")?;
+                        let aggregate_result = lookup("aggregate-result")?;
+                        let typedef_inout = lookup("typedef-inout")?;
+                        Ok(GuestIndices {
                             tuple_arg,
                             tuple_result,
                             empty_arg,

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::records::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::records::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::records::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::records::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::records::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::records::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -638,7 +724,7 @@ pub mod exports {
                     typedef_inout: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     tuple_arg: wasmtime::component::ComponentExportIndex,
                     tuple_result: wasmtime::component::ComponentExportIndex,
                     empty_arg: wasmtime::component::ComponentExportIndex,
@@ -651,11 +737,16 @@ pub mod exports {
                     aggregate_result: wasmtime::component::ComponentExportIndex,
                     typedef_inout: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/records")
                             .ok_or_else(|| {
@@ -663,10 +754,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/records")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/records`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/records` does \
@@ -674,18 +789,19 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let tuple_arg = _lookup("tuple-arg")?;
-                        let tuple_result = _lookup("tuple-result")?;
-                        let empty_arg = _lookup("empty-arg")?;
-                        let empty_result = _lookup("empty-result")?;
-                        let scalar_arg = _lookup("scalar-arg")?;
-                        let scalar_result = _lookup("scalar-result")?;
-                        let flags_arg = _lookup("flags-arg")?;
-                        let flags_result = _lookup("flags-result")?;
-                        let aggregate_arg = _lookup("aggregate-arg")?;
-                        let aggregate_result = _lookup("aggregate-result")?;
-                        let typedef_inout = _lookup("typedef-inout")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let tuple_arg = lookup("tuple-arg")?;
+                        let tuple_result = lookup("tuple-result")?;
+                        let empty_arg = lookup("empty-arg")?;
+                        let empty_result = lookup("empty-result")?;
+                        let scalar_arg = lookup("scalar-arg")?;
+                        let scalar_result = lookup("scalar-result")?;
+                        let flags_arg = lookup("flags-arg")?;
+                        let flags_result = lookup("flags-result")?;
+                        let aggregate_arg = lookup("aggregate-arg")?;
+                        let aggregate_result = lookup("aggregate-result")?;
+                        let typedef_inout = lookup("typedef-inout")?;
+                        Ok(GuestIndices {
                             tuple_arg,
                             tuple_result,
                             empty_arg,

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -4,59 +4,135 @@
 /// This structure is created through [`NeptunePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Neptune`] as well.
 pub struct NeptunePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: NeptuneIndices,
 }
 impl<T> Clone for NeptunePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> NeptunePre<_T> {
+    /// Creates a new copy of `NeptunePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = NeptuneIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Neptune`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Neptune> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `neptune`.
+///
+/// This is an implementation detail of [`NeptunePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Neptune`] as well.
+#[derive(Clone)]
+pub struct NeptuneIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `neptune`.
 ///
-/// This structure is created through either
-/// [`Neptune::instantiate`] or by first creating
-/// a [`NeptunePre`] followed by using
-/// [`NeptunePre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Neptune::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`NeptunePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`NeptunePre::instantiate`] to
+///   create a [`Neptune`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Neptune::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`NeptuneIndices::new_instance`] followed
+///   by [`NeptuneIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Neptune {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> NeptunePre<_T> {
-        /// Creates a new copy of `NeptunePre` bindings which can then
+    impl NeptuneIndices {
+        /// Creates a new copy of `NeptuneIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(NeptunePre { instance_pre })
+            let _component = component;
+            Ok(NeptuneIndices {})
         }
-        /// Instantiates a new instance of [`Neptune`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`NeptuneIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Neptune`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Neptune`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(NeptuneIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Neptune`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Neptune> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(Neptune {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Neptune {
@@ -69,6 +145,15 @@ const _: () = {
         ) -> wasmtime::Result<Neptune> {
             let pre = linker.instantiate_pre(component)?;
             NeptunePre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`NeptuneIndices::new_instance`] and
+        /// [`NeptuneIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Neptune> {
+            let indices = NeptuneIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -78,7 +78,7 @@ pub struct NeptuneIndices {}
 ///   create a [`Neptune`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Neptune::new_instance`]
+///   then you can use [`Neptune::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`NeptuneIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -4,62 +4,138 @@
 /// This structure is created through [`NeptunePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Neptune`] as well.
 pub struct NeptunePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: NeptuneIndices,
 }
 impl<T> Clone for NeptunePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> NeptunePre<_T> {
+    /// Creates a new copy of `NeptunePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = NeptuneIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Neptune`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Neptune>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `neptune`.
+///
+/// This is an implementation detail of [`NeptunePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Neptune`] as well.
+#[derive(Clone)]
+pub struct NeptuneIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `neptune`.
 ///
-/// This structure is created through either
-/// [`Neptune::instantiate_async`] or by first creating
-/// a [`NeptunePre`] followed by using
-/// [`NeptunePre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Neptune::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`NeptunePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`NeptunePre::instantiate_async`] to
+///   create a [`Neptune`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Neptune::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`NeptuneIndices::new_instance`] followed
+///   by [`NeptuneIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Neptune {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> NeptunePre<_T> {
-        /// Creates a new copy of `NeptunePre` bindings which can then
+    impl NeptuneIndices {
+        /// Creates a new copy of `NeptuneIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(NeptunePre { instance_pre })
+            let _component = component;
+            Ok(NeptuneIndices {})
         }
-        /// Instantiates a new instance of [`Neptune`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`NeptuneIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Neptune`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Neptune`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(NeptuneIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Neptune`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Neptune>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Neptune> {
+            let _instance = instance;
             Ok(Neptune {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Neptune {
@@ -75,6 +151,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             NeptunePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`NeptuneIndices::new_instance`] and
+        /// [`NeptuneIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Neptune> {
+            let indices = NeptuneIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -81,7 +81,7 @@ pub struct NeptuneIndices {}
 ///   create a [`Neptune`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Neptune::new_instance`]
+///   then you can use [`Neptune::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`NeptuneIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -83,7 +83,7 @@ pub struct WIndices {
 ///   create a [`W`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`W::new_instance`]
+///   then you can use [`W::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`WIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -4,31 +4,98 @@
 /// This structure is created through [`WPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`W`] as well.
 pub struct WPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::simple_export::GuestPre,
-    interface1: exports::foo::foo::export_using_import::GuestPre,
-    interface2: exports::foo::foo::export_using_export1::GuestPre,
-    interface3: exports::foo::foo::export_using_export2::GuestPre,
+    indices: WIndices,
 }
 impl<T> Clone for WPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
-            interface1: self.interface1.clone(),
-            interface2: self.interface2.clone(),
-            interface3: self.interface3.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> WPre<_T> {
+    /// Creates a new copy of `WPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = WIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`W`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<W> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `w`.
+///
+/// This is an implementation detail of [`WPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`W`] as well.
+#[derive(Clone)]
+pub struct WIndices {
+    interface0: exports::foo::foo::simple_export::GuestIndices,
+    interface1: exports::foo::foo::export_using_import::GuestIndices,
+    interface2: exports::foo::foo::export_using_export1::GuestIndices,
+    interface3: exports::foo::foo::export_using_export2::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `w`.
 ///
-/// This structure is created through either
-/// [`W::instantiate`] or by first creating
-/// a [`WPre`] followed by using
-/// [`WPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`W::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`WPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`WPre::instantiate`] to
+///   create a [`W`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`W::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`WIndices::new_instance`] followed
+///   by [`WIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct W {
     interface0: exports::foo::foo::simple_export::Guest,
     interface1: exports::foo::foo::export_using_import::Guest,
@@ -38,49 +105,81 @@ pub struct W {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> WPre<_T> {
-        /// Creates a new copy of `WPre` bindings which can then
+    impl WIndices {
+        /// Creates a new copy of `WIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::simple_export::GuestPre::new(
+            let _component = component;
+            let interface0 = exports::foo::foo::simple_export::GuestIndices::new(
                 _component,
             )?;
-            let interface1 = exports::foo::foo::export_using_import::GuestPre::new(
+            let interface1 = exports::foo::foo::export_using_import::GuestIndices::new(
                 _component,
             )?;
-            let interface2 = exports::foo::foo::export_using_export1::GuestPre::new(
+            let interface2 = exports::foo::foo::export_using_export1::GuestIndices::new(
                 _component,
             )?;
-            let interface3 = exports::foo::foo::export_using_export2::GuestPre::new(
+            let interface3 = exports::foo::foo::export_using_export2::GuestIndices::new(
                 _component,
             )?;
-            Ok(WPre {
-                instance_pre,
+            Ok(WIndices {
                 interface0,
                 interface1,
                 interface2,
                 interface3,
             })
         }
-        /// Instantiates a new instance of [`W`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`WIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`W`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`W`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple_export::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface1 = exports::foo::foo::export_using_import::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface2 = exports::foo::foo::export_using_export1::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface3 = exports::foo::foo::export_using_export2::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(WIndices {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`W`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<W> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             let interface1 = self.interface1.load(&mut store, &_instance)?;
             let interface2 = self.interface2.load(&mut store, &_instance)?;
@@ -91,12 +190,6 @@ const _: () = {
                 interface2,
                 interface3,
             })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl W {
@@ -109,6 +202,15 @@ const _: () = {
         ) -> wasmtime::Result<W> {
             let pre = linker.instantiate_pre(component)?;
             WPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`WIndices::new_instance`] and
+        /// [`WIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<W> {
+            let indices = WIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -221,16 +323,21 @@ pub mod exports {
                     method_a_method_a: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_a_constructor: wasmtime::component::ComponentExportIndex,
                     static_a_static_a: wasmtime::component::ComponentExportIndex,
                     method_a_method_a: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/simple-export")
                             .ok_or_else(|| {
@@ -238,10 +345,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple-export")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-export`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/simple-export` does \
@@ -249,10 +380,11 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_a_constructor = _lookup("[constructor]a")?;
-                        let static_a_static_a = _lookup("[static]a.static-a")?;
-                        let method_a_method_a = _lookup("[method]a.method-a")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
                             constructor_a_constructor,
                             static_a_static_a,
                             method_a_method_a,
@@ -357,16 +489,21 @@ pub mod exports {
                     method_a_method_a: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_a_constructor: wasmtime::component::ComponentExportIndex,
                     static_a_static_a: wasmtime::component::ComponentExportIndex,
                     method_a_method_a: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/export-using-import")
                             .ok_or_else(|| {
@@ -374,10 +511,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-import")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-import`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-import` does \
@@ -385,10 +546,11 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_a_constructor = _lookup("[constructor]a")?;
-                        let static_a_static_a = _lookup("[static]a.static-a")?;
-                        let method_a_method_a = _lookup("[method]a.method-a")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
                             constructor_a_constructor,
                             static_a_static_a,
                             method_a_method_a,
@@ -498,14 +660,19 @@ pub mod exports {
                     constructor_a_constructor: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_a_constructor: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/export-using-export1")
                             .ok_or_else(|| {
@@ -513,10 +680,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-export1")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export1`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-export1` does \
@@ -524,8 +715,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_a_constructor = _lookup("[constructor]a")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        Ok(GuestIndices {
                             constructor_a_constructor,
                         })
                     }
@@ -581,14 +773,19 @@ pub mod exports {
                     constructor_b_constructor: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_b_constructor: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/export-using-export2")
                             .ok_or_else(|| {
@@ -596,10 +793,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-export2")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export2`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-export2` does \
@@ -607,8 +828,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_b_constructor = _lookup("[constructor]b")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_b_constructor = lookup("[constructor]b")?;
+                        Ok(GuestIndices {
                             constructor_b_constructor,
                         })
                     }

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -4,31 +4,101 @@
 /// This structure is created through [`WPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`W`] as well.
 pub struct WPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::simple_export::GuestPre,
-    interface1: exports::foo::foo::export_using_import::GuestPre,
-    interface2: exports::foo::foo::export_using_export1::GuestPre,
-    interface3: exports::foo::foo::export_using_export2::GuestPre,
+    indices: WIndices,
 }
 impl<T> Clone for WPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
-            interface1: self.interface1.clone(),
-            interface2: self.interface2.clone(),
-            interface3: self.interface3.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> WPre<_T> {
+    /// Creates a new copy of `WPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = WIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`W`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<W>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `w`.
+///
+/// This is an implementation detail of [`WPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`W`] as well.
+#[derive(Clone)]
+pub struct WIndices {
+    interface0: exports::foo::foo::simple_export::GuestIndices,
+    interface1: exports::foo::foo::export_using_import::GuestIndices,
+    interface2: exports::foo::foo::export_using_export1::GuestIndices,
+    interface3: exports::foo::foo::export_using_export2::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `w`.
 ///
-/// This structure is created through either
-/// [`W::instantiate_async`] or by first creating
-/// a [`WPre`] followed by using
-/// [`WPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`W::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`WPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`WPre::instantiate_async`] to
+///   create a [`W`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`W::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`WIndices::new_instance`] followed
+///   by [`WIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct W {
     interface0: exports::foo::foo::simple_export::Guest,
     interface1: exports::foo::foo::export_using_import::Guest,
@@ -38,52 +108,81 @@ pub struct W {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> WPre<_T> {
-        /// Creates a new copy of `WPre` bindings which can then
+    impl WIndices {
+        /// Creates a new copy of `WIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::simple_export::GuestPre::new(
+            let _component = component;
+            let interface0 = exports::foo::foo::simple_export::GuestIndices::new(
                 _component,
             )?;
-            let interface1 = exports::foo::foo::export_using_import::GuestPre::new(
+            let interface1 = exports::foo::foo::export_using_import::GuestIndices::new(
                 _component,
             )?;
-            let interface2 = exports::foo::foo::export_using_export1::GuestPre::new(
+            let interface2 = exports::foo::foo::export_using_export1::GuestIndices::new(
                 _component,
             )?;
-            let interface3 = exports::foo::foo::export_using_export2::GuestPre::new(
+            let interface3 = exports::foo::foo::export_using_export2::GuestIndices::new(
                 _component,
             )?;
-            Ok(WPre {
-                instance_pre,
+            Ok(WIndices {
                 interface0,
                 interface1,
                 interface2,
                 interface3,
             })
         }
-        /// Instantiates a new instance of [`W`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`WIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`W`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`W`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple_export::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface1 = exports::foo::foo::export_using_import::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface2 = exports::foo::foo::export_using_export1::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface3 = exports::foo::foo::export_using_export2::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(WIndices {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`W`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<W>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<W> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             let interface1 = self.interface1.load(&mut store, &_instance)?;
             let interface2 = self.interface2.load(&mut store, &_instance)?;
@@ -94,12 +193,6 @@ const _: () = {
                 interface2,
                 interface3,
             })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl W {
@@ -115,6 +208,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             WPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`WIndices::new_instance`] and
+        /// [`WIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<W> {
+            let indices = WIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -239,16 +341,21 @@ pub mod exports {
                     method_a_method_a: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_a_constructor: wasmtime::component::ComponentExportIndex,
                     static_a_static_a: wasmtime::component::ComponentExportIndex,
                     method_a_method_a: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/simple-export")
                             .ok_or_else(|| {
@@ -256,10 +363,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple-export")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-export`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/simple-export` does \
@@ -267,10 +398,11 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_a_constructor = _lookup("[constructor]a")?;
-                        let static_a_static_a = _lookup("[static]a.static-a")?;
-                        let method_a_method_a = _lookup("[method]a.method-a")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
                             constructor_a_constructor,
                             static_a_static_a,
                             method_a_method_a,
@@ -390,16 +522,21 @@ pub mod exports {
                     method_a_method_a: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_a_constructor: wasmtime::component::ComponentExportIndex,
                     static_a_static_a: wasmtime::component::ComponentExportIndex,
                     method_a_method_a: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/export-using-import")
                             .ok_or_else(|| {
@@ -407,10 +544,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-import")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-import`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-import` does \
@@ -418,10 +579,11 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_a_constructor = _lookup("[constructor]a")?;
-                        let static_a_static_a = _lookup("[static]a.static-a")?;
-                        let method_a_method_a = _lookup("[method]a.method-a")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
                             constructor_a_constructor,
                             static_a_static_a,
                             method_a_method_a,
@@ -546,14 +708,19 @@ pub mod exports {
                     constructor_a_constructor: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_a_constructor: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/export-using-export1")
                             .ok_or_else(|| {
@@ -561,10 +728,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-export1")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export1`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-export1` does \
@@ -572,8 +763,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_a_constructor = _lookup("[constructor]a")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        Ok(GuestIndices {
                             constructor_a_constructor,
                         })
                     }
@@ -634,14 +826,19 @@ pub mod exports {
                     constructor_b_constructor: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     constructor_b_constructor: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/export-using-export2")
                             .ok_or_else(|| {
@@ -649,10 +846,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-export2")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export2`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-export2` does \
@@ -660,8 +881,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let constructor_b_constructor = _lookup("[constructor]b")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let constructor_b_constructor = lookup("[constructor]b")?;
+                        Ok(GuestIndices {
                             constructor_b_constructor,
                         })
                     }

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -86,7 +86,7 @@ pub struct WIndices {
 ///   create a [`W`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`W::new_instance`]
+///   then you can use [`W::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`WIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -108,7 +108,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -31,27 +31,96 @@ impl<_T: HostWorldResource + ?Sized> HostWorldResource for &mut _T {
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface1: exports::foo::foo::uses_resource_transitively::GuestPre,
-    some_world_func2: wasmtime::component::ComponentExportIndex,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface1: self.interface1.clone(),
-            some_world_func2: self.some_world_func2.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface1: exports::foo::foo::uses_resource_transitively::GuestIndices,
+    some_world_func2: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface1: exports::foo::foo::uses_resource_transitively::Guest,
     some_world_func2: wasmtime::component::Func,
@@ -79,17 +148,17 @@ impl<_T: TheWorldImports + ?Sized> TheWorldImports for &mut _T {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface1 = exports::foo::foo::uses_resource_transitively::GuestPre::new(
+            let _component = component;
+            let interface1 = exports::foo::foo::uses_resource_transitively::GuestIndices::new(
                 _component,
             )?;
             let some_world_func2 = _component
@@ -98,25 +167,48 @@ const _: () = {
                     anyhow::anyhow!("no function export `some-world-func2` found")
                 })?
                 .1;
-            Ok(TheWorldPre {
-                instance_pre,
+            Ok(TheWorldIndices {
                 interface1,
                 some_world_func2,
             })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface1 = exports::foo::foo::uses_resource_transitively::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let some_world_func2 = _instance
+                .get_export(&mut store, None, "some-world-func2")
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no function export `some-world-func2` found")
+                })?;
+            Ok(TheWorldIndices {
+                interface1,
+                some_world_func2,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface1 = self.interface1.load(&mut store, &_instance)?;
             let some_world_func2 = *_instance
                 .get_typed_func::<
@@ -129,12 +221,6 @@ const _: () = {
                 some_world_func2,
             })
         }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
-        }
     }
     impl TheWorld {
         /// Convenience wrapper around [`TheWorldPre::new`] and
@@ -146,6 +232,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker_imports_get_host<T>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -1019,14 +1114,19 @@ pub mod exports {
                     handle: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     handle: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/uses-resource-transitively")
                             .ok_or_else(|| {
@@ -1034,19 +1134,48 @@ pub mod exports {
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(
+                                &mut store,
+                                None,
+                                "foo:foo/uses-resource-transitively",
+                            )
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/uses-resource-transitively`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/uses-resource-transitively` does \
-                      not have export `{name}`"
+                        not have export `{name}`"
                                     )
                                 })
                         };
-                        let handle = _lookup("handle")?;
-                        Ok(GuestPre { handle })
+                        let _ = &mut lookup;
+                        let handle = lookup("handle")?;
+                        Ok(GuestIndices { handle })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -113,7 +113,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -33,27 +33,99 @@ impl<_T: HostWorldResource + ?Sized + Send> HostWorldResource for &mut _T {
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface1: exports::foo::foo::uses_resource_transitively::GuestPre,
-    some_world_func2: wasmtime::component::ComponentExportIndex,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface1: self.interface1.clone(),
-            some_world_func2: self.some_world_func2.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface1: exports::foo::foo::uses_resource_transitively::GuestIndices,
+    some_world_func2: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface1: exports::foo::foo::uses_resource_transitively::Guest,
     some_world_func2: wasmtime::component::Func,
@@ -83,17 +155,17 @@ impl<_T: TheWorldImports + ?Sized + Send> TheWorldImports for &mut _T {
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface1 = exports::foo::foo::uses_resource_transitively::GuestPre::new(
+            let _component = component;
+            let interface1 = exports::foo::foo::uses_resource_transitively::GuestIndices::new(
                 _component,
             )?;
             let some_world_func2 = _component
@@ -102,28 +174,48 @@ const _: () = {
                     anyhow::anyhow!("no function export `some-world-func2` found")
                 })?
                 .1;
-            Ok(TheWorldPre {
-                instance_pre,
+            Ok(TheWorldIndices {
                 interface1,
                 some_world_func2,
             })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface1 = exports::foo::foo::uses_resource_transitively::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let some_world_func2 = _instance
+                .get_export(&mut store, None, "some-world-func2")
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no function export `some-world-func2` found")
+                })?;
+            Ok(TheWorldIndices {
+                interface1,
+                some_world_func2,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface1 = self.interface1.load(&mut store, &_instance)?;
             let some_world_func2 = *_instance
                 .get_typed_func::<
@@ -135,12 +227,6 @@ const _: () = {
                 interface1,
                 some_world_func2,
             })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -156,6 +242,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker_imports_get_host<T>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -1104,14 +1199,19 @@ pub mod exports {
                     handle: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     handle: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/uses-resource-transitively")
                             .ok_or_else(|| {
@@ -1119,19 +1219,48 @@ pub mod exports {
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(
+                                &mut store,
+                                None,
+                                "foo:foo/uses-resource-transitively",
+                            )
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/uses-resource-transitively`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/uses-resource-transitively` does \
-                      not have export `{name}`"
+                        not have export `{name}`"
                                     )
                                 })
                         };
-                        let handle = _lookup("handle")?;
-                        Ok(GuestPre { handle })
+                        let _ = &mut lookup;
+                        let handle = lookup("handle")?;
+                        Ok(GuestIndices { handle })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`HttpInterfacePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`HttpInterface`] as well.
 pub struct HttpInterfacePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::http_handler::GuestPre,
+    indices: HttpInterfaceIndices,
 }
 impl<T> Clone for HttpInterfacePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> HttpInterfacePre<_T> {
+    /// Creates a new copy of `HttpInterfacePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = HttpInterfaceIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`HttpInterface`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<HttpInterface> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `http-interface`.
+///
+/// This is an implementation detail of [`HttpInterfacePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`HttpInterface`] as well.
+#[derive(Clone)]
+pub struct HttpInterfaceIndices {
+    interface0: exports::http_handler::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `http-interface`.
 ///
-/// This structure is created through either
-/// [`HttpInterface::instantiate`] or by first creating
-/// a [`HttpInterfacePre`] followed by using
-/// [`HttpInterfacePre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`HttpInterface::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`HttpInterfacePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`HttpInterfacePre::instantiate`] to
+///   create a [`HttpInterface`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`HttpInterface::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`HttpInterfaceIndices::new_instance`] followed
+///   by [`HttpInterfaceIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct HttpInterface {
     interface0: exports::http_handler::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> HttpInterfacePre<_T> {
-        /// Creates a new copy of `HttpInterfacePre` bindings which can then
+    impl HttpInterfaceIndices {
+        /// Creates a new copy of `HttpInterfaceIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::http_handler::GuestPre::new(_component)?;
-            Ok(HttpInterfacePre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::http_handler::GuestIndices::new(_component)?;
+            Ok(HttpInterfaceIndices { interface0 })
         }
-        /// Instantiates a new instance of [`HttpInterface`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`HttpInterfaceIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`HttpInterface`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`HttpInterface`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::http_handler::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(HttpInterfaceIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`HttpInterface`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<HttpInterface> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(HttpInterface { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl HttpInterface {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<HttpInterface> {
             let pre = linker.instantiate_pre(component)?;
             HttpInterfacePre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`HttpInterfaceIndices::new_instance`] and
+        /// [`HttpInterfaceIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<HttpInterface> {
+            let indices = HttpInterfaceIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -250,23 +336,50 @@ pub mod exports {
             handle_request: wasmtime::component::Func,
         }
         #[derive(Clone)]
-        pub struct GuestPre {
+        pub struct GuestIndices {
             handle_request: wasmtime::component::ComponentExportIndex,
         }
-        impl GuestPre {
+        impl GuestIndices {
+            /// Constructor for [`GuestIndices`] which takes a
+            /// [`Component`](wasmtime::component::Component) as input and can be executed
+            /// before instantiation.
+            ///
+            /// This constructor can be used to front-load string lookups to find exports
+            /// within a component.
             pub fn new(
                 component: &wasmtime::component::Component,
-            ) -> wasmtime::Result<GuestPre> {
-                let _component = component;
+            ) -> wasmtime::Result<GuestIndices> {
                 let (_, instance) = component
                     .export_index(None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
-                let _lookup = |name: &str| {
-                    _component
-                        .export_index(Some(&instance), name)
-                        .map(|p| p.1)
+                Self::_new(|name| {
+                    component.export_index(Some(&instance), name).map(|p| p.1)
+                })
+            }
+            /// This constructor is similar to [`GuestIndices::new`] except that it
+            /// performs string lookups after instantiation time.
+            pub fn new_instance(
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<GuestIndices> {
+                let instance_export = instance
+                    .get_export(&mut store, None, "http-handler")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `http-handler`")
+                    })?;
+                Self::_new(|name| {
+                    instance.get_export(&mut store, Some(&instance_export), name)
+                })
+            }
+            fn _new(
+                mut lookup: impl FnMut(
+                    &str,
+                ) -> Option<wasmtime::component::ComponentExportIndex>,
+            ) -> wasmtime::Result<GuestIndices> {
+                let mut lookup = move |name| {
+                    lookup(name)
                         .ok_or_else(|| {
                             anyhow::anyhow!(
                                 "instance export `http-handler` does \
@@ -274,8 +387,9 @@ pub mod exports {
                             )
                         })
                 };
-                let handle_request = _lookup("handle-request")?;
-                Ok(GuestPre { handle_request })
+                let _ = &mut lookup;
+                let handle_request = lookup("handle-request")?;
+                Ok(GuestIndices { handle_request })
             }
             pub fn load(
                 &self,

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -80,7 +80,7 @@ pub struct HttpInterfaceIndices {
 ///   create a [`HttpInterface`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`HttpInterface::new_instance`]
+///   then you can use [`HttpInterface::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`HttpInterfaceIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -83,7 +83,7 @@ pub struct HttpInterfaceIndices {
 ///   create a [`HttpInterface`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`HttpInterface::new_instance`]
+///   then you can use [`HttpInterface::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`HttpInterfaceIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`HttpInterfacePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`HttpInterface`] as well.
 pub struct HttpInterfacePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::http_handler::GuestPre,
+    indices: HttpInterfaceIndices,
 }
 impl<T> Clone for HttpInterfacePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> HttpInterfacePre<_T> {
+    /// Creates a new copy of `HttpInterfacePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = HttpInterfaceIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`HttpInterface`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<HttpInterface>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `http-interface`.
+///
+/// This is an implementation detail of [`HttpInterfacePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`HttpInterface`] as well.
+#[derive(Clone)]
+pub struct HttpInterfaceIndices {
+    interface0: exports::http_handler::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `http-interface`.
 ///
-/// This structure is created through either
-/// [`HttpInterface::instantiate_async`] or by first creating
-/// a [`HttpInterfacePre`] followed by using
-/// [`HttpInterfacePre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`HttpInterface::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`HttpInterfacePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`HttpInterfacePre::instantiate_async`] to
+///   create a [`HttpInterface`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`HttpInterface::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`HttpInterfaceIndices::new_instance`] followed
+///   by [`HttpInterfaceIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct HttpInterface {
     interface0: exports::http_handler::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> HttpInterfacePre<_T> {
-        /// Creates a new copy of `HttpInterfacePre` bindings which can then
+    impl HttpInterfaceIndices {
+        /// Creates a new copy of `HttpInterfaceIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::http_handler::GuestPre::new(_component)?;
-            Ok(HttpInterfacePre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::http_handler::GuestIndices::new(_component)?;
+            Ok(HttpInterfaceIndices { interface0 })
         }
-        /// Instantiates a new instance of [`HttpInterface`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`HttpInterfaceIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`HttpInterface`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`HttpInterface`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::http_handler::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(HttpInterfaceIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`HttpInterface`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<HttpInterface>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<HttpInterface> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(HttpInterface { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl HttpInterface {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             HttpInterfacePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`HttpInterfaceIndices::new_instance`] and
+        /// [`HttpInterfaceIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<HttpInterface> {
+            let indices = HttpInterfaceIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -269,23 +355,50 @@ pub mod exports {
             handle_request: wasmtime::component::Func,
         }
         #[derive(Clone)]
-        pub struct GuestPre {
+        pub struct GuestIndices {
             handle_request: wasmtime::component::ComponentExportIndex,
         }
-        impl GuestPre {
+        impl GuestIndices {
+            /// Constructor for [`GuestIndices`] which takes a
+            /// [`Component`](wasmtime::component::Component) as input and can be executed
+            /// before instantiation.
+            ///
+            /// This constructor can be used to front-load string lookups to find exports
+            /// within a component.
             pub fn new(
                 component: &wasmtime::component::Component,
-            ) -> wasmtime::Result<GuestPre> {
-                let _component = component;
+            ) -> wasmtime::Result<GuestIndices> {
                 let (_, instance) = component
                     .export_index(None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
-                let _lookup = |name: &str| {
-                    _component
-                        .export_index(Some(&instance), name)
-                        .map(|p| p.1)
+                Self::_new(|name| {
+                    component.export_index(Some(&instance), name).map(|p| p.1)
+                })
+            }
+            /// This constructor is similar to [`GuestIndices::new`] except that it
+            /// performs string lookups after instantiation time.
+            pub fn new_instance(
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<GuestIndices> {
+                let instance_export = instance
+                    .get_export(&mut store, None, "http-handler")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `http-handler`")
+                    })?;
+                Self::_new(|name| {
+                    instance.get_export(&mut store, Some(&instance_export), name)
+                })
+            }
+            fn _new(
+                mut lookup: impl FnMut(
+                    &str,
+                ) -> Option<wasmtime::component::ComponentExportIndex>,
+            ) -> wasmtime::Result<GuestIndices> {
+                let mut lookup = move |name| {
+                    lookup(name)
                         .ok_or_else(|| {
                             anyhow::anyhow!(
                                 "instance export `http-handler` does \
@@ -293,8 +406,9 @@ pub mod exports {
                             )
                         })
                 };
-                let handle_request = _lookup("handle-request")?;
-                Ok(GuestPre { handle_request })
+                let _ = &mut lookup;
+                let handle_request = lookup("handle-request")?;
+                Ok(GuestIndices { handle_request })
             }
             pub fn load(
                 &self,

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::simple::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::simple::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::simple::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::simple::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::simple::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -229,7 +315,7 @@ pub mod exports {
                     f6: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     f1: wasmtime::component::ComponentExportIndex,
                     f2: wasmtime::component::ComponentExportIndex,
                     f3: wasmtime::component::ComponentExportIndex,
@@ -237,11 +323,16 @@ pub mod exports {
                     f5: wasmtime::component::ComponentExportIndex,
                     f6: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/simple")
                             .ok_or_else(|| {
@@ -249,10 +340,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/simple` does \
@@ -260,13 +375,21 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let f1 = _lookup("f1")?;
-                        let f2 = _lookup("f2")?;
-                        let f3 = _lookup("f3")?;
-                        let f4 = _lookup("f4")?;
-                        let f5 = _lookup("f5")?;
-                        let f6 = _lookup("f6")?;
-                        Ok(GuestPre { f1, f2, f3, f4, f5, f6 })
+                        let _ = &mut lookup;
+                        let f1 = lookup("f1")?;
+                        let f2 = lookup("f2")?;
+                        let f3 = lookup("f3")?;
+                        let f4 = lookup("f4")?;
+                        let f5 = lookup("f5")?;
+                        let f6 = lookup("f6")?;
+                        Ok(GuestIndices {
+                            f1,
+                            f2,
+                            f3,
+                            f4,
+                            f5,
+                            f6,
+                        })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::simple::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::simple::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::simple::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::simple::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::simple::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -242,7 +328,7 @@ pub mod exports {
                     f6: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     f1: wasmtime::component::ComponentExportIndex,
                     f2: wasmtime::component::ComponentExportIndex,
                     f3: wasmtime::component::ComponentExportIndex,
@@ -250,11 +336,16 @@ pub mod exports {
                     f5: wasmtime::component::ComponentExportIndex,
                     f6: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/simple")
                             .ok_or_else(|| {
@@ -262,10 +353,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/simple` does \
@@ -273,13 +388,21 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let f1 = _lookup("f1")?;
-                        let f2 = _lookup("f2")?;
-                        let f3 = _lookup("f3")?;
-                        let f4 = _lookup("f4")?;
-                        let f5 = _lookup("f5")?;
-                        let f6 = _lookup("f6")?;
-                        Ok(GuestPre { f1, f2, f3, f4, f5, f6 })
+                        let _ = &mut lookup;
+                        let f1 = lookup("f1")?;
+                        let f2 = lookup("f2")?;
+                        let f3 = lookup("f3")?;
+                        let f4 = lookup("f4")?;
+                        let f5 = lookup("f5")?;
+                        let f6 = lookup("f6")?;
+                        Ok(GuestIndices {
+                            f1,
+                            f2,
+                            f3,
+                            f4,
+                            f5,
+                            f6,
+                        })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -4,68 +4,147 @@
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`MyWorld`] as well.
 pub struct MyWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::simple_lists::GuestPre,
+    indices: MyWorldIndices,
 }
 impl<T> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> MyWorldPre<_T> {
+    /// Creates a new copy of `MyWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = MyWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`MyWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<MyWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `my-world`.
+///
+/// This is an implementation detail of [`MyWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`MyWorld`] as well.
+#[derive(Clone)]
+pub struct MyWorldIndices {
+    interface0: exports::foo::foo::simple_lists::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `my-world`.
 ///
-/// This structure is created through either
-/// [`MyWorld::instantiate`] or by first creating
-/// a [`MyWorldPre`] followed by using
-/// [`MyWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`MyWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`MyWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`MyWorldPre::instantiate`] to
+///   create a [`MyWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`MyWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`MyWorldIndices::new_instance`] followed
+///   by [`MyWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct MyWorld {
     interface0: exports::foo::foo::simple_lists::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> MyWorldPre<_T> {
-        /// Creates a new copy of `MyWorldPre` bindings which can then
+    impl MyWorldIndices {
+        /// Creates a new copy of `MyWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::simple_lists::GuestPre::new(_component)?;
-            Ok(MyWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::simple_lists::GuestIndices::new(
+                _component,
+            )?;
+            Ok(MyWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`MyWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`MyWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`MyWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`MyWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple_lists::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`MyWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<MyWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(MyWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl MyWorld {
@@ -78,6 +157,15 @@ const _: () = {
         ) -> wasmtime::Result<MyWorld> {
             let pre = linker.instantiate_pre(component)?;
             MyWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`MyWorldIndices::new_instance`] and
+        /// [`MyWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let indices = MyWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -252,17 +340,22 @@ pub mod exports {
                     simple_list4: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     simple_list1: wasmtime::component::ComponentExportIndex,
                     simple_list2: wasmtime::component::ComponentExportIndex,
                     simple_list3: wasmtime::component::ComponentExportIndex,
                     simple_list4: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
@@ -270,10 +363,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple-lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/simple-lists` does \
@@ -281,11 +398,12 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let simple_list1 = _lookup("simple-list1")?;
-                        let simple_list2 = _lookup("simple-list2")?;
-                        let simple_list3 = _lookup("simple-list3")?;
-                        let simple_list4 = _lookup("simple-list4")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let simple_list1 = lookup("simple-list1")?;
+                        let simple_list2 = lookup("simple-list2")?;
+                        let simple_list3 = lookup("simple-list3")?;
+                        let simple_list4 = lookup("simple-list4")?;
+                        Ok(GuestIndices {
                             simple_list1,
                             simple_list2,
                             simple_list3,

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -80,7 +80,7 @@ pub struct MyWorldIndices {
 ///   create a [`MyWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`MyWorld::new_instance`]
+///   then you can use [`MyWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`MyWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -4,71 +4,150 @@
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`MyWorld`] as well.
 pub struct MyWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::simple_lists::GuestPre,
+    indices: MyWorldIndices,
 }
 impl<T> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> MyWorldPre<_T> {
+    /// Creates a new copy of `MyWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = MyWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`MyWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<MyWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `my-world`.
+///
+/// This is an implementation detail of [`MyWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`MyWorld`] as well.
+#[derive(Clone)]
+pub struct MyWorldIndices {
+    interface0: exports::foo::foo::simple_lists::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `my-world`.
 ///
-/// This structure is created through either
-/// [`MyWorld::instantiate_async`] or by first creating
-/// a [`MyWorldPre`] followed by using
-/// [`MyWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`MyWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`MyWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`MyWorldPre::instantiate_async`] to
+///   create a [`MyWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`MyWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`MyWorldIndices::new_instance`] followed
+///   by [`MyWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct MyWorld {
     interface0: exports::foo::foo::simple_lists::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> MyWorldPre<_T> {
-        /// Creates a new copy of `MyWorldPre` bindings which can then
+    impl MyWorldIndices {
+        /// Creates a new copy of `MyWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::simple_lists::GuestPre::new(_component)?;
-            Ok(MyWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::simple_lists::GuestIndices::new(
+                _component,
+            )?;
+            Ok(MyWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`MyWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`MyWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`MyWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`MyWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple_lists::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`MyWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<MyWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(MyWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl MyWorld {
@@ -84,6 +163,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             MyWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`MyWorldIndices::new_instance`] and
+        /// [`MyWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let indices = MyWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -269,17 +357,22 @@ pub mod exports {
                     simple_list4: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     simple_list1: wasmtime::component::ComponentExportIndex,
                     simple_list2: wasmtime::component::ComponentExportIndex,
                     simple_list3: wasmtime::component::ComponentExportIndex,
                     simple_list4: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
@@ -287,10 +380,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple-lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/simple-lists` does \
@@ -298,11 +415,12 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let simple_list1 = _lookup("simple-list1")?;
-                        let simple_list2 = _lookup("simple-list2")?;
-                        let simple_list3 = _lookup("simple-list3")?;
-                        let simple_list4 = _lookup("simple-list4")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let simple_list1 = lookup("simple-list1")?;
+                        let simple_list2 = lookup("simple-list2")?;
+                        let simple_list3 = lookup("simple-list3")?;
+                        let simple_list4 = lookup("simple-list4")?;
+                        Ok(GuestIndices {
                             simple_list1,
                             simple_list2,
                             simple_list3,

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -83,7 +83,7 @@ pub struct MyWorldIndices {
 ///   create a [`MyWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`MyWorld::new_instance`]
+///   then you can use [`MyWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`MyWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -4,59 +4,135 @@
 /// This structure is created through [`WasiPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Wasi`] as well.
 pub struct WasiPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: WasiIndices,
 }
 impl<T> Clone for WasiPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> WasiPre<_T> {
+    /// Creates a new copy of `WasiPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = WasiIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Wasi`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Wasi> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `wasi`.
+///
+/// This is an implementation detail of [`WasiPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Wasi`] as well.
+#[derive(Clone)]
+pub struct WasiIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `wasi`.
 ///
-/// This structure is created through either
-/// [`Wasi::instantiate`] or by first creating
-/// a [`WasiPre`] followed by using
-/// [`WasiPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Wasi::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`WasiPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`WasiPre::instantiate`] to
+///   create a [`Wasi`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Wasi::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`WasiIndices::new_instance`] followed
+///   by [`WasiIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Wasi {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> WasiPre<_T> {
-        /// Creates a new copy of `WasiPre` bindings which can then
+    impl WasiIndices {
+        /// Creates a new copy of `WasiIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(WasiPre { instance_pre })
+            let _component = component;
+            Ok(WasiIndices {})
         }
-        /// Instantiates a new instance of [`Wasi`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`WasiIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Wasi`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Wasi`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(WasiIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Wasi`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Wasi> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(Wasi {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Wasi {
@@ -69,6 +145,15 @@ const _: () = {
         ) -> wasmtime::Result<Wasi> {
             let pre = linker.instantiate_pre(component)?;
             WasiPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`WasiIndices::new_instance`] and
+        /// [`WasiIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Wasi> {
+            let indices = WasiIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -78,7 +78,7 @@ pub struct WasiIndices {}
 ///   create a [`Wasi`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Wasi::new_instance`]
+///   then you can use [`Wasi::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`WasiIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -81,7 +81,7 @@ pub struct WasiIndices {}
 ///   create a [`Wasi`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Wasi::new_instance`]
+///   then you can use [`Wasi::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`WasiIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -4,62 +4,138 @@
 /// This structure is created through [`WasiPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Wasi`] as well.
 pub struct WasiPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: WasiIndices,
 }
 impl<T> Clone for WasiPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> WasiPre<_T> {
+    /// Creates a new copy of `WasiPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = WasiIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Wasi`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Wasi>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `wasi`.
+///
+/// This is an implementation detail of [`WasiPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Wasi`] as well.
+#[derive(Clone)]
+pub struct WasiIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `wasi`.
 ///
-/// This structure is created through either
-/// [`Wasi::instantiate_async`] or by first creating
-/// a [`WasiPre`] followed by using
-/// [`WasiPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Wasi::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`WasiPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`WasiPre::instantiate_async`] to
+///   create a [`Wasi`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Wasi::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`WasiIndices::new_instance`] followed
+///   by [`WasiIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Wasi {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> WasiPre<_T> {
-        /// Creates a new copy of `WasiPre` bindings which can then
+    impl WasiIndices {
+        /// Creates a new copy of `WasiIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(WasiPre { instance_pre })
+            let _component = component;
+            Ok(WasiIndices {})
         }
-        /// Instantiates a new instance of [`Wasi`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`WasiIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Wasi`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Wasi`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(WasiIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Wasi`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Wasi>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Wasi> {
+            let _instance = instance;
             Ok(Wasi {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Wasi {
@@ -75,6 +151,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             WasiPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`WasiIndices::new_instance`] and
+        /// [`WasiIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Wasi> {
+            let indices = WasiIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::anon::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::anon::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::anon::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::anon::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::anon::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::anon::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -262,23 +348,50 @@ pub mod exports {
                     option_test: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     option_test: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/anon")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("no exported instance named `foo:foo/anon`")
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/anon` does \
@@ -286,8 +399,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let option_test = _lookup("option-test")?;
-                        Ok(GuestPre { option_test })
+                        let _ = &mut lookup;
+                        let option_test = lookup("option-test")?;
+                        Ok(GuestIndices { option_test })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::anon::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::anon::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::anon::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::anon::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::anon::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::anon::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -275,23 +361,50 @@ pub mod exports {
                     option_test: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     option_test: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/anon")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("no exported instance named `foo:foo/anon`")
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/anon` does \
@@ -299,8 +412,9 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let option_test = _lookup("option-test")?;
-                        Ok(GuestPre { option_test })
+                        let _ = &mut lookup;
+                        let option_test = lookup("option-test")?;
+                        Ok(GuestIndices { option_test })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -4,68 +4,147 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    y: wasmtime::component::ComponentExportIndex,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            y: self.y.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    y: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     y: wasmtime::component::Func,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
+            let _component = component;
             let y = _component
                 .export_index(None, "y")
                 .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?
                 .1;
-            Ok(TheWorldPre { instance_pre, y })
+            Ok(TheWorldIndices { y })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let y = _instance
+                .get_export(&mut store, None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
+            Ok(TheWorldIndices { y })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let y = *_instance.get_typed_func::<(), ()>(&mut store, &self.y)?.func();
             Ok(TheWorld { y })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +157,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn call_y<S: wasmtime::AsContextMut>(
             &self,

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/smoke-default_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_async.rs
@@ -4,71 +4,150 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    y: wasmtime::component::ComponentExportIndex,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            y: self.y.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    y: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     y: wasmtime::component::Func,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
+            let _component = component;
             let y = _component
                 .export_index(None, "y")
                 .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?
                 .1;
-            Ok(TheWorldPre { instance_pre, y })
+            Ok(TheWorldIndices { y })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let y = _instance
+                .get_export(&mut store, None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
+            Ok(TheWorldIndices { y })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let y = *_instance.get_typed_func::<(), ()>(&mut store, &self.y)?.func();
             Ok(TheWorld { y })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +163,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub async fn call_y<S: wasmtime::AsContextMut>(
             &self,

--- a/crates/component-macro/tests/expanded/smoke-default_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::the_name::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::the_name::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::the_name::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::the_name::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::the_name::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::the_name::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn the_name(&self) -> &exports::the_name::Guest {
             &self.interface0
@@ -93,23 +179,50 @@ pub mod exports {
             y: wasmtime::component::Func,
         }
         #[derive(Clone)]
-        pub struct GuestPre {
+        pub struct GuestIndices {
             y: wasmtime::component::ComponentExportIndex,
         }
-        impl GuestPre {
+        impl GuestIndices {
+            /// Constructor for [`GuestIndices`] which takes a
+            /// [`Component`](wasmtime::component::Component) as input and can be executed
+            /// before instantiation.
+            ///
+            /// This constructor can be used to front-load string lookups to find exports
+            /// within a component.
             pub fn new(
                 component: &wasmtime::component::Component,
-            ) -> wasmtime::Result<GuestPre> {
-                let _component = component;
+            ) -> wasmtime::Result<GuestIndices> {
                 let (_, instance) = component
                     .export_index(None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
-                let _lookup = |name: &str| {
-                    _component
-                        .export_index(Some(&instance), name)
-                        .map(|p| p.1)
+                Self::_new(|name| {
+                    component.export_index(Some(&instance), name).map(|p| p.1)
+                })
+            }
+            /// This constructor is similar to [`GuestIndices::new`] except that it
+            /// performs string lookups after instantiation time.
+            pub fn new_instance(
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<GuestIndices> {
+                let instance_export = instance
+                    .get_export(&mut store, None, "the-name")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `the-name`")
+                    })?;
+                Self::_new(|name| {
+                    instance.get_export(&mut store, Some(&instance_export), name)
+                })
+            }
+            fn _new(
+                mut lookup: impl FnMut(
+                    &str,
+                ) -> Option<wasmtime::component::ComponentExportIndex>,
+            ) -> wasmtime::Result<GuestIndices> {
+                let mut lookup = move |name| {
+                    lookup(name)
                         .ok_or_else(|| {
                             anyhow::anyhow!(
                                 "instance export `the-name` does \
@@ -117,8 +230,9 @@ pub mod exports {
                             )
                         })
                 };
-                let y = _lookup("y")?;
-                Ok(GuestPre { y })
+                let _ = &mut lookup;
+                let y = lookup("y")?;
+                Ok(GuestIndices { y })
             }
             pub fn load(
                 &self,

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::the_name::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::the_name::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::the_name::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::the_name::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::the_name::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::the_name::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -85,6 +162,15 @@ const _: () = {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
         }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
         pub fn the_name(&self) -> &exports::the_name::Guest {
             &self.interface0
         }
@@ -99,23 +185,50 @@ pub mod exports {
             y: wasmtime::component::Func,
         }
         #[derive(Clone)]
-        pub struct GuestPre {
+        pub struct GuestIndices {
             y: wasmtime::component::ComponentExportIndex,
         }
-        impl GuestPre {
+        impl GuestIndices {
+            /// Constructor for [`GuestIndices`] which takes a
+            /// [`Component`](wasmtime::component::Component) as input and can be executed
+            /// before instantiation.
+            ///
+            /// This constructor can be used to front-load string lookups to find exports
+            /// within a component.
             pub fn new(
                 component: &wasmtime::component::Component,
-            ) -> wasmtime::Result<GuestPre> {
-                let _component = component;
+            ) -> wasmtime::Result<GuestIndices> {
                 let (_, instance) = component
                     .export_index(None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
-                let _lookup = |name: &str| {
-                    _component
-                        .export_index(Some(&instance), name)
-                        .map(|p| p.1)
+                Self::_new(|name| {
+                    component.export_index(Some(&instance), name).map(|p| p.1)
+                })
+            }
+            /// This constructor is similar to [`GuestIndices::new`] except that it
+            /// performs string lookups after instantiation time.
+            pub fn new_instance(
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<GuestIndices> {
+                let instance_export = instance
+                    .get_export(&mut store, None, "the-name")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `the-name`")
+                    })?;
+                Self::_new(|name| {
+                    instance.get_export(&mut store, Some(&instance_export), name)
+                })
+            }
+            fn _new(
+                mut lookup: impl FnMut(
+                    &str,
+                ) -> Option<wasmtime::component::ComponentExportIndex>,
+            ) -> wasmtime::Result<GuestIndices> {
+                let mut lookup = move |name| {
+                    lookup(name)
                         .ok_or_else(|| {
                             anyhow::anyhow!(
                                 "instance export `the-name` does \
@@ -123,8 +236,9 @@ pub mod exports {
                             )
                         })
                 };
-                let y = _lookup("y")?;
-                Ok(GuestPre { y })
+                let _ = &mut lookup;
+                let y = lookup("y")?;
+                Ok(GuestIndices { y })
             }
             pub fn load(
                 &self,

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -4,59 +4,135 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(TheWorldPre { instance_pre })
+            let _component = component;
+            Ok(TheWorldIndices {})
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(TheWorldIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(TheWorld {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -69,6 +145,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -78,7 +78,7 @@ pub struct TheWorldIndices {}
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -81,7 +81,7 @@ pub struct TheWorldIndices {}
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -4,62 +4,138 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(TheWorldPre { instance_pre })
+            let _component = component;
+            Ok(TheWorldIndices {})
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(TheWorldIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             Ok(TheWorld {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -75,6 +151,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -80,7 +80,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::strings::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::strings::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::strings::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::strings::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::strings::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::strings::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<TheWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<TheWorld> {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -204,16 +290,21 @@ pub mod exports {
                     c: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     a: wasmtime::component::ComponentExportIndex,
                     b: wasmtime::component::ComponentExportIndex,
                     c: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/strings")
                             .ok_or_else(|| {
@@ -221,10 +312,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/strings")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/strings`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/strings` does \
@@ -232,10 +347,11 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let a = _lookup("a")?;
-                        let b = _lookup("b")?;
-                        let c = _lookup("c")?;
-                        Ok(GuestPre { a, b, c })
+                        let _ = &mut lookup;
+                        let a = lookup("a")?;
+                        let b = lookup("b")?;
+                        let c = lookup("c")?;
+                        Ok(GuestIndices { a, b, c })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -83,7 +83,7 @@ pub struct TheWorldIndices {
 ///   create a [`TheWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new_instance`]
+///   then you can use [`TheWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`TheWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`TheWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
 pub struct TheWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::strings::GuestPre,
+    indices: TheWorldIndices,
 }
 impl<T> Clone for TheWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::strings::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `the-world`.
 ///
-/// This structure is created through either
-/// [`TheWorld::instantiate_async`] or by first creating
-/// a [`TheWorldPre`] followed by using
-/// [`TheWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {
     interface0: exports::foo::foo::strings::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> TheWorldPre<_T> {
-        /// Creates a new copy of `TheWorldPre` bindings which can then
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::strings::GuestPre::new(_component)?;
-            Ok(TheWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::strings::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`TheWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::strings::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<TheWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(TheWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl TheWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -217,16 +303,21 @@ pub mod exports {
                     c: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     a: wasmtime::component::ComponentExportIndex,
                     b: wasmtime::component::ComponentExportIndex,
                     c: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/strings")
                             .ok_or_else(|| {
@@ -234,10 +325,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/strings")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/strings`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/strings` does \
@@ -245,10 +360,11 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let a = _lookup("a")?;
-                        let b = _lookup("b")?;
-                        let c = _lookup("c")?;
-                        Ok(GuestPre { a, b, c })
+                        let _ = &mut lookup;
+                        let a = lookup("a")?;
+                        let b = lookup("b")?;
+                        let c = lookup("c")?;
+                        Ok(GuestIndices { a, b, c })
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -4,59 +4,135 @@
 /// This structure is created through [`NopePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Nope`] as well.
 pub struct NopePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: NopeIndices,
 }
 impl<T> Clone for NopePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> NopePre<_T> {
+    /// Creates a new copy of `NopePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = NopeIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Nope`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Nope> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `nope`.
+///
+/// This is an implementation detail of [`NopePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Nope`] as well.
+#[derive(Clone)]
+pub struct NopeIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `nope`.
 ///
-/// This structure is created through either
-/// [`Nope::instantiate`] or by first creating
-/// a [`NopePre`] followed by using
-/// [`NopePre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Nope::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`NopePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`NopePre::instantiate`] to
+///   create a [`Nope`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Nope::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`NopeIndices::new_instance`] followed
+///   by [`NopeIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Nope {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> NopePre<_T> {
-        /// Creates a new copy of `NopePre` bindings which can then
+    impl NopeIndices {
+        /// Creates a new copy of `NopeIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(NopePre { instance_pre })
+            let _component = component;
+            Ok(NopeIndices {})
         }
-        /// Instantiates a new instance of [`Nope`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`NopeIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Nope`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Nope`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(NopeIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Nope`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Nope> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(Nope {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Nope {
@@ -69,6 +145,15 @@ const _: () = {
         ) -> wasmtime::Result<Nope> {
             let pre = linker.instantiate_pre(component)?;
             NopePre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`NopeIndices::new_instance`] and
+        /// [`NopeIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Nope> {
+            let indices = NopeIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -78,7 +78,7 @@ pub struct NopeIndices {}
 ///   create a [`Nope`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Nope::new_instance`]
+///   then you can use [`Nope::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`NopeIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -4,62 +4,138 @@
 /// This structure is created through [`NopePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Nope`] as well.
 pub struct NopePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: NopeIndices,
 }
 impl<T> Clone for NopePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> NopePre<_T> {
+    /// Creates a new copy of `NopePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = NopeIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Nope`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Nope>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `nope`.
+///
+/// This is an implementation detail of [`NopePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Nope`] as well.
+#[derive(Clone)]
+pub struct NopeIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `nope`.
 ///
-/// This structure is created through either
-/// [`Nope::instantiate_async`] or by first creating
-/// a [`NopePre`] followed by using
-/// [`NopePre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Nope::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`NopePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`NopePre::instantiate_async`] to
+///   create a [`Nope`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Nope::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`NopeIndices::new_instance`] followed
+///   by [`NopeIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Nope {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> NopePre<_T> {
-        /// Creates a new copy of `NopePre` bindings which can then
+    impl NopeIndices {
+        /// Creates a new copy of `NopeIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(NopePre { instance_pre })
+            let _component = component;
+            Ok(NopeIndices {})
         }
-        /// Instantiates a new instance of [`Nope`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`NopeIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Nope`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Nope`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(NopeIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Nope`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Nope>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Nope> {
+            let _instance = instance;
             Ok(Nope {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Nope {
@@ -75,6 +151,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             NopePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`NopeIndices::new_instance`] and
+        /// [`NopeIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Nope> {
+            let indices = NopeIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -81,7 +81,7 @@ pub struct NopeIndices {}
 ///   create a [`Nope`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Nope::new_instance`]
+///   then you can use [`Nope::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`NopeIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -4,59 +4,135 @@
 /// This structure is created through [`DPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`D`] as well.
 pub struct DPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: DIndices,
 }
 impl<T> Clone for DPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> DPre<_T> {
+    /// Creates a new copy of `DPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = DIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`D`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<D> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `d`.
+///
+/// This is an implementation detail of [`DPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`D`] as well.
+#[derive(Clone)]
+pub struct DIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `d`.
 ///
-/// This structure is created through either
-/// [`D::instantiate`] or by first creating
-/// a [`DPre`] followed by using
-/// [`DPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`D::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`DPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`DPre::instantiate`] to
+///   create a [`D`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`D::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`DIndices::new_instance`] followed
+///   by [`DIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct D {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> DPre<_T> {
-        /// Creates a new copy of `DPre` bindings which can then
+    impl DIndices {
+        /// Creates a new copy of `DIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(DPre { instance_pre })
+            let _component = component;
+            Ok(DIndices {})
         }
-        /// Instantiates a new instance of [`D`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`DIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`D`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`D`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(DIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`D`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<D> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             Ok(D {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl D {
@@ -69,6 +145,15 @@ const _: () = {
         ) -> wasmtime::Result<D> {
             let pre = linker.instantiate_pre(component)?;
             DPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`DIndices::new_instance`] and
+        /// [`DIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<D> {
+            let indices = DIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -78,7 +78,7 @@ pub struct DIndices {}
 ///   create a [`D`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`D::new_instance`]
+///   then you can use [`D::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`DIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -4,62 +4,138 @@
 /// This structure is created through [`DPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`D`] as well.
 pub struct DPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
+    indices: DIndices,
 }
 impl<T> Clone for DPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
         }
     }
 }
+impl<_T> DPre<_T> {
+    /// Creates a new copy of `DPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = DIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`D`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<D>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `d`.
+///
+/// This is an implementation detail of [`DPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`D`] as well.
+#[derive(Clone)]
+pub struct DIndices {}
 /// Auto-generated bindings for an instance a component which
 /// implements the world `d`.
 ///
-/// This structure is created through either
-/// [`D::instantiate_async`] or by first creating
-/// a [`DPre`] followed by using
-/// [`DPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`D::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`DPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`DPre::instantiate_async`] to
+///   create a [`D`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`D::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`DIndices::new_instance`] followed
+///   by [`DIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct D {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> DPre<_T> {
-        /// Creates a new copy of `DPre` bindings which can then
+    impl DIndices {
+        /// Creates a new copy of `DIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            Ok(DPre { instance_pre })
+            let _component = component;
+            Ok(DIndices {})
         }
-        /// Instantiates a new instance of [`D`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`DIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`D`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`D`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(DIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`D`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<D>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<D> {
+            let _instance = instance;
             Ok(D {})
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl D {
@@ -75,6 +151,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             DPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`DIndices::new_instance`] and
+        /// [`DIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<D> {
+            let indices = DIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -81,7 +81,7 @@ pub struct DIndices {}
 ///   create a [`D`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`D::new_instance`]
+///   then you can use [`D::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`DIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -4,68 +4,145 @@
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`MyWorld`] as well.
 pub struct MyWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::variants::GuestPre,
+    indices: MyWorldIndices,
 }
 impl<T> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> MyWorldPre<_T> {
+    /// Creates a new copy of `MyWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = MyWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`MyWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<MyWorld> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `my-world`.
+///
+/// This is an implementation detail of [`MyWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`MyWorld`] as well.
+#[derive(Clone)]
+pub struct MyWorldIndices {
+    interface0: exports::foo::foo::variants::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `my-world`.
 ///
-/// This structure is created through either
-/// [`MyWorld::instantiate`] or by first creating
-/// a [`MyWorldPre`] followed by using
-/// [`MyWorldPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`MyWorld::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`MyWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`MyWorldPre::instantiate`] to
+///   create a [`MyWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`MyWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`MyWorldIndices::new_instance`] followed
+///   by [`MyWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct MyWorld {
     interface0: exports::foo::foo::variants::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> MyWorldPre<_T> {
-        /// Creates a new copy of `MyWorldPre` bindings which can then
+    impl MyWorldIndices {
+        /// Creates a new copy of `MyWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::variants::GuestPre::new(_component)?;
-            Ok(MyWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::variants::GuestIndices::new(_component)?;
+            Ok(MyWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`MyWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`MyWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`MyWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`MyWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::variants::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`MyWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<MyWorld> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(MyWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl MyWorld {
@@ -78,6 +155,15 @@ const _: () = {
         ) -> wasmtime::Result<MyWorld> {
             let pre = linker.instantiate_pre(component)?;
             MyWorldPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`MyWorldIndices::new_instance`] and
+        /// [`MyWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let indices = MyWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -1212,7 +1298,7 @@ pub mod exports {
                     return_named_result: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     e1_arg: wasmtime::component::ComponentExportIndex,
                     e1_result: wasmtime::component::ComponentExportIndex,
                     v1_arg: wasmtime::component::ComponentExportIndex,
@@ -1236,11 +1322,16 @@ pub mod exports {
                     return_named_option: wasmtime::component::ComponentExportIndex,
                     return_named_result: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/variants")
                             .ok_or_else(|| {
@@ -1248,10 +1339,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/variants")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/variants`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/variants` does \
@@ -1259,29 +1374,30 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let e1_arg = _lookup("e1-arg")?;
-                        let e1_result = _lookup("e1-result")?;
-                        let v1_arg = _lookup("v1-arg")?;
-                        let v1_result = _lookup("v1-result")?;
-                        let bool_arg = _lookup("bool-arg")?;
-                        let bool_result = _lookup("bool-result")?;
-                        let option_arg = _lookup("option-arg")?;
-                        let option_result = _lookup("option-result")?;
-                        let casts = _lookup("casts")?;
-                        let result_arg = _lookup("result-arg")?;
-                        let result_result = _lookup("result-result")?;
-                        let return_result_sugar = _lookup("return-result-sugar")?;
-                        let return_result_sugar2 = _lookup("return-result-sugar2")?;
-                        let return_result_sugar3 = _lookup("return-result-sugar3")?;
-                        let return_result_sugar4 = _lookup("return-result-sugar4")?;
-                        let return_option_sugar = _lookup("return-option-sugar")?;
-                        let return_option_sugar2 = _lookup("return-option-sugar2")?;
-                        let result_simple = _lookup("result-simple")?;
-                        let is_clone_arg = _lookup("is-clone-arg")?;
-                        let is_clone_return = _lookup("is-clone-return")?;
-                        let return_named_option = _lookup("return-named-option")?;
-                        let return_named_result = _lookup("return-named-result")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let e1_arg = lookup("e1-arg")?;
+                        let e1_result = lookup("e1-result")?;
+                        let v1_arg = lookup("v1-arg")?;
+                        let v1_result = lookup("v1-result")?;
+                        let bool_arg = lookup("bool-arg")?;
+                        let bool_result = lookup("bool-result")?;
+                        let option_arg = lookup("option-arg")?;
+                        let option_result = lookup("option-result")?;
+                        let casts = lookup("casts")?;
+                        let result_arg = lookup("result-arg")?;
+                        let result_result = lookup("result-result")?;
+                        let return_result_sugar = lookup("return-result-sugar")?;
+                        let return_result_sugar2 = lookup("return-result-sugar2")?;
+                        let return_result_sugar3 = lookup("return-result-sugar3")?;
+                        let return_result_sugar4 = lookup("return-result-sugar4")?;
+                        let return_option_sugar = lookup("return-option-sugar")?;
+                        let return_option_sugar2 = lookup("return-option-sugar2")?;
+                        let result_simple = lookup("result-simple")?;
+                        let is_clone_arg = lookup("is-clone-arg")?;
+                        let is_clone_return = lookup("is-clone-return")?;
+                        let return_named_option = lookup("return-named-option")?;
+                        let return_named_result = lookup("return-named-result")?;
+                        Ok(GuestIndices {
                             e1_arg,
                             e1_result,
                             v1_arg,

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -80,7 +80,7 @@ pub struct MyWorldIndices {
 ///   create a [`MyWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`MyWorld::new_instance`]
+///   then you can use [`MyWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`MyWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -4,71 +4,148 @@
 /// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`MyWorld`] as well.
 pub struct MyWorldPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::foo::foo::variants::GuestPre,
+    indices: MyWorldIndices,
 }
 impl<T> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> MyWorldPre<_T> {
+    /// Creates a new copy of `MyWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = MyWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`MyWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<MyWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `my-world`.
+///
+/// This is an implementation detail of [`MyWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`MyWorld`] as well.
+#[derive(Clone)]
+pub struct MyWorldIndices {
+    interface0: exports::foo::foo::variants::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `my-world`.
 ///
-/// This structure is created through either
-/// [`MyWorld::instantiate_async`] or by first creating
-/// a [`MyWorldPre`] followed by using
-/// [`MyWorldPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`MyWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`MyWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`MyWorldPre::instantiate_async`] to
+///   create a [`MyWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`MyWorld::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`MyWorldIndices::new_instance`] followed
+///   by [`MyWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct MyWorld {
     interface0: exports::foo::foo::variants::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> MyWorldPre<_T> {
-        /// Creates a new copy of `MyWorldPre` bindings which can then
+    impl MyWorldIndices {
+        /// Creates a new copy of `MyWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::foo::foo::variants::GuestPre::new(_component)?;
-            Ok(MyWorldPre {
-                instance_pre,
-                interface0,
-            })
+            let _component = component;
+            let interface0 = exports::foo::foo::variants::GuestIndices::new(_component)?;
+            Ok(MyWorldIndices { interface0 })
         }
-        /// Instantiates a new instance of [`MyWorld`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`MyWorldIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`MyWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`MyWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::variants::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`MyWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<MyWorld>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(MyWorld { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl MyWorld {
@@ -84,6 +161,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             MyWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`MyWorldIndices::new_instance`] and
+        /// [`MyWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let indices = MyWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,
@@ -1228,7 +1314,7 @@ pub mod exports {
                     return_named_result: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
-                pub struct GuestPre {
+                pub struct GuestIndices {
                     e1_arg: wasmtime::component::ComponentExportIndex,
                     e1_result: wasmtime::component::ComponentExportIndex,
                     v1_arg: wasmtime::component::ComponentExportIndex,
@@ -1252,11 +1338,16 @@ pub mod exports {
                     return_named_option: wasmtime::component::ComponentExportIndex,
                     return_named_result: wasmtime::component::ComponentExportIndex,
                 }
-                impl GuestPre {
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "foo:foo/variants")
                             .ok_or_else(|| {
@@ -1264,10 +1355,34 @@ pub mod exports {
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/variants")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/variants`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/variants` does \
@@ -1275,29 +1390,30 @@ pub mod exports {
                                     )
                                 })
                         };
-                        let e1_arg = _lookup("e1-arg")?;
-                        let e1_result = _lookup("e1-result")?;
-                        let v1_arg = _lookup("v1-arg")?;
-                        let v1_result = _lookup("v1-result")?;
-                        let bool_arg = _lookup("bool-arg")?;
-                        let bool_result = _lookup("bool-result")?;
-                        let option_arg = _lookup("option-arg")?;
-                        let option_result = _lookup("option-result")?;
-                        let casts = _lookup("casts")?;
-                        let result_arg = _lookup("result-arg")?;
-                        let result_result = _lookup("result-result")?;
-                        let return_result_sugar = _lookup("return-result-sugar")?;
-                        let return_result_sugar2 = _lookup("return-result-sugar2")?;
-                        let return_result_sugar3 = _lookup("return-result-sugar3")?;
-                        let return_result_sugar4 = _lookup("return-result-sugar4")?;
-                        let return_option_sugar = _lookup("return-option-sugar")?;
-                        let return_option_sugar2 = _lookup("return-option-sugar2")?;
-                        let result_simple = _lookup("result-simple")?;
-                        let is_clone_arg = _lookup("is-clone-arg")?;
-                        let is_clone_return = _lookup("is-clone-return")?;
-                        let return_named_option = _lookup("return-named-option")?;
-                        let return_named_result = _lookup("return-named-result")?;
-                        Ok(GuestPre {
+                        let _ = &mut lookup;
+                        let e1_arg = lookup("e1-arg")?;
+                        let e1_result = lookup("e1-result")?;
+                        let v1_arg = lookup("v1-arg")?;
+                        let v1_result = lookup("v1-result")?;
+                        let bool_arg = lookup("bool-arg")?;
+                        let bool_result = lookup("bool-result")?;
+                        let option_arg = lookup("option-arg")?;
+                        let option_result = lookup("option-result")?;
+                        let casts = lookup("casts")?;
+                        let result_arg = lookup("result-arg")?;
+                        let result_result = lookup("result-result")?;
+                        let return_result_sugar = lookup("return-result-sugar")?;
+                        let return_result_sugar2 = lookup("return-result-sugar2")?;
+                        let return_result_sugar3 = lookup("return-result-sugar3")?;
+                        let return_result_sugar4 = lookup("return-result-sugar4")?;
+                        let return_option_sugar = lookup("return-option-sugar")?;
+                        let return_option_sugar2 = lookup("return-option-sugar2")?;
+                        let result_simple = lookup("result-simple")?;
+                        let is_clone_arg = lookup("is-clone-arg")?;
+                        let is_clone_return = lookup("is-clone-return")?;
+                        let return_named_option = lookup("return-named-option")?;
+                        let return_named_result = lookup("return-named-result")?;
+                        Ok(GuestIndices {
                             e1_arg,
                             e1_result,
                             v1_arg,

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -83,7 +83,7 @@ pub struct MyWorldIndices {
 ///   create a [`MyWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`MyWorld::new_instance`]
+///   then you can use [`MyWorld::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`MyWorldIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/wat.rs
+++ b/crates/component-macro/tests/expanded/wat.rs
@@ -4,70 +4,147 @@
 /// This structure is created through [`ExamplePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Example`] as well.
 pub struct ExamplePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::same::name::this_name_is_duplicated::GuestPre,
+    indices: ExampleIndices,
 }
 impl<T> Clone for ExamplePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> ExamplePre<_T> {
+    /// Creates a new copy of `ExamplePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = ExampleIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Example`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Example> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `example`.
+///
+/// This is an implementation detail of [`ExamplePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Example`] as well.
+#[derive(Clone)]
+pub struct ExampleIndices {
+    interface0: exports::same::name::this_name_is_duplicated::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `example`.
 ///
-/// This structure is created through either
-/// [`Example::instantiate`] or by first creating
-/// a [`ExamplePre`] followed by using
-/// [`ExamplePre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Example::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`ExamplePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`ExamplePre::instantiate`] to
+///   create a [`Example`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Example::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`ExampleIndices::new_instance`] followed
+///   by [`ExampleIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Example {
     interface0: exports::same::name::this_name_is_duplicated::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> ExamplePre<_T> {
-        /// Creates a new copy of `ExamplePre` bindings which can then
+    impl ExampleIndices {
+        /// Creates a new copy of `ExampleIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::same::name::this_name_is_duplicated::GuestPre::new(
+            let _component = component;
+            let interface0 = exports::same::name::this_name_is_duplicated::GuestIndices::new(
                 _component,
             )?;
-            Ok(ExamplePre {
-                instance_pre,
-                interface0,
-            })
+            Ok(ExampleIndices { interface0 })
         }
-        /// Instantiates a new instance of [`Example`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`ExampleIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Example`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Example`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::same::name::this_name_is_duplicated::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(ExampleIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Example`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Example> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(Example { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Example {
@@ -80,6 +157,15 @@ const _: () = {
         ) -> wasmtime::Result<Example> {
             let pre = linker.instantiate_pre(component)?;
             ExamplePre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`ExampleIndices::new_instance`] and
+        /// [`ExampleIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Example> {
+            let indices = ExampleIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn same_name_this_name_is_duplicated(
             &self,
@@ -101,12 +187,17 @@ pub mod exports {
                 }
                 pub struct Guest {}
                 #[derive(Clone)]
-                pub struct GuestPre {}
-                impl GuestPre {
+                pub struct GuestIndices {}
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "same:name/this-name-is-duplicated")
                             .ok_or_else(|| {
@@ -114,10 +205,38 @@ pub mod exports {
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(
+                                &mut store,
+                                None,
+                                "same:name/this-name-is-duplicated",
+                            )
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `same:name/this-name-is-duplicated`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `same:name/this-name-is-duplicated` does \
@@ -125,7 +244,8 @@ pub mod exports {
                                     )
                                 })
                         };
-                        Ok(GuestPre {})
+                        let _ = &mut lookup;
+                        Ok(GuestIndices {})
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/wat.rs
+++ b/crates/component-macro/tests/expanded/wat.rs
@@ -80,7 +80,7 @@ pub struct ExampleIndices {
 ///   create a [`Example`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Example::new_instance`]
+///   then you can use [`Example::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`ExampleIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/wat_async.rs
+++ b/crates/component-macro/tests/expanded/wat_async.rs
@@ -4,73 +4,150 @@
 /// This structure is created through [`ExamplePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Example`] as well.
 pub struct ExamplePre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    interface0: exports::same::name::this_name_is_duplicated::GuestPre,
+    indices: ExampleIndices,
 }
 impl<T> Clone for ExamplePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            interface0: self.interface0.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> ExamplePre<_T> {
+    /// Creates a new copy of `ExamplePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = ExampleIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Example`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Example>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `example`.
+///
+/// This is an implementation detail of [`ExamplePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Example`] as well.
+#[derive(Clone)]
+pub struct ExampleIndices {
+    interface0: exports::same::name::this_name_is_duplicated::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `example`.
 ///
-/// This structure is created through either
-/// [`Example::instantiate_async`] or by first creating
-/// a [`ExamplePre`] followed by using
-/// [`ExamplePre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Example::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`ExamplePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`ExamplePre::instantiate_async`] to
+///   create a [`Example`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Example::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`ExampleIndices::new_instance`] followed
+///   by [`ExampleIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Example {
     interface0: exports::same::name::this_name_is_duplicated::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> ExamplePre<_T> {
-        /// Creates a new copy of `ExamplePre` bindings which can then
+    impl ExampleIndices {
+        /// Creates a new copy of `ExampleIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
-            let interface0 = exports::same::name::this_name_is_duplicated::GuestPre::new(
+            let _component = component;
+            let interface0 = exports::same::name::this_name_is_duplicated::GuestIndices::new(
                 _component,
             )?;
-            Ok(ExamplePre {
-                instance_pre,
-                interface0,
-            })
+            Ok(ExampleIndices { interface0 })
         }
-        /// Instantiates a new instance of [`Example`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`ExampleIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Example`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Example`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::same::name::this_name_is_duplicated::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(ExampleIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Example`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Example>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Example> {
+            let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
             Ok(Example { interface0 })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Example {
@@ -86,6 +163,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             ExamplePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`ExampleIndices::new_instance`] and
+        /// [`ExampleIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Example> {
+            let indices = ExampleIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn same_name_this_name_is_duplicated(
             &self,
@@ -107,12 +193,17 @@ pub mod exports {
                 }
                 pub struct Guest {}
                 #[derive(Clone)]
-                pub struct GuestPre {}
-                impl GuestPre {
+                pub struct GuestIndices {}
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
                     pub fn new(
                         component: &wasmtime::component::Component,
-                    ) -> wasmtime::Result<GuestPre> {
-                        let _component = component;
+                    ) -> wasmtime::Result<GuestIndices> {
                         let (_, instance) = component
                             .export_index(None, "same:name/this-name-is-duplicated")
                             .ok_or_else(|| {
@@ -120,10 +211,38 @@ pub mod exports {
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
-                        let _lookup = |name: &str| {
-                            _component
-                                .export_index(Some(&instance), name)
-                                .map(|p| p.1)
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(
+                                &mut store,
+                                None,
+                                "same:name/this-name-is-duplicated",
+                            )
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `same:name/this-name-is-duplicated`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `same:name/this-name-is-duplicated` does \
@@ -131,7 +250,8 @@ pub mod exports {
                                     )
                                 })
                         };
-                        Ok(GuestPre {})
+                        let _ = &mut lookup;
+                        Ok(GuestIndices {})
                     }
                     pub fn load(
                         &self,

--- a/crates/component-macro/tests/expanded/wat_async.rs
+++ b/crates/component-macro/tests/expanded/wat_async.rs
@@ -83,7 +83,7 @@ pub struct ExampleIndices {
 ///   create a [`Example`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Example::new_instance`]
+///   then you can use [`Example::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`ExampleIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -105,7 +105,7 @@ pub struct FooIndices {
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -29,70 +29,149 @@ const _: () = {
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    f: wasmtime::component::ComponentExportIndex,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            f: self.f.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    f: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {
     f: wasmtime::component::Func,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
+            let _component = component;
             let f = _component
                 .export_index(None, "f")
                 .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?
                 .1;
-            Ok(FooPre { instance_pre, f })
+            Ok(FooIndices { f })
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub fn instantiate(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let f = _instance
+                .get_export(&mut store, None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
+            Ok(FooIndices { f })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
         ) -> wasmtime::Result<Foo> {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate(&mut store)?;
+            let _instance = instance;
             let f = *_instance
                 .get_typed_func::<(), ((T, U, R),)>(&mut store, &self.f)?
                 .func();
             Ok(Foo { f })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -105,6 +184,15 @@ const _: () = {
         ) -> wasmtime::Result<Foo> {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -29,73 +29,152 @@ const _: () = {
 /// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
 pub struct FooPre<T> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    f: wasmtime::component::ComponentExportIndex,
+    indices: FooIndices,
 }
 impl<T> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
-            f: self.f.clone(),
+            indices: self.indices.clone(),
         }
     }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    f: wasmtime::component::ComponentExportIndex,
 }
 /// Auto-generated bindings for an instance a component which
 /// implements the world `foo`.
 ///
-/// This structure is created through either
-/// [`Foo::instantiate_async`] or by first creating
-/// a [`FooPre`] followed by using
-/// [`FooPre::instantiate_async`].
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new_instance`]
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {
     f: wasmtime::component::Func,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl<_T> FooPre<_T> {
-        /// Creates a new copy of `FooPre` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
-        /// This method may fail if the component behind `instance_pre`
-        /// does not have the required exports.
+        /// This method may fail if the component does not have the
+        /// required exports.
         pub fn new(
-            instance_pre: wasmtime::component::InstancePre<_T>,
+            component: &wasmtime::component::Component,
         ) -> wasmtime::Result<Self> {
-            let _component = instance_pre.component();
+            let _component = component;
             let f = _component
                 .export_index(None, "f")
                 .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?
                 .1;
-            Ok(FooPre { instance_pre, f })
+            Ok(FooIndices { f })
         }
-        /// Instantiates a new instance of [`Foo`] within the
-        /// `store` provided.
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
         ///
-        /// This function will use `self` as the pre-instantiated
-        /// instance to perform instantiation. Afterwards the preloaded
-        /// indices in `self` are used to lookup all exports on the
-        /// resulting instance.
-        pub async fn instantiate_async(
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let f = _instance
+                .get_export(&mut store, None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
+            Ok(FooIndices { f })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
             &self,
-            mut store: impl wasmtime::AsContextMut<Data = _T>,
-        ) -> wasmtime::Result<Foo>
-        where
-            _T: Send,
-        {
-            let mut store = store.as_context_mut();
-            let _instance = self.instance_pre.instantiate_async(&mut store).await?;
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
             let f = *_instance
                 .get_typed_func::<(), ((T, U, R),)>(&mut store, &self.f)?
                 .func();
             Ok(Foo { f })
-        }
-        pub fn engine(&self) -> &wasmtime::Engine {
-            self.instance_pre.engine()
-        }
-        pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
-            &self.instance_pre
         }
     }
     impl Foo {
@@ -111,6 +190,15 @@ const _: () = {
         {
             let pre = linker.instantiate_pre(component)?;
             FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
         }
         pub fn add_to_linker<T, U>(
             linker: &mut wasmtime::component::Linker<T>,

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -108,7 +108,7 @@ pub struct FooIndices {
 ///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new_instance`]
+///   then you can use [`Foo::new`].
 ///
 /// * You can also access the guts of instantiation through
 ///   [`FooIndices::new_instance`] followed

--- a/crates/wasi-http/src/bindings.rs
+++ b/crates/wasi-http/src/bindings.rs
@@ -47,7 +47,7 @@ pub use self::generated::wasi::*;
 pub use self::generated::exports;
 
 /// Bindings to the `wasi:http/proxy` world.
-pub use self::generated::{Proxy, ProxyPre};
+pub use self::generated::{Proxy, ProxyIndices, ProxyPre};
 
 /// Sync implementation of the `wasi:http/proxy` world.
 pub mod sync {
@@ -73,5 +73,5 @@ pub mod sync {
     pub use self::generated::exports;
 
     /// Bindings to the `wasi:http/proxy` world.
-    pub use self::generated::{Proxy, ProxyPre};
+    pub use self::generated::{Proxy, ProxyIndices, ProxyPre};
 }

--- a/crates/wasi/src/bindings.rs
+++ b/crates/wasi/src/bindings.rs
@@ -318,6 +318,8 @@ pub mod sync {
     ///
     /// ---
     pub use self::generated::CommandPre;
+
+    pub use self::generated::CommandIndices;
 }
 
 mod async_io {
@@ -557,3 +559,5 @@ pub use self::async_io::Command;
 ///
 /// ---
 pub use self::async_io::CommandPre;
+
+pub use self::async_io::CommandIndices;


### PR DESCRIPTION
This commit expands the set of supported constructors for `bindgen!` generated structures with the goal of bringing back `World::new(&mut store, instance)`. This method was removed previously in a refactoring to add `*Pre` structures but refactoring preexisting code to use `*Pre` isn't always easy, so these extra generated bindings provide a smoother migration path for code from before.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
