### PR TITLE
Enable debugging features for `cranelift-codegen` in `wasmtime-cli` dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ test-programs-artifacts = { workspace = true }
 bytesize = "1.3.0"
 wit-component = { workspace = true }
 cranelift-filetests = { workspace = true }
-cranelift-codegen = { workspace = true }
+cranelift-codegen = { workspace = true, features = ["disas", "trace-log", "timing"] }
 cranelift-reader = { workspace = true }
 toml = { workspace = true }
 similar = { workspace = true }


### PR DESCRIPTION
This allows, for example, getting `trace!` logs from Cranelift out of `wasmtime-cli` tests, rather than needing to modify `cranelift-codegen`'s default features or whatever.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
