### PR TITLE
Refactor `CallInfo` amongst Cranelift's backends

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1014,13 +1014,13 @@ impl ABIMachineSpec for AArch64MachineDeps {
         insts
     }
 
-    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo) -> SmallVec<[Inst; 2]> {
+    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: Box<CallInfo>) -> SmallVec<[Inst; 2]> {
         let mut insts = SmallVec::new();
         match &dest {
             &CallDest::ExtName(ref name, RelocDistance::Near) => {
                 insts.push(Inst::Call {
                     dest: name.clone(),
-                    info: Box::new(info),
+                    info,
                 });
             }
             &CallDest::ExtName(ref name, RelocDistance::Far) => {
@@ -1031,13 +1031,10 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 });
                 insts.push(Inst::CallInd {
                     rn: tmp.to_reg(),
-                    info: Box::new(info),
+                    info,
                 });
             }
-            &CallDest::Reg(reg) => insts.push(Inst::CallInd {
-                rn: *reg,
-                info: Box::new(info),
-            }),
+            &CallDest::Reg(reg) => insts.push(Inst::CallInd { rn: *reg, info }),
         }
 
         insts

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -806,24 +806,16 @@
        ;; of type `Reloc::Arm64Call`); if the destination distance is not `RelocDistance::Near`, the
        ;; code should use a `LoadExtName` / `CallInd` sequence instead, allowing an arbitrary 64-bit
        ;; target.
-       (Call
-        (dest ExternalName)
-        (info BoxCallInfo))
+       (Call (info BoxCallInfo))
 
        ;; A machine indirect-call instruction.
-       (CallInd
-        (rn Reg)
-        (info BoxCallInfo))
+       (CallInd (info BoxCallIndInfo))
 
        ;; A return-call macro instruction.
-       (ReturnCall
-        (callee BoxExternalName)
-        (info BoxReturnCallInfo))
+       (ReturnCall (info BoxReturnCallInfo))
 
        ;; An indirect return-call macro instruction.
-       (ReturnCallInd
-        (callee Reg)
-        (info BoxReturnCallInfo))
+       (ReturnCallInd (info BoxReturnCallIndInfo))
 
        ;; A pseudo-instruction that captures register arguments in vregs.
        (Args
@@ -1073,7 +1065,9 @@
 (type SImm7Scaled (primitive SImm7Scaled))
 
 (type BoxCallInfo (primitive BoxCallInfo))
+(type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
+(type BoxReturnCallIndInfo (primitive BoxReturnCallIndInfo))
 (type CondBrKind (primitive CondBrKind))
 (type BranchTarget (primitive BranchTarget))
 (type BoxJTSequenceInfo (primitive BoxJTSequenceInfo))

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -807,11 +807,13 @@
        ;; code should use a `LoadExtName` / `CallInd` sequence instead, allowing an arbitrary 64-bit
        ;; target.
        (Call
+        (dest ExternalName)
         (info BoxCallInfo))
 
        ;; A machine indirect-call instruction.
        (CallInd
-        (info BoxCallIndInfo))
+        (rn Reg)
+        (info BoxCallInfo))
 
        ;; A return-call macro instruction.
        (ReturnCall
@@ -1071,7 +1073,6 @@
 (type SImm7Scaled (primitive SImm7Scaled))
 
 (type BoxCallInfo (primitive BoxCallInfo))
-(type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
 (type CondBrKind (primitive CondBrKind))
 (type BranchTarget (primitive BranchTarget))

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -2923,9 +2923,9 @@ impl MachInstEmit for Inst {
                     sink.put4(0xd65f0bff | (op2 << 9)); // reta{key}
                 }
             }
-            &Inst::Call { ref dest, ref info } => {
+            &Inst::Call { ref info } => {
                 let user_stack_map = state.take_stack_map();
-                sink.add_reloc(Reloc::Arm64Call, dest, 0);
+                sink.add_reloc(Reloc::Arm64Call, &info.dest, 0);
                 sink.put4(enc_jump26(0b100101, 0));
                 if let Some(s) = user_stack_map {
                     let offset = sink.cur_offset();
@@ -2941,9 +2941,11 @@ impl MachInstEmit for Inst {
                     }
                 }
             }
-            &Inst::CallInd { rn, ref info } => {
+            &Inst::CallInd { ref info } => {
                 let user_stack_map = state.take_stack_map();
-                sink.put4(0b1101011_0001_11111_000000_00000_00000 | (machreg_to_gpr(rn) << 5));
+                sink.put4(
+                    0b1101011_0001_11111_000000_00000_00000 | (machreg_to_gpr(info.dest) << 5),
+                );
                 if let Some(s) = user_stack_map {
                     let offset = sink.cur_offset();
                     sink.push_user_stack_map(state, offset, s);
@@ -2958,16 +2960,13 @@ impl MachInstEmit for Inst {
                     }
                 }
             }
-            &Inst::ReturnCall {
-                ref callee,
-                ref info,
-            } => {
+            &Inst::ReturnCall { ref info } => {
                 emit_return_call_common_sequence(sink, emit_info, state, info);
 
                 // Note: this is not `Inst::Jump { .. }.emit(..)` because we
                 // have different metadata in this case: we don't have a label
                 // for the target, but rather a function relocation.
-                sink.add_reloc(Reloc::Arm64Call, &**callee, 0);
+                sink.add_reloc(Reloc::Arm64Call, &info.dest, 0);
                 sink.put4(enc_jump26(0b000101, 0));
                 sink.add_call_site();
 
@@ -2976,11 +2975,11 @@ impl MachInstEmit for Inst {
                 // in this case.
                 start_off = sink.cur_offset();
             }
-            &Inst::ReturnCallInd { callee, ref info } => {
+            &Inst::ReturnCallInd { ref info } => {
                 emit_return_call_common_sequence(sink, emit_info, state, info);
 
                 Inst::IndirectBr {
-                    rn: callee,
+                    rn: info.dest,
                     targets: vec![],
                 }
                 .emit(sink, emit_info, state);
@@ -3371,8 +3370,7 @@ impl MachInstEmit for Inst {
                 // blr tmp
                 sink.add_reloc(Reloc::Aarch64TlsDescCall, &**symbol, 0);
                 Inst::CallInd {
-                    rn: tmp.to_reg(),
-                    info: crate::isa::Box::new(CallInfo::empty(CallConv::SystemV)),
+                    info: crate::isa::Box::new(CallInfo::empty(tmp.to_reg(), CallConv::SystemV)),
                 }
                 .emit(sink, emit_info, state);
 
@@ -3424,8 +3422,10 @@ impl MachInstEmit for Inst {
 
                 // call function pointer in temp register
                 Inst::CallInd {
-                    rn: rtmp.to_reg(),
-                    info: crate::isa::Box::new(CallInfo::empty(CallConv::AppleAarch64)),
+                    info: crate::isa::Box::new(CallInfo::empty(
+                        rtmp.to_reg(),
+                        CallConv::AppleAarch64,
+                    )),
                 }
                 .emit(sink, emit_info, state);
             }
@@ -3518,11 +3518,11 @@ impl MachInstEmit for Inst {
     }
 }
 
-fn emit_return_call_common_sequence(
+fn emit_return_call_common_sequence<T>(
     sink: &mut MachBuffer<Inst>,
     emit_info: &EmitInfo,
     state: &mut EmitState,
-    info: &ReturnCallInfo,
+    info: &ReturnCallInfo<T>,
 ) {
     for inst in
         AArch64MachineDeps::gen_clobber_restore(CallConv::Tail, &emit_info.0, state.frame_layout())

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1,5 +1,5 @@
 use crate::ir::types::*;
-use crate::ir::TrapCode;
+use crate::ir::{ExternalName, TrapCode};
 use crate::isa::aarch64::inst::*;
 
 use alloc::boxed::Box;
@@ -6056,15 +6056,8 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::Call {
-            info: Box::new(CallInfo {
-                dest: ExternalName::testcase("test0"),
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: PRegSet::empty(),
-                caller_callconv: CallConv::SystemV,
-                callee_callconv: CallConv::SystemV,
-                callee_pop_size: 0,
-            }),
+            dest: ExternalName::testcase("test0"),
+            info: Box::new(CallInfo::empty(CallConv::SystemV)),
         },
         "00000094",
         "bl 0",
@@ -6072,15 +6065,8 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::CallInd {
-            info: Box::new(CallIndInfo {
-                rn: xreg(10),
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: PRegSet::empty(),
-                caller_callconv: CallConv::SystemV,
-                callee_callconv: CallConv::SystemV,
-                callee_pop_size: 0,
-            }),
+            rn: xreg(10),
+            info: Box::new(CallInfo::empty(CallConv::SystemV)),
         },
         "40013FD6",
         "blr x10",

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -6056,8 +6056,10 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::Call {
-            dest: ExternalName::testcase("test0"),
-            info: Box::new(CallInfo::empty(CallConv::SystemV)),
+            info: Box::new(CallInfo::empty(
+                ExternalName::testcase("test0"),
+                CallConv::SystemV,
+            )),
         },
         "00000094",
         "bl 0",
@@ -6065,8 +6067,7 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::CallInd {
-            rn: xreg(10),
-            info: Box::new(CallInfo::empty(CallConv::SystemV)),
+            info: Box::new(CallInfo::empty(xreg(10), CallConv::SystemV)),
         },
         "40013FD6",
         "blr x10",

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -7,9 +7,9 @@ use generated_code::Context;
 // Types that the generated ISLE code uses via `use super::*`.
 use super::{
     fp_reg, lower_condcode, lower_fp_condcode, stack_reg, writable_link_reg, writable_zero_reg,
-    zero_reg, ASIMDFPModImm, ASIMDMovModImm, BranchTarget, CallIndInfo, CallInfo, Cond, CondBrKind,
-    ExtendOp, FPUOpRI, FPUOpRIMod, FloatCC, Imm12, ImmLogic, ImmShift, Inst as MInst, IntCC,
-    MachLabel, MemLabel, MoveWideConst, MoveWideOp, Opcode, OperandSize, Reg, SImm9, ScalarSize,
+    zero_reg, ASIMDFPModImm, ASIMDMovModImm, BranchTarget, CallInfo, Cond, CondBrKind, ExtendOp,
+    FPUOpRI, FPUOpRIMod, FloatCC, Imm12, ImmLogic, ImmShift, Inst as MInst, IntCC, MachLabel,
+    MemLabel, MoveWideConst, MoveWideOp, Opcode, OperandSize, Reg, SImm9, ScalarSize,
     ShiftOpAndAmt, UImm12Scaled, UImm5, VecMisc2, VectorSize, NZCV,
 };
 use crate::ir::{condcodes, ArgumentExtension};
@@ -35,7 +35,6 @@ use std::boxed::Box;
 use std::vec::Vec;
 
 type BoxCallInfo = Box<CallInfo>;
-type BoxCallIndInfo = Box<CallIndInfo>;
 type BoxReturnCallInfo = Box<ReturnCallInfo>;
 type VecMachLabel = Vec<MachLabel>;
 type BoxExternalName = Box<ExternalName>;

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -34,8 +34,10 @@ use regalloc2::PReg;
 use std::boxed::Box;
 use std::vec::Vec;
 
-type BoxCallInfo = Box<CallInfo>;
-type BoxReturnCallInfo = Box<ReturnCallInfo>;
+type BoxCallInfo = Box<CallInfo<ExternalName>>;
+type BoxCallIndInfo = Box<CallInfo<Reg>>;
+type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
+type BoxReturnCallIndInfo = Box<ReturnCallInfo<Reg>>;
 type VecMachLabel = Vec<MachLabel>;
 type BoxExternalName = Box<ExternalName>;
 type VecArgPair = Vec<ArgPair>;

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -522,16 +522,11 @@ where
         insts
     }
 
-    fn gen_call(
-        dest: &CallDest,
-        tmp: Writable<Reg>,
-        info: Box<CallInfo>,
-    ) -> SmallVec<[Self::I; 2]> {
+    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo<()>) -> SmallVec<[Self::I; 2]> {
         if info.callee_conv == isa::CallConv::Tail || info.callee_conv == isa::CallConv::Fast {
             match &dest {
                 &CallDest::ExtName(ref name, RelocDistance::Near) => smallvec![Inst::Call {
-                    callee: Box::new(name.clone()),
-                    info,
+                    info: Box::new(info.map(|()| name.clone()))
                 }
                 .into()],
                 &CallDest::ExtName(ref name, RelocDistance::Far) => smallvec![
@@ -542,14 +537,12 @@ where
                     }
                     .into(),
                     Inst::IndirectCall {
-                        callee: XReg::new(tmp.to_reg()).unwrap(),
-                        info,
+                        info: Box::new(info.map(|()| XReg::new(tmp.to_reg()).unwrap()))
                     }
                     .into(),
                 ],
                 &CallDest::Reg(reg) => smallvec![Inst::IndirectCall {
-                    callee: XReg::new(*reg).unwrap(),
-                    info,
+                    info: Box::new(info.map(|()| XReg::new(*reg).unwrap()))
                 }
                 .into()],
             }

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -522,12 +522,16 @@ where
         insts
     }
 
-    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo) -> SmallVec<[Self::I; 2]> {
+    fn gen_call(
+        dest: &CallDest,
+        tmp: Writable<Reg>,
+        info: Box<CallInfo>,
+    ) -> SmallVec<[Self::I; 2]> {
         if info.callee_conv == isa::CallConv::Tail || info.callee_conv == isa::CallConv::Fast {
             match &dest {
                 &CallDest::ExtName(ref name, RelocDistance::Near) => smallvec![Inst::Call {
                     callee: Box::new(name.clone()),
-                    info: Box::new(info),
+                    info,
                 }
                 .into()],
                 &CallDest::ExtName(ref name, RelocDistance::Far) => smallvec![
@@ -539,13 +543,13 @@ where
                     .into(),
                     Inst::IndirectCall {
                         callee: XReg::new(tmp.to_reg()).unwrap(),
-                        info: Box::new(info),
+                        info,
                     }
                     .into(),
                 ],
                 &CallDest::Reg(reg) => smallvec![Inst::IndirectCall {
                     callee: XReg::new(*reg).unwrap(),
-                    info: Box::new(info),
+                    info,
                 }
                 .into()],
             }

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -522,26 +522,12 @@ where
         insts
     }
 
-    fn gen_call(
-        dest: &CallDest,
-        uses: CallArgList,
-        defs: CallRetList,
-        clobbers: PRegSet,
-        tmp: Writable<Reg>,
-        callee_conv: isa::CallConv,
-        caller_conv: isa::CallConv,
-        callee_pop_size: u32,
-    ) -> SmallVec<[Self::I; 2]> {
-        if callee_conv == isa::CallConv::Tail || callee_conv == isa::CallConv::Fast {
+    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo) -> SmallVec<[Self::I; 2]> {
+        if info.callee_conv == isa::CallConv::Tail || info.callee_conv == isa::CallConv::Fast {
             match &dest {
                 &CallDest::ExtName(ref name, RelocDistance::Near) => smallvec![Inst::Call {
                     callee: Box::new(name.clone()),
-                    info: Box::new(CallInfo {
-                        uses,
-                        defs,
-                        clobbers,
-                        callee_pop_size,
-                    }),
+                    info: Box::new(info),
                 }
                 .into()],
                 &CallDest::ExtName(ref name, RelocDistance::Far) => smallvec![
@@ -553,28 +539,22 @@ where
                     .into(),
                     Inst::IndirectCall {
                         callee: XReg::new(tmp.to_reg()).unwrap(),
-                        info: Box::new(CallInfo {
-                            uses,
-                            defs,
-                            clobbers,
-                            callee_pop_size,
-                        }),
+                        info: Box::new(info),
                     }
                     .into(),
                 ],
                 &CallDest::Reg(reg) => smallvec![Inst::IndirectCall {
                     callee: XReg::new(*reg).unwrap(),
-                    info: Box::new(CallInfo {
-                        uses,
-                        defs,
-                        clobbers,
-                        callee_pop_size,
-                    }),
+                    info: Box::new(info),
                 }
                 .into()],
             }
         } else {
-            todo!("host calls? callee_conv = {callee_conv:?}; caller_conv = {caller_conv:?}")
+            todo!(
+                "host calls? callee_conv = {:?}; caller_conv = {:?}",
+                info.callee_conv,
+                info.caller_conv,
+            )
         }
     }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -35,12 +35,10 @@
                  (offset i64))
 
     ;; A direct call to a known callee.
-    (Call (callee BoxExternalName)
-          (info BoxCallInfo))
+    (Call (info BoxCallInfo))
 
     ;; An indirect call to an unknown callee.
-    (IndirectCall (callee XReg)
-                  (info BoxCallInfo))
+    (IndirectCall (info BoxCallIndInfo))
 
     ;; Unconditional jumps.
     (Jump (label MachLabel))
@@ -103,6 +101,7 @@
 )
 
 (type BoxCallInfo (primitive BoxCallInfo))
+(type BoxCallIndInfo (primitive BoxCallIndInfo))
 
 ;;;; Address Modes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -147,12 +147,12 @@ fn pulley_emit<P>(
 
         Inst::LoadExtName { .. } => todo!(),
 
-        Inst::Call { callee, info } => {
+        Inst::Call { info } => {
             sink.put1(pulley_interpreter::Opcode::Call as u8);
             sink.add_reloc(
                 // TODO: is it actually okay to reuse this reloc here?
                 Reloc::X86CallPCRel4,
-                &**callee,
+                &info.dest,
                 // This addend adjusts for the difference between the start of
                 // the instruction and the beginning of the immediate field.
                 -1,

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -80,7 +80,7 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_def(dst);
         }
 
-        Inst::Call { callee: _, info } => {
+        Inst::Call { info } => {
             let CallInfo { uses, defs, .. } = &mut **info;
             for CallArgPair { vreg, preg } in uses {
                 collector.reg_fixed_use(vreg, *preg);
@@ -90,8 +90,8 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             }
             collector.reg_clobbers(info.clobbers);
         }
-        Inst::IndirectCall { callee, info } => {
-            collector.reg_use(callee);
+        Inst::IndirectCall { info } => {
+            collector.reg_use(&mut info.dest);
             let CallInfo { uses, defs, .. } = &mut **info;
             for CallArgPair { vreg, preg } in uses {
                 collector.reg_fixed_use(vreg, *preg);
@@ -537,12 +537,12 @@ impl Inst {
                 format!("{dst} = load_ext_name {name:?}, {offset}")
             }
 
-            Inst::Call { callee, info } => {
-                format!("call {callee:?}, {info:?}")
+            Inst::Call { info } => {
+                format!("call {info:?}")
             }
 
-            Inst::IndirectCall { callee, info } => {
-                let callee = format_reg(**callee);
+            Inst::IndirectCall { info } => {
+                let callee = format_reg(*info.dest);
                 format!("indirect_call {callee}, {info:?}")
             }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -10,7 +10,7 @@ use crate::isa::FunctionAlignment;
 use crate::{machinst::*, trace};
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::string::{String, ToString};
-use regalloc2::{PRegSet, RegClass};
+use regalloc2::RegClass;
 use smallvec::SmallVec;
 
 pub mod regs;
@@ -26,17 +26,6 @@ pub use self::emit::*;
 pub use crate::isa::pulley_shared::lower::isle::generated_code::MInst as Inst;
 
 use super::PulleyTargetKind;
-
-/// Additional information for direct and indirect call instructions.
-///
-/// Left out of line to lower the size of the `Inst` enum.
-#[derive(Clone, Debug)]
-pub struct CallInfo {
-    pub uses: CallArgList,
-    pub defs: CallRetList,
-    pub clobbers: PRegSet,
-    pub callee_pop_size: u32,
-}
 
 impl Inst {
     /// Generic constructor for a load (zero-extending where appropriate).

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -9,13 +9,13 @@ use inst::InstAndKind;
 use crate::ir::{condcodes::*, immediates::*, types::*, *};
 use crate::isa::pulley_shared::{
     abi::*,
-    inst::{CallInfo, FReg, VReg, WritableFReg, WritableVReg, WritableXReg, XReg},
+    inst::{FReg, VReg, WritableFReg, WritableVReg, WritableXReg, XReg},
     *,
 };
 use crate::machinst::{
     abi::{ArgPair, RetPair, StackAMode},
     isle::*,
-    IsTailCall, MachInst, Reg, VCodeConstant, VCodeConstantData,
+    CallInfo, IsTailCall, MachInst, Reg, VCodeConstant, VCodeConstantData,
 };
 use alloc::boxed::Box;
 use regalloc2::PReg;

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -22,7 +22,8 @@ use regalloc2::PReg;
 type Unit = ();
 type VecArgPair = Vec<ArgPair>;
 type VecRetPair = Vec<RetPair>;
-type BoxCallInfo = Box<CallInfo>;
+type BoxCallInfo = Box<CallInfo<ExternalName>>;
+type BoxCallIndInfo = Box<CallInfo<XReg>>;
 type BoxExternalName = Box<ExternalName>;
 
 pub(crate) struct PulleyIsleContext<'a, 'b, I, B>

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -424,13 +424,15 @@ impl ABIMachineSpec for Riscv64MachineDeps {
 
     fn gen_probestack(insts: &mut SmallInstVec<Self::I>, frame_size: u32) {
         insts.extend(Inst::load_constant_u32(writable_a0(), frame_size as u64));
-        let mut info = CallInfo::empty(CallConv::SystemV);
+        let mut info = CallInfo::empty(
+            ExternalName::LibCall(LibCall::Probestack),
+            CallConv::SystemV,
+        );
         info.uses.push(CallArgPair {
             vreg: a0(),
             preg: a0(),
         });
         insts.push(Inst::Call {
-            dest: ExternalName::LibCall(LibCall::Probestack),
             info: Box::new(info),
         });
     }
@@ -562,29 +564,26 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         insts
     }
 
-    fn gen_call(
-        dest: &CallDest,
-        tmp: Writable<Reg>,
-        info: Box<CallInfo>,
-    ) -> SmallVec<[Self::I; 2]> {
+    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo<()>) -> SmallVec<[Self::I; 2]> {
         let mut insts = SmallVec::new();
         match &dest {
-            &CallDest::ExtName(ref name, RelocDistance::Near) => insts.push(Inst::Call {
-                dest: name.clone(),
-                info,
-            }),
+            &CallDest::ExtName(ref name, RelocDistance::Near) => {
+                let info = Box::new(info.map(|()| name.clone()));
+                insts.push(Inst::Call { info })
+            }
             &CallDest::ExtName(ref name, RelocDistance::Far) => {
                 insts.push(Inst::LoadExtName {
                     rd: tmp,
                     name: Box::new(name.clone()),
                     offset: 0,
                 });
-                insts.push(Inst::CallInd {
-                    rn: tmp.to_reg(),
-                    info,
-                });
+                let info = Box::new(info.map(|()| tmp.to_reg()));
+                insts.push(Inst::CallInd { info });
             }
-            &CallDest::Reg(reg) => insts.push(Inst::CallInd { rn: *reg, info }),
+            &CallDest::Reg(reg) => {
+                let info = Box::new(info.map(|()| *reg));
+                insts.push(Inst::CallInd { info });
+            }
         }
         insts
     }
@@ -603,8 +602,8 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         let tmp = alloc_tmp(Self::word_type());
         insts.extend(Inst::load_constant_u64(tmp, size as u64).into_iter());
         insts.push(Inst::Call {
-            dest: ExternalName::LibCall(LibCall::Memcpy),
             info: Box::new(CallInfo {
+                dest: ExternalName::LibCall(LibCall::Memcpy),
                 uses: smallvec![
                     CallArgPair {
                         vreg: dst,
@@ -739,17 +738,15 @@ impl Riscv64ABICallSite {
 
         let dest = self.dest().clone();
         let uses = self.take_uses();
-        let info = Box::new(ReturnCallInfo {
-            uses,
-            new_stack_arg_size,
-        });
 
         match dest {
             CallDest::ExtName(name, RelocDistance::Near) => {
-                ctx.emit(Inst::ReturnCall {
-                    callee: Box::new(name),
-                    info,
+                let info = Box::new(ReturnCallInfo {
+                    dest: name,
+                    uses,
+                    new_stack_arg_size,
                 });
+                ctx.emit(Inst::ReturnCall { info });
             }
             CallDest::ExtName(name, RelocDistance::Far) => {
                 let callee = ctx.alloc_tmp(ir::types::I64).only_reg().unwrap();
@@ -758,12 +755,21 @@ impl Riscv64ABICallSite {
                     name: Box::new(name),
                     offset: 0,
                 });
-                ctx.emit(Inst::ReturnCallInd {
-                    callee: callee.to_reg(),
-                    info,
+                let info = Box::new(ReturnCallInfo {
+                    dest: callee.to_reg(),
+                    uses,
+                    new_stack_arg_size,
                 });
+                ctx.emit(Inst::ReturnCallInd { info });
             }
-            CallDest::Reg(callee) => ctx.emit(Inst::ReturnCallInd { callee, info }),
+            CallDest::Reg(callee) => {
+                let info = Box::new(ReturnCallInfo {
+                    dest: callee,
+                    uses,
+                    new_stack_arg_size,
+                });
+                ctx.emit(Inst::ReturnCallInd { info });
+            }
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -562,12 +562,16 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         insts
     }
 
-    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo) -> SmallVec<[Self::I; 2]> {
+    fn gen_call(
+        dest: &CallDest,
+        tmp: Writable<Reg>,
+        info: Box<CallInfo>,
+    ) -> SmallVec<[Self::I; 2]> {
         let mut insts = SmallVec::new();
         match &dest {
             &CallDest::ExtName(ref name, RelocDistance::Near) => insts.push(Inst::Call {
                 dest: name.clone(),
-                info: Box::new(info),
+                info,
             }),
             &CallDest::ExtName(ref name, RelocDistance::Far) => {
                 insts.push(Inst::LoadExtName {
@@ -577,13 +581,10 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 });
                 insts.push(Inst::CallInd {
                     rn: tmp.to_reg(),
-                    info: Box::new(info),
+                    info,
                 });
             }
-            &CallDest::Reg(reg) => insts.push(Inst::CallInd {
-                rn: *reg,
-                info: Box::new(info),
-            }),
+            &CallDest::Reg(reg) => insts.push(Inst::CallInd { rn: *reg, info }),
         }
         insts
     }

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -111,24 +111,16 @@
       (from_bits u8)
       (to_bits u8))
 
-    (Call
-      (dest ExternalName)
-      (info BoxCallInfo))
+    (Call (info BoxCallInfo))
 
       ;; A machine indirect-call instruction.
-    (CallInd
-      (rn Reg)
-      (info BoxCallInfo))
+    (CallInd (info BoxCallIndInfo))
 
     ;; A direct return-call macro instruction.
-    (ReturnCall
-      (callee BoxExternalName)
-      (info BoxReturnCallInfo))
+    (ReturnCall (info BoxReturnCallInfo))
 
     ;; An indirect return-call macro instruction.
-    (ReturnCallInd
-      (callee Reg)
-      (info BoxReturnCallInfo))
+    (ReturnCallInd (info BoxReturnCallIndInfo))
 
     ;; Emits a trap with the given trap code if the comparison succeeds
     (TrapIf
@@ -782,6 +774,7 @@
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
+(type BoxReturnCallIndInfo (primitive BoxReturnCallIndInfo))
 (type IntegerCompare (primitive IntegerCompare))
 (type AMode (primitive AMode))
 (type OptionReg (primitive OptionReg))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -112,11 +112,13 @@
       (to_bits u8))
 
     (Call
+      (dest ExternalName)
       (info BoxCallInfo))
 
       ;; A machine indirect-call instruction.
     (CallInd
-      (info BoxCallIndInfo))
+      (rn Reg)
+      (info BoxCallInfo))
 
     ;; A direct return-call macro instruction.
     (ReturnCall

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -14,7 +14,7 @@ use crate::isa::riscv64::lower::args::{
 };
 use crate::isa::riscv64::Riscv64Backend;
 use crate::machinst::Reg;
-use crate::machinst::{isle::*, MachInst};
+use crate::machinst::{isle::*, CallInfo, MachInst};
 use crate::machinst::{VCodeConstant, VCodeConstantData};
 use crate::{
     ir::{
@@ -29,7 +29,6 @@ use std::boxed::Box;
 use std::vec::Vec;
 
 type BoxCallInfo = Box<CallInfo>;
-type BoxCallIndInfo = Box<CallIndInfo>;
 type BoxReturnCallInfo = Box<ReturnCallInfo>;
 type BoxExternalName = Box<ExternalName>;
 type VecMachLabel = Vec<MachLabel>;

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -28,8 +28,10 @@ use regalloc2::PReg;
 use std::boxed::Box;
 use std::vec::Vec;
 
-type BoxCallInfo = Box<CallInfo>;
-type BoxReturnCallInfo = Box<ReturnCallInfo>;
+type BoxCallInfo = Box<CallInfo<ExternalName>>;
+type BoxCallIndInfo = Box<CallInfo<Reg>>;
+type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
+type BoxReturnCallIndInfo = Box<ReturnCallInfo<Reg>>;
 type BoxExternalName = Box<ExternalName>;
 type VecMachLabel = Vec<MachLabel>;
 type VecArgPair = Vec<ArgPair>;

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -803,13 +803,8 @@ impl ABIMachineSpec for S390xMachineDeps {
 
     fn gen_call(
         _dest: &CallDest,
-        _uses: CallArgList,
-        _defs: CallRetList,
-        _clobbers: PRegSet,
         _tmp: Writable<Reg>,
-        _callee_conv: isa::CallConv,
-        _caller_conv: isa::CallConv,
-        _callee_pop_size: u32,
+        _info: crate::machinst::CallInfo,
     ) -> SmallVec<[Inst; 2]> {
         unreachable!();
     }

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -147,6 +147,7 @@ use crate::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
 use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
+use std::boxed::Box;
 use std::sync::OnceLock;
 
 // We use a generic implementation that factors out ABI commonalities.
@@ -804,7 +805,7 @@ impl ABIMachineSpec for S390xMachineDeps {
     fn gen_call(
         _dest: &CallDest,
         _tmp: Writable<Reg>,
-        _info: crate::machinst::CallInfo,
+        _info: Box<crate::machinst::CallInfo>,
     ) -> SmallVec<[Inst; 2]> {
         unreachable!();
     }

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -147,7 +147,6 @@ use crate::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
 use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::boxed::Box;
 use std::sync::OnceLock;
 
 // We use a generic implementation that factors out ABI commonalities.
@@ -802,11 +801,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         insts
     }
 
-    fn gen_call(
-        _dest: &CallDest,
-        _tmp: Writable<Reg>,
-        _info: Box<crate::machinst::CallInfo>,
-    ) -> SmallVec<[Inst; 2]> {
+    fn gen_call(_dest: &CallDest, _tmp: Writable<Reg>, _info: CallInfo<()>) -> SmallVec<[Inst; 2]> {
         unreachable!();
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -893,13 +893,15 @@
 
     ;; A machine call instruction.
     (Call
+      (dest ExternalName)
       (link WritableReg)
       (info BoxCallInfo))
 
     ;; A machine indirect-call instruction.
     (CallInd
+      (rn Reg)
       (link WritableReg)
-      (info BoxCallIndInfo))
+      (info BoxCallInfo))
 
     ;; A machine tail call instruction.
     (ReturnCall
@@ -1014,12 +1016,20 @@
     ;; machine at this program point.
     (Unwind
       (inst UnwindInst))
+
+    ;; Pseudo-instruction used for `tls_value` to call the libcall of the same
+    ;; name.
+    (ElfTlsGetOffset
+      (tls_offset WritableReg)
+      (got Reg)
+      (got_offset Reg)
+      (link WritableReg)
+      (symbol SymbolReloc))
 ))
 
 ;; Primitive types used in instruction formats.
 
 (type BoxCallInfo (primitive BoxCallInfo))
-(type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
 (type BoxReturnCallIndInfo (primitive BoxReturnCallIndInfo))
 (type BoxJTSequenceInfo (primitive BoxJTSequenceInfo))
@@ -2690,14 +2700,14 @@
         dst))
 
 ;; Helper for emitting `MInst.Call` instructions.
-(decl call_impl (WritableReg BoxCallInfo) SideEffectNoResult)
-(rule (call_impl reg info)
-      (SideEffectNoResult.Inst (MInst.Call reg info)))
+(decl call_impl (ExternalName WritableReg BoxCallInfo) SideEffectNoResult)
+(rule (call_impl dest reg info)
+      (SideEffectNoResult.Inst (MInst.Call dest reg info)))
 
 ;; Helper for emitting `MInst.CallInd` instructions.
-(decl call_ind_impl (WritableReg BoxCallIndInfo) SideEffectNoResult)
-(rule (call_ind_impl reg info)
-      (SideEffectNoResult.Inst (MInst.CallInd reg info)))
+(decl call_ind_impl (Reg WritableReg BoxCallInfo) SideEffectNoResult)
+(rule (call_ind_impl rn reg info)
+      (SideEffectNoResult.Inst (MInst.CallInd rn reg info)))
 
 ;; Helper for emitting `MInst.ReturnCall` instructions.
 (decl return_call_impl (BoxReturnCallInfo) SideEffectNoResult)
@@ -2912,7 +2922,9 @@
 (rule 1 (memcpy dst src (len_minus_one len))
       (mvc (memarg_pair dst) (memarg_pair src) len))
 (rule (memcpy dst src len)
-      (lib_call (lib_call_info_memcpy (load_addr dst) (load_addr src) (imm $I64 len))))
+      (lib_call
+        (LibCall.Memcpy)
+        (lib_call_info_memcpy (load_addr dst) (load_addr src) (imm $I64 len))))
 
 ;; Prepare a stack copy of a single (oversized) argument.
 (decl copy_to_buffer (MemArg ABIArg Value) InstOutput)
@@ -3557,11 +3569,8 @@
 (decl abi_first_ret (SigRef Sig) usize)
 (extern constructor abi_first_ret abi_first_ret)
 
-(decl abi_call_info (Sig ExternalName CallArgList CallRetList) BoxCallInfo)
+(decl abi_call_info (Sig CallArgList CallRetList) BoxCallInfo)
 (extern constructor abi_call_info abi_call_info)
-
-(decl abi_call_ind_info (Sig Reg CallArgList CallRetList) BoxCallIndInfo)
-(extern constructor abi_call_ind_info abi_call_ind_info)
 
 (decl abi_return_call_info (Sig ExternalName CallArgList) BoxReturnCallInfo)
 (extern constructor abi_return_call_info abi_return_call_info)
@@ -3583,11 +3592,11 @@
 
 (decl abi_call (Sig ExternalName CallArgList CallRetList) SideEffectNoResult)
 (rule (abi_call abi name uses defs)
-      (call_impl (writable_link_reg) (abi_call_info abi name uses defs)))
+      (call_impl name (writable_link_reg) (abi_call_info abi uses defs)))
 
 (decl abi_call_ind (Sig Reg CallArgList CallRetList) SideEffectNoResult)
 (rule (abi_call_ind abi target uses defs)
-      (call_ind_impl (writable_link_reg) (abi_call_ind_info abi target uses defs)))
+      (call_ind_impl target (writable_link_reg) (abi_call_info abi uses defs)))
 
 (decl abi_return_call (Sig ExternalName CallArgList) SideEffectNoResult)
 (rule (abi_return_call abi name uses)
@@ -3605,18 +3614,19 @@
 
 (type LibCallInfo extern (enum))
 
-(decl lib_call_info_memcpy (Reg Reg Reg) LibCallInfo)
+(type LibCall extern
+      (enum
+        Memcpy))
+
+(decl lib_call_info_memcpy (Reg Reg Reg) BoxCallInfo)
 (extern constructor lib_call_info_memcpy lib_call_info_memcpy)
 
-(decl lib_call_info_tls_get_offset (WritableReg Reg Reg SymbolReloc) LibCallInfo)
-(extern constructor lib_call_info_tls_get_offset lib_call_info_tls_get_offset)
+(decl libcall_name (LibCall) ExternalName)
+(extern constructor libcall_name libcall_name)
 
-(decl lib_call_info (LibCallInfo) BoxCallInfo)
-(extern constructor lib_call_info lib_call_info)
-
-(decl lib_call (LibCallInfo) SideEffectNoResult)
-(rule (lib_call libcall)
-      (call_impl (writable_link_reg) (lib_call_info libcall)))
+(decl lib_call (LibCall BoxCallInfo) SideEffectNoResult)
+(rule (lib_call libcall info)
+      (call_impl (libcall_name libcall) (writable_link_reg) info))
 
 
 ;; Helpers for generating vector pack and unpack instructions ;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -893,15 +893,13 @@
 
     ;; A machine call instruction.
     (Call
-      (dest ExternalName)
       (link WritableReg)
       (info BoxCallInfo))
 
     ;; A machine indirect-call instruction.
     (CallInd
-      (rn Reg)
       (link WritableReg)
-      (info BoxCallInfo))
+      (info BoxCallIndInfo))
 
     ;; A machine tail call instruction.
     (ReturnCall
@@ -1024,12 +1022,13 @@
       (got Reg)
       (got_offset Reg)
       (link WritableReg)
-      (symbol SymbolReloc))
+      (symbol BoxSymbolReloc))
 ))
 
 ;; Primitive types used in instruction formats.
 
 (type BoxCallInfo (primitive BoxCallInfo))
+(type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
 (type BoxReturnCallIndInfo (primitive BoxReturnCallIndInfo))
 (type BoxJTSequenceInfo (primitive BoxJTSequenceInfo))
@@ -2700,14 +2699,14 @@
         dst))
 
 ;; Helper for emitting `MInst.Call` instructions.
-(decl call_impl (ExternalName WritableReg BoxCallInfo) SideEffectNoResult)
-(rule (call_impl dest reg info)
-      (SideEffectNoResult.Inst (MInst.Call dest reg info)))
+(decl call_impl (WritableReg BoxCallInfo) SideEffectNoResult)
+(rule (call_impl reg info)
+      (SideEffectNoResult.Inst (MInst.Call reg info)))
 
 ;; Helper for emitting `MInst.CallInd` instructions.
-(decl call_ind_impl (Reg WritableReg BoxCallInfo) SideEffectNoResult)
-(rule (call_ind_impl rn reg info)
-      (SideEffectNoResult.Inst (MInst.CallInd rn reg info)))
+(decl call_ind_impl (WritableReg BoxCallIndInfo) SideEffectNoResult)
+(rule (call_ind_impl reg info)
+      (SideEffectNoResult.Inst (MInst.CallInd reg info)))
 
 ;; Helper for emitting `MInst.ReturnCall` instructions.
 (decl return_call_impl (BoxReturnCallInfo) SideEffectNoResult)
@@ -2923,7 +2922,6 @@
       (mvc (memarg_pair dst) (memarg_pair src) len))
 (rule (memcpy dst src len)
       (lib_call
-        (LibCall.Memcpy)
         (lib_call_info_memcpy (load_addr dst) (load_addr src) (imm $I64 len))))
 
 ;; Prepare a stack copy of a single (oversized) argument.
@@ -3569,8 +3567,11 @@
 (decl abi_first_ret (SigRef Sig) usize)
 (extern constructor abi_first_ret abi_first_ret)
 
-(decl abi_call_info (Sig CallArgList CallRetList) BoxCallInfo)
+(decl abi_call_info (Sig ExternalName CallArgList CallRetList) BoxCallInfo)
 (extern constructor abi_call_info abi_call_info)
+
+(decl abi_call_ind_info (Sig Reg CallArgList CallRetList) BoxCallIndInfo)
+(extern constructor abi_call_ind_info abi_call_ind_info)
 
 (decl abi_return_call_info (Sig ExternalName CallArgList) BoxReturnCallInfo)
 (extern constructor abi_return_call_info abi_return_call_info)
@@ -3592,11 +3593,11 @@
 
 (decl abi_call (Sig ExternalName CallArgList CallRetList) SideEffectNoResult)
 (rule (abi_call abi name uses defs)
-      (call_impl name (writable_link_reg) (abi_call_info abi uses defs)))
+      (call_impl (writable_link_reg) (abi_call_info abi name uses defs)))
 
 (decl abi_call_ind (Sig Reg CallArgList CallRetList) SideEffectNoResult)
 (rule (abi_call_ind abi target uses defs)
-      (call_ind_impl target (writable_link_reg) (abi_call_info abi uses defs)))
+      (call_ind_impl (writable_link_reg) (abi_call_ind_info abi target uses defs)))
 
 (decl abi_return_call (Sig ExternalName CallArgList) SideEffectNoResult)
 (rule (abi_return_call abi name uses)
@@ -3614,19 +3615,12 @@
 
 (type LibCallInfo extern (enum))
 
-(type LibCall extern
-      (enum
-        Memcpy))
-
 (decl lib_call_info_memcpy (Reg Reg Reg) BoxCallInfo)
 (extern constructor lib_call_info_memcpy lib_call_info_memcpy)
 
-(decl libcall_name (LibCall) ExternalName)
-(extern constructor libcall_name libcall_name)
-
-(decl lib_call (LibCall BoxCallInfo) SideEffectNoResult)
-(rule (lib_call libcall info)
-      (call_impl (libcall_name libcall) (writable_link_reg) info))
+(decl lib_call (BoxCallInfo) SideEffectNoResult)
+(rule (lib_call info)
+      (call_impl (writable_link_reg) info))
 
 
 ;; Helpers for generating vector pack and unpack instructions ;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -1,7 +1,6 @@
 use crate::ir::{MemFlags, TrapCode};
 use crate::isa::s390x::inst::*;
 use crate::isa::s390x::settings as s390x_settings;
-use smallvec::smallvec;
 
 #[cfg(test)]
 fn simm20_zero() -> SImm20 {
@@ -6984,16 +6983,8 @@ fn test_s390x_binemit() {
     insns.push((
         Inst::Call {
             link: writable_gpr(14),
-            info: Box::new(CallInfo {
-                dest: ExternalName::testcase("test0"),
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: PRegSet::empty(),
-                callee_pop_size: 0,
-                caller_callconv: CallConv::SystemV,
-                callee_callconv: CallConv::SystemV,
-                tls_symbol: None,
-            }),
+            dest: ExternalName::testcase("test0"),
+            info: Box::new(CallInfo::empty(CallConv::SystemV)),
         },
         "C0E500000000",
         "brasl %r14, %test0",
@@ -7002,15 +6993,8 @@ fn test_s390x_binemit() {
     insns.push((
         Inst::CallInd {
             link: writable_gpr(14),
-            info: Box::new(CallIndInfo {
-                rn: gpr(1),
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: PRegSet::empty(),
-                callee_pop_size: 0,
-                caller_callconv: CallConv::SystemV,
-                callee_callconv: CallConv::SystemV,
-            }),
+            rn: gpr(1),
+            info: Box::new(CallInfo::empty(CallConv::SystemV)),
         },
         "0DE1",
         "basr %r14, %r1",

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -6983,8 +6983,10 @@ fn test_s390x_binemit() {
     insns.push((
         Inst::Call {
             link: writable_gpr(14),
-            dest: ExternalName::testcase("test0"),
-            info: Box::new(CallInfo::empty(CallConv::SystemV)),
+            info: Box::new(CallInfo::empty(
+                ExternalName::testcase("test0"),
+                CallConv::SystemV,
+            )),
         },
         "C0E500000000",
         "brasl %r14, %test0",
@@ -6993,8 +6995,7 @@ fn test_s390x_binemit() {
     insns.push((
         Inst::CallInd {
             link: writable_gpr(14),
-            rn: gpr(1),
-            info: Box::new(CallInfo::empty(CallConv::SystemV)),
+            info: Box::new(CallInfo::empty(gpr(1), CallConv::SystemV)),
         },
         "0DE1",
         "basr %r14, %r1",

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -2269,9 +2269,12 @@
 (decl lib_call_tls_get_offset (Reg Reg SymbolReloc) Reg)
 (rule (lib_call_tls_get_offset got got_offset symbol)
       (let ((tls_offset WritableReg (temp_writable_reg $I64))
-            (libcall LibCallInfo (lib_call_info_tls_get_offset tls_offset got got_offset symbol))
-            (_ InstOutput (side_effect (lib_call libcall))))
+            (_ Unit (abi_for_elf_tls_get_offset))
+            (_ Unit (emit (MInst.ElfTlsGetOffset tls_offset got got_offset (writable_link_reg) symbol))))
         tls_offset))
+
+(decl abi_for_elf_tls_get_offset () Unit)
+(extern constructor abi_for_elf_tls_get_offset abi_for_elf_tls_get_offset)
 
 ;; Helper to extract the current thread pointer from %a0/%a1.
 (decl thread_pointer () Reg)

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -7,13 +7,13 @@ use crate::ir::ExternalName;
 // Types that the generated ISLE code uses via `use super::*`.
 use crate::isa::s390x::abi::{S390xMachineDeps, REG_SAVE_AREA_SIZE};
 use crate::isa::s390x::inst::{
-    gpr, stack_reg, writable_gpr, zero_reg, CallIndInfo, CallInfo, Cond, Inst as MInst, LaneOrder,
-    MemArg, MemArgPair, RegPair, ReturnCallIndInfo, ReturnCallInfo, SymbolReloc, UImm12,
-    UImm16Shifted, UImm32Shifted, WritableRegPair,
+    gpr, stack_reg, writable_gpr, zero_reg, Cond, Inst as MInst, LaneOrder, MemArg, MemArgPair,
+    RegPair, ReturnCallIndInfo, ReturnCallInfo, SymbolReloc, UImm12, UImm16Shifted, UImm32Shifted,
+    WritableRegPair,
 };
 use crate::isa::s390x::S390xBackend;
 use crate::machinst::isle::*;
-use crate::machinst::{MachLabel, Reg};
+use crate::machinst::{CallInfo, MachLabel, Reg};
 use crate::{
     ir::{
         condcodes::*, immediates::*, types::*, ArgumentExtension, ArgumentPurpose, AtomicRmwOp,
@@ -33,16 +33,7 @@ use std::boxed::Box;
 use std::cell::Cell;
 use std::vec::Vec;
 
-/// Information describing a library call to be emitted.
-pub struct LibCallInfo {
-    libcall: LibCall,
-    uses: CallArgList,
-    defs: CallRetList,
-    tls_symbol: Option<SymbolReloc>,
-}
-
 type BoxCallInfo = Box<CallInfo>;
-type BoxCallIndInfo = Box<CallIndInfo>;
 type BoxReturnCallInfo = Box<ReturnCallInfo>;
 type BoxReturnCallIndInfo = Box<ReturnCallIndInfo>;
 type VecMachLabel = Vec<MachLabel>;
@@ -268,13 +259,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
         MemArg::InitialSPOffset { off: 0 }
     }
 
-    fn abi_call_info(
-        &mut self,
-        abi: Sig,
-        name: ExternalName,
-        uses: &CallArgList,
-        defs: &CallRetList,
-    ) -> BoxCallInfo {
+    fn abi_call_info(&mut self, abi: Sig, uses: &CallArgList, defs: &CallRetList) -> BoxCallInfo {
         let sig_data = &self.lower_ctx.sigs()[abi];
         // Get clobbers: all caller-saves. These may include return value
         // regs, which we will remove from the clobber set later.
@@ -285,41 +270,12 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
             0
         };
         Box::new(CallInfo {
-            dest: name.clone(),
             uses: uses.clone(),
             defs: defs.clone(),
             clobbers,
             callee_pop_size,
-            caller_callconv: self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
-            callee_callconv: self.lower_ctx.sigs()[abi].call_conv(),
-            tls_symbol: None,
-        })
-    }
-
-    fn abi_call_ind_info(
-        &mut self,
-        abi: Sig,
-        target: Reg,
-        uses: &CallArgList,
-        defs: &CallRetList,
-    ) -> BoxCallIndInfo {
-        let sig_data = &self.lower_ctx.sigs()[abi];
-        // Get clobbers: all caller-saves. These may include return value
-        // regs, which we will remove from the clobber set later.
-        let clobbers = S390xMachineDeps::get_regs_clobbered_by_call(sig_data.call_conv());
-        let callee_pop_size = if sig_data.call_conv() == CallConv::Tail {
-            sig_data.sized_stack_arg_space() as u32
-        } else {
-            0
-        };
-        Box::new(CallIndInfo {
-            rn: target,
-            uses: uses.clone(),
-            defs: defs.clone(),
-            clobbers,
-            callee_pop_size,
-            caller_callconv: self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
-            callee_callconv: self.lower_ctx.sigs()[abi].call_conv(),
+            caller_conv: self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
+            callee_conv: self.lower_ctx.sigs()[abi].call_conv(),
         })
     }
 
@@ -353,9 +309,19 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
         })
     }
 
-    fn lib_call_info_memcpy(&mut self, dst: Reg, src: Reg, len: Reg) -> LibCallInfo {
-        LibCallInfo {
-            libcall: LibCall::Memcpy,
+    fn lib_call_info_memcpy(&mut self, dst: Reg, src: Reg, len: Reg) -> Box<CallInfo> {
+        let caller_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
+        let callee_conv = CallConv::for_libcall(&self.backend.flags, caller_conv);
+
+        // Clobbers are defined by the calling convention. We will remove return value regs later.
+        let clobbers = S390xMachineDeps::get_regs_clobbered_by_call(callee_conv);
+
+        // Libcalls only require the register save area.
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_outgoing_args_size(REG_SAVE_AREA_SIZE);
+
+        Box::new(CallInfo {
             uses: smallvec![
                 CallArgPair {
                     vreg: dst,
@@ -371,59 +337,21 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
                 },
             ],
             defs: smallvec![],
-            tls_symbol: None,
-        }
+            clobbers,
+            caller_conv,
+            callee_conv,
+            callee_pop_size: 0,
+        })
     }
 
-    fn lib_call_info_tls_get_offset(
-        &mut self,
-        tls_offset: WritableReg,
-        got: Reg,
-        got_offset: Reg,
-        tls_symbol: &SymbolReloc,
-    ) -> LibCallInfo {
-        LibCallInfo {
-            libcall: LibCall::ElfTlsGetOffset,
-            uses: smallvec![
-                CallArgPair {
-                    vreg: got,
-                    preg: gpr(12),
-                },
-                CallArgPair {
-                    vreg: got_offset,
-                    preg: gpr(2),
-                },
-            ],
-            defs: smallvec![CallRetPair {
-                vreg: tls_offset,
-                preg: gpr(2),
-            },],
-            tls_symbol: Some(tls_symbol.clone()),
-        }
+    fn libcall_name(&mut self, libcall: &libcall::LibCall) -> ExternalName {
+        ExternalName::LibCall(*libcall)
     }
 
-    fn lib_call_info(&mut self, info: &LibCallInfo) -> BoxCallInfo {
-        let caller_callconv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
-        let callee_callconv = CallConv::for_libcall(&self.backend.flags, caller_callconv);
-
-        // Clobbers are defined by the calling convention. We will remove return value regs later.
-        let clobbers = S390xMachineDeps::get_regs_clobbered_by_call(callee_callconv);
-
-        // Libcalls only require the register save area.
+    fn abi_for_elf_tls_get_offset(&mut self) {
         self.lower_ctx
             .abi_mut()
             .accumulate_outgoing_args_size(REG_SAVE_AREA_SIZE);
-
-        Box::new(CallInfo {
-            dest: ExternalName::LibCall(info.libcall),
-            uses: info.uses.clone(),
-            defs: info.defs.clone(),
-            clobbers,
-            callee_pop_size: 0,
-            caller_callconv,
-            callee_callconv,
-            tls_symbol: info.tls_symbol.clone(),
-        })
     }
 
     #[inline]

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -823,8 +823,11 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     }
 
     /// Generate a call instruction/sequence.
-    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo) -> SmallVec<[Self::I; 2]> {
-        let info = Box::new(info);
+    fn gen_call(
+        dest: &CallDest,
+        tmp: Writable<Reg>,
+        info: Box<CallInfo>,
+    ) -> SmallVec<[Self::I; 2]> {
         let mut insts = SmallVec::new();
         match dest {
             &CallDest::ExtName(ref name, RelocDistance::Near) => {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -617,17 +617,12 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             Writable::from_reg(regs::rax()),
         ));
         insts.push(Inst::CallKnown {
-            dest: ExternalName::LibCall(LibCall::Probestack),
-            info: Some(Box::new(CallInfo {
-                // No need to include arg here: we are post-regalloc
-                // so no constraints will be seen anyway.
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: PRegSet::empty(),
-                callee_pop_size: 0,
-                callee_conv: CallConv::Probestack,
-                caller_conv: CallConv::Probestack,
-            })),
+            // No need to include arg here: we are post-regalloc
+            // so no constraints will be seen anyway.
+            info: Box::new(CallInfo::empty(
+                ExternalName::LibCall(LibCall::Probestack),
+                CallConv::Probestack,
+            )),
         });
     }
 
@@ -823,15 +818,12 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     }
 
     /// Generate a call instruction/sequence.
-    fn gen_call(
-        dest: &CallDest,
-        tmp: Writable<Reg>,
-        info: Box<CallInfo>,
-    ) -> SmallVec<[Self::I; 2]> {
+    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo<()>) -> SmallVec<[Self::I; 2]> {
         let mut insts = SmallVec::new();
         match dest {
             &CallDest::ExtName(ref name, RelocDistance::Near) => {
-                insts.push(Inst::call_known(name.clone(), info));
+                let info = Box::new(info.map(|()| name.clone()));
+                insts.push(Inst::call_known(info));
             }
             &CallDest::ExtName(ref name, RelocDistance::Far) => {
                 insts.push(Inst::LoadExtName {
@@ -840,10 +832,12 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                     offset: 0,
                     distance: RelocDistance::Far,
                 });
-                insts.push(Inst::call_unknown(RegMem::reg(tmp.to_reg()), info));
+                let info = Box::new(info.map(|()| RegMem::reg(tmp.to_reg())));
+                insts.push(Inst::call_unknown(info));
             }
             &CallDest::Reg(reg) => {
-                insts.push(Inst::call_unknown(RegMem::reg(reg), info));
+                let info = Box::new(info.map(|()| RegMem::reg(reg)));
+                insts.push(Inst::call_unknown(info));
             }
         }
         insts
@@ -873,30 +867,28 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             distance: RelocDistance::Far,
         });
         let callee_pop_size = 0;
-        insts.push(Inst::call_unknown(
-            RegMem::reg(temp2.to_reg()),
-            Box::new(CallInfo {
-                uses: smallvec![
-                    CallArgPair {
-                        vreg: dst,
-                        preg: arg0
-                    },
-                    CallArgPair {
-                        vreg: src,
-                        preg: arg1
-                    },
-                    CallArgPair {
-                        vreg: temp.to_reg(),
-                        preg: arg2
-                    },
-                ],
-                defs: smallvec![],
-                clobbers: Self::get_regs_clobbered_by_call(call_conv),
-                callee_pop_size,
-                callee_conv: call_conv,
-                caller_conv: call_conv,
-            }),
-        ));
+        insts.push(Inst::call_unknown(Box::new(CallInfo {
+            dest: RegMem::reg(temp2.to_reg()),
+            uses: smallvec![
+                CallArgPair {
+                    vreg: dst,
+                    preg: arg0
+                },
+                CallArgPair {
+                    vreg: src,
+                    preg: arg1
+                },
+                CallArgPair {
+                    vreg: temp.to_reg(),
+                    preg: arg2
+                },
+            ],
+            defs: smallvec![],
+            clobbers: Self::get_regs_clobbered_by_call(call_conv),
+            callee_pop_size,
+            callee_conv: call_conv,
+            caller_conv: call_conv,
+        })));
         insts
     }
 
@@ -1005,14 +997,17 @@ impl X64CallSite {
 
         // Finally, do the actual tail call!
         let dest = self.dest().clone();
-        let info = Box::new(ReturnCallInfo {
-            new_stack_arg_size,
-            uses: self.take_uses(),
-            tmp: ctx.temp_writable_gpr(),
-        });
+        let uses = self.take_uses();
+        let tmp = ctx.temp_writable_gpr();
         match dest {
             CallDest::ExtName(callee, RelocDistance::Near) => {
-                ctx.emit(Inst::ReturnCallKnown { callee, info });
+                let info = Box::new(ReturnCallInfo {
+                    dest: callee,
+                    uses,
+                    tmp,
+                    new_stack_arg_size,
+                });
+                ctx.emit(Inst::ReturnCallKnown { info });
             }
             CallDest::ExtName(callee, RelocDistance::Far) => {
                 let tmp2 = ctx.temp_writable_gpr();
@@ -1022,15 +1017,23 @@ impl X64CallSite {
                     offset: 0,
                     distance: RelocDistance::Far,
                 });
-                ctx.emit(Inst::ReturnCallUnknown {
-                    callee: tmp2.to_reg().to_reg(),
-                    info,
+                let info = Box::new(ReturnCallInfo {
+                    dest: tmp2.to_reg().to_reg().into(),
+                    uses,
+                    tmp,
+                    new_stack_arg_size,
                 });
+                ctx.emit(Inst::ReturnCallUnknown { info });
             }
-            CallDest::Reg(callee) => ctx.emit(Inst::ReturnCallUnknown {
-                callee: callee.into(),
-                info,
-            }),
+            CallDest::Reg(callee) => {
+                let info = Box::new(ReturnCallInfo {
+                    dest: callee.into(),
+                    uses,
+                    tmp,
+                    new_stack_arg_size,
+                });
+                ctx.emit(Inst::ReturnCallUnknown { info });
+            }
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -531,20 +531,16 @@
        ;; Control flow instructions.
 
        ;; Direct call: call simm32.
-       (CallKnown (dest ExternalName)
-                  (info BoxCallInfo))
+       (CallKnown (info BoxCallInfo))
 
        ;; Indirect call: callq (reg mem)
-       (CallUnknown (dest RegMem)
-                    (info BoxCallInfo))
+       (CallUnknown (info BoxCallIndInfo))
 
        ;; Tail call to a direct destination.
-       (ReturnCallKnown (callee ExternalName)
-                        (info BoxReturnCallInfo))
+       (ReturnCallKnown (info BoxReturnCallInfo))
 
        ;; Tail call to an indirect destination.
-       (ReturnCallUnknown (callee Reg)
-                          (info BoxReturnCallInfo))
+       (ReturnCallUnknown (info BoxReturnCallIndInfo))
 
        ;; A pseudo-instruction that captures register arguments in vregs.
        (Args
@@ -748,7 +744,9 @@
             SFence))
 
 (type BoxCallInfo extern (enum))
+(type BoxCallIndInfo extern (enum))
 (type BoxReturnCallInfo extern (enum))
+(type BoxReturnCallIndInfo extern (enum))
 
 ;; Get the `OperandSize` for a given `Type`, rounding smaller types up to 32 bits.
 (decl operand_size_of_type_32_64 (Type) OperandSize)

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3747,10 +3747,10 @@ fn test_x64_emit() {
     // ========================================================
     // CallKnown
     insns.push((
-        Inst::call_known(
+        Inst::call_known(Box::new(CallInfo::empty(
             ExternalName::User(UserExternalNameRef::new(0)),
-            Box::new(CallInfo::empty(CallConv::SystemV)),
-        ),
+            CallConv::SystemV,
+        ))),
         "E800000000",
         "call    User(userextname0)",
     ));
@@ -3758,7 +3758,7 @@ fn test_x64_emit() {
     // ========================================================
     // CallUnknown
     fn call_unknown(rm: RegMem) -> Inst {
-        Inst::call_unknown(rm, Box::new(CallInfo::empty(CallConv::SystemV)))
+        Inst::call_unknown(Box::new(CallInfo::empty(rm, CallConv::SystemV)))
     }
 
     insns.push((call_unknown(RegMem::reg(rbp)), "FFD5", "call    *%rbp"));

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3749,11 +3749,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::call_known(
             ExternalName::User(UserExternalNameRef::new(0)),
-            smallvec![],
-            smallvec![],
-            PRegSet::default(),
-            0,
-            CallConv::SystemV,
+            Box::new(CallInfo::empty(CallConv::SystemV)),
         ),
         "E800000000",
         "call    User(userextname0)",
@@ -3762,14 +3758,7 @@ fn test_x64_emit() {
     // ========================================================
     // CallUnknown
     fn call_unknown(rm: RegMem) -> Inst {
-        Inst::call_unknown(
-            rm,
-            smallvec![],
-            smallvec![],
-            PRegSet::default(),
-            0,
-            CallConv::SystemV,
-        )
+        Inst::call_unknown(rm, Box::new(CallInfo::empty(CallConv::SystemV)))
     }
 
     insns.push((call_unknown(RegMem::reg(rbp)), "FFD5", "call    *%rbp"));

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -34,7 +34,10 @@ pub use super::lower::isle::generated_code::MInst as Inst;
 
 /// Out-of-line data for return-calls, to keep the size of `Inst` down.
 #[derive(Clone, Debug)]
-pub struct ReturnCallInfo {
+pub struct ReturnCallInfo<T> {
+    /// Where this call is going.
+    pub dest: T,
+
     /// The size of the argument area for this return-call, potentially smaller than that of the
     /// caller, but never larger.
     pub new_stack_arg_size: u32,
@@ -520,19 +523,13 @@ impl Inst {
         Inst::Pop64 { dst }
     }
 
-    pub(crate) fn call_known(dest: ExternalName, info: Box<CallInfo>) -> Inst {
-        Inst::CallKnown {
-            dest,
-            info: Some(info),
-        }
+    pub(crate) fn call_known(info: Box<CallInfo<ExternalName>>) -> Inst {
+        Inst::CallKnown { info }
     }
 
-    pub(crate) fn call_unknown(dest: RegMem, info: Box<CallInfo>) -> Inst {
-        dest.assert_regclass_is(RegClass::Int);
-        Inst::CallUnknown {
-            dest,
-            info: Some(info),
-        }
+    pub(crate) fn call_unknown(info: Box<CallInfo<RegMem>>) -> Inst {
+        info.dest.assert_regclass_is(RegClass::Int);
+        Inst::CallUnknown { info }
     }
 
     pub(crate) fn ret(stack_bytes_to_pop: u32) -> Inst {
@@ -1616,26 +1613,26 @@ impl PrettyPrint for Inst {
                 format!("{op} {dst}")
             }
 
-            Inst::CallKnown { dest, .. } => {
+            Inst::CallKnown { info } => {
                 let op = ljustify("call".to_string());
-                format!("{op} {dest:?}")
+                format!("{op} {:?}", info.dest)
             }
 
-            Inst::CallUnknown { dest, .. } => {
-                let dest = dest.pretty_print(8);
+            Inst::CallUnknown { info } => {
+                let dest = info.dest.pretty_print(8);
                 let op = ljustify("call".to_string());
                 format!("{op} *{dest}")
             }
 
-            Inst::ReturnCallKnown { callee, info } => {
+            Inst::ReturnCallKnown { info } => {
                 let ReturnCallInfo {
                     uses,
                     new_stack_arg_size,
                     tmp,
+                    dest,
                 } = &**info;
                 let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8);
-                let mut s =
-                    format!("return_call_known {callee:?} ({new_stack_arg_size}) tmp={tmp}");
+                let mut s = format!("return_call_known {dest:?} ({new_stack_arg_size}) tmp={tmp}");
                 for ret in uses {
                     let preg = regs::show_reg(ret.preg);
                     let vreg = pretty_print_reg(ret.vreg, 8);
@@ -1644,13 +1641,14 @@ impl PrettyPrint for Inst {
                 s
             }
 
-            Inst::ReturnCallUnknown { callee, info } => {
+            Inst::ReturnCallUnknown { info } => {
                 let ReturnCallInfo {
                     uses,
                     new_stack_arg_size,
                     tmp,
+                    dest,
                 } = &**info;
-                let callee = pretty_print_reg(*callee, 8);
+                let callee = pretty_print_reg(*dest, 8);
                 let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8);
                 let mut s =
                     format!("return_call_unknown {callee} ({new_stack_arg_size}) tmp={tmp}");
@@ -2296,7 +2294,7 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_early_def(tmp);
         }
 
-        Inst::CallKnown { dest, info, .. } => {
+        Inst::CallKnown { info } => {
             // Probestack is special and is only inserted after
             // regalloc, so we do not need to represent its ABI to the
             // register allocator. Assert that we don't alter that
@@ -2305,8 +2303,9 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
                 uses,
                 defs,
                 clobbers,
+                dest,
                 ..
-            } = &mut **info.as_mut().expect("CallInfo is expected in this path");
+            } = &mut **info;
             debug_assert_ne!(*dest, ExternalName::LibCall(LibCall::Probestack));
             for CallArgPair { vreg, preg } in uses {
                 collector.reg_fixed_use(vreg, *preg);
@@ -2317,14 +2316,15 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_clobbers(*clobbers);
         }
 
-        Inst::CallUnknown { info, dest, .. } => {
+        Inst::CallUnknown { info } => {
             let CallInfo {
                 uses,
                 defs,
                 clobbers,
                 callee_conv,
+                dest,
                 ..
-            } = &mut **info.as_mut().expect("CallInfo is expected in this path");
+            } = &mut **info;
             match dest {
                 RegMem::Reg { reg } if *callee_conv == CallConv::Winch => {
                     // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
@@ -2364,25 +2364,29 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_clobbers(clobbers);
         }
 
-        Inst::ReturnCallKnown { callee, info } => {
-            let ReturnCallInfo { uses, tmp, .. } = &mut **info;
+        Inst::ReturnCallKnown { info } => {
+            let ReturnCallInfo {
+                dest, uses, tmp, ..
+            } = &mut **info;
             collector.reg_fixed_def(tmp, regs::r11());
             // Same as in the `Inst::CallKnown` branch.
-            debug_assert_ne!(*callee, ExternalName::LibCall(LibCall::Probestack));
+            debug_assert_ne!(*dest, ExternalName::LibCall(LibCall::Probestack));
             for CallArgPair { vreg, preg } in uses {
                 collector.reg_fixed_use(vreg, *preg);
             }
         }
 
-        Inst::ReturnCallUnknown { callee, info } => {
-            let ReturnCallInfo { uses, tmp, .. } = &mut **info;
+        Inst::ReturnCallUnknown { info } => {
+            let ReturnCallInfo {
+                dest, uses, tmp, ..
+            } = &mut **info;
 
             // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
             // This shouldn't be a fixed register constraint, but it's not clear how to
             // pick a register that won't be clobbered by the callee-save restore code
             // emitted with a return_call_indirect. r10 is caller-saved, so this should be
             // safe to use.
-            collector.reg_fixed_use(callee, regs::r10());
+            collector.reg_fixed_use(dest, regs::r10());
 
             collector.reg_fixed_def(tmp, regs::r11());
             for CallArgPair { vreg, preg } in uses {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -34,8 +34,10 @@ use std::boxed::Box;
 /// call instruction is also used by Winch to emit calls, but the
 /// `Box<CallInfo>` field is not used, it's only used by Cranelift. By making it
 /// optional, we reduce the number of heap allocations in Winch.
-type BoxCallInfo = Option<Box<CallInfo>>;
-type BoxReturnCallInfo = Box<ReturnCallInfo>;
+type BoxCallInfo = Box<CallInfo<ExternalName>>;
+type BoxCallIndInfo = Box<CallInfo<RegMem>>;
+type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
+type BoxReturnCallIndInfo = Box<ReturnCallInfo<Reg>>;
 type VecArgPair = Vec<ArgPair>;
 
 pub struct SinkableLoad {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -19,10 +19,10 @@ use crate::{
     },
     isa::x64::{
         abi::X64CallSite,
-        inst::{args::*, regs, CallInfo, ReturnCallInfo},
+        inst::{args::*, regs, ReturnCallInfo},
     },
     machinst::{
-        isle::*, ArgPair, InsnInput, InstOutput, IsTailCall, MachAtomicRmwOp, MachInst,
+        isle::*, ArgPair, CallInfo, InsnInput, InstOutput, IsTailCall, MachAtomicRmwOp, MachInst,
         VCodeConstant, VCodeConstantData,
     },
 };

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -1,6 +1,6 @@
 //! X86_64-bit Instruction Set Architecture.
 
-pub use self::inst::{args, CallInfo, EmitInfo, EmitState, Inst};
+pub use self::inst::{args, EmitInfo, EmitState, Inst};
 
 use super::{OwnedTargetIsa, TargetIsa};
 use crate::dominator_tree::DominatorTree;

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -843,8 +843,14 @@ pub(crate) fn check(
 
         Inst::ReturnCallUnknown { .. } => Ok(()),
 
-        Inst::CallUnknown { ref dest, .. }
-        | Inst::JmpUnknown {
+        Inst::CallUnknown { ref info } => match <&RegMem>::from(&info.dest) {
+            RegMem::Mem { ref addr } => {
+                check_load(ctx, None, addr, vcode, I64, 64)?;
+                Ok(())
+            }
+            RegMem::Reg { .. } => Ok(()),
+        },
+        Inst::JmpUnknown {
             target: ref dest, ..
         } => match <&RegMem>::from(dest) {
             RegMem::Mem { ref addr } => {

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::machinst::buffer::{
     MachTrap, OpenPatchRegion, PatchRegion,
 };
 pub use crate::machinst::{
-    CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,
+    CallInfo, CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,
     MachInstEmitState, MachLabel, RealReg, Reg, RelocDistance, TextSectionBuilder,
     VCodeConstantData, VCodeConstants, Writable,
 };

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -19,7 +19,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -60,7 +60,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -106,7 +106,7 @@ block0:
 ;   x1 = xconst8 1
 ;   x2 = xconst8 2
 ;   x3 = xconst8 3
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
 ;   x30 = xconst8 16
@@ -148,7 +148,7 @@ block0:
 ;   store64 sp+0, x29 // flags =  notrap aligned
 ;   x29 = xmov x27
 ; block0:
-;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x4 = xadd64 x0, x2
 ;   x3 = xadd64 x1, x3
 ;   x0 = xadd64 x4, x3
@@ -214,7 +214,7 @@ block0:
 ;   x12 = xmov x15
 ;   x13 = xmov x15
 ;   x14 = xmov x15
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x30 = xconst8 48
 ;   x27 = xadd32 x27, x30
 ;   x28 = load64_u sp+8 // flags = notrap aligned
@@ -310,7 +310,7 @@ block0:
 ;   store64 sp+48, x18 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x16 = xmov x13
 ;   x18 = xmov x11
 ;   x25 = load64_u OutgoingArg(0) // flags = notrap aligned

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -19,7 +19,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -60,7 +60,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -106,7 +106,7 @@ block0:
 ;   x1 = xconst8 1
 ;   x2 = xconst8 2
 ;   x3 = xconst8 3
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
 ;   x30 = xconst8 16
@@ -148,7 +148,7 @@ block0:
 ;   store64 sp+0, x29 // flags =  notrap aligned
 ;   x29 = xmov x27
 ; block0:
-;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x4 = xadd64 x0, x2
 ;   x3 = xadd64 x1, x3
 ;   x0 = xadd64 x4, x3
@@ -214,7 +214,7 @@ block0:
 ;   x12 = xmov x15
 ;   x13 = xmov x15
 ;   x14 = xmov x15
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x30 = xconst8 48
 ;   x27 = xadd32 x27, x30
 ;   x28 = load64_u sp+8 // flags = notrap aligned
@@ -310,7 +310,7 @@ block0:
 ;   store64 sp+48, x18 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x16 = xmov x13
 ;   x18 = xmov x11
 ;   x25 = load64_u OutgoingArg(0) // flags = notrap aligned

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -19,7 +19,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -60,7 +60,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -106,7 +106,7 @@ block0:
 ;   x1 = xconst8 1
 ;   x2 = xconst8 2
 ;   x3 = xconst8 3
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
 ;   x30 = xconst8 16
@@ -148,7 +148,7 @@ block0:
 ;   store64 sp+0, x29 // flags =  notrap aligned
 ;   x29 = xmov x27
 ; block0:
-;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x4 = xadd64 x0, x2
 ;   x3 = xadd64 x1, x3
 ;   x0 = xadd64 x4, x3
@@ -214,7 +214,7 @@ block0:
 ;   x12 = xmov x15
 ;   x13 = xmov x15
 ;   x14 = xmov x15
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x30 = xconst8 48
 ;   x27 = xadd32 x27, x30
 ;   x28 = load64_u sp+8 // flags = notrap aligned
@@ -310,7 +310,7 @@ block0:
 ;   store64 sp+48, x18 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_pop_size: 0 }
+;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x16 = xmov x13
 ;   x18 = xmov x11
 ;   x25 = load64_u OutgoingArg(0) // flags = notrap aligned

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -19,7 +19,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -60,7 +60,7 @@ block0:
 ;   x29 = xmov x27
 ; block0:
 ;   x0 = xconst8 0
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x0 = xconst8 1
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
@@ -106,7 +106,7 @@ block0:
 ;   x1 = xconst8 1
 ;   x2 = xconst8 2
 ;   x3 = xconst8 3
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x28 = load64_u sp+8 // flags = notrap aligned
 ;   x29 = load64_u sp+0 // flags = notrap aligned
 ;   x30 = xconst8 16
@@ -148,7 +148,7 @@ block0:
 ;   store64 sp+0, x29 // flags =  notrap aligned
 ;   x29 = xmov x27
 ; block0:
-;   call TestCase(%g), CallInfo { uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x4 = xadd64 x0, x2
 ;   x3 = xadd64 x1, x3
 ;   x0 = xadd64 x4, x3
@@ -214,7 +214,7 @@ block0:
 ;   x12 = xmov x15
 ;   x13 = xmov x15
 ;   x14 = xmov x15
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x30 = xconst8 48
 ;   x27 = xadd32 x27, x30
 ;   x28 = load64_u sp+8 // flags = notrap aligned
@@ -310,7 +310,7 @@ block0:
 ;   store64 sp+48, x18 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
-;   call TestCase(%g), CallInfo { uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   x16 = xmov x13
 ;   x18 = xmov x11
 ;   x25 = load64_u OutgoingArg(0) // flags = notrap aligned

--- a/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
@@ -16,7 +16,7 @@ block0(v0: i32):
 ; block0:
 ;   larl %r12, %ElfGlobalOffsetTable + 0
 ;   bras %r1, 12 ; data userextname0@tlsgd ; lg %r2, 0(%r1)
-;   brasl %r14, %ElfTlsGetOffset:tls_gdcall:userextname0
+;   brasl %r14, tls_gdcall:userextname0
 ;   ear %r4, %a0
 ;   sllg %r3, %r4, 32
 ;   ear %r3, %a1

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -21,9 +21,10 @@ use cranelift_codegen::{
             encoding::rex::{encode_modrm, RexFlags},
             settings as x64_settings, EmitInfo, EmitState, Inst,
         },
+        CallConv,
     },
-    settings, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState, MachLabel,
-    PatchRegion, RelocDistance, VCodeConstantData, VCodeConstants, Writable,
+    settings, CallInfo, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState,
+    MachLabel, PatchRegion, RelocDistance, VCodeConstantData, VCodeConstants, Writable,
 };
 
 use super::address::Address;
@@ -1250,15 +1251,18 @@ impl Assembler {
     /// Emit a call to an unknown location through a register.
     pub fn call_with_reg(&mut self, callee: Reg) {
         self.emit(Inst::CallUnknown {
-            dest: RegMem::reg(callee.into()),
-            info: None,
+            info: Box::new(CallInfo::empty(
+                RegMem::reg(callee.into()),
+                CallConv::SystemV,
+            )),
         });
     }
 
     /// Emit a call to a locally defined function through an index.
     pub fn call_with_name(&mut self, name: UserExternalNameRef) {
-        let dest = ExternalName::user(name);
-        self.emit(Inst::CallKnown { dest, info: None });
+        self.emit(Inst::CallKnown {
+            info: Box::new(CallInfo::empty(ExternalName::user(name), CallConv::SystemV)),
+        });
     }
 
     /// Emit a call to a well-known libcall.


### PR DESCRIPTION
This commit is aimed at making it easier to extend `CallInfo` amongst the backends with more fields. Most backends already share almost all the same fields except for minor differences so this commit moves backends to all roughly the same track for handling this to enable having one definition of `CallInfo` that is shared everywhere.