### PR TITLE
Explicitly require write permissions on release process

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -32,6 +32,9 @@ on:
         required: false
         default: 'cut'
 
+permissions:
+  contents: write
+
 jobs:
   release_process:
     if: "github.repository == 'bytecodealliance/wasmtime' || !github.event.schedule"


### PR DESCRIPTION
The default token for this repository is now read-only but this workflow needs writable permissions. Local testing seems to show that this should work so let's try it out here.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
