### PR TITLE
[wasi-http] Return `none` from `future-trailers.get` when trailers absent

### DIFF
--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -526,19 +526,21 @@ mod executor {
 
                         Inner::Trailers(trailers) => {
                             match trailers.get() {
-                                Some(Ok(Ok(Some(_)))) => {
-                                    // Currently, we just ignore any trailers.  TODO: Add a test that expects
-                                    // trailers and verify they match the expected contents.
+                                Some(Ok(trailers)) => {
                                     incoming.0 = Inner::Closed;
-                                }
-                                Some(Ok(Ok(None))) => {
-                                    // No trailers; nothing else to do.
-                                    incoming.0 = Inner::Closed;
-                                }
-                                Some(Ok(Err(error))) => {
-                                    // Error reading the trailers: pass it on to the application.
-                                    incoming.0 = Inner::Closed;
-                                    return Poll::Ready(Some(Err(anyhow!("{error:?}"))));
+                                    match trailers {
+                                        Ok(Some(_)) => {
+                                            // Currently, we just ignore any trailers.  TODO: Add a test that
+                                            // expects trailers and verify they match the expected contents.
+                                        }
+                                        Ok(None) => {
+                                            // No trailers; nothing else to do.
+                                        }
+                                        Err(error) => {
+                                            // Error reading the trailers: pass it on to the application.
+                                            return Poll::Ready(Some(Err(anyhow!("{error:?}"))));
+                                        }
+                                    }
                                 }
                                 Some(Err(_)) => {
                                     // Should only happen if we try to retrieve the trailers twice, i.e. a bug in

--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -347,12 +347,9 @@ impl Subscribe for HostFutureTrailers {
                 // were reached. It's up to us now to complete the body.
                 Ok(StreamEnd::Remaining(b)) => body.body = IncomingBodyState::Start(b),
 
-                // Technically this shouldn't be possible as the sender
-                // shouldn't get destroyed without receiving a message. Handle
-                // this just in case though.
+                // This means there were no trailers present.
                 Err(_) => {
-                    debug_assert!(false, "should be unreachable");
-                    *self = HostFutureTrailers::Done(Err(types::ErrorCode::ConnectionTerminated));
+                    *self = HostFutureTrailers::Done(Ok(None));
                 }
             }
         }


### PR DESCRIPTION
Previously, we would return `error-code::connection-terminated` in this case, whereas the `wasi-http` spec says we should simply return `none` (i.e. it's not an error if there are no trailers present).

This also adds code to `api_proxy_streaming.rs` to check for trailers after reading the body content.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
