### PR TITLE
Warn against `clippy::cast_possible_truncation` in Wasmtime

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -837,7 +837,7 @@ macro_rules! integers {
 
         unsafe impl Lift for $primitive {
             #[inline]
-            #[allow(trivial_numeric_casts)]
+            #[allow(trivial_numeric_casts, clippy::cast_possible_truncation)]
             fn lift(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 Ok(src.$get() as $primitive)
@@ -1110,8 +1110,8 @@ unsafe impl Lower for str {
         debug_assert!(offset % (Self::ALIGN32 as usize) == 0);
         let (ptr, len) = lower_string(cx, self)?;
         // FIXME: needs memory64 handling
-        *cx.get(offset + 0) = (ptr as i32).to_le_bytes();
-        *cx.get(offset + 4) = (len as i32).to_le_bytes();
+        *cx.get(offset + 0) = u32::try_from(ptr).unwrap().to_le_bytes();
+        *cx.get(offset + 4) = u32::try_from(len).unwrap().to_le_bytes();
         Ok(())
     }
 }
@@ -1457,8 +1457,8 @@ where
         };
         debug_assert!(offset % (Self::ALIGN32 as usize) == 0);
         let (ptr, len) = lower_list(cx, elem, self)?;
-        *cx.get(offset + 0) = (ptr as i32).to_le_bytes();
-        *cx.get(offset + 4) = (len as i32).to_le_bytes();
+        *cx.get(offset + 0) = u32::try_from(ptr).unwrap().to_le_bytes();
+        *cx.get(offset + 4) = u32::try_from(len).unwrap().to_le_bytes();
         Ok(())
     }
 }

--- a/crates/wasmtime/src/runtime/component/resource_table.rs
+++ b/crates/wasmtime/src/runtime/component/resource_table.rs
@@ -161,7 +161,7 @@ impl ResourceTable {
     fn push_(&mut self, e: TableEntry) -> Result<u32, ResourceTableError> {
         if let Some(free) = self.pop_free_list() {
             self.entries[free] = Entry::Occupied { entry: e };
-            Ok(free as u32)
+            Ok(free.try_into().unwrap())
         } else {
             let ix = self
                 .entries

--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -187,11 +187,11 @@ impl Val {
                 let u32_count = cx.types.canonical_abi(&ty).flat_count(usize::MAX).unwrap();
                 let ty = &cx.types[i];
                 let mut flags = Vec::new();
-                for i in 0..u32_count {
+                for i in 0..u32::try_from(u32_count).unwrap() {
                     push_flags(
                         ty,
                         &mut flags,
-                        (i as u32) * 32,
+                        i * 32,
                         u32::lift(cx, InterfaceType::U32, next(src))?,
                     );
                 }
@@ -480,8 +480,8 @@ impl Val {
                 let ty = &cx.types[ty];
                 let (ptr, len) = lower_list(cx, ty.element, values)?;
                 // FIXME: needs memory64 handling
-                *cx.get(offset + 0) = (ptr as i32).to_le_bytes();
-                *cx.get(offset + 4) = (len as i32).to_le_bytes();
+                *cx.get(offset + 0) = u32::try_from(ptr).unwrap().to_le_bytes();
+                *cx.get(offset + 4) = u32::try_from(len).unwrap().to_le_bytes();
                 Ok(())
             }
             (InterfaceType::List(_), _) => unexpected(ty, self),
@@ -947,7 +947,7 @@ fn get_enum_discriminant(ty: &TypeEnum, n: &str) -> Result<u32> {
     ty.names
         .get_index_of(n)
         .ok_or_else(|| anyhow::anyhow!("enum variant name `{n}` is not valid"))
-        .map(|i| i as u32)
+        .map(|i| i.try_into().unwrap())
 }
 
 fn get_variant_discriminant<'a>(
@@ -958,7 +958,7 @@ fn get_variant_discriminant<'a>(
         .cases
         .get_full(name)
         .ok_or_else(|| anyhow::anyhow!("unknown variant case: `{name}`"))?;
-    Ok((i as u32, ty))
+    Ok((i.try_into().unwrap(), ty))
 }
 
 fn next<'a>(src: &mut Iter<'a, ValRaw>) -> &'a ValRaw {

--- a/crates/wasmtime/src/runtime/instantiate.rs
+++ b/crates/wasmtime/src/runtime/instantiate.rs
@@ -274,9 +274,12 @@ impl CompiledModule {
                 .meta
                 .dwarf
                 .binary_search_by_key(&(id as u8), |(id, _)| *id)
-                .map(|i| {
+                .ok()
+                .and_then(|i| {
                     let (_, range) = &self.meta.dwarf[i];
-                    &self.code_memory().dwarf()[range.start as usize..range.end as usize]
+                    let start = range.start.try_into().ok()?;
+                    let end = range.end.try_into().ok()?;
+                    self.code_memory().dwarf().get(start..end)
                 })
                 .unwrap_or(&[]);
             Ok(EndianSlice::new(data, gimli::LittleEndian))

--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -4,9 +4,7 @@ use crate::prelude::*;
 use crate::store::StoreOpaque;
 use crate::{AsContext, Module};
 use core::fmt;
-use wasmtime_environ::{
-    demangle_function_name, demangle_function_name_or_index, EntityRef, FilePos,
-};
+use wasmtime_environ::{demangle_function_name, demangle_function_name_or_index, FilePos};
 
 /// Representation of a WebAssembly trap and what caused it to occur.
 ///
@@ -451,7 +449,7 @@ impl FrameInfo {
             text_offset,
         );
         let index = compiled_module.module().func_index(index);
-        let func_index = index.index() as u32;
+        let func_index = index.as_u32();
         let func_name = compiled_module.func_name(index).map(|s| s.to_string());
 
         // In debug mode for now assert that we found a mapping for `pc` within

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -23,6 +23,8 @@ use sptr::Strict;
 use wasmtime_environ::component::*;
 use wasmtime_environ::{HostPtr, PrimaryMap, VMSharedTypeIndex};
 
+#[allow(clippy::cast_possible_truncation)] // it's intended this is truncated on
+                                           // 32-bit platforms
 const INVALID_PTR: usize = 0xdead_dead_beef_beef_u64 as usize;
 
 mod libcalls;

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -72,10 +72,13 @@ impl MemoryImage {
         data: &[u8],
         mmap: Option<&MmapVec>,
     ) -> Result<Option<MemoryImage>> {
+        let assert_page_aligned = |val: usize| {
+            assert_eq!(val % (page_size as usize), 0);
+        };
         // Sanity-check that various parameters are page-aligned.
         let len = data.len();
         assert_eq!(offset % u64::from(page_size), 0);
-        assert_eq!((len as u32) % page_size, 0);
+        assert_page_aligned(len);
         let linear_memory_offset = match usize::try_from(offset) {
             Ok(offset) => offset,
             Err(_) => return Ok(None),
@@ -101,10 +104,10 @@ impl MemoryImage {
             let data_start = data.as_ptr() as usize;
             let data_end = data_start + data.len();
             assert!(start <= data_start && data_end <= end);
-            assert_eq!((start as u32) % page_size, 0);
-            assert_eq!((data_start as u32) % page_size, 0);
-            assert_eq!((data_end as u32) % page_size, 0);
-            assert_eq!((mmap.original_offset() as u32) % page_size, 0);
+            assert_page_aligned(start);
+            assert_page_aligned(data_start);
+            assert_page_aligned(data_end);
+            assert_page_aligned(mmap.original_offset());
 
             #[cfg(feature = "std")]
             if let Some(file) = mmap.original_file() {
@@ -167,7 +170,8 @@ impl ModuleMemoryImages {
             _ => return Ok(None),
         };
         let mut memories = PrimaryMap::with_capacity(map.len());
-        let page_size = crate::runtime::vm::host_page_size() as u32;
+        let page_size = crate::runtime::vm::host_page_size();
+        let page_size = u32::try_from(page_size).unwrap();
         for (memory_index, init) in map {
             // mmap-based-initialization only works for defined memories with a
             // known starting point of all zeros, so bail out if the mmeory is

--- a/crates/wasmtime/src/runtime/vm/gc/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled.rs
@@ -27,3 +27,15 @@ const DEFAULT_GC_HEAP_CAPACITY: usize = 1 << 19;
 /// The default GC heap capacity for miri: 64KiB.
 #[cfg(miri)]
 const DEFAULT_GC_HEAP_CAPACITY: usize = 1 << 16;
+
+// Explicit methods with `#[allow]` to clearly indicate that truncation is
+// desired when used.
+#[allow(clippy::cast_possible_truncation)]
+fn truncate_i32_to_i16(a: i32) -> i16 {
+    a as i16
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn truncate_i32_to_i8(a: i32) -> i8 {
+    a as i8
+}

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/arrayref.rs
@@ -1,3 +1,4 @@
+use super::{truncate_i32_to_i16, truncate_i32_to_i8};
 use crate::{
     prelude::*,
     runtime::vm::{GcHeap, GcStore, VMGcRef},
@@ -193,8 +194,8 @@ impl VMArrayRef {
         let offset = layout.elem_offset(index, ty.byte_size_in_gc_heap());
         let mut data = store.unwrap_gc_store_mut().gc_object_data(self.as_gc_ref());
         match val {
-            Val::I32(i) if ty.is_i8() => data.write_i8(offset, i as i8),
-            Val::I32(i) if ty.is_i16() => data.write_i16(offset, i as i16),
+            Val::I32(i) if ty.is_i8() => data.write_i8(offset, truncate_i32_to_i8(i)),
+            Val::I32(i) if ty.is_i16() => data.write_i16(offset, truncate_i32_to_i16(i)),
             Val::I32(i) => data.write_i32(offset, i),
             Val::I64(i) => data.write_i64(offset, i),
             Val::F32(f) => data.write_u32(offset, f),
@@ -279,11 +280,11 @@ impl VMArrayRef {
             Val::I32(i) if ty.is_i8() => store
                 .gc_store_mut()?
                 .gc_object_data(self.as_gc_ref())
-                .write_i8(offset, i as i8),
+                .write_i8(offset, truncate_i32_to_i8(i)),
             Val::I32(i) if ty.is_i16() => store
                 .gc_store_mut()?
                 .gc_object_data(self.as_gc_ref())
-                .write_i16(offset, i as i16),
+                .write_i16(offset, truncate_i32_to_i16(i)),
             Val::I32(i) => store
                 .gc_store_mut()?
                 .gc_object_data(self.as_gc_ref())

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
@@ -14,8 +14,8 @@ pub(crate) struct FreeList {
 
 /// Our minimum and maximum supported alignment. Every allocation is aligned to
 /// this.
-const ALIGN_USIZE: usize = 8;
-const ALIGN_U32: u32 = ALIGN_USIZE as u32;
+const ALIGN_U32: u32 = 8;
+const ALIGN_USIZE: usize = ALIGN_U32 as usize;
 
 /// Our minimum allocation size.
 const MIN_BLOCK_SIZE: u32 = 24;

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
@@ -1,3 +1,4 @@
+use super::{truncate_i32_to_i16, truncate_i32_to_i8};
 use crate::{
     prelude::*,
     runtime::vm::{GcHeap, GcStore, VMGcRef},
@@ -187,8 +188,8 @@ impl VMStructRef {
         let offset = layout.fields[field];
         let mut data = store.gc_store_mut()?.gc_object_data(self.as_gc_ref());
         match val {
-            Val::I32(i) if ty.is_i8() => data.write_i8(offset, i as i8),
-            Val::I32(i) if ty.is_i16() => data.write_i16(offset, i as i16),
+            Val::I32(i) if ty.is_i8() => data.write_i8(offset, truncate_i32_to_i8(i)),
+            Val::I32(i) if ty.is_i16() => data.write_i16(offset, truncate_i32_to_i16(i)),
             Val::I32(i) => data.write_i32(offset, i),
             Val::I64(i) => data.write_i64(offset, i),
             Val::F32(f) => data.write_u32(offset, f),
@@ -273,11 +274,11 @@ impl VMStructRef {
             Val::I32(i) if ty.is_i8() => store
                 .gc_store_mut()?
                 .gc_object_data(self.as_gc_ref())
-                .write_i8(offset, i as i8),
+                .write_i8(offset, truncate_i32_to_i8(i)),
             Val::I32(i) if ty.is_i16() => store
                 .gc_store_mut()?
                 .gc_object_data(self.as_gc_ref())
-                .write_i16(offset, i as i16),
+                .write_i16(offset, truncate_i32_to_i16(i)),
             Val::I32(i) => store
                 .gc_store_mut()?
                 .gc_object_data(self.as_gc_ref())

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -944,6 +944,7 @@ impl Instance {
 
         let src = self.validate_inbounds(src_mem.current_length(), src, len)?;
         let dst = self.validate_inbounds(dst_mem.current_length(), dst, len)?;
+        let len = usize::try_from(len).unwrap();
 
         // Bounds and casts are checked above, by this point we know that
         // everything is safe.
@@ -952,7 +953,7 @@ impl Instance {
             let src = src_mem.base.add(src);
             // FIXME audit whether this is safe in the presence of shared memory
             // (https://github.com/bytecodealliance/wasmtime/issues/4203).
-            ptr::copy(src, dst, len as usize);
+            ptr::copy(src, dst, len);
         }
 
         Ok(())
@@ -967,7 +968,7 @@ impl Instance {
         if end > max {
             Err(oob())
         } else {
-            Ok(ptr as usize)
+            Ok(ptr.try_into().unwrap())
         }
     }
 
@@ -985,6 +986,7 @@ impl Instance {
     ) -> Result<(), Trap> {
         let memory = self.get_memory(memory_index);
         let dst = self.validate_inbounds(memory.current_length(), dst, len)?;
+        let len = usize::try_from(len).unwrap();
 
         // Bounds and casts are checked above, by this point we know that
         // everything is safe.
@@ -992,7 +994,7 @@ impl Instance {
             let dst = memory.base.add(dst);
             // FIXME audit whether this is safe in the presence of shared memory
             // (https://github.com/bytecodealliance/wasmtime/issues/4203).
-            ptr::write_bytes(dst, val, len as usize);
+            ptr::write_bytes(dst, val, len);
         }
 
         Ok(())

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -491,9 +491,9 @@ mod test {
     fn test_next_available_allocation_strategy() {
         for size in 0..20 {
             let state = ModuleAffinityIndexAllocator::new(size, 0);
-            assert_eq!(state.num_empty_slots() as u32, size);
+            assert_eq!(state.num_empty_slots(), usize::try_from(size).unwrap());
             for i in 0..size {
-                assert_eq!(state.num_empty_slots() as u32, size - i);
+                assert_eq!(state.num_empty_slots(), usize::try_from(size - i).unwrap());
                 assert_eq!(state.alloc(None).unwrap().index(), i as usize);
             }
             assert!(state.alloc(None).is_none());

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -378,7 +378,8 @@ impl MemoryPool {
             // the process to continue, because we never perform a
             // mmap that would leave an open space for someone
             // else to come in and map something.
-            slot.instantiate(initial_size as usize, image, memory_plan)?;
+            let initial_size = usize::try_from(initial_size).unwrap();
+            slot.instantiate(initial_size, image, memory_plan)?;
 
             Memory::new_static(
                 memory_plan,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -205,8 +205,9 @@ impl StackPool {
 
         let index = (start_of_stack - base) / self.stack_size;
         assert!(index < self.max_stacks);
+        let index = u32::try_from(index).unwrap();
 
-        self.index_allocator.free(SlotId(index as u32));
+        self.index_allocator.free(SlotId(index));
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -346,6 +346,7 @@ fn memory_fill(
     len: u64,
 ) -> Result<(), Trap> {
     let memory_index = MemoryIndex::from_u32(memory_index);
+    #[allow(clippy::cast_possible_truncation)]
     instance.memory_fill(memory_index, dst, val as u8, len)
 }
 

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -811,5 +811,6 @@ pub fn validate_atomic_addr(
         return Err(Trap::MemoryOutOfBounds);
     }
 
-    Ok(def.base.wrapping_add(addr as usize))
+    let addr = usize::try_from(addr).unwrap();
+    Ok(def.base.wrapping_add(addr))
 }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -248,6 +248,8 @@ unsafe extern "C" fn trap_handler(
     }
 }
 
+#[allow(clippy::cast_possible_truncation)] // too fiddly to handle and wouldn't
+                                           // help much anyway
 unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> TrapRegisters {
     cfg_if::cfg_if! {
         if #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "x86_64"))] {

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -79,12 +79,12 @@ mod test_vmfunction_import {
     use super::VMFunctionImport;
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
     fn check_vmfunction_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMFunctionImport>(),
             usize::from(offsets.size_of_vmfunction_import())
@@ -144,12 +144,12 @@ mod test_vmtable_import {
     use super::VMTableImport;
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
     fn check_vmtable_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMTableImport>(),
             usize::from(offsets.size_of_vmtable_import())
@@ -190,12 +190,12 @@ mod test_vmmemory_import {
     use super::VMMemoryImport;
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
     fn check_vmmemory_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMMemoryImport>(),
             usize::from(offsets.size_of_vmmemory_import())
@@ -234,12 +234,12 @@ mod test_vmglobal_import {
     use super::VMGlobalImport;
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
     fn check_vmglobal_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMGlobalImport>(),
             usize::from(offsets.size_of_vmglobal_import())
@@ -297,12 +297,12 @@ mod test_vmmemory_definition {
     use super::VMMemoryDefinition;
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, PtrSize, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, PtrSize, VMOffsets};
 
     #[test]
     fn check_vmmemory_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMMemoryDefinition>(),
             usize::from(offsets.ptr.size_of_vmmemory_definition())
@@ -341,12 +341,12 @@ mod test_vmtable_definition {
     use super::VMTableDefinition;
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
     fn check_vmtable_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMTableDefinition>(),
             usize::from(offsets.size_of_vmtable_definition())
@@ -377,7 +377,7 @@ pub struct VMGlobalDefinition {
 mod test_vmglobal_definition {
     use super::VMGlobalDefinition;
     use std::mem::{align_of, size_of};
-    use wasmtime_environ::{Module, PtrSize, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, PtrSize, VMOffsets};
 
     #[test]
     fn check_vmglobal_definition_alignment() {
@@ -391,7 +391,7 @@ mod test_vmglobal_definition {
     #[test]
     fn check_vmglobal_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMGlobalDefinition>(),
             usize::from(offsets.ptr.size_of_vmglobal_definition())
@@ -401,7 +401,7 @@ mod test_vmglobal_definition {
     #[test]
     fn check_vmglobal_begins_aligned() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(offsets.vmctx_globals_begin() % 16, 0);
     }
 
@@ -608,12 +608,12 @@ impl VMGlobalDefinition {
 mod test_vmshared_type_index {
     use super::VMSharedTypeIndex;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
     fn check_vmshared_type_index() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMSharedTypeIndex>(),
             usize::from(offsets.size_of_vmshared_type_index())
@@ -673,12 +673,12 @@ mod test_vm_func_ref {
     use super::VMFuncRef;
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, PtrSize, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, PtrSize, VMOffsets};
 
     #[test]
     fn check_vm_func_ref_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMFuncRef>(),
             usize::from(offsets.ptr.size_of_vm_func_ref())
@@ -837,13 +837,12 @@ impl Default for VMRuntimeLimits {
 mod test_vmruntime_limits {
     use super::VMRuntimeLimits;
     use core::mem::offset_of;
-    use std::mem::size_of;
-    use wasmtime_environ::{Module, PtrSize, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, PtrSize, VMOffsets};
 
     #[test]
     fn field_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             offset_of!(VMRuntimeLimits, stack_limit),
             usize::from(offsets.ptr.vmruntime_limits_stack_limit())


### PR DESCRIPTION
This commit explicitly enables the `clippy::cast_possible_truncation` lint in Clippy for just the `wasmtime::runtime` module. This does not enable it for the entire workspace since it's a very noisy lint and in general has a low signal value. For the domain that `wasmtime::runtime` is working in, however, this is a much more useful lint. We in general want to be very careful about casting between `usize`, `u32`, and `u64` and the purpose of this module-targeted lint is to help with just that. I was inspired to do this after reading over #9206 where especially when refactoring code and changing types I think it would be useful to have locations flagged as "truncation may happen here" which previously weren't truncating.

The failure mode for this lint is that panics might be introduced where truncation is explicitly intended. Most of the time though this isn't actually desired so the more practical consequence of this lint is to probably slow down wasmtime ever so slightly and bloat it ever so slightly by having a few more checks in a few places. This is likely best addressed in a more comprehensive manner, however, rather than specifically for just this one case. This problem isn't unique to just casts, but to many other forms of `.unwrap()` for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
