### PR TITLE
 Optimize 128-bit multiplication some more in backends 

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -255,6 +255,21 @@
            (x_hi ValueRegs (value_regs_get x_regs 1)))
         (output_pair x_lo x_hi)))
 
+;; Special-case the lowering of an `isplit` of a 128-bit multiply where the
+;; lower bits of the result are discarded and the operands are sign or zero
+;; extended. This maps directly to `umulh` and `smulh`.
+(rule 1 (lower i @ (isplit (has_type $I128 (imul (uextend x) (uextend y)))))
+  (if-let (first_result lo) i)
+  (if-let $true (value_is_unused lo))
+  (output_pair (invalid_reg)
+               (umulh $I64 (put_in_reg_zext64 x) (put_in_reg_zext64 y))))
+
+(rule 1 (lower i @ (isplit (has_type $I128 (imul (sextend x) (sextend y)))))
+  (if-let (first_result lo) i)
+  (if-let $true (value_is_unused lo))
+  (output_pair (invalid_reg)
+               (smulh $I64 (put_in_reg_sext64 x) (put_in_reg_sext64 y))))
+
 ;;;; Rules for `iconcat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I128 (iconcat lo hi)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -480,6 +480,20 @@
       (dst_lo XReg (madd x_lo y_lo (zero_reg))))
     (value_regs dst_lo dst_hi)))
 
+;; Special case 128-bit multiplication where the operands are extended since
+;; that maps directly to the `mulhu` and `mulh` instructions.
+(rule 6 (lower (has_type $I128 (imul (uextend x) (uextend y))))
+  (let ((x XReg (zext x))
+        (y XReg (zext y)))
+    (value_regs (rv_mul x y) (rv_mulhu x y))))
+
+(rule 6 (lower (has_type $I128 (imul (sextend x) (sextend y))))
+  (let ((x XReg (sext x))
+        (y XReg (sext y)))
+    (value_regs (rv_mul x y) (rv_mulh x y))))
+
+;; Vector multiplication
+
 (rule 3 (lower (has_type (ty_supported_vec ty) (imul x y)))
   (rv_vmul_vv x y (unmasked) ty))
 
@@ -1931,6 +1945,18 @@
       (t2 XReg y))
     (value_regs t1 t2)))
 
+;; Special-case the lowering of an `isplit` of a 128-bit multiply where the
+;; lower bits of the result are discarded and the operands are sign or zero
+;; extended. This maps directly to `umulh` and `smulh`.
+(rule 1 (lower i @ (isplit (has_type $I128 (imul (uextend x) (uextend y)))))
+  (if-let (first_result lo) i)
+  (if-let $true (value_is_unused lo))
+  (output_pair (invalid_reg) (rv_mulhu (zext x) (zext y))))
+
+(rule 1 (lower i @ (isplit (has_type $I128 (imul (sextend x) (sextend y)))))
+  (if-let (first_result lo) i)
+  (if-let $true (value_is_unused lo))
+  (output_pair (invalid_reg) (rv_mulh (sext x) (sext y))))
 
 ;;;;;  Rules for `smax`;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -409,6 +409,15 @@
             (res_hi Reg (add_reg $I64 res_hi_3 (add_reg $I64 res_hi_2 res_hi_1))))
         (mov_to_vec128 $I64X2 res_hi res_lo)))
 
+;; Special-case the lowering of a 128-bit multiply where the operands are sign
+;; or zero extended. This maps directly to `umul_wide` and `smul_wide`.
+(rule 16 (lower (has_type $I128 (imul (uextend x) (uextend y))))
+  (let ((pair RegPair (umul_wide (put_in_reg_zext64 x) (put_in_reg_zext64 y))))
+    (mov_to_vec128 $I64X2 (regpair_hi pair) (regpair_lo pair))))
+
+(rule 16 (lower (has_type $I128 (imul (sextend x) (sextend y))))
+  (let ((pair RegPair (smul_wide (put_in_reg_sext64 x) (put_in_reg_sext64 y))))
+    (mov_to_vec128 $I64X2 (regpair_hi pair) (regpair_lo pair))))
 
 ;;;; Rules for `umulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1001,20 +1001,28 @@
 
 ;; 8-bit base case, needs a special instruction encoding and additionally
 ;; move sinkable loads to the right.
-(rule -7 (lower (has_type $I8 (imul x y))) (x64_mul8 $false x y))
-(rule -6 (lower (has_type $I8 (imul (sinkable_load x) y))) (x64_mul8 $false y x))
+(rule -8 (lower (has_type $I8 (imul x y))) (x64_mul8 $false x y))
+(rule -7 (lower (has_type $I8 (imul (sinkable_load x) y))) (x64_mul8 $false y x))
 
 ;; 16-to-64-bit base cases, same as above by moving sinkable loads to the right.
-(rule -5 (lower (has_type (ty_int_ref_16_to_64 ty) (imul x y)))
+(rule -6 (lower (has_type (ty_int_ref_16_to_64 ty) (imul x y)))
          (x64_imul ty x y))
-(rule -4 (lower (has_type (ty_int_ref_16_to_64 ty) (imul (sinkable_load x) y)))
+(rule -5 (lower (has_type (ty_int_ref_16_to_64 ty) (imul (sinkable_load x) y)))
          (x64_imul ty y x))
 
 ;; lift out constants to use 3-operand form
-(rule -3 (lower (has_type (ty_int_ref_16_to_64 ty) (imul x (i32_from_iconst y))))
+(rule -4 (lower (has_type (ty_int_ref_16_to_64 ty) (imul x (i32_from_iconst y))))
          (x64_imul_imm ty x y))
-(rule -2 (lower (has_type (ty_int_ref_16_to_64 ty) (imul (i32_from_iconst x) y)))
+(rule -3 (lower (has_type (ty_int_ref_16_to_64 ty) (imul (i32_from_iconst x) y)))
          (x64_imul_imm ty y x))
+
+;; Special case widening multiplication from 8-to-16-bits with a single
+;; instruction since the 8-bit-multiply places both the high and low halves in
+;; the same register
+(rule -2 (lower (has_type $I16 (imul (sextend x) (sextend y))))
+  (x64_mul8 $true x y))
+(rule -2 (lower (has_type $I16 (imul (uextend x) (uextend y))))
+  (x64_mul8 $false x y))
 
 ;; `i128`.
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -724,6 +724,10 @@ macro_rules! isle_lower_prelude_methods {
             self.lower_ctx.add_range_fact(reg, bits, min, max);
             reg
         }
+
+        fn value_is_unused(&mut self, val: Value) -> bool {
+            self.lower_ctx.value_is_unused(val)
+        }
     };
 }
 

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -255,6 +255,11 @@
 (decl inst_results (ValueSlice) Inst)
 (extern extractor infallible inst_results inst_results)
 
+;; Returns whether the given value is unused in this function and is a dead
+;; result.
+(decl pure value_is_unused (Value) bool)
+(extern constructor value_is_unused value_is_unused)
+
 ;; Extract the first result value of the given instruction.
 (decl first_result (Value) Inst)
 (extern extractor first_result first_result)

--- a/cranelift/filetests/filetests/isa/aarch64/i128.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/i128.clif
@@ -78,16 +78,13 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   madd x3, x0, x1, xzr
 ;   smulh x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mul x3, x0, x1
 ;   smulh x0, x0, x1
 ;   ret
-
 
 function %umul_high_i64_pattern(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -120,13 +117,11 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   madd x3, x0, x1, xzr
 ;   umulh x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mul x3, x0, x1
 ;   umulh x0, x0, x1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/i128.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/i128.clif
@@ -12,30 +12,16 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   li a5,0
-;   li a2,0
-;   mulhu a3,a0,a1
-;   mul a2,a0,a2
-;   add a3,a2,a3
-;   mul a5,a5,a1
-;   mv a2,a1
-;   add a1,a5,a3
-;   mul a3,a0,a2
-;   add a0,a3,zero
+;   mul a3,a0,a1
+;   mulhu a1,a0,a1
+;   mv a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv a5, zero
-;   mv a2, zero
-;   mulhu a3, a0, a1
-;   mul a2, a0, a2
-;   add a3, a2, a3
-;   mul a5, a5, a1
-;   mv a2, a1
-;   add a1, a5, a3
-;   mul a3, a0, a2
-;   add a0, a3, zero
+;   mul a3, a0, a1
+;   mulhu a1, a0, a1
+;   mv a0, a3
 ;   ret
 
 function %mul_sextend_i64(i64, i64) -> i128 {
@@ -48,30 +34,16 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   srai a5,a0,63
-;   srai a2,a1,63
-;   mulhu a3,a0,a1
-;   mul a2,a0,a2
-;   add a3,a2,a3
-;   mul a5,a5,a1
-;   mv a2,a1
-;   add a1,a5,a3
-;   mul a3,a0,a2
-;   add a0,a3,zero
+;   mul a3,a0,a1
+;   mulh a1,a0,a1
+;   mv a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   srai a5, a0, 0x3f
-;   srai a2, a1, 0x3f
-;   mulhu a3, a0, a1
-;   mul a2, a0, a2
-;   add a3, a2, a3
-;   mul a5, a5, a1
-;   mv a2, a1
-;   add a1, a5, a3
-;   mul a3, a0, a2
-;   add a0, a3, zero
+;   mul a3, a0, a1
+;   mulh a1, a0, a1
+;   mv a0, a3
 ;   ret
 
 function %smul_high_i64_pattern(i64, i64) -> i64 {
@@ -105,32 +77,12 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   srai a5,a0,63
-;   srai a2,a1,63
-;   mulhu a3,a0,a1
-;   mul a2,a0,a2
-;   mv a4,a0
-;   add a3,a2,a3
-;   mul a5,a5,a1
-;   add a0,a5,a3
-;   mv a2,a4
-;   mul a3,a2,a1
-;   add a5,a3,zero
+;   mulh a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   srai a5, a0, 0x3f
-;   srai a2, a1, 0x3f
-;   mulhu a3, a0, a1
-;   mul a2, a0, a2
-;   mv a4, a0
-;   add a3, a2, a3
-;   mul a5, a5, a1
-;   add a0, a5, a3
-;   mv a2, a4
-;   mul a3, a2, a1
-;   add a5, a3, zero
+;   mulh a0, a0, a1
 ;   ret
 
 function %umul_high_i64_pattern(i64, i64) -> i64 {
@@ -164,31 +116,11 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   li a5,0
-;   li a2,0
-;   mulhu a3,a0,a1
-;   mul a2,a0,a2
-;   mv a4,a0
-;   add a3,a2,a3
-;   mul a5,a5,a1
-;   add a0,a5,a3
-;   mv a2,a4
-;   mul a3,a2,a1
-;   add a5,a3,zero
+;   mulhu a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv a5, zero
-;   mv a2, zero
-;   mulhu a3, a0, a1
-;   mul a2, a0, a2
-;   mv a4, a0
-;   add a3, a2, a3
-;   mul a5, a5, a1
-;   add a0, a5, a3
-;   mv a2, a4
-;   mul a3, a2, a1
-;   add a5, a3, zero
+;   mulhu a0, a0, a1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/i128.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/i128.clif
@@ -1,7 +1,6 @@
 test compile precise-output
-set enable_llvm_abi_extensions=true
 set opt_level=speed
-target aarch64
+target riscv64
 
 function %mul_uextend_i64(i64, i64) -> i128 {
 block0(v0: i64, v1: i64):
@@ -13,16 +12,30 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   madd x3, x0, x1, xzr
-;   umulh x1, x0, x1
-;   mov x0, x3
+;   li a5,0
+;   li a2,0
+;   mulhu a3,a0,a1
+;   mul a2,a0,a2
+;   add a3,a2,a3
+;   mul a5,a5,a1
+;   mv a2,a1
+;   add a1,a5,a3
+;   mul a3,a0,a2
+;   add a0,a3,zero
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mul x3, x0, x1
-;   umulh x1, x0, x1
-;   mov x0, x3
+;   mv a5, zero
+;   mv a2, zero
+;   mulhu a3, a0, a1
+;   mul a2, a0, a2
+;   add a3, a2, a3
+;   mul a5, a5, a1
+;   mv a2, a1
+;   add a1, a5, a3
+;   mul a3, a0, a2
+;   add a0, a3, zero
 ;   ret
 
 function %mul_sextend_i64(i64, i64) -> i128 {
@@ -35,16 +48,30 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   madd x3, x0, x1, xzr
-;   smulh x1, x0, x1
-;   mov x0, x3
+;   srai a5,a0,63
+;   srai a2,a1,63
+;   mulhu a3,a0,a1
+;   mul a2,a0,a2
+;   add a3,a2,a3
+;   mul a5,a5,a1
+;   mv a2,a1
+;   add a1,a5,a3
+;   mul a3,a0,a2
+;   add a0,a3,zero
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mul x3, x0, x1
-;   smulh x1, x0, x1
-;   mov x0, x3
+;   srai a5, a0, 0x3f
+;   srai a2, a1, 0x3f
+;   mulhu a3, a0, a1
+;   mul a2, a0, a2
+;   add a3, a2, a3
+;   mul a5, a5, a1
+;   mv a2, a1
+;   add a1, a5, a3
+;   mul a3, a0, a2
+;   add a0, a3, zero
 ;   ret
 
 function %smul_high_i64_pattern(i64, i64) -> i64 {
@@ -59,12 +86,12 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   smulh x0, x0, x1
+;   mulh a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   smulh x0, x0, x1
+;   mulh a0, a0, a1
 ;   ret
 
 function %smul_high_i64_isplit(i64, i64) -> i64 {
@@ -78,16 +105,33 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   madd x3, x0, x1, xzr
-;   smulh x0, x0, x1
+;   srai a5,a0,63
+;   srai a2,a1,63
+;   mulhu a3,a0,a1
+;   mul a2,a0,a2
+;   mv a4,a0
+;   add a3,a2,a3
+;   mul a5,a5,a1
+;   add a0,a5,a3
+;   mv a2,a4
+;   mul a3,a2,a1
+;   add a5,a3,zero
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mul x3, x0, x1
-;   smulh x0, x0, x1
+;   srai a5, a0, 0x3f
+;   srai a2, a1, 0x3f
+;   mulhu a3, a0, a1
+;   mul a2, a0, a2
+;   mv a4, a0
+;   add a3, a2, a3
+;   mul a5, a5, a1
+;   add a0, a5, a3
+;   mv a2, a4
+;   mul a3, a2, a1
+;   add a5, a3, zero
 ;   ret
-
 
 function %umul_high_i64_pattern(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -101,12 +145,12 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   umulh x0, x0, x1
+;   mulhu a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   umulh x0, x0, x1
+;   mulhu a0, a0, a1
 ;   ret
 
 function %umul_high_i64_isplit(i64, i64) -> i64 {
@@ -120,13 +164,31 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   madd x3, x0, x1, xzr
-;   umulh x0, x0, x1
+;   li a5,0
+;   li a2,0
+;   mulhu a3,a0,a1
+;   mul a2,a0,a2
+;   mv a4,a0
+;   add a3,a2,a3
+;   mul a5,a5,a1
+;   add a0,a5,a3
+;   mv a2,a4
+;   mul a3,a2,a1
+;   add a5,a3,zero
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mul x3, x0, x1
-;   umulh x0, x0, x1
+;   mv a5, zero
+;   mv a2, zero
+;   mulhu a3, a0, a1
+;   mul a2, a0, a2
+;   mv a4, a0
+;   add a3, a2, a3
+;   mul a5, a5, a1
+;   add a0, a5, a3
+;   mv a2, a4
+;   mul a3, a2, a1
+;   add a5, a3, zero
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/s390x/i128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/i128.clif
@@ -1,0 +1,274 @@
+test compile precise-output
+set opt_level=speed
+target s390x
+
+function %mul_uextend_i64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = imul v2, v3
+    return v4
+}
+
+; VCode:
+;   stmg %r7, %r15, 56(%r15)
+; block0:
+;   lgr %r7, %r2
+;   vgbm %v26, 0
+;   vlvgg %v26, %r3, 1
+;   vgbm %v27, 0
+;   vlvgg %v27, %r4, 1
+;   vlgvg %r4, %v26, 0
+;   vlgvg %r5, %v26, 1
+;   vlgvg %r9, %v27, 0
+;   vlgvg %r11, %v27, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r11
+;   msgr %r5, %r9
+;   msgr %r4, %r11
+;   agr %r5, %r2
+;   agr %r4, %r5
+;   vlvgp %v3, %r4, %r3
+;   lgr %r2, %r7
+;   vst %v3, 0(%r2)
+;   lmg %r7, %r15, 56(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r7, %r15, 0x38(%r15)
+; block1: ; offset 0x6
+;   lgr %r7, %r2
+;   vzero %v26
+;   vlvgg %v26, %r3, 1
+;   vzero %v27
+;   vlvgg %v27, %r4, 1
+;   vlgvg %r4, %v26, 0
+;   vlgvg %r5, %v26, 1
+;   vlgvg %r9, %v27, 0
+;   vlgvg %r11, %v27, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r11
+;   msgr %r5, %r9
+;   msgr %r4, %r11
+;   agr %r5, %r2
+;   agr %r4, %r5
+;   vlvgp %v3, %r4, %r3
+;   lgr %r2, %r7
+;   vst %v3, 0(%r2)
+;   lmg %r7, %r15, 0x38(%r15)
+;   br %r14
+
+function %mul_sextend_i64(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+    v2 = sextend.i128 v0
+    v3 = sextend.i128 v1
+    v4 = imul v2, v3
+    return v4
+}
+
+; VCode:
+;   stmg %r7, %r15, 56(%r15)
+; block0:
+;   lgr %r7, %r2
+;   srag %r5, %r3, 63
+;   vlvgp %v27, %r5, %r3
+;   srag %r3, %r4, 63
+;   vlvgp %v28, %r3, %r4
+;   vlgvg %r4, %v27, 0
+;   vlgvg %r5, %v27, 1
+;   vlgvg %r9, %v28, 0
+;   vlgvg %r11, %v28, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r11
+;   msgr %r5, %r9
+;   msgr %r4, %r11
+;   agr %r5, %r2
+;   agr %r4, %r5
+;   vlvgp %v3, %r4, %r3
+;   lgr %r2, %r7
+;   vst %v3, 0(%r2)
+;   lmg %r7, %r15, 56(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r7, %r15, 0x38(%r15)
+; block1: ; offset 0x6
+;   lgr %r7, %r2
+;   srag %r5, %r3, 0x3f
+;   vlvgp %v27, %r5, %r3
+;   srag %r3, %r4, 0x3f
+;   vlvgp %v28, %r3, %r4
+;   vlgvg %r4, %v27, 0
+;   vlgvg %r5, %v27, 1
+;   vlgvg %r9, %v28, 0
+;   vlgvg %r11, %v28, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r11
+;   msgr %r5, %r9
+;   msgr %r4, %r11
+;   agr %r5, %r2
+;   agr %r4, %r5
+;   vlvgp %v3, %r4, %r3
+;   lgr %r2, %r7
+;   vst %v3, 0(%r2)
+;   lmg %r7, %r15, 0x38(%r15)
+;   br %r14
+
+function %smul_high_i64_pattern(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = sextend.i128 v0
+    v3 = sextend.i128 v1
+    v4 = imul v2, v3
+    v5 = sshr_imm v4, 64
+    v6 = ireduce.i64 v5
+    return v6
+}
+
+; VCode:
+; block0:
+;   mgrk %r2, %r2, %r3
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mgrk %r2, %r2, %r3
+;   br %r14
+
+function %smul_high_i64_isplit(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = sextend.i128 v0
+    v3 = sextend.i128 v1
+    v4 = imul v2, v3
+    v5, v6 = isplit v4
+    return v6
+}
+
+; VCode:
+;   stmg %r10, %r15, 80(%r15)
+; block0:
+;   srag %r4, %r2, 63
+;   vlvgp %v28, %r4, %r2
+;   srag %r4, %r3, 63
+;   vlvgp %v29, %r4, %r3
+;   vlgvg %r4, %v28, 0
+;   vlgvg %r5, %v28, 1
+;   vlgvg %r10, %v29, 0
+;   vlgvg %r12, %v29, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r12
+;   msgr %r5, %r10
+;   msgr %r4, %r12
+;   agrk %r2, %r5, %r2
+;   agr %r4, %r2
+;   vlvgp %v4, %r4, %r3
+;   lgdr %r2, %f4
+;   vlgvg %r5, %v4, 1
+;   lmg %r10, %r15, 80(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r10, %r15, 0x50(%r15)
+; block1: ; offset 0x6
+;   srag %r4, %r2, 0x3f
+;   vlvgp %v28, %r4, %r2
+;   srag %r4, %r3, 0x3f
+;   vlvgp %v29, %r4, %r3
+;   vlgvg %r4, %v28, 0
+;   vlgvg %r5, %v28, 1
+;   vlgvg %r10, %v29, 0
+;   vlgvg %r12, %v29, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r12
+;   msgr %r5, %r10
+;   msgr %r4, %r12
+;   agrk %r2, %r5, %r2
+;   agr %r4, %r2
+;   vlvgp %v4, %r4, %r3
+;   lgdr %r2, %f4
+;   vlgvg %r5, %v4, 1
+;   lmg %r10, %r15, 0x50(%r15)
+;   br %r14
+
+function %umul_high_i64_pattern(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = imul v2, v3
+    v5 = ushr_imm v4, 64
+    v6 = ireduce.i64 v5
+    return v6
+}
+
+; VCode:
+; block0:
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   mlgr %r2, %r4
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   mlgr %r2, %r4
+;   br %r14
+
+function %umul_high_i64_isplit(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = imul v2, v3
+    v5, v6 = isplit v4
+    return v6
+}
+
+; VCode:
+;   stmg %r10, %r15, 80(%r15)
+; block0:
+;   vgbm %v27, 0
+;   vlvgg %v27, %r2, 1
+;   vgbm %v28, 0
+;   vlvgg %v28, %r3, 1
+;   vlgvg %r4, %v27, 0
+;   vlgvg %r5, %v27, 1
+;   vlgvg %r10, %v28, 0
+;   vlgvg %r12, %v28, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r12
+;   msgr %r5, %r10
+;   msgr %r4, %r12
+;   agrk %r2, %r5, %r2
+;   agr %r4, %r2
+;   vlvgp %v4, %r4, %r3
+;   lgdr %r2, %f4
+;   vlgvg %r5, %v4, 1
+;   lmg %r10, %r15, 80(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r10, %r15, 0x50(%r15)
+; block1: ; offset 0x6
+;   vzero %v27
+;   vlvgg %v27, %r2, 1
+;   vzero %v28
+;   vlvgg %v28, %r3, 1
+;   vlgvg %r4, %v27, 0
+;   vlgvg %r5, %v27, 1
+;   vlgvg %r10, %v28, 0
+;   vlgvg %r12, %v28, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r12
+;   msgr %r5, %r10
+;   msgr %r4, %r12
+;   agrk %r2, %r5, %r2
+;   agr %r4, %r2
+;   vlvgp %v4, %r4, %r3
+;   lgdr %r2, %f4
+;   vlgvg %r5, %v4, 1
+;   lmg %r10, %r15, 0x50(%r15)
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/s390x/i128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/i128.clif
@@ -11,52 +11,21 @@ block0(v0: i64, v1: i64):
 }
 
 ; VCode:
-;   stmg %r7, %r15, 56(%r15)
 ; block0:
-;   lgr %r7, %r2
-;   vgbm %v26, 0
-;   vlvgg %v26, %r3, 1
-;   vgbm %v27, 0
-;   vlvgg %v27, %r4, 1
-;   vlgvg %r4, %v26, 0
-;   vlgvg %r5, %v26, 1
-;   vlgvg %r9, %v27, 0
-;   vlgvg %r11, %v27, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r11
-;   msgr %r5, %r9
-;   msgr %r4, %r11
-;   agr %r5, %r2
-;   agr %r4, %r5
-;   vlvgp %v3, %r4, %r3
-;   lgr %r2, %r7
-;   vst %v3, 0(%r2)
-;   lmg %r7, %r15, 56(%r15)
+;   lgr %r5, %r2
+;   mlgr %r2, %r4
+;   vlvgp %v7, %r2, %r3
+;   lgr %r2, %r5
+;   vst %v7, 0(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stmg %r7, %r15, 0x38(%r15)
-; block1: ; offset 0x6
-;   lgr %r7, %r2
-;   vzero %v26
-;   vlvgg %v26, %r3, 1
-;   vzero %v27
-;   vlvgg %v27, %r4, 1
-;   vlgvg %r4, %v26, 0
-;   vlgvg %r5, %v26, 1
-;   vlgvg %r9, %v27, 0
-;   vlgvg %r11, %v27, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r11
-;   msgr %r5, %r9
-;   msgr %r4, %r11
-;   agr %r5, %r2
-;   agr %r4, %r5
-;   vlvgp %v3, %r4, %r3
-;   lgr %r2, %r7
-;   vst %v3, 0(%r2)
-;   lmg %r7, %r15, 0x38(%r15)
+;   lgr %r5, %r2
+;   mlgr %r2, %r4
+;   vlvgp %v7, %r2, %r3
+;   lgr %r2, %r5
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %mul_sextend_i64(i64, i64) -> i128 {
@@ -68,52 +37,21 @@ block0(v0: i64, v1: i64):
 }
 
 ; VCode:
-;   stmg %r7, %r15, 56(%r15)
 ; block0:
-;   lgr %r7, %r2
-;   srag %r5, %r3, 63
-;   vlvgp %v27, %r5, %r3
-;   srag %r3, %r4, 63
-;   vlvgp %v28, %r3, %r4
-;   vlgvg %r4, %v27, 0
-;   vlgvg %r5, %v27, 1
-;   vlgvg %r9, %v28, 0
-;   vlgvg %r11, %v28, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r11
-;   msgr %r5, %r9
-;   msgr %r4, %r11
-;   agr %r5, %r2
-;   agr %r4, %r5
-;   vlvgp %v3, %r4, %r3
-;   lgr %r2, %r7
-;   vst %v3, 0(%r2)
-;   lmg %r7, %r15, 56(%r15)
+;   lgr %r5, %r2
+;   mgrk %r2, %r3, %r4
+;   vlvgp %v7, %r2, %r3
+;   lgr %r2, %r5
+;   vst %v7, 0(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stmg %r7, %r15, 0x38(%r15)
-; block1: ; offset 0x6
-;   lgr %r7, %r2
-;   srag %r5, %r3, 0x3f
-;   vlvgp %v27, %r5, %r3
-;   srag %r3, %r4, 0x3f
-;   vlvgp %v28, %r3, %r4
-;   vlgvg %r4, %v27, 0
-;   vlgvg %r5, %v27, 1
-;   vlgvg %r9, %v28, 0
-;   vlgvg %r11, %v28, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r11
-;   msgr %r5, %r9
-;   msgr %r4, %r11
-;   agr %r5, %r2
-;   agr %r4, %r5
-;   vlvgp %v3, %r4, %r3
-;   lgr %r2, %r7
-;   vst %v3, 0(%r2)
-;   lmg %r7, %r15, 0x38(%r15)
+;   lgr %r5, %r2
+;   mgrk %r2, %r3, %r4
+;   vlvgp %v7, %r2, %r3
+;   lgr %r2, %r5
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %smul_high_i64_pattern(i64, i64) -> i64 {
@@ -146,50 +84,19 @@ block0(v0: i64, v1: i64):
 }
 
 ; VCode:
-;   stmg %r10, %r15, 80(%r15)
 ; block0:
-;   srag %r4, %r2, 63
-;   vlvgp %v28, %r4, %r2
-;   srag %r4, %r3, 63
-;   vlvgp %v29, %r4, %r3
-;   vlgvg %r4, %v28, 0
-;   vlgvg %r5, %v28, 1
-;   vlgvg %r10, %v29, 0
-;   vlgvg %r12, %v29, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r12
-;   msgr %r5, %r10
-;   msgr %r4, %r12
-;   agrk %r2, %r5, %r2
-;   agr %r4, %r2
-;   vlvgp %v4, %r4, %r3
-;   lgdr %r2, %f4
-;   vlgvg %r5, %v4, 1
-;   lmg %r10, %r15, 80(%r15)
+;   mgrk %r2, %r2, %r3
+;   vlvgp %v16, %r2, %r3
+;   vlgvg %r2, %v16, 0
+;   vlgvg %r5, %v16, 1
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stmg %r10, %r15, 0x50(%r15)
-; block1: ; offset 0x6
-;   srag %r4, %r2, 0x3f
-;   vlvgp %v28, %r4, %r2
-;   srag %r4, %r3, 0x3f
-;   vlvgp %v29, %r4, %r3
-;   vlgvg %r4, %v28, 0
-;   vlgvg %r5, %v28, 1
-;   vlgvg %r10, %v29, 0
-;   vlgvg %r12, %v29, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r12
-;   msgr %r5, %r10
-;   msgr %r4, %r12
-;   agrk %r2, %r5, %r2
-;   agr %r4, %r2
-;   vlvgp %v4, %r4, %r3
-;   lgdr %r2, %f4
-;   vlgvg %r5, %v4, 1
-;   lmg %r10, %r15, 0x50(%r15)
+;   mgrk %r2, %r2, %r3
+;   vlvgp %v16, %r2, %r3
+;   vlgvg %r2, %v16, 0
+;   vlgvg %r5, %v16, 1
 ;   br %r14
 
 function %umul_high_i64_pattern(i64, i64) -> i64 {
@@ -226,49 +133,22 @@ block0(v0: i64, v1: i64):
 }
 
 ; VCode:
-;   stmg %r10, %r15, 80(%r15)
 ; block0:
-;   vgbm %v27, 0
-;   vlvgg %v27, %r2, 1
-;   vgbm %v28, 0
-;   vlvgg %v28, %r3, 1
-;   vlgvg %r4, %v27, 0
-;   vlgvg %r5, %v27, 1
-;   vlgvg %r10, %v28, 0
-;   vlgvg %r12, %v28, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r12
-;   msgr %r5, %r10
-;   msgr %r4, %r12
-;   agrk %r2, %r5, %r2
-;   agr %r4, %r2
-;   vlvgp %v4, %r4, %r3
-;   lgdr %r2, %f4
-;   vlgvg %r5, %v4, 1
-;   lmg %r10, %r15, 80(%r15)
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   mlgr %r2, %r4
+;   vlvgp %v16, %r2, %r3
+;   vlgvg %r2, %v16, 0
+;   vlgvg %r5, %v16, 1
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stmg %r10, %r15, 0x50(%r15)
-; block1: ; offset 0x6
-;   vzero %v27
-;   vlvgg %v27, %r2, 1
-;   vzero %v28
-;   vlvgg %v28, %r3, 1
-;   vlgvg %r4, %v27, 0
-;   vlgvg %r5, %v27, 1
-;   vlgvg %r10, %v28, 0
-;   vlgvg %r12, %v28, 1
-;   lgr %r3, %r5
-;   mlgr %r2, %r12
-;   msgr %r5, %r10
-;   msgr %r4, %r12
-;   agrk %r2, %r5, %r2
-;   agr %r4, %r2
-;   vlvgp %v4, %r4, %r3
-;   lgdr %r2, %f4
-;   vlgvg %r5, %v4, 1
-;   lmg %r10, %r15, 0x50(%r15)
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   mlgr %r2, %r4
+;   vlvgp %v16, %r2, %r3
+;   vlgvg %r2, %v16, 0
+;   vlgvg %r5, %v16, 1
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/x64/mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/mul.clif
@@ -487,3 +487,66 @@ block0(v0: i64):
 ;   popq %rbp
 ;   retq
 
+
+function %widening_smul_from_8bit(i8, i8) -> i16 {
+block0(v0: i8, v1: i8):
+    v2 = sextend.i16 v0
+    v3 = sextend.i16 v1
+    v4 = imul v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movsbl  %dil, %eax
+;   movsbl  %sil, %r8d
+;   imulw   %ax, %r8w, %ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movsbl %dil, %eax
+;   movsbl %sil, %r8d
+;   imull %r8d, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %widening_umul_from_8bit(i8, i8) -> i16 {
+block0(v0: i8, v1: i8):
+    v2 = uextend.i16 v0
+    v3 = uextend.i16 v1
+    v4 = imul v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movzbl  %dil, %eax
+;   movzbl  %sil, %r8d
+;   imulw   %ax, %r8w, %ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbl %dil, %eax
+;   movzbl %sil, %r8d
+;   imull %r8d, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/mul.clif
@@ -500,9 +500,8 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movsbl  %dil, %eax
-;   movsbl  %sil, %r8d
-;   imulw   %ax, %r8w, %ax
+;   movq    %rdi, %rax
+;   imulb   %al, %sil, %al
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -512,9 +511,8 @@ block0(v0: i8, v1: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movsbl %dil, %eax
-;   movsbl %sil, %r8d
-;   imull %r8d, %eax
+;   movq %rdi, %rax
+;   imulb %sil
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -531,9 +529,8 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbl  %dil, %eax
-;   movzbl  %sil, %r8d
-;   imulw   %ax, %r8w, %ax
+;   movq    %rdi, %rax
+;   mulb    %al, %sil, %al
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -543,9 +540,8 @@ block0(v0: i8, v1: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movzbl %dil, %eax
-;   movzbl %sil, %r8d
-;   imull %r8d, %eax
+;   movq %rdi, %rax
+;   mulb %sil
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq


### PR DESCRIPTION
This commits adds support for more patterns of improved 128-bit
multiplication to the various backends of Cranelift. Notably:

* Using `isplit` to discard the lower bits of a multiplication maps
  directly to instructions on aarch64 and riscv64.
* Multiplying sign-extended 64-bit halves maps directly to supported
  instructions on s390x/riscv64/aarch64 (x86_64 already has these
  implemented).

This relies on adding a new method to test whether a `Value` is dead and
unused during lowering. While generally not useful this is applicable
for multi-result instructions such as `isplit` where one result may end
up not being used. This also is required because the egraph
optimizations can't currently handle multi-result instructions like
`isplit` so this can't be optimized to `umulhi` or `smulhi` in CLIF.