### PR TITLE
Winch multi values results

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -281,8 +281,10 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
                 let push_to_reg =
                     if call_conv == isa::CallConv::Winch && args_or_rets == ArgsOrRets::Rets {
+                        // Winch uses the first registry to return the last result
                         i == params.len() - 1
                     } else {
+                        // Use max_per_class_reg_vals & remaining_reg_vals otherwise
                         *next_reg < max_per_class_reg_vals && remaining_reg_vals > 0
                     };
 
@@ -318,7 +320,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             let size = if is_apple_cc
                 || (call_conv == isa::CallConv::Winch && args_or_rets == ArgsOrRets::Rets)
             {
-                // MacOS aarch64 allows stack slots with
+                // MacOS and Winch aarch64 allows stack slots with
                 // sizes less than 8 bytes. They still need to be
                 // properly aligned on their natural data alignment,
                 // though.

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -141,20 +141,15 @@ impl ABIMachineSpec for AArch64MachineDeps {
         let mut next_vreg = 0;
         let mut next_stack: u32 = 0;
 
-        let (max_per_class_reg_vals, mut remaining_reg_vals) = match args_or_rets {
-            ArgsOrRets::Args => (8, 16), // x0-x7 and v0-v7
+        // Note on return values: on the regular ABI, we may return values
+        // in 8 registers for V128 and I64 registers independently of the
+        // number of register values returned in the other class. That is,
+        // we can return values in up to 8 integer and
+        // 8 vector registers at once.
+        let max_per_class_reg_vals = 8; // x0-x7 and v0-v7
+        let mut remaining_reg_vals = 16;
 
-            // Note on return values: on the regular ABI, we may return values
-            // in 8 registers for V128 and I64 registers independently of the
-            // number of register values returned in the other class. That is,
-            // we can return values in up to 8 integer and
-            // 8 vector registers at once.
-            ArgsOrRets::Rets => {
-                (8, 16) // x0-x7 and v0-v7
-            }
-        };
-
-        for param in params {
+        for (i, param) in params.into_iter().enumerate() {
             if is_apple_cc && param.value_type == types::F128 && !flags.enable_llvm_abi_extensions()
             {
                 panic!(
@@ -284,7 +279,14 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     RegClass::Vector => unreachable!(),
                 };
 
-                if *next_reg < max_per_class_reg_vals && remaining_reg_vals > 0 {
+                let push_to_reg =
+                    if call_conv == isa::CallConv::Winch && args_or_rets == ArgsOrRets::Rets {
+                        i == params.len() - 1
+                    } else {
+                        *next_reg < max_per_class_reg_vals && remaining_reg_vals > 0
+                    };
+
+                if push_to_reg {
                     let reg = match rc {
                         RegClass::Int => xreg(*next_reg),
                         RegClass::Float => vreg(*next_reg),
@@ -313,7 +315,9 @@ impl ABIMachineSpec for AArch64MachineDeps {
             // Compute the stack slot's size.
             let size = (ty_bits(param.value_type) / 8) as u32;
 
-            let size = if is_apple_cc {
+            let size = if is_apple_cc
+                || (call_conv == isa::CallConv::Winch && args_or_rets == ArgsOrRets::Rets)
+            {
                 // MacOS aarch64 allows stack slots with
                 // sizes less than 8 bytes. They still need to be
                 // properly aligned on their natural data alignment,
@@ -325,9 +329,11 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 std::cmp::max(size, 8)
             };
 
-            // Align the stack slot.
-            debug_assert!(size.is_power_of_two());
-            next_stack = align_to(next_stack, size);
+            if call_conv != isa::CallConv::Winch || args_or_rets != ArgsOrRets::Rets {
+                // Align the stack slot.
+                debug_assert!(size.is_power_of_two());
+                next_stack = align_to(next_stack, size);
+            }
 
             let slots = reg_types
                 .iter()
@@ -385,6 +391,23 @@ impl ABIMachineSpec for AArch64MachineDeps {
         } else {
             None
         };
+
+        // Winch writes the first result to the highest offset, so we need to iterate through the
+        // args and adjust the offsets down.
+        if call_conv == isa::CallConv::Winch && args_or_rets == ArgsOrRets::Rets {
+            for arg in args.args_mut() {
+                if let ABIArg::Slots { slots, .. } = arg {
+                    for slot in slots.iter_mut() {
+                        if let ABIArgSlot::Stack { offset, ty, .. } = slot {
+                            let size = i64::from(ty.bytes());
+                            *offset = i64::from(next_stack) - *offset - size;
+                        }
+                    }
+                } else {
+                    unreachable!("Winch cannot handle {arg:?}");
+                }
+            }
+        }
 
         next_stack = align_to(next_stack, 16);
 

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -85,6 +85,7 @@ mod pulley_shared;
 pub mod unwind;
 
 mod call_conv;
+mod winch;
 
 /// Returns a builder that can create a corresponding `TargetIsa`
 /// or `Err(LookupError::SupportDisabled)` if not enabled.

--- a/cranelift/codegen/src/isa/winch.rs
+++ b/cranelift/codegen/src/isa/winch.rs
@@ -1,0 +1,22 @@
+use crate::machinst::{ABIArg, ABIArgSlot, ArgsAccumulator};
+
+// Winch writes the first result to the highest offset, so we need to iterate through the
+// args and adjust the offsets down.
+pub(super) fn reverse_stack(mut args: ArgsAccumulator, next_stack: u32, uses_extension: bool) {
+    for arg in args.args_mut() {
+        if let ABIArg::Slots { slots, .. } = arg {
+            for slot in slots.iter_mut() {
+                if let ABIArgSlot::Stack { offset, ty, .. } = slot {
+                    let size = if uses_extension {
+                        i64::from(std::cmp::max(ty.bytes(), 8))
+                    } else {
+                        i64::from(ty.bytes())
+                    };
+                    *offset = i64::from(next_stack) - *offset - size;
+                }
+            }
+        } else {
+            unreachable!("Winch cannot handle {arg:?}");
+        }
+    }
+}

--- a/tests/disas/winch/aarch64/br/br_jump.wat
+++ b/tests/disas/winch/aarch64/br/br_jump.wat
@@ -25,14 +25,14 @@
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w16, [x28, #4]
-;;       sub     sp, sp, #8
+;;       sub     sp, sp, #4
 ;;       mov     x28, sp
-;;       stur    x16, [x28, #8]
-;;       ldur    w16, [x28, #0xc]
-;;       sub     sp, sp, #8
+;;       stur    w16, [x28]
+;;       ldur    w16, [x28, #8]
+;;       sub     sp, sp, #4
 ;;       mov     x28, sp
-;;       stur    x16, [x28, #8]
-;;       add     sp, sp, #8
+;;       stur    w16, [x28]
+;;       add     sp, sp, #4
 ;;       mov     x28, sp
 ;;       b       #0x38
 ;;   54: add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/params/multi_values.wat
+++ b/tests/disas/winch/aarch64/params/multi_values.wat
@@ -1,0 +1,55 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+	(func (export "run") (param i32 i32 f32 f32) (result i32 i32 f32 f32)
+		local.get 0
+		local.get 1
+		local.get 2
+		local.get 3
+	)
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x28
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x20]
+;;       stur    x1, [x28, #0x18]
+;;       stur    w2, [x28, #0x14]
+;;       stur    w3, [x28, #0x10]
+;;       stur    s0, [x28, #0xc]
+;;       stur    s1, [x28, #8]
+;;       stur    x4, [x28]
+;;       ldur    s0, [x28, #8]
+;;       ldur    w16, [x28, #0x14]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x28]
+;;       ldur    w16, [x28, #0x14]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x28]
+;;       ldur    s31, [x28, #0x14]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    s31, [x28]
+;;       ldur    x0, [x28, #0xc]
+;;       ldur    s31, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    s31, [x0]
+;;       ldur    w16, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x0, #4]
+;;       ldur    w16, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x0, #8]
+;;       add     sp, sp, #0x28
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -319,6 +319,23 @@ impl Imm {
             _ => None,
         }
     }
+
+    /// Returns true if the [`Imm`] is float.
+    pub fn is_float(&self) -> bool {
+        match self {
+            Self::F32(_) | Self::F64(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Get the operand size of the immediate.
+    pub fn size(&self) -> OperandSize {
+        match self {
+            Self::I32(_) | Self::F32(_) => OperandSize::S32,
+            Self::I64(_) | Self::F64(_) => OperandSize::S64,
+            Self::V128(_) => OperandSize::S128,
+        }
+    }
 }
 
 /// The location of the [VMcontext] used for function calls.


### PR DESCRIPTION
Hey 👋

This PR fixes how results are returned when using Winch. Cranelift uses x0-x7 and v0-v7 to store the first results, and then stores the remaining ones in the stack from sp to fp. Winch stores the last result in either x0 or v0, with the other results placed on the stack from fp to sp.

Thank you @saulecabrera for helping me figure this out ☺️

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
