### PR TITLE
Update wasm-tools to 217

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,7 +3313,8 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
 dependencies = [
  "leb128",
  "wasmparser 0.217.0",
@@ -3338,7 +3339,8 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65a146bf9a60e9264f0548a2599aa9656dba9a641eff9ab88299dc2a637e483c"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3353,7 +3355,8 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa80f2d6a07ca8aeabd1aefaf380c0f7a7f358d260f008760c41a6c4f37b0ff4"
 dependencies = [
  "egg",
  "log",
@@ -3366,7 +3369,8 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee14ba28222f942fe64cefffdb7bd8ef3a84cc4e3299e5a3cee7cd4355f6d3a2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3432,7 +3436,8 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -3454,7 +3459,8 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dc568b3e0d47e8f96ea547c90790cfa783f0205160c40de894a427114185ce"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -4075,7 +4081,8 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "217.0.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79004ecebded92d3c710d4841383368c7f04b63d0992ddd6b0c7d5029b7629b7"
 dependencies = [
  "bumpalo",
  "leb128",
@@ -4087,7 +4094,8 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c126271c3d92ca0f7c63e4e462e40c69cca52fd4245fcda730d1cf558fb55088"
 dependencies = [
  "wast 217.0.0",
 ]
@@ -4501,7 +4509,8 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7117809905e49db716d81e794f79590c052bf2fdbbcda1731ca0fb28f6f3ddf"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4537,7 +4546,8 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.217.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb893dcd6d370cfdf19a0d9adfcd403efb8e544e1a0ea3a8b81a21fe392eaa78"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmtime-types",
  "wat",
 ]
@@ -2821,7 +2821,7 @@ dependencies = [
  "cargo_metadata",
  "heck 0.4.0",
  "wasmtime",
- "wit-component",
+ "wit-component 0.217.0",
 ]
 
 [[package]]
@@ -3149,7 +3149,7 @@ name = "verify-component-adapter"
 version = "26.0.0"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wat",
 ]
 
@@ -3242,7 +3242,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi",
- "wasm-encoder",
+ "wasm-encoder 0.217.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3307,7 +3307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
 dependencies = [
  "leb128",
- "wasmparser",
+ "wasmparser 0.216.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+dependencies = [
+ "leb128",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -3322,36 +3331,49 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.216.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17002e0f291e0c330a81b9285cf0e4e316e10e75b00d4f5c625d325f14582d11"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.216.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25e5a09d7934b471fb84ea864cc91ed1a4467ea8aaa32c09f60f3fb262e070e"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder",
+ "wasm-encoder 0.217.0",
 ]
 
 [[package]]
@@ -3405,6 +3427,18 @@ dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+dependencies = [
+ "ahash",
+ "bitflags 2.4.1",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.6",
+ "semver",
  "serde",
 ]
 
@@ -3419,13 +3453,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.216.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f82916f3892e53620639217d6ec78fe15c678352a3fbf3f3745b6417d0bd70f"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -3469,8 +3502,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3612,7 +3645,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3628,10 +3661,10 @@ dependencies = [
  "wasmtime-wasi-runtime-config",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 216.0.0",
+ "wast 217.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component",
+ "wit-component 0.217.0",
 ]
 
 [[package]]
@@ -3664,7 +3697,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -3689,7 +3722,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3714,8 +3747,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3730,7 +3763,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3790,7 +3823,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3811,12 +3844,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder",
+ "wasm-encoder 0.217.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3866,7 +3899,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -3998,7 +4031,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 216.0.0",
+ "wast 217.0.0",
 ]
 
 [[package]]
@@ -4010,7 +4043,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -4023,7 +4056,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.0",
  "indexmap 2.2.6",
- "wit-parser",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -4041,24 +4074,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "216.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7eb1f2eecd913fdde0dc6c3439d0f24530a98ac6db6cb3d14d92a5328554a08"
+version = "217.0.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.217.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.216.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0409090fb5154f95fb5ba3235675fd9e579e731524d63b6a2f653e1280c82a"
+version = "1.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
 dependencies = [
- "wast 216.0.0",
+ "wast 217.0.0",
 ]
 
 [[package]]
@@ -4188,7 +4219,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.217.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4405,7 +4436,7 @@ checksum = "175a2edcf18d1efd1412cb560b895dd09903f4fe73c3a597fbb0075ad86a03e8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
@@ -4428,9 +4459,9 @@ dependencies = [
  "indexmap 2.2.6",
  "prettyplease",
  "syn 2.0.60",
- "wasm-metadata",
+ "wasm-metadata 0.216.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.216.0",
 ]
 
 [[package]]
@@ -4461,10 +4492,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.216.0",
+ "wasm-metadata 0.216.0",
+ "wasmparser 0.216.0",
+ "wit-parser 0.216.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "indexmap 2.2.6",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.217.0",
+ "wasm-metadata 0.217.0",
+ "wasmparser 0.217.0",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -4482,7 +4531,24 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.216.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.217.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci/release-1.217.0#e6a0a9f9c959598bb6b9f6eebf46910db8495f80"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,15 +266,15 @@ wit-bindgen = { version = "0.31.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.31.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.216.0", default-features = false }
-wat = "1.216.0"
-wast = "216.0.0"
-wasmprinter = "0.216.0"
-wasm-encoder = "0.216.0"
-wasm-smith = "0.216.0"
-wasm-mutate = "0.216.0"
-wit-parser = "0.216.0"
-wit-component = "0.216.0"
+wasmparser = { version = "0.217.0", default-features = false }
+wat = "1.217.0"
+wast = "217.0.0"
+wasmprinter = "0.217.0"
+wasm-encoder = "0.217.0"
+wasm-smith = "0.217.0"
+wasm-mutate = "0.217.0"
+wit-parser = "0.217.0"
+wit-component = "0.217.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
@@ -505,3 +505,14 @@ opt-level = 's'
 inherits = "release"
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wat = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wast = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
+wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -505,14 +505,3 @@ opt-level = 's'
 inherits = "release"
 codegen-units = 1
 lto = true
-
-[patch.crates-io]
-wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wat = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wast = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }
-wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.217.0' }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -24,7 +24,7 @@ cpp_demangle = { version = "0.4.3", optional = true }
 cranelift-entity = { workspace = true }
 cranelift-bitset = { workspace = true, features = ['enable-serde'] }
 wasmtime-types = { workspace = true }
-wasmparser = { workspace = true, features = ['validate', 'serde'] }
+wasmparser = { workspace = true, features = ['validate', 'serde', 'features'] }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1805,7 +1805,7 @@ impl Config {
     fn features(&self) -> WasmFeatures {
         // Wasmtime by default supports all of the wasm 2.0 version of the
         // specification.
-        let mut features = WasmFeatures::wasm2();
+        let mut features = WasmFeatures::WASM2;
 
         // On-by-default features that wasmtime has. Note that these are all
         // subject to the criteria at

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -215,7 +215,7 @@ where
     }
 
     /// Define a module and register it.
-    fn wat(&mut self, mut wat: QuoteWat<'_>) -> Result<()> {
+    fn module(&mut self, mut wat: QuoteWat<'_>) -> Result<()> {
         let (is_module, name) = match &wat {
             QuoteWat::Wat(Wat::Module(m)) => (true, m.id),
             QuoteWat::QuoteModule(..) => (true, None),
@@ -428,7 +428,9 @@ where
         use wast::WastDirective::*;
 
         match directive {
-            Wat(module) => self.wat(module)?,
+            Module(module) => self.module(module)?,
+            ModuleDefinition(_) => bail!("module definition not implemented yet"),
+            ModuleInstance { .. } => bail!("module instance not implemented yet"),
             Register {
                 span: _,
                 name,
@@ -468,7 +470,7 @@ where
                 module,
                 message,
             } => {
-                let err = match self.wat(module) {
+                let err = match self.module(module) {
                     Ok(()) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };
@@ -486,7 +488,7 @@ where
                 span: _,
                 message: _,
             } => {
-                if let Ok(_) = self.wat(module) {
+                if let Ok(_) = self.module(module) {
                     bail!("expected malformed module to fail to instantiate");
                 }
             }
@@ -495,7 +497,7 @@ where
                 module,
                 message,
             } => {
-                let err = match self.wat(QuoteWat::Wat(module)) {
+                let err = match self.module(QuoteWat::Wat(module)) {
                     Ok(()) => bail!("expected module to fail to link"),
                     Err(e) => e,
                 };

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1449,6 +1449,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-encoder]]
+version = "0.217.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-metadata]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1464,6 +1470,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasm-metadata]]
 version = "0.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasm-metadata]]
+version = "0.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1485,6 +1497,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmparser]]
+version = "0.217.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmprinter]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1500,6 +1518,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmprinter]]
 version = "0.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmprinter]]
+version = "0.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1809,6 +1833,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wast]]
+version = "217.0.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wat]]
 version = "1.214.0"
 when = "2024-07-16"
@@ -1824,6 +1854,12 @@ user-login = "wasmtime-publish"
 [[publisher.wat]]
 version = "1.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wat]]
+version = "1.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2188,6 +2224,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-component]]
+version = "0.217.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-parser]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -2203,6 +2245,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-parser]]
 version = "0.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-parser]]
+version = "0.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Brings a few fixes and such from recent PRs and additionally some new `*.wast` directives. These aren't supported yet and will come in a future commit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
