### PR TITLE
[25.0.0] Update wasm-tools to 217

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmtime-types",
  "wat",
 ]
@@ -2821,7 +2821,7 @@ dependencies = [
  "cargo_metadata",
  "heck 0.4.0",
  "wasmtime",
- "wit-component 0.216.0",
+ "wit-component 0.217.0",
 ]
 
 [[package]]
@@ -3149,7 +3149,7 @@ name = "verify-component-adapter"
 version = "25.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wat",
 ]
 
@@ -3242,7 +3242,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi",
- "wasm-encoder 0.216.0",
+ "wasm-encoder 0.217.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3312,12 +3312,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
+checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
 dependencies = [
  "leb128",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -3338,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8154d703a6b0e45acf6bd172fa002fc3c7058a9f7615e517220aeca27c638"
+checksum = "65a146bf9a60e9264f0548a2599aa9656dba9a641eff9ab88299dc2a637e483c"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3348,36 +3348,36 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.216.0",
- "wasmparser 0.216.0",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17002e0f291e0c330a81b9285cf0e4e316e10e75b00d4f5c625d325f14582d11"
+checksum = "aa80f2d6a07ca8aeabd1aefaf380c0f7a7f358d260f008760c41a6c4f37b0ff4"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.216.0",
- "wasmparser 0.216.0",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25e5a09d7934b471fb84ea864cc91ed1a4467ea8aaa32c09f60f3fb262e070e"
+checksum = "ee14ba28222f942fe64cefffdb7bd8ef3a84cc4e3299e5a3cee7cd4355f6d3a2"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder 0.216.0",
+ "wasm-encoder 0.217.0",
 ]
 
 [[package]]
@@ -3435,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdee6bea3619d311fb4b299721e89a986c3470f804b6d534340e412589028e3"
+checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
 dependencies = [
  "ahash",
  "bitflags 2.4.1",
@@ -3458,13 +3458,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f82916f3892e53620639217d6ec78fe15c678352a3fbf3f3745b6417d0bd70f"
+checksum = "50dc568b3e0d47e8f96ea547c90790cfa783f0205160c40de894a427114185ce"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -3508,8 +3508,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder 0.216.0",
- "wasmparser 0.216.0",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -3651,7 +3651,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3667,10 +3667,10 @@ dependencies = [
  "wasmtime-wasi-runtime-config",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 216.0.0",
+ "wast 217.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component 0.216.0",
+ "wit-component 0.217.0",
 ]
 
 [[package]]
@@ -3703,7 +3703,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.216.0",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -3728,7 +3728,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -3753,8 +3753,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.216.0",
- "wasmparser 0.216.0",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3769,7 +3769,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3829,7 +3829,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3850,12 +3850,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.216.0",
+ "wasm-encoder 0.217.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3905,7 +3905,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -4037,7 +4037,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 216.0.0",
+ "wast 217.0.0",
 ]
 
 [[package]]
@@ -4049,7 +4049,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -4062,7 +4062,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.0",
  "indexmap 2.2.6",
- "wit-parser 0.216.0",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -4080,24 +4080,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "216.0.0"
+version = "217.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7eb1f2eecd913fdde0dc6c3439d0f24530a98ac6db6cb3d14d92a5328554a08"
+checksum = "79004ecebded92d3c710d4841383368c7f04b63d0992ddd6b0c7d5029b7629b7"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.216.0",
+ "wasm-encoder 0.217.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.216.0"
+version = "1.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0409090fb5154f95fb5ba3235675fd9e579e731524d63b6a2f653e1280c82a"
+checksum = "c126271c3d92ca0f7c63e4e462e40c69cca52fd4245fcda730d1cf558fb55088"
 dependencies = [
- "wast 216.0.0",
+ "wast 217.0.0",
 ]
 
 [[package]]
@@ -4227,7 +4227,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4508,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2ca3ece38ea2447a9069b43074ba73d96dde1944cba276c54e41371745f9dc"
+checksum = "d7117809905e49db716d81e794f79590c052bf2fdbbcda1731ca0fb28f6f3ddf"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4519,10 +4519,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.216.0",
- "wasm-metadata 0.216.0",
- "wasmparser 0.216.0",
- "wit-parser 0.216.0",
+ "wasm-encoder 0.217.0",
+ "wasm-metadata 0.217.0",
+ "wasmparser 0.217.0",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -4545,9 +4545,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d108165c1167a4ccc8a803dcf5c28e0a51d6739fd228cc7adce768632c764c"
+checksum = "fb893dcd6d370cfdf19a0d9adfcd403efb8e544e1a0ea3a8b81a21fe392eaa78"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4558,7 +4558,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.216.0",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,15 +266,15 @@ wit-bindgen = { version = "0.30.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.30.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.216.0", default-features = false }
-wat = "1.216.0"
-wast = "216.0.0"
-wasmprinter = "0.216.0"
-wasm-encoder = "0.216.0"
-wasm-smith = "0.216.0"
-wasm-mutate = "0.216.0"
-wit-parser = "0.216.0"
-wit-component = "0.216.0"
+wasmparser = { version = "0.217.0", default-features = false }
+wat = "1.217.0"
+wast = "217.0.0"
+wasmprinter = "0.217.0"
+wasm-encoder = "0.217.0"
+wasm-smith = "0.217.0"
+wasm-mutate = "0.217.0"
+wit-parser = "0.217.0"
+wit-component = "0.217.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -24,7 +24,7 @@ cpp_demangle = { version = "0.4.3", optional = true }
 cranelift-entity = { workspace = true }
 cranelift-bitset = { workspace = true, features = ['enable-serde'] }
 wasmtime-types = { workspace = true }
-wasmparser = { workspace = true, features = ['validate', 'serde'] }
+wasmparser = { workspace = true, features = ['validate', 'serde', 'features'] }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1805,7 +1805,7 @@ impl Config {
     fn features(&self) -> WasmFeatures {
         // Wasmtime by default supports all of the wasm 2.0 version of the
         // specification.
-        let mut features = WasmFeatures::wasm2();
+        let mut features = WasmFeatures::WASM2;
 
         // On-by-default features that wasmtime has. Note that these are all
         // subject to the criteria at

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -215,7 +215,7 @@ where
     }
 
     /// Define a module and register it.
-    fn wat(&mut self, mut wat: QuoteWat<'_>) -> Result<()> {
+    fn module(&mut self, mut wat: QuoteWat<'_>) -> Result<()> {
         let (is_module, name) = match &wat {
             QuoteWat::Wat(Wat::Module(m)) => (true, m.id),
             QuoteWat::QuoteModule(..) => (true, None),
@@ -428,7 +428,9 @@ where
         use wast::WastDirective::*;
 
         match directive {
-            Wat(module) => self.wat(module)?,
+            Module(module) => self.module(module)?,
+            ModuleDefinition(_) => bail!("module definition not implemented yet"),
+            ModuleInstance { .. } => bail!("module instance not implemented yet"),
             Register {
                 span: _,
                 name,
@@ -468,7 +470,7 @@ where
                 module,
                 message,
             } => {
-                let err = match self.wat(module) {
+                let err = match self.module(module) {
                     Ok(()) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };
@@ -486,7 +488,7 @@ where
                 span: _,
                 message: _,
             } => {
-                if let Ok(_) = self.wat(module) {
+                if let Ok(_) = self.module(module) {
                     bail!("expected malformed module to fail to instantiate");
                 }
             }
@@ -495,7 +497,7 @@ where
                 module,
                 message,
             } => {
-                let err = match self.wat(QuoteWat::Wat(module)) {
+                let err = match self.module(QuoteWat::Wat(module)) {
                     Ok(()) => bail!("expected module to fail to link"),
                     Err(e) => e,
                 };

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1139,6 +1139,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasm-encoder]]
+version = "0.217.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-metadata]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1154,6 +1160,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasm-metadata]]
 version = "0.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasm-metadata]]
+version = "0.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1175,6 +1187,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmparser]]
+version = "0.217.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmprinter]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1190,6 +1208,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmprinter]]
 version = "0.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmprinter]]
+version = "0.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1361,6 +1385,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wast]]
+version = "217.0.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wat]]
 version = "1.214.0"
 when = "2024-07-16"
@@ -1376,6 +1406,12 @@ user-login = "wasmtime-publish"
 [[publisher.wat]]
 version = "1.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wat]]
+version = "1.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1686,6 +1722,12 @@ when = "2024-08-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-component]]
+version = "0.217.0"
+when = "2024-09-10"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-parser]]
 version = "0.214.0"
 when = "2024-07-16"
@@ -1701,6 +1743,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-parser]]
 version = "0.216.0"
 when = "2024-08-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-parser]]
+version = "0.217.0"
+when = "2024-09-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is a backport of #9219 to the release branch to notably get https://github.com/bytecodealliance/wasm-tools/pull/1765 out a bit sooner which fixes https://github.com/bytecodealliance/wasm-tools/issues/1763