### PR TITLE
Implement new `*.wast` directives in `wasmtime-wast`

### DIFF
--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -542,7 +542,8 @@ where
                 module,
                 message,
             } => {
-                let err = match self.module_definition(QuoteWat::Wat(module)) {
+                let (name, module) = self.module_definition(QuoteWat::Wat(module))?;
+                let err = match self.module(name, &module) {
                     Ok(_) => bail!("expected module to fail to link"),
                     Err(e) => e,
                 };

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -250,12 +250,17 @@ where
                                 let module = instance.get_module(&mut self.store, name).unwrap();
                                 linker.module(name, &module)?;
                             }
+                            component::types::ComponentItem::Resource(_) => {
+                                let resource =
+                                    instance.get_resource(&mut self.store, name).unwrap();
+                                linker.resource(name, resource, |_, _| Ok(()))?;
+                            }
                             // TODO: should ideally reflect more than just
-                            // modules into the linker's namespace but that's
-                            // not easily supported today for host functions due
-                            // to the inability to take a function from one
-                            // instance and put it into the linker (must go
-                            // through the host right now).
+                            // modules/resources into the linker's namespace
+                            // but that's not easily supported today for host
+                            // functions due to the inability to take a
+                            // function from one instance and put it into the
+                            // linker (must go through the host right now).
                             _ => {}
                         }
                     }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -19,6 +19,7 @@ pub struct WastContext<T> {
     /// recently defined.
     current: Option<InstanceKind>,
     core_linker: Linker<T>,
+    modules: HashMap<String, ModuleKind>,
     #[cfg(feature = "component-model")]
     component_linker: component::Linker<T>,
     store: Store<T>,
@@ -50,6 +51,13 @@ enum Results {
     Core(Vec<Val>),
     #[cfg(feature = "component-model")]
     Component(Vec<component::Val>),
+}
+
+#[derive(Clone)]
+enum ModuleKind {
+    Core(Module),
+    #[cfg(feature = "component-model")]
+    Component(component::Component),
 }
 
 enum InstanceKind {
@@ -85,6 +93,7 @@ where
                 linker
             },
             store,
+            modules: Default::default(),
         }
     }
 
@@ -114,8 +123,7 @@ where
         })
     }
 
-    fn instantiate_module(&mut self, module: &[u8]) -> Result<Outcome<Instance>> {
-        let module = Module::new(self.store.engine(), module)?;
+    fn instantiate_module(&mut self, module: &Module) -> Result<Outcome<Instance>> {
         Ok(
             match self.core_linker.instantiate(&mut self.store, &module) {
                 Ok(i) => Outcome::Ok(i),
@@ -127,16 +135,14 @@ where
     #[cfg(feature = "component-model")]
     fn instantiate_component(
         &mut self,
-        component: &[u8],
+        component: &component::Component,
     ) -> Result<Outcome<(component::Component, component::Instance)>> {
-        let engine = self.store.engine();
-        let component = component::Component::new(engine, component)?;
         Ok(
             match self
                 .component_linker
                 .instantiate(&mut self.store, &component)
             {
-                Ok(i) => Outcome::Ok((component, i)),
+                Ok(i) => Outcome::Ok((component.clone(), i)),
                 Err(e) => Outcome::Trap(e),
             },
         )
@@ -154,17 +160,17 @@ where
     fn perform_execute(&mut self, exec: WastExecute<'_>) -> Result<Outcome> {
         match exec {
             WastExecute::Invoke(invoke) => self.perform_invoke(invoke),
-            WastExecute::Wat(mut module) => Ok(match &mut module {
-                Wat::Module(m) => self
-                    .instantiate_module(&m.encode()?)?
-                    .map(|_| Results::Core(Vec::new())),
-                #[cfg(feature = "component-model")]
-                Wat::Component(m) => self
-                    .instantiate_component(&m.encode()?)?
-                    .map(|_| Results::Component(Vec::new())),
-                #[cfg(not(feature = "component-model"))]
-                Wat::Component(_) => bail!("component-model support not enabled"),
-            }),
+            WastExecute::Wat(module) => {
+                Ok(match self.module_definition(QuoteWat::Wat(module))? {
+                    (_, ModuleKind::Core(module)) => self
+                        .instantiate_module(&module)?
+                        .map(|_| Results::Core(Vec::new())),
+                    #[cfg(feature = "component-model")]
+                    (_, ModuleKind::Component(component)) => self
+                        .instantiate_component(&component)?
+                        .map(|_| Results::Component(Vec::new())),
+                })
+            }
             WastExecute::Get { module, global, .. } => self.get(module.map(|s| s.name()), global),
         }
     }
@@ -214,35 +220,29 @@ where
         }
     }
 
-    /// Define a module and register it.
-    fn module(&mut self, mut wat: QuoteWat<'_>) -> Result<()> {
-        let (is_module, name) = match &wat {
-            QuoteWat::Wat(Wat::Module(m)) => (true, m.id),
-            QuoteWat::QuoteModule(..) => (true, None),
-            QuoteWat::Wat(Wat::Component(m)) => (false, m.id),
-            QuoteWat::QuoteComponent(..) => (false, None),
-        };
-        let bytes = wat.encode()?;
-        if is_module {
-            let instance = match self.instantiate_module(&bytes)? {
-                Outcome::Ok(i) => i,
-                Outcome::Trap(e) => return Err(e).context("instantiation failed"),
-            };
-            if let Some(name) = name {
-                self.core_linker
-                    .instance(&mut self.store, name.name(), instance)?;
+    /// Instantiates the `module` provided and registers the instance under the
+    /// `name` provided if successful.
+    fn module(&mut self, name: Option<&str>, module: &ModuleKind) -> Result<()> {
+        match module {
+            ModuleKind::Core(module) => {
+                let instance = match self.instantiate_module(&module)? {
+                    Outcome::Ok(i) => i,
+                    Outcome::Trap(e) => return Err(e).context("instantiation failed"),
+                };
+                if let Some(name) = name {
+                    self.core_linker.instance(&mut self.store, name, instance)?;
+                }
+                self.current = Some(InstanceKind::Core(instance));
             }
-            self.current = Some(InstanceKind::Core(instance));
-        } else {
             #[cfg(feature = "component-model")]
-            {
-                let (component, instance) = match self.instantiate_component(&bytes)? {
+            ModuleKind::Component(module) => {
+                let (component, instance) = match self.instantiate_component(&module)? {
                     Outcome::Ok(i) => i,
                     Outcome::Trap(e) => return Err(e).context("instantiation failed"),
                 };
                 if let Some(name) = name {
                     let ty = component.component_type();
-                    let mut linker = self.component_linker.instance(name.name())?;
+                    let mut linker = self.component_linker.instance(name)?;
                     let engine = self.store.engine().clone();
                     for (name, item) in ty.exports(&engine) {
                         match item {
@@ -262,10 +262,37 @@ where
                 }
                 self.current = Some(InstanceKind::Component(instance));
             }
+        }
+        Ok(())
+    }
+
+    /// Compiles the module `wat` into binary and returns the name found within
+    /// it, if any.
+    ///
+    /// This will not register the name within `self.modules`.
+    fn module_definition<'a>(
+        &mut self,
+        mut wat: QuoteWat<'a>,
+    ) -> Result<(Option<&'a str>, ModuleKind)> {
+        let (is_module, name) = match &wat {
+            QuoteWat::Wat(Wat::Module(m)) => (true, m.id),
+            QuoteWat::QuoteModule(..) => (true, None),
+            QuoteWat::Wat(Wat::Component(m)) => (false, m.id),
+            QuoteWat::QuoteComponent(..) => (false, None),
+        };
+        let bytes = wat.encode()?;
+        if is_module {
+            let module = Module::new(self.store.engine(), &bytes)?;
+            Ok((name.map(|n| n.name()), ModuleKind::Core(module)))
+        } else {
+            #[cfg(feature = "component-model")]
+            {
+                let component = component::Component::new(self.store.engine(), &bytes)?;
+                Ok((name.map(|n| n.name()), ModuleKind::Component(component)))
+            }
             #[cfg(not(feature = "component-model"))]
             bail!("component-model support not enabled");
         }
-        Ok(())
     }
 
     /// Register an instance to make it available for performing actions.
@@ -428,9 +455,27 @@ where
         use wast::WastDirective::*;
 
         match directive {
-            Module(module) => self.module(module)?,
-            ModuleDefinition(_) => bail!("module definition not implemented yet"),
-            ModuleInstance { .. } => bail!("module instance not implemented yet"),
+            Module(module) => {
+                let (name, module) = self.module_definition(module)?;
+                self.module(name, &module)?;
+            }
+            ModuleDefinition(module) => {
+                let (name, module) = self.module_definition(module)?;
+                if let Some(name) = name {
+                    self.modules.insert(name.to_string(), module.clone());
+                }
+            }
+            ModuleInstance {
+                instance,
+                module,
+                span: _,
+            } => {
+                let module = module
+                    .and_then(|n| self.modules.get(n.name()))
+                    .cloned()
+                    .ok_or_else(|| anyhow!("no module named {module:?}"))?;
+                self.module(instance.map(|n| n.name()), &module)?;
+            }
             Register {
                 span: _,
                 name,
@@ -470,8 +515,8 @@ where
                 module,
                 message,
             } => {
-                let err = match self.module(module) {
-                    Ok(()) => bail!("expected module to fail to build"),
+                let err = match self.module_definition(module) {
+                    Ok(_) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };
                 let error_message = format!("{err:?}");
@@ -488,7 +533,7 @@ where
                 span: _,
                 message: _,
             } => {
-                if let Ok(_) = self.module(module) {
+                if let Ok(_) = self.module_definition(module) {
                     bail!("expected malformed module to fail to instantiate");
                 }
             }
@@ -497,8 +542,8 @@ where
                 module,
                 message,
             } => {
-                let err = match self.module(QuoteWat::Wat(module)) {
-                    Ok(()) => bail!("expected module to fail to link"),
+                let err = match self.module_definition(QuoteWat::Wat(module)) {
+                    Ok(_) => bail!("expected module to fail to link"),
                     Err(e) => e,
                 };
                 let error_message = format!("{err:?}");
@@ -530,6 +575,7 @@ where
                     #[cfg(feature = "component-model")]
                     component_linker: component::Linker::new(self.store.engine()),
                     store: Store::new(self.store.engine(), self.store.data().clone()),
+                    modules: self.modules.clone(),
                 };
                 let name = thread.name.name();
                 let child =

--- a/tests/misc_testsuite/component-model/import.wast
+++ b/tests/misc_testsuite/component-model/import.wast
@@ -4,7 +4,7 @@
     (export "x" (func $f)))
   "component export `x` is a reexport of an imported function which is not implemented")
 
-(assert_invalid
+(assert_unlinkable
   (component
     (import "host-return-two" (instance))
   )

--- a/tests/misc_testsuite/component-model/instance.wast
+++ b/tests/misc_testsuite/component-model/instance.wast
@@ -267,3 +267,61 @@
   (export "i" (instance $i))
 )
 
+
+(component definition $C1
+  (type $r1 (resource (rep i32)))
+  (export "r" (type $r1))
+)
+(component definition $C2
+  (type $r1 (resource (rep i32)))
+  (export "r" (type $r1))
+)
+
+(component instance $I1 $C1)
+(component instance $I2 $C1)
+(component instance $I3 $C2)
+(component instance $I4 $C2)
+
+;; all instances have different resource types
+(assert_unlinkable
+  (component
+    (import "I1" (instance $i1 (export "r" (type (sub resource)))))
+    (alias export $i1 "r" (type $r))
+    (import "I2" (instance $i2 (export "r" (type (eq $r)))))
+  )
+  "mismatched resource types")
+(assert_unlinkable
+  (component
+    (import "I1" (instance $i1 (export "r" (type (sub resource)))))
+    (alias export $i1 "r" (type $r))
+    (import "I3" (instance $i2 (export "r" (type (eq $r)))))
+  )
+  "mismatched resource types")
+(assert_unlinkable
+  (component
+    (import "I1" (instance $i1 (export "r" (type (sub resource)))))
+    (alias export $i1 "r" (type $r))
+    (import "I4" (instance $i2 (export "r" (type (eq $r)))))
+  )
+  "mismatched resource types")
+(assert_unlinkable
+  (component
+    (import "I2" (instance $i1 (export "r" (type (sub resource)))))
+    (alias export $i1 "r" (type $r))
+    (import "I3" (instance $i2 (export "r" (type (eq $r)))))
+  )
+  "mismatched resource types")
+(assert_unlinkable
+  (component
+    (import "I2" (instance $i1 (export "r" (type (sub resource)))))
+    (alias export $i1 "r" (type $r))
+    (import "I4" (instance $i2 (export "r" (type (eq $r)))))
+  )
+  "mismatched resource types")
+(assert_unlinkable
+  (component
+    (import "I3" (instance $i1 (export "r" (type (sub resource)))))
+    (alias export $i1 "r" (type $r))
+    (import "I4" (instance $i2 (export "r" (type (eq $r)))))
+  )
+  "mismatched resource types")

--- a/tests/misc_testsuite/function-references/instance.wast
+++ b/tests/misc_testsuite/function-references/instance.wast
@@ -1,0 +1,121 @@
+;; Instantiation is generative
+
+(module definition $M
+  (global (export "glob") (mut i32) (i32.const 0))
+  (table (export "tab") 10 funcref (ref.null func))
+  (memory (export "mem") 1)
+)
+
+(module instance $I1 $M)
+(module instance $I2 $M)
+(register "I1" $I1)
+(register "I2" $I2)
+
+(module
+  (import "I1" "glob" (global $glob1 (mut i32)))
+  (import "I2" "glob" (global $glob2 (mut i32)))
+  (import "I1" "tab" (table $tab1 10 funcref))
+  (import "I2" "tab" (table $tab2 10 funcref))
+  (import "I1" "mem" (memory $mem1 1))
+  (import "I2" "mem" (memory $mem2 1))
+
+  (func $f)
+  (elem declare func $f)
+
+  (func (export "glob") (result i32)
+    (global.set $glob1 (i32.const 1))
+    (global.get $glob2)
+  )
+  (func (export "tab") (result funcref)
+    (table.set $tab1 (i32.const 0) (ref.func $f))
+    (table.get $tab2 (i32.const 0))
+  )
+  (func (export "mem") (result i32)
+    (i32.store $mem1 (i32.const 0) (i32.const 1))
+    (i32.load $mem2 (i32.const 0))
+  )
+)
+
+(assert_return (invoke "glob") (i32.const 0))
+(assert_return (invoke "tab") (ref.null))
+(assert_return (invoke "mem") (i32.const 0))
+
+
+;; Import is not generative
+
+(module
+  (import "I1" "glob" (global $glob1 (mut i32)))
+  (import "I1" "glob" (global $glob2 (mut i32)))
+  (import "I1" "tab" (table $tab1 10 funcref))
+  (import "I1" "tab" (table $tab2 10 funcref))
+  (import "I1" "mem" (memory $mem1 1))
+  (import "I1" "mem" (memory $mem2 1))
+
+  (func $f)
+  (elem declare func $f)
+
+  (func (export "glob") (result i32)
+    (global.set $glob1 (i32.const 1))
+    (global.get $glob2)
+  )
+  (func (export "tab") (result funcref)
+    (table.set $tab1 (i32.const 0) (ref.func $f))
+    (table.get $tab2 (i32.const 0))
+  )
+  (func (export "mem") (result i32)
+    (i32.store $mem1 (i32.const 0) (i32.const 1))
+    (i32.load $mem2 (i32.const 0))
+  )
+)
+
+(assert_return (invoke "glob") (i32.const 1))
+(assert_return (invoke "tab") (ref.func))
+(assert_return (invoke "mem") (i32.const 1))
+
+
+;; Export is not generative
+
+(module definition $N
+  (global $glob (mut i32) (i32.const 0))
+  (table $tab 10 funcref (ref.null func))
+  (memory $mem 1)
+
+  (export "glob1" (global $glob))
+  (export "glob2" (global $glob))
+  (export "tab1" (table $tab))
+  (export "tab2" (table $tab))
+  (export "mem1" (memory $mem))
+  (export "mem2" (memory $mem))
+)
+
+(module instance $I $N)
+(register "I" $I)
+
+(module
+  (import "I" "glob1" (global $glob1 (mut i32)))
+  (import "I" "glob2" (global $glob2 (mut i32)))
+  (import "I" "tab1" (table $tab1 10 funcref))
+  (import "I" "tab2" (table $tab2 10 funcref))
+  (import "I" "mem1" (memory $mem1 1))
+  (import "I" "mem2" (memory $mem2 1))
+
+  (func $f)
+  (elem declare func $f)
+
+  (func (export "glob") (result i32)
+    (global.set $glob1 (i32.const 1))
+    (global.get $glob2)
+  )
+  (func (export "tab") (result funcref)
+    (table.set $tab1 (i32.const 0) (ref.func $f))
+    (table.get $tab2 (i32.const 0))
+  )
+  (func (export "mem") (result i32)
+    (i32.store $mem1 (i32.const 0) (i32.const 1))
+    (i32.load $mem2 (i32.const 0))
+  )
+)
+
+(assert_return (invoke "glob") (i32.const 1))
+(assert_return (invoke "tab") (ref.func))
+(assert_return (invoke "mem") (i32.const 1))

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -284,12 +284,14 @@ fn run_wast(wast: &Path, strategy: Strategy, pooling: bool) -> anyhow::Result<()
 
     let wast = Path::new(wast);
 
+    let misc = feature_found(wast, "misc_testsuite");
     let memory64 = feature_found(wast, "memory64");
     let custom_page_sizes = feature_found(wast, "custom-page-sizes");
     let multi_memory = feature_found(wast, "multi-memory")
         || feature_found(wast, "component-model")
         || custom_page_sizes
-        || memory64;
+        || memory64
+        || misc;
     let threads = feature_found(wast, "threads");
     let gc = feature_found(wast, "gc") || memory64;
     let function_references = gc || memory64 || feature_found(wast, "function-references");


### PR DESCRIPTION
This is a follow-up from #9219 to add support for a few more directives in `*.wast` tests to notably compile a module and possibly instantiate it multiple times.

This copies the upstream spec test using these new directives and edits it to remove the unsupported exception-handling bits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
