### PR TITLE
wasi-sockets: Fix `shutdown` bugs

### DIFF
--- a/crates/test-programs/src/sockets.rs
+++ b/crates/test-programs/src/sockets.rs
@@ -29,6 +29,19 @@ impl Pollable {
     }
 }
 
+impl InputStream {
+    pub fn blocking_read_to_end(&self) -> Result<Vec<u8>, crate::wasi::io::error::Error> {
+        let mut data = vec![];
+        loop {
+            match self.blocking_read(1024 * 1024) {
+                Ok(chunk) => data.extend(chunk),
+                Err(StreamError::Closed) => return Ok(data),
+                Err(StreamError::LastOperationFailed(e)) => return Err(e),
+            }
+        }
+    }
+}
+
 impl OutputStream {
     pub fn blocking_write_util(&self, mut bytes: &[u8]) -> Result<(), StreamError> {
         let timeout = monotonic_clock::subscribe_duration(TIMEOUT_NS);

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -361,7 +361,7 @@ impl HostInputStream for FileInputStream {
                 // background tasks. Also, the guest is only blocked if
                 // the stream was dropped mid-read, which we don't expect to
                 // occur frequently.
-                task.abort_wait().await;
+                task.cancel().await;
             }
             _ => {}
         }
@@ -558,7 +558,7 @@ impl HostOutputStream for FileOutputStream {
                 // background tasks. Also, the guest is only blocked if
                 // the stream was dropped mid-write, which we don't expect to
                 // occur frequently.
-                task.abort_wait().await;
+                task.cancel().await;
             }
             _ => {}
         }

--- a/crates/wasi/src/host/tcp.rs
+++ b/crates/wasi/src/host/tcp.rs
@@ -298,7 +298,7 @@ where
             ShutdownType::Send => std::net::Shutdown::Write,
             ShutdownType::Both => std::net::Shutdown::Both,
         };
-        Ok(socket.shutdown(how)?)
+        socket.shutdown(how)
     }
 
     fn drop(&mut self, this: Resource<tcp::TcpSocket>) -> Result<(), anyhow::Error> {

--- a/crates/wasi/src/pipe.rs
+++ b/crates/wasi/src/pipe.rs
@@ -193,7 +193,7 @@ impl HostInputStream for AsyncReadStream {
 
     async fn cancel(&mut self) {
         match self.join_handle.take() {
-            Some(task) => _ = task.abort_wait().await,
+            Some(task) => _ = task.cancel().await,
             None => {}
         }
     }

--- a/crates/wasi/src/runtime.rs
+++ b/crates/wasi/src/runtime.rs
@@ -43,21 +43,13 @@ impl<T> AbortOnDropJoinHandle<T> {
     /// Abort the task and wait for it to finish. Optionally returns the result
     /// of the task if it ran to completion prior to being aborted.
     pub(crate) async fn cancel(mut self) -> Option<T> {
-        std::future::poll_fn(move |cx| self.poll_cancel(cx)).await
-    }
-
-    /// Abort the task and wait for it to finish. Optionally returns the result
-    /// of the task if it ran to completion prior to being aborted.
-    pub(crate) fn poll_cancel(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.0.abort();
 
-        Poll::Ready(
-            match std::task::ready!(std::pin::pin!(&mut self.0).poll(cx)) {
-                Ok(value) => Some(value),
-                Err(err) if err.is_cancelled() => None,
-                Err(err) => std::panic::resume_unwind(err.into_panic()),
-            },
-        )
+        match (&mut self.0).await {
+            Ok(value) => Some(value),
+            Err(err) if err.is_cancelled() => None,
+            Err(err) => std::panic::resume_unwind(err.into_panic()),
+        }
     }
 }
 impl<T> Drop for AbortOnDropJoinHandle<T> {

--- a/crates/wasi/src/tcp.rs
+++ b/crates/wasi/src/tcp.rs
@@ -924,16 +924,11 @@ impl TcpWriter {
     }
 
     fn poll_cancel(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        self.state = match mem::replace(&mut self.state, WriteState::Closed) {
-            WriteState::Writing(task) | WriteState::Closing(task) => WriteState::Closing(task),
-            WriteState::Ready | WriteState::Closed => WriteState::Closed,
-            WriteState::Error(e) => WriteState::Error(e),
-        };
-
-        if let WriteState::Closing(task) = &mut self.state {
-            task.poll_cancel(cx).map(|_| ())
-        } else {
-            Poll::Ready(())
+        match &mut self.state {
+            WriteState::Writing(task) | WriteState::Closing(task) => {
+                task.poll_cancel(cx).map(|_| ())
+            }
+            _ => Poll::Ready(()),
         }
     }
 

--- a/crates/wasi/src/tcp.rs
+++ b/crates/wasi/src/tcp.rs
@@ -739,6 +739,7 @@ impl TcpReader {
             .stream
             .as_socketlike_view::<std::net::TcpStream>()
             .shutdown(Shutdown::Read);
+        self.closed = true;
     }
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<()> {

--- a/crates/wasi/src/write_stream.rs
+++ b/crates/wasi/src/write_stream.rs
@@ -198,7 +198,7 @@ impl HostOutputStream for AsyncWriteStream {
 
     async fn cancel(&mut self) {
         match self.join_handle.take() {
-            Some(task) => _ = task.abort_wait().await,
+            Some(task) => _ = task.cancel().await,
             None => {}
         }
     }


### PR DESCRIPTION
- Fix Linux-specific peculiarity where recv continues to work even after `shutdown(sock, SHUT_RD)` has been called.
- Calling `shutdown` _after_ data has been accepted by `write`, but _before_ it has been fully flushed, caused the in-flight data to be lost. Now, the native `shutdown` syscall is deferred until the background write finishes.

To facilitate the parent/child resource communication, I've placed the TCP stream implementations behind an `Arc<Mutex<..>>`. WASI is single threaded, so in practice these Mutexes should never be contended. It does make async functions like `ready` a bit awkward, though.

Tangentially related:
- Renamed:
	- `abort_wait` -> `cancel`
	- `LastWrite` -> `WriteState`
	- `Done` -> `Ready`
	- `Waiting` -> `Writing`