### PR TITLE
Make host trap handlers optional

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -245,7 +245,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             // We do nothing
         }
         Operator::Unreachable => {
-            builder.ins().trap(ir::TrapCode::UnreachableCodeReached);
+            environ.trap(builder, ir::TrapCode::UnreachableCodeReached);
             state.reachable = false;
         }
         /***************************** Control flow blocks **********************************
@@ -1016,19 +1016,19 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::I64TruncF64S | Operator::I64TruncF32S => {
             let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_sint(I64, val));
+            state.push1(environ.translate_fcvt_to_sint(builder, I64, val));
         }
         Operator::I32TruncF64S | Operator::I32TruncF32S => {
             let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_sint(I32, val));
+            state.push1(environ.translate_fcvt_to_sint(builder, I32, val));
         }
         Operator::I64TruncF64U | Operator::I64TruncF32U => {
             let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_uint(I64, val));
+            state.push1(environ.translate_fcvt_to_uint(builder, I64, val));
         }
         Operator::I32TruncF64U | Operator::I32TruncF32U => {
             let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_uint(I32, val));
+            state.push1(environ.translate_fcvt_to_uint(builder, I32, val));
         }
         Operator::I64TruncSatF64S | Operator::I64TruncSatF32S => {
             let val = state.pop1();
@@ -1155,19 +1155,19 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::I32DivS | Operator::I64DivS => {
             let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().sdiv(arg1, arg2));
+            state.push1(environ.translate_sdiv(builder, arg1, arg2));
         }
         Operator::I32DivU | Operator::I64DivU => {
             let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().udiv(arg1, arg2));
+            state.push1(environ.translate_udiv(builder, arg1, arg2));
         }
         Operator::I32RemS | Operator::I64RemS => {
             let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().srem(arg1, arg2));
+            state.push1(environ.translate_srem(builder, arg1, arg2));
         }
         Operator::I32RemU | Operator::I64RemU => {
             let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().urem(arg1, arg2));
+            state.push1(environ.translate_urem(builder, arg1, arg2));
         }
         Operator::F32Min | Operator::F64Min => {
             let (arg1, arg2) = state.pop2();
@@ -1255,9 +1255,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             } else {
                 let index_type = environ.heaps()[heap].index_type;
                 let offset = builder.ins().iconst(index_type, memarg.offset as i64);
-                builder
-                    .ins()
-                    .uadd_overflow_trap(addr, offset, ir::TrapCode::HeapOutOfBounds)
+                environ.uadd_overflow_trap(builder, addr, offset, ir::TrapCode::HeapOutOfBounds)
             };
             // `fn translate_atomic_wait` can inspect the type of `expected` to figure out what
             // code it needs to generate, if it wants.
@@ -1281,9 +1279,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             } else {
                 let index_type = environ.heaps()[heap].index_type;
                 let offset = builder.ins().iconst(index_type, memarg.offset as i64);
-                builder
-                    .ins()
-                    .uadd_overflow_trap(addr, offset, ir::TrapCode::HeapOutOfBounds)
+                environ.uadd_overflow_trap(builder, addr, offset, ir::TrapCode::HeapOutOfBounds)
             };
             let res = environ.translate_atomic_notify(
                 builder.cursor(),
@@ -2485,7 +2481,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::RefAsNonNull => {
             let r = state.pop1();
             let is_null = environ.translate_ref_is_null(builder.cursor(), r)?;
-            builder.ins().trapnz(is_null, ir::TrapCode::NullReference);
+            environ.trapnz(builder, is_null, ir::TrapCode::NullReference);
             state.push1(r);
         }
 
@@ -2496,12 +2492,12 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::I31GetS => {
             let i31ref = state.pop1();
-            let val = environ.translate_i31_get_s(builder.cursor(), i31ref)?;
+            let val = environ.translate_i31_get_s(builder, i31ref)?;
             state.push1(val);
         }
         Operator::I31GetU => {
             let i31ref = state.pop1();
-            let val = environ.translate_i31_get_u(builder.cursor(), i31ref)?;
+            let val = environ.translate_i31_get_u(builder, i31ref)?;
             state.push1(val);
         }
 
@@ -2863,9 +2859,7 @@ where
         Err(_) => {
             let offset = builder.ins().iconst(heap.index_type, memarg.offset as i64);
             let adjusted_index =
-                builder
-                    .ins()
-                    .uadd_overflow_trap(index, offset, ir::TrapCode::HeapOutOfBounds);
+                environ.uadd_overflow_trap(builder, index, offset, ir::TrapCode::HeapOutOfBounds);
             bounds_checks::bounds_check_and_compute_addr(
                 builder,
                 environ,
@@ -2902,11 +2896,12 @@ where
     Ok(Reachability::Reachable((flags, index, addr)))
 }
 
-fn align_atomic_addr(
+fn align_atomic_addr<FE: FuncEnvironment + ?Sized>(
     memarg: &MemArg,
     loaded_bytes: u8,
     builder: &mut FunctionBuilder,
     state: &mut FuncTranslationState,
+    environ: &mut FE,
 ) {
     // Atomic addresses must all be aligned correctly, and for now we check
     // alignment before we check out-of-bounds-ness. The order of this check may
@@ -2933,7 +2928,7 @@ fn align_atomic_addr(
             .ins()
             .band_imm(effective_addr, i64::from(loaded_bytes - 1));
         let f = builder.ins().icmp_imm(IntCC::NotEqual, misalignment, 0);
-        builder.ins().trapnz(f, ir::TrapCode::HeapMisaligned);
+        environ.trapnz(builder, f, ir::TrapCode::HeapMisaligned);
     }
 }
 
@@ -2947,7 +2942,7 @@ fn prepare_atomic_addr<FE: FuncEnvironment + ?Sized>(
     state: &mut FuncTranslationState,
     environ: &mut FE,
 ) -> WasmResult<Reachability<(MemFlags, Value, Value)>> {
-    align_atomic_addr(memarg, loaded_bytes, builder, state);
+    align_atomic_addr(memarg, loaded_bytes, builder, state, environ);
     prepare_addr(memarg, loaded_bytes, builder, state, environ)
 }
 

--- a/cranelift/wasm/src/code_translator/bounds_checks.rs
+++ b/cranelift/wasm/src/code_translator/bounds_checks.rs
@@ -64,7 +64,7 @@ where
 
     let host_page_size_log2 = env.target_config().page_size_align_log2;
     let can_use_virtual_memory =
-        heap.page_size_log2 >= host_page_size_log2 && env.can_use_virtual_memory_traps();
+        heap.page_size_log2 >= host_page_size_log2 && env.signals_based_traps();
 
     let make_compare = |builder: &mut FunctionBuilder,
                         compare_kind: IntCC,
@@ -576,6 +576,9 @@ fn explicit_check_oob_condition_and_compute_addr<FE: FuncEnvironment + ?Sized>(
     let mut addr = compute_addr(&mut builder.cursor(), heap, addr_ty, index, offset, pcc);
 
     if spectre_mitigations_enabled {
+        // These mitigations rely on trapping when loading from NULL so
+        // signals-based traps must be allowed for this to be generated.
+        assert!(env.signals_based_traps());
         let null = builder.ins().iconst(addr_ty, 0);
         addr = builder
             .ins()

--- a/cranelift/wasm/src/code_translator/bounds_checks.rs
+++ b/cranelift/wasm/src/code_translator/bounds_checks.rs
@@ -63,7 +63,8 @@ where
     let pcc = env.proof_carrying_code();
 
     let host_page_size_log2 = env.target_config().page_size_align_log2;
-    let can_use_virtual_memory = heap.page_size_log2 >= host_page_size_log2;
+    let can_use_virtual_memory =
+        heap.page_size_log2 >= host_page_size_log2 && env.can_use_virtual_memory_traps();
 
     let make_compare = |builder: &mut FunctionBuilder,
                         compare_kind: IntCC,
@@ -154,9 +155,9 @@ where
                 Some(0),
             );
             Reachable(explicit_check_oob_condition_and_compute_addr(
-                &mut builder.cursor(),
+                env,
+                builder,
                 heap,
-                env.pointer_type(),
                 index,
                 offset,
                 access_size,
@@ -204,9 +205,9 @@ where
                 Some(0),
             );
             Reachable(explicit_check_oob_condition_and_compute_addr(
-                &mut builder.cursor(),
+                env,
+                builder,
                 heap,
-                env.pointer_type(),
                 index,
                 offset,
                 access_size,
@@ -248,9 +249,9 @@ where
                 Some(adjustment),
             );
             Reachable(explicit_check_oob_condition_and_compute_addr(
-                &mut builder.cursor(),
+                env,
+                builder,
                 heap,
-                env.pointer_type(),
                 index,
                 offset,
                 access_size,
@@ -275,7 +276,8 @@ where
                 builder.func.dfg.facts[access_size_val] =
                     Some(Fact::constant(pointer_bit_width, offset_and_size));
             }
-            let adjusted_index = builder.ins().uadd_overflow_trap(
+            let adjusted_index = env.uadd_overflow_trap(
+                builder,
                 index,
                 access_size_val,
                 ir::TrapCode::HeapOutOfBounds,
@@ -297,9 +299,9 @@ where
                 Some(0),
             );
             Reachable(explicit_check_oob_condition_and_compute_addr(
-                &mut builder.cursor(),
+                env,
+                builder,
                 heap,
-                env.pointer_type(),
                 index,
                 offset,
                 access_size,
@@ -323,7 +325,7 @@ where
                 "static memories require the ability to use virtual memory"
             );
             env.before_unconditionally_trapping_memory_access(builder)?;
-            builder.ins().trap(ir::TrapCode::HeapOutOfBounds);
+            env.trap(builder, ir::TrapCode::HeapOutOfBounds);
             Unreachable
         }
 
@@ -423,9 +425,9 @@ where
                 Some(0),
             );
             Reachable(explicit_check_oob_condition_and_compute_addr(
-                &mut builder.cursor(),
+                env,
+                builder,
                 heap,
-                env.pointer_type(),
                 index,
                 offset,
                 access_size,
@@ -550,10 +552,10 @@ impl AddrPcc {
 ///
 /// This function deduplicates explicit bounds checks and Spectre mitigations
 /// that inherently also implement bounds checking.
-fn explicit_check_oob_condition_and_compute_addr(
-    pos: &mut FuncCursor,
+fn explicit_check_oob_condition_and_compute_addr<FE: FuncEnvironment + ?Sized>(
+    env: &mut FE,
+    builder: &mut FunctionBuilder,
     heap: &HeapData,
-    addr_ty: ir::Type,
     index: ir::Value,
     offset: u32,
     access_size: u8,
@@ -567,22 +569,24 @@ fn explicit_check_oob_condition_and_compute_addr(
     oob_condition: ir::Value,
 ) -> ir::Value {
     if !spectre_mitigations_enabled {
-        pos.ins()
-            .trapnz(oob_condition, ir::TrapCode::HeapOutOfBounds);
+        env.trapnz(builder, oob_condition, ir::TrapCode::HeapOutOfBounds);
     }
+    let addr_ty = env.pointer_type();
 
-    let mut addr = compute_addr(pos, heap, addr_ty, index, offset, pcc);
+    let mut addr = compute_addr(&mut builder.cursor(), heap, addr_ty, index, offset, pcc);
 
     if spectre_mitigations_enabled {
-        let null = pos.ins().iconst(addr_ty, 0);
-        addr = pos.ins().select_spectre_guard(oob_condition, null, addr);
+        let null = builder.ins().iconst(addr_ty, 0);
+        addr = builder
+            .ins()
+            .select_spectre_guard(oob_condition, null, addr);
 
         match pcc {
             None => {}
             Some(AddrPcc::Static32(ty, size)) => {
-                pos.func.dfg.facts[null] =
+                builder.func.dfg.facts[null] =
                     Some(Fact::constant(u16::try_from(addr_ty.bits()).unwrap(), 0));
-                pos.func.dfg.facts[addr] = Some(Fact::Mem {
+                builder.func.dfg.facts[addr] = Some(Fact::Mem {
                     ty,
                     min_offset: 0,
                     max_offset: size.checked_sub(u64::from(access_size)).unwrap(),
@@ -590,9 +594,9 @@ fn explicit_check_oob_condition_and_compute_addr(
                 });
             }
             Some(AddrPcc::Dynamic(ty, gv)) => {
-                pos.func.dfg.facts[null] =
+                builder.func.dfg.facts[null] =
                     Some(Fact::constant(u16::try_from(addr_ty.bits()).unwrap(), 0));
-                pos.func.dfg.facts[addr] = Some(Fact::DynamicMem {
+                builder.func.dfg.facts[addr] = Some(Fact::DynamicMem {
                     ty,
                     min: Expr::constant(0),
                     max: Expr::offset(

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -695,9 +695,9 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// Accesses the ISA that is being compiled for.
     fn isa(&self) -> &dyn TargetIsa;
 
-    /// Embedder-defined hook for indicating whether virtual memory should not
-    /// be used which forces more explicit bounds checks for example.
-    fn can_use_virtual_memory_traps(&self) -> bool {
+    /// Embedder-defined hook for indicating whether signals can be used to
+    /// indicate traps.
+    fn signals_based_traps(&self) -> bool {
         true
     }
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -123,6 +123,9 @@ wasmtime_option_group! {
         /// The maximum size, in bytes, allocated for a core instance's metadata
         /// when using the pooling allocator.
         pub pooling_max_core_instance_size: Option<usize>,
+
+        /// Enable or disable the use of host trap handlers.
+        pub host_trap_handlers: Option<bool>,
     }
 
     enum Optimize {
@@ -592,6 +595,9 @@ impl CommonOptions {
         }
         if let Some(enable) = self.opts.memory_init_cow {
             config.memory_init_cow(enable);
+        }
+        if let Some(enable) = self.opts.host_trap_handlers {
+            config.host_trap_handlers(enable);
         }
 
         match_feature! {

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -124,8 +124,8 @@ wasmtime_option_group! {
         /// when using the pooling allocator.
         pub pooling_max_core_instance_size: Option<usize>,
 
-        /// Enable or disable the use of host trap handlers.
-        pub host_trap_handlers: Option<bool>,
+        /// Enable or disable the use of host signal handlers for traps.
+        pub signals_based_traps: Option<bool>,
     }
 
     enum Optimize {
@@ -596,8 +596,8 @@ impl CommonOptions {
         if let Some(enable) = self.opts.memory_init_cow {
             config.memory_init_cow(enable);
         }
-        if let Some(enable) = self.opts.host_trap_handlers {
-            config.host_trap_handlers(enable);
+        if let Some(enable) = self.opts.signals_based_traps {
+            config.signals_based_traps(enable);
         }
 
         match_feature! {

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -15,7 +15,9 @@ use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::{CompiledCode, Context};
 use cranelift_entity::PrimaryMap;
 use cranelift_frontend::FunctionBuilder;
-use cranelift_wasm::{DefinedFuncIndex, FuncTranslator, WasmFuncType, WasmValType};
+use cranelift_wasm::{
+    DefinedFuncIndex, FuncEnvironment as _, FuncTranslator, WasmFuncType, WasmValType,
+};
 use object::write::{Object, StandardSegment, SymbolId};
 use object::{RelocationEncoding, RelocationFlags, RelocationKind, SectionKind};
 use std::any::Any;
@@ -206,10 +208,10 @@ impl wasmtime_environ::Compiler for Compiler {
             global_type: isa.pointer_type(),
             flags: MemFlags::trusted(),
         });
-        if func_env.use_libcall_traps() {
-            func_env.stack_limit_at_function_entry = Some(stack_limit);
-        } else {
+        if func_env.signals_based_traps() {
             context.func.stack_limit = Some(stack_limit);
+        } else {
+            func_env.stack_limit_at_function_entry = Some(stack_limit);
         }
         let FunctionBodyData { validator, body } = input;
         let mut validator =

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -206,7 +206,11 @@ impl wasmtime_environ::Compiler for Compiler {
             global_type: isa.pointer_type(),
             flags: MemFlags::trusted(),
         });
-        context.func.stack_limit = Some(stack_limit);
+        if func_env.use_libcall_traps() {
+            func_env.stack_limit_at_function_entry = Some(stack_limit);
+        } else {
+            context.func.stack_limit = Some(stack_limit);
+        }
         let FunctionBodyData { validator, body } = input;
         let mut validator =
             validator.into_validator(mem::take(&mut compiler.cx.validator_allocations));

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -8,7 +8,7 @@ use cranelift_frontend::FunctionBuilder;
 use cranelift_wasm::ModuleInternedTypeIndex;
 use std::any::Any;
 use wasmtime_environ::component::*;
-use wasmtime_environ::{PtrSize, WasmValType};
+use wasmtime_environ::{PtrSize, Tunables, WasmValType};
 
 struct TrampolineCompiler<'a> {
     compiler: &'a Compiler,
@@ -20,6 +20,7 @@ struct TrampolineCompiler<'a> {
     abi: Abi,
     block0: ir::Block,
     signature: ModuleInternedTypeIndex,
+    tunables: &'a Tunables,
 }
 
 #[derive(Copy, Clone)]
@@ -36,6 +37,7 @@ impl<'a> TrampolineCompiler<'a> {
         types: &'a ComponentTypesBuilder,
         index: TrampolineIndex,
         abi: Abi,
+        tunables: &'a Tunables,
     ) -> TrampolineCompiler<'a> {
         let isa = &*compiler.isa;
         let signature = component.trampolines[index];
@@ -58,6 +60,7 @@ impl<'a> TrampolineCompiler<'a> {
             abi,
             block0,
             signature,
+            tunables,
         }
     }
 
@@ -91,9 +94,7 @@ impl<'a> TrampolineCompiler<'a> {
                 self.translate_lower_import(*index, options, *lower_ty);
             }
             Trampoline::AlwaysTrap => {
-                self.builder
-                    .ins()
-                    .trap(ir::TrapCode::User(ALWAYS_TRAP_CODE));
+                self.translate_always_trap();
             }
             Trampoline::ResourceNew(ty) => self.translate_resource_new(*ty),
             Trampoline::ResourceRep(ty) => self.translate_resource_rep(*ty),
@@ -259,6 +260,32 @@ impl<'a> TrampolineCompiler<'a> {
                 self.builder.ins().return_(&[]);
             }
         }
+    }
+
+    fn translate_always_trap(&mut self) {
+        if self.tunables.host_trap_handlers {
+            self.builder
+                .ins()
+                .trap(ir::TrapCode::User(ALWAYS_TRAP_CODE));
+            return;
+        }
+
+        let args = self.abi_load_params();
+        let vmctx = args[0];
+
+        let (host_sig, offset) = host::trap(self.isa, &mut self.builder.func);
+        let host_fn = self.load_libcall(vmctx, offset);
+
+        let code = self.builder.ins().iconst(
+            ir::types::I32,
+            i64::from(wasmtime_environ::Trap::AlwaysTrapAdapter as u8),
+        );
+        self.builder
+            .ins()
+            .call_indirect(host_sig, host_fn, &[vmctx, code]);
+        self.builder
+            .ins()
+            .trap(ir::TrapCode::User(crate::DEBUG_ASSERT_TRAP_CODE));
     }
 
     fn translate_resource_new(&mut self, resource: TypeResourceTableIndex) {
@@ -625,6 +652,7 @@ impl ComponentCompiler for Compiler {
         component: &ComponentTranslation,
         types: &ComponentTypesBuilder,
         index: TrampolineIndex,
+        tunables: &Tunables,
     ) -> Result<AllCallFunc<Box<dyn Any + Send>>> {
         let compile = |abi: Abi| -> Result<_> {
             let mut compiler = self.function_compiler();
@@ -635,6 +663,7 @@ impl ComponentCompiler for Compiler {
                 types,
                 index,
                 abi,
+                tunables,
             );
 
             // If we are crossing the Wasm-to-native boundary, we need to save the

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -142,6 +142,15 @@ pub struct FuncEnvironment<'module_environment> {
 
     #[cfg(feature = "wmemcheck")]
     wmemcheck: bool,
+
+    /// A `GlobalValue` in CLIF which represents the stack limit.
+    ///
+    /// Typically this resides in the `stack_limit` value of `ir::Function` but
+    /// that requires signal handlers on the host and when that's disabled this
+    /// is here with an explicit check instead. Note that the explicit check is
+    /// always present even if this is a leaf function, as that's what host trap
+    /// handlers enable.
+    pub(crate) stack_limit_at_function_entry: Option<ir::GlobalValue>,
 }
 
 impl<'module_environment> FuncEnvironment<'module_environment> {
@@ -186,6 +195,8 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             wmemcheck,
             #[cfg(feature = "wmemcheck")]
             translation,
+
+            stack_limit_at_function_entry: None,
         }
     }
 
@@ -852,13 +863,13 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     ) -> ir::Value {
         let pointer_type = self.pointer_type();
         self.ensure_table_exists(builder.func, table_index);
-        let table_data = self.tables[table_index].as_ref().unwrap();
+        let table_data = self.tables[table_index].clone().unwrap();
 
         // To support lazy initialization of table
         // contents, we check for a null entry here, and
         // if null, we take a slow-path that invokes a
         // libcall.
-        let (table_entry_addr, flags) = table_data.prepare_table_addr(&*self.isa, builder, index);
+        let (table_entry_addr, flags) = table_data.prepare_table_addr(self, builder, index);
         let value = builder.ins().load(pointer_type, flags, table_entry_addr, 0);
 
         if !lazy_init {
@@ -1014,6 +1025,102 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             pointee_mt
         });
         (pointee, mt)
+    }
+
+    pub fn use_libcall_traps(&self) -> bool {
+        !self.tunables.host_trap_handlers
+    }
+
+    /// Helper to emit a conditional trap based on `trap_cond`.
+    ///
+    /// This should only be used if `self.use_libcall_traps()` is true,
+    /// otherwise native CLIF instructions should be used instead.
+    pub fn conditionally_trap(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        trap_cond: ir::Value,
+        trap: ir::TrapCode,
+    ) {
+        assert!(self.use_libcall_traps());
+
+        let trap_block = builder.create_block();
+        builder.set_cold_block(trap_block);
+        let continuation_block = builder.create_block();
+
+        builder
+            .ins()
+            .brif(trap_cond, trap_block, &[], continuation_block, &[]);
+
+        builder.seal_block(trap_block);
+        builder.seal_block(continuation_block);
+
+        builder.switch_to_block(trap_block);
+        self.trap(builder, trap);
+        builder.switch_to_block(continuation_block);
+    }
+
+    /// Helper used when `self.use_libcall_traps()` is enabled to test whether
+    /// the divisor is zero.
+    fn guard_zero_divisor(&mut self, builder: &mut FunctionBuilder, rhs: ir::Value) {
+        if !self.use_libcall_traps() {
+            return;
+        }
+        self.trapz(builder, rhs, ir::TrapCode::IntegerDivisionByZero);
+    }
+
+    /// Helper used when `self.use_libcall_traps()` is enabled to test whether a
+    /// signed division operation will raise a trap.
+    fn guard_signed_divide(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lhs: ir::Value,
+        rhs: ir::Value,
+    ) {
+        if !self.use_libcall_traps() {
+            return;
+        }
+        self.trapz(builder, rhs, ir::TrapCode::IntegerDivisionByZero);
+
+        let ty = builder.func.dfg.value_type(rhs);
+        let minus_one = builder.ins().iconst(ty, -1);
+        let rhs_is_minus_one = builder.ins().icmp(IntCC::Equal, rhs, minus_one);
+        let int_min = builder.ins().iconst(
+            ty,
+            match ty {
+                I32 => i64::from(i32::MIN),
+                I64 => i64::MIN,
+                _ => unreachable!(),
+            },
+        );
+        let lhs_is_int_min = builder.ins().icmp(IntCC::Equal, lhs, int_min);
+        let is_integer_overflow = builder.ins().band(rhs_is_minus_one, lhs_is_int_min);
+        self.conditionally_trap(builder, is_integer_overflow, ir::TrapCode::IntegerOverflow);
+    }
+
+    /// Helper used when `self.use_libcall_traps()` is enabled to perform
+    /// trapping float-to-int conversions.
+    fn fcvt_to_int(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        ty: ir::Type,
+        val: ir::Value,
+        i32: fn(&mut Self, &mut Function) -> ir::FuncRef,
+        i64: fn(&mut Self, &mut Function) -> ir::FuncRef,
+    ) -> ir::Value {
+        let val_ty = builder.func.dfg.value_type(val);
+        let val = if val_ty == F64 {
+            val
+        } else {
+            builder.ins().fpromote(F64, val)
+        };
+        let libcall = match ty {
+            I32 => i32(self, &mut builder.func),
+            I64 => i64(self, &mut builder.func),
+            _ => unreachable!(),
+        };
+        let vmctx = self.vmctx_val(&mut builder.cursor());
+        let call = builder.ins().call(libcall, &[vmctx, val]);
+        *builder.func.dfg.inst_results(call).first().unwrap()
     }
 }
 
@@ -1247,15 +1354,20 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
                 // null pointer, then this was a call to null. Otherwise if it
                 // succeeds then we know it won't match, so trap anyway.
                 if table.table.ref_type.nullable {
-                    let mem_flags = ir::MemFlags::trusted().with_readonly();
-                    self.builder.ins().load(
-                        sig_id_type,
-                        mem_flags.with_trap_code(Some(ir::TrapCode::IndirectCallToNull)),
-                        funcref_ptr,
-                        i32::from(self.env.offsets.ptr.vm_func_ref_type_index()),
-                    );
+                    if self.env.use_libcall_traps() {
+                        self.env
+                            .trapz(self.builder, funcref_ptr, ir::TrapCode::IndirectCallToNull);
+                    } else {
+                        let mem_flags = ir::MemFlags::trusted().with_readonly();
+                        self.builder.ins().load(
+                            sig_id_type,
+                            mem_flags.with_trap_code(Some(ir::TrapCode::IndirectCallToNull)),
+                            funcref_ptr,
+                            i32::from(self.env.offsets.ptr.vm_func_ref_type_index()),
+                        );
+                    }
                 }
-                self.builder.ins().trap(ir::TrapCode::BadSignature);
+                self.env.trap(self.builder, ir::TrapCode::BadSignature);
                 return CheckIndirectCallTypeSignature::StaticTrap;
             }
 
@@ -1263,7 +1375,8 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
             // trap with that.
             WasmHeapType::NoFunc => {
                 assert!(table.table.ref_type.nullable);
-                self.builder.ins().trap(ir::TrapCode::IndirectCallToNull);
+                self.env
+                    .trap(self.builder, ir::TrapCode::IndirectCallToNull);
                 return CheckIndirectCallTypeSignature::StaticTrap;
             }
 
@@ -1311,10 +1424,16 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         //
         // Note that the callee may be null in which case this load may
         // trap. If so use the `IndirectCallToNull` trap code.
-        let mem_flags = ir::MemFlags::trusted().with_readonly();
+        let mut mem_flags = ir::MemFlags::trusted().with_readonly();
+        if self.env.use_libcall_traps() {
+            self.env
+                .trapz(self.builder, funcref_ptr, ir::TrapCode::IndirectCallToNull);
+        } else {
+            mem_flags = mem_flags.with_trap_code(Some(ir::TrapCode::IndirectCallToNull));
+        }
         let callee_sig_id = self.builder.ins().load(
             sig_id_type,
-            mem_flags.with_trap_code(Some(ir::TrapCode::IndirectCallToNull)),
+            mem_flags,
             funcref_ptr,
             i32::from(self.env.offsets.ptr.vm_func_ref_type_index()),
         );
@@ -1324,7 +1443,8 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
             .builder
             .ins()
             .icmp(IntCC::Equal, callee_sig_id, caller_sig_id);
-        self.builder.ins().trapz(cmp, ir::TrapCode::BadSignature);
+        self.env
+            .trapz(self.builder, cmp, ir::TrapCode::BadSignature);
         CheckIndirectCallTypeSignature::Runtime
     }
 
@@ -1377,9 +1497,17 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         // will handle the case where this is either already known to be
         // non-null or may trap.
         let mem_flags = ir::MemFlags::trusted().with_readonly();
+        let mut callee_flags = mem_flags;
+        if self.env.use_libcall_traps() {
+            if let Some(trap) = callee_load_trap_code {
+                self.env.trapz(self.builder, callee, trap);
+            }
+        } else {
+            callee_flags = callee_flags.with_trap_code(callee_load_trap_code);
+        }
         let func_addr = self.builder.ins().load(
             pointer_type,
-            mem_flags.with_trap_code(callee_load_trap_code),
+            callee_flags,
             callee,
             i32::from(self.env.offsets.ptr.vm_func_ref_wasm_call()),
         );
@@ -1588,19 +1716,19 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let plan = &self.module.table_plans[table_index];
         let table = plan.table;
         self.ensure_table_exists(builder.func, table_index);
-        let table_data = self.tables[table_index].as_ref().unwrap();
+        let table_data = self.tables[table_index].clone().unwrap();
         let heap_ty = table.ref_type.heap_type;
         match heap_ty.top() {
             // `i31ref`s never need barriers, and therefore don't need to go
             // through the GC compiler.
             WasmHeapTopType::Any if heap_ty == WasmHeapType::I31 => {
-                let (src, flags) = table_data.prepare_table_addr(&*self.isa, builder, index);
+                let (src, flags) = table_data.prepare_table_addr(self, builder, index);
                 gc::unbarriered_load_gc_ref(self, builder, WasmHeapType::I31, src, flags)
             }
 
             // GC-managed types.
             WasmHeapTopType::Any | WasmHeapTopType::Extern => {
-                let (src, flags) = table_data.prepare_table_addr(&*self.isa, builder, index);
+                let (src, flags) = table_data.prepare_table_addr(self, builder, index);
                 gc::gc_compiler(self).translate_read_gc_reference(
                     self,
                     builder,
@@ -1634,19 +1762,19 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let plan = &self.module.table_plans[table_index];
         let table = plan.table;
         self.ensure_table_exists(builder.func, table_index);
-        let table_data = self.tables[table_index].as_ref().unwrap();
+        let table_data = self.tables[table_index].clone().unwrap();
         let heap_ty = table.ref_type.heap_type;
         match heap_ty.top() {
             // `i31ref`s never need GC barriers, and therefore don't need to go
             // through the GC compiler.
             WasmHeapTopType::Any if heap_ty == WasmHeapType::I31 => {
-                let (addr, flags) = table_data.prepare_table_addr(&*self.isa, builder, index);
+                let (addr, flags) = table_data.prepare_table_addr(self, builder, index);
                 gc::unbarriered_store_gc_ref(self, builder, WasmHeapType::I31, addr, value, flags)
             }
 
             // GC-managed types.
             WasmHeapTopType::Any | WasmHeapTopType::Extern => {
-                let (dst, flags) = table_data.prepare_table_addr(&*self.isa, builder, index);
+                let (dst, flags) = table_data.prepare_table_addr(self, builder, index);
                 gc::gc_compiler(self).translate_write_gc_reference(
                     self,
                     builder,
@@ -1662,7 +1790,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 match plan.style {
                     TableStyle::CallerChecksSignature { lazy_init } => {
                         let (elem_addr, flags) =
-                            table_data.prepare_table_addr(&*self.isa, builder, index);
+                            table_data.prepare_table_addr(self, builder, index);
                         // Set the "initialized bit". See doc-comment on
                         // `FUNCREF_INIT_BIT` in
                         // crates/environ/src/ref_bits.rs for details.
@@ -1725,20 +1853,20 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
     fn translate_i31_get_s(
         &mut self,
-        mut pos: FuncCursor,
+        builder: &mut FunctionBuilder,
         i31ref: ir::Value,
     ) -> WasmResult<ir::Value> {
-        pos.ins().trapz(i31ref, ir::TrapCode::NullI31Ref);
-        Ok(pos.ins().sshr_imm(i31ref, 1))
+        self.trapz(builder, i31ref, ir::TrapCode::NullI31Ref);
+        Ok(builder.ins().sshr_imm(i31ref, 1))
     }
 
     fn translate_i31_get_u(
         &mut self,
-        mut pos: FuncCursor,
+        builder: &mut FunctionBuilder,
         i31ref: ir::Value,
     ) -> WasmResult<ir::Value> {
-        pos.ins().trapz(i31ref, ir::TrapCode::NullI31Ref);
-        Ok(pos.ins().ushr_imm(i31ref, 1))
+        self.trapz(builder, i31ref, ir::TrapCode::NullI31Ref);
+        Ok(builder.ins().ushr_imm(i31ref, 1))
     }
 
     fn translate_ref_null(
@@ -2631,6 +2759,15 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         builder: &mut FunctionBuilder,
         _state: &FuncTranslationState,
     ) -> WasmResult<()> {
+        // If an explicit stack limit is requested, emit one here at the start
+        // of the function.
+        if let Some(gv) = self.stack_limit_at_function_entry {
+            let limit = builder.ins().global_value(self.pointer_type(), gv);
+            let sp = builder.ins().get_stack_pointer(self.pointer_type());
+            let overflow = builder.ins().icmp(IntCC::UnsignedLessThan, sp, limit);
+            self.conditionally_trap(builder, overflow, ir::TrapCode::StackOverflow);
+        }
+
         // If the `vmruntime_limits_ptr` variable will get used then we initialize
         // it here.
         if self.tunables.consume_fuel || self.tunables.epoch_interruption {
@@ -2776,6 +2913,157 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             let update_mem_size = self.builtin_functions.update_mem_size(builder.func);
             let vmctx = self.vmctx_val(&mut builder.cursor());
             builder.ins().call(update_mem_size, &[vmctx, num_pages]);
+        }
+    }
+
+    fn isa(&self) -> &dyn TargetIsa {
+        &*self.isa
+    }
+
+    fn trap(&mut self, builder: &mut FunctionBuilder, trap: ir::TrapCode) {
+        match (self.use_libcall_traps(), crate::clif_trap_to_env_trap(trap)) {
+            // If libcall traps are disabled or there's no wasmtime-defined trap
+            // code for this, then emit a native trap instruction.
+            (false, _) | (_, None) => {
+                builder.ins().trap(trap);
+            }
+            // ... otherwise with libcall traps explicitly enabled and a
+            // wasmtime-based trap code invoke the libcall to raise a trap and
+            // pass in our trap code. Leave a debug `unreachable` in place
+            // afterwards as a defense-in-depth measure.
+            (true, Some(trap)) => {
+                let libcall = self.builtin_functions.trap(&mut builder.func);
+                let vmctx = self.vmctx_val(&mut builder.cursor());
+                let trap_code = builder.ins().iconst(I32, i64::from(trap as u8));
+                builder.ins().call(libcall, &[vmctx, trap_code]);
+                builder
+                    .ins()
+                    .trap(ir::TrapCode::User(crate::DEBUG_ASSERT_TRAP_CODE));
+            }
+        }
+    }
+
+    fn trapz(&mut self, builder: &mut FunctionBuilder, value: ir::Value, trap: ir::TrapCode) {
+        if self.use_libcall_traps() {
+            let ty = builder.func.dfg.value_type(value);
+            let zero = builder.ins().iconst(ty, 0);
+            let cmp = builder.ins().icmp(IntCC::Equal, value, zero);
+            self.conditionally_trap(builder, cmp, trap);
+        } else {
+            builder.ins().trapz(value, trap);
+        }
+    }
+
+    fn trapnz(&mut self, builder: &mut FunctionBuilder, value: ir::Value, trap: ir::TrapCode) {
+        if self.use_libcall_traps() {
+            let ty = builder.func.dfg.value_type(value);
+            let zero = builder.ins().iconst(ty, 0);
+            let cmp = builder.ins().icmp(IntCC::NotEqual, value, zero);
+            self.conditionally_trap(builder, cmp, trap);
+        } else {
+            builder.ins().trapnz(value, trap);
+        }
+    }
+
+    fn uadd_overflow_trap(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lhs: ir::Value,
+        rhs: ir::Value,
+        trap: ir::TrapCode,
+    ) -> ir::Value {
+        if self.use_libcall_traps() {
+            let (ret, overflow) = builder.ins().uadd_overflow(lhs, rhs);
+            self.conditionally_trap(builder, overflow, trap);
+            ret
+        } else {
+            builder.ins().uadd_overflow_trap(lhs, rhs, trap)
+        }
+    }
+
+    fn can_use_virtual_memory_traps(&self) -> bool {
+        !self.use_libcall_traps()
+    }
+
+    fn translate_sdiv(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lhs: ir::Value,
+        rhs: ir::Value,
+    ) -> ir::Value {
+        self.guard_signed_divide(builder, lhs, rhs);
+        builder.ins().sdiv(lhs, rhs)
+    }
+
+    fn translate_udiv(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lhs: ir::Value,
+        rhs: ir::Value,
+    ) -> ir::Value {
+        self.guard_zero_divisor(builder, rhs);
+        builder.ins().udiv(lhs, rhs)
+    }
+
+    fn translate_srem(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lhs: ir::Value,
+        rhs: ir::Value,
+    ) -> ir::Value {
+        self.guard_zero_divisor(builder, rhs);
+        builder.ins().srem(lhs, rhs)
+    }
+
+    fn translate_urem(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lhs: ir::Value,
+        rhs: ir::Value,
+    ) -> ir::Value {
+        self.guard_zero_divisor(builder, rhs);
+        builder.ins().urem(lhs, rhs)
+    }
+
+    fn translate_fcvt_to_sint(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        ty: ir::Type,
+        val: ir::Value,
+    ) -> ir::Value {
+        // NB: for now avoid translating this entire instruction to CLIF and
+        // just do it in a libcall.
+        if self.use_libcall_traps() {
+            self.fcvt_to_int(
+                builder,
+                ty,
+                val,
+                |me, func| me.builtin_functions.f64_to_i32(func),
+                |me, func| me.builtin_functions.f64_to_i64(func),
+            )
+        } else {
+            builder.ins().fcvt_to_sint(ty, val)
+        }
+    }
+
+    fn translate_fcvt_to_uint(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        ty: ir::Type,
+        val: ir::Value,
+    ) -> ir::Value {
+        // NB: for now avoid translating this entire instruction to CLIF and
+        // just do it in a libcall.
+        if self.use_libcall_traps() {
+            self.fcvt_to_int(
+                builder,
+                ty,
+                val,
+                |me, func| me.builtin_functions.f64_to_u32(func),
+                |me, func| me.builtin_functions.f64_to_u64(func),
+            )
+        } else {
+            builder.ins().fcvt_to_uint(ty, val)
         }
     }
 }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -370,6 +370,10 @@ impl BuiltinFunctionSignatures {
         AbiParam::new(ir::types::F64)
     }
 
+    fn u8(&self) -> AbiParam {
+        AbiParam::new(ir::types::I8)
+    }
+
     fn signature(&self, builtin: BuiltinFunctionIndex) -> Signature {
         let mut _cur = 0;
         macro_rules! iter {

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -228,31 +228,35 @@ pub fn mach_trap_to_trap(trap: &MachTrap) -> Option<TrapInformation> {
     let &MachTrap { offset, code } = trap;
     Some(TrapInformation {
         code_offset: offset,
-        trap_code: match code {
-            ir::TrapCode::StackOverflow => Trap::StackOverflow,
-            ir::TrapCode::HeapOutOfBounds => Trap::MemoryOutOfBounds,
-            ir::TrapCode::HeapMisaligned => Trap::HeapMisaligned,
-            ir::TrapCode::TableOutOfBounds => Trap::TableOutOfBounds,
-            ir::TrapCode::IndirectCallToNull => Trap::IndirectCallToNull,
-            ir::TrapCode::BadSignature => Trap::BadSignature,
-            ir::TrapCode::IntegerOverflow => Trap::IntegerOverflow,
-            ir::TrapCode::IntegerDivisionByZero => Trap::IntegerDivisionByZero,
-            ir::TrapCode::BadConversionToInteger => Trap::BadConversionToInteger,
-            ir::TrapCode::UnreachableCodeReached => Trap::UnreachableCodeReached,
-            ir::TrapCode::Interrupt => Trap::Interrupt,
-            ir::TrapCode::User(ALWAYS_TRAP_CODE) => Trap::AlwaysTrapAdapter,
-            ir::TrapCode::User(CANNOT_ENTER_CODE) => Trap::CannotEnterComponent,
-            ir::TrapCode::NullReference => Trap::NullReference,
-            ir::TrapCode::NullI31Ref => Trap::NullI31Ref,
+        trap_code: clif_trap_to_env_trap(code)?,
+    })
+}
 
-            // These do not get converted to wasmtime traps, since they
-            // shouldn't ever be hit in theory. Instead of catching and handling
-            // these, we let the signal crash the process.
-            ir::TrapCode::User(DEBUG_ASSERT_TRAP_CODE) => return None,
+fn clif_trap_to_env_trap(trap: ir::TrapCode) -> Option<Trap> {
+    Some(match trap {
+        ir::TrapCode::StackOverflow => Trap::StackOverflow,
+        ir::TrapCode::HeapOutOfBounds => Trap::MemoryOutOfBounds,
+        ir::TrapCode::HeapMisaligned => Trap::HeapMisaligned,
+        ir::TrapCode::TableOutOfBounds => Trap::TableOutOfBounds,
+        ir::TrapCode::IndirectCallToNull => Trap::IndirectCallToNull,
+        ir::TrapCode::BadSignature => Trap::BadSignature,
+        ir::TrapCode::IntegerOverflow => Trap::IntegerOverflow,
+        ir::TrapCode::IntegerDivisionByZero => Trap::IntegerDivisionByZero,
+        ir::TrapCode::BadConversionToInteger => Trap::BadConversionToInteger,
+        ir::TrapCode::UnreachableCodeReached => Trap::UnreachableCodeReached,
+        ir::TrapCode::Interrupt => Trap::Interrupt,
+        ir::TrapCode::User(ALWAYS_TRAP_CODE) => Trap::AlwaysTrapAdapter,
+        ir::TrapCode::User(CANNOT_ENTER_CODE) => Trap::CannotEnterComponent,
+        ir::TrapCode::NullReference => Trap::NullReference,
+        ir::TrapCode::NullI31Ref => Trap::NullI31Ref,
 
-            // these should never be emitted by wasmtime-cranelift
-            ir::TrapCode::User(_) => unreachable!(),
-        },
+        // These do not get converted to wasmtime traps, since they
+        // shouldn't ever be hit in theory. Instead of catching and handling
+        // these, we let the signal crash the process.
+        ir::TrapCode::User(DEBUG_ASSERT_TRAP_CODE) => return None,
+
+        // these should never be emitted by wasmtime-cranelift
+        ir::TrapCode::User(_) => unreachable!(),
     })
 }
 
@@ -360,6 +364,10 @@ impl BuiltinFunctionSignatures {
 
     fn i64(&self) -> AbiParam {
         AbiParam::new(ir::types::I64)
+    }
+
+    fn f64(&self) -> AbiParam {
+        AbiParam::new(ir::types::F64)
     }
 
     fn signature(&self, builtin: BuiltinFunctionIndex) -> Signature {

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -98,7 +98,7 @@ macro_rules! foreach_builtin_function {
             table_fill_gc_ref(vmctx: vmctx, table: i32, dst: i64, val: reference, len: i64);
 
             // Raises an unconditional trap.
-            trap(vmctx: vmctx, code: i32);
+            trap(vmctx: vmctx, code: u8);
 
             // Implementation of `i{32,64}.trunc_f{32,64}_{u,s}` when host trap
             // handlers are disabled. These will raise a trap if necessary. Note

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -96,6 +96,19 @@ macro_rules! foreach_builtin_function {
             // Returns an index for Wasm's `table.fill` instruction for GC references.
             #[cfg(feature = "gc")]
             table_fill_gc_ref(vmctx: vmctx, table: i32, dst: i64, val: reference, len: i64);
+
+            // Raises an unconditional trap.
+            trap(vmctx: vmctx, code: i32);
+
+            // Implementation of `i{32,64}.trunc_f{32,64}_{u,s}` when host trap
+            // handlers are disabled. These will raise a trap if necessary. Note
+            // that f32 inputs are always converted to f64 as the argument. Also
+            // note that the signed-ness of the result is not reflected in the
+            // type here.
+            f64_to_i64(vmctx: vmctx, float: f64) -> i64;
+            f64_to_u64(vmctx: vmctx, float: f64) -> i64;
+            f64_to_i32(vmctx: vmctx, float: f64) -> i32;
+            f64_to_u32(vmctx: vmctx, float: f64) -> i32;
         }
     };
 }

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -105,7 +105,7 @@ macro_rules! foreach_builtin_component_function {
             resource_enter_call(vmctx: vmctx);
             resource_exit_call(vmctx: vmctx);
 
-            trap(vmctx: vmctx, code: u32);
+            trap(vmctx: vmctx, code: u8);
         }
     };
 }

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -104,6 +104,8 @@ macro_rules! foreach_builtin_component_function {
             resource_transfer_borrow(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u32;
             resource_enter_call(vmctx: vmctx);
             resource_exit_call(vmctx: vmctx);
+
+            trap(vmctx: vmctx, code: u32);
         }
     };
 }

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -1,5 +1,6 @@
 use crate::component::{AllCallFunc, ComponentTranslation, ComponentTypesBuilder, TrampolineIndex};
 use crate::prelude::*;
+use crate::Tunables;
 use anyhow::Result;
 use std::any::Any;
 
@@ -16,5 +17,6 @@ pub trait ComponentCompiler: Send + Sync {
         component: &ComponentTranslation,
         types: &ComponentTypesBuilder,
         trampoline: TrampolineIndex,
+        tunables: &Tunables,
     ) -> Result<AllCallFunc<Box<dyn Any + Send>>>;
 }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -33,6 +33,7 @@ impl MemoryStyle {
             // page size, but unfortunately that is a little hard to plumb
             // through here.
             memory.page_size_log2 >= Memory::DEFAULT_PAGE_SIZE_LOG2
+            && tunables.host_trap_handlers
             && match memory.maximum_byte_size() {
                 Ok(mut maximum) => {
                     if tunables.static_memory_bound_is_maximum {

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -33,7 +33,7 @@ impl MemoryStyle {
             // page size, but unfortunately that is a little hard to plumb
             // through here.
             memory.page_size_log2 >= Memory::DEFAULT_PAGE_SIZE_LOG2
-            && tunables.host_trap_handlers
+            && tunables.signals_based_traps
             && match memory.maximum_byte_size() {
                 Ok(mut maximum) => {
                     if tunables.static_memory_bound_is_maximum {

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -62,6 +62,10 @@ pub struct Tunables {
 
     /// Whether or not Wasm functions target the winch abi.
     pub winch_callable: bool,
+
+    /// Whether or not the host will be using trap handlers such as signal
+    /// handlers.
+    pub host_trap_handlers: bool,
 }
 
 impl Tunables {
@@ -113,6 +117,7 @@ impl Tunables {
             debug_adapter_modules: false,
             relaxed_simd_deterministic: false,
             winch_callable: false,
+            host_trap_handlers: true,
         }
     }
 

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -63,9 +63,9 @@ pub struct Tunables {
     /// Whether or not Wasm functions target the winch abi.
     pub winch_callable: bool,
 
-    /// Whether or not the host will be using trap handlers such as signal
-    /// handlers.
-    pub host_trap_handlers: bool,
+    /// Whether or not the host will be using native signals (e.g. SIGILL,
+    /// SIGSEGV, etc) to implement traps.
+    pub signals_based_traps: bool,
 }
 
 impl Tunables {
@@ -117,7 +117,7 @@ impl Tunables {
             debug_adapter_modules: false,
             relaxed_simd_deterministic: false,
             winch_callable: false,
-            host_trap_handlers: true,
+            signals_based_traps: true,
         }
     }
 

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -180,7 +180,8 @@ impl Config {
                 self.wasmtime.memory_guaranteed_dense_image_size,
             ))
             .allocation_strategy(self.wasmtime.strategy.to_wasmtime())
-            .generate_address_map(self.wasmtime.generate_address_map);
+            .generate_address_map(self.wasmtime.generate_address_map)
+            .host_trap_handlers(self.wasmtime.host_trap_handlers);
 
         if !self.module_config.config.simd_enabled {
             cfg.wasm_relaxed_simd(false);
@@ -361,20 +362,6 @@ impl Config {
         unsafe { Ok(Module::deserialize_file(engine, &file).unwrap()) }
     }
 
-    /// Winch doesn't support the same set of wasm proposal as Cranelift at
-    /// this time, so if winch is selected be sure to disable wasm proposals
-    /// in `Config` to ensure that Winch can compile the module that
-    /// wasm-smith generates.
-    pub fn disable_unimplemented_winch_proposals(&mut self) {
-        self.module_config.config.simd_enabled = false;
-        self.module_config.config.relaxed_simd_enabled = false;
-        self.module_config.config.gc_enabled = false;
-        self.module_config.config.threads_enabled = false;
-        self.module_config.config.tail_call_enabled = false;
-        self.module_config.config.exceptions_enabled = false;
-        self.module_config.config.reference_types_enabled = false;
-    }
-
     /// Updates this configuration to forcibly enable async support. Only useful
     /// in fuzzers which do async calls.
     pub fn enable_async(&mut self, u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
@@ -400,71 +387,9 @@ impl<'a> Arbitrary<'a> for Config {
             module_config: u.arbitrary()?,
         };
 
-        if let CompilerStrategy::Winch = config.wasmtime.compiler_strategy {
-            config.disable_unimplemented_winch_proposals();
-        }
-
-        // If using the pooling allocator, constrain the memory and module configurations
-        // to the module limits.
-        if let InstanceAllocationStrategy::Pooling(pooling) = &mut config.wasmtime.strategy {
-            // Forcibly don't use the `CustomUnaligned` memory configuration
-            // with the pooling allocator active.
-            if let MemoryConfig::CustomUnaligned = config.wasmtime.memory_config {
-                config.wasmtime.memory_config = MemoryConfig::Normal(u.arbitrary()?);
-            }
-
-            let cfg = &mut config.module_config.config;
-            // If the pooling allocator is used, do not allow shared memory to
-            // be created. FIXME: see
-            // https://github.com/bytecodealliance/wasmtime/issues/4244.
-            cfg.threads_enabled = false;
-
-            // Ensure the pooling allocator can support the maximal size of
-            // memory, picking the smaller of the two to win.
-            let min_bytes = cfg
-                .max_memory32_bytes
-                // memory64_bytes is a u128, but since we are taking the min
-                // we can truncate it down to a u64.
-                .min(cfg.max_memory64_bytes.try_into().unwrap_or(u64::MAX));
-            let mut min = min_bytes.min(pooling.max_memory_size as u64);
-            if let MemoryConfig::Normal(cfg) = &config.wasmtime.memory_config {
-                min = min.min(cfg.static_memory_maximum_size.unwrap_or(0));
-            }
-            pooling.max_memory_size = min as usize;
-            cfg.max_memory32_bytes = min;
-            cfg.max_memory64_bytes = min as u128;
-
-            // If traps are disallowed then memories must have at least one page
-            // of memory so if we still are only allowing 0 pages of memory then
-            // increase that to one here.
-            if cfg.disallow_traps {
-                if pooling.max_memory_size < (1 << 16) {
-                    pooling.max_memory_size = 1 << 16;
-                    cfg.max_memory32_bytes = 1 << 16;
-                    cfg.max_memory64_bytes = 1 << 16;
-                    if let MemoryConfig::Normal(cfg) = &mut config.wasmtime.memory_config {
-                        match &mut cfg.static_memory_maximum_size {
-                            Some(size) => *size = (*size).max(pooling.max_memory_size as u64),
-                            size @ None => *size = Some(pooling.max_memory_size as u64),
-                        }
-                    }
-                }
-                // .. additionally update tables
-                if pooling.table_elements == 0 {
-                    pooling.table_elements = 1;
-                }
-            }
-
-            // Don't allow too many linear memories per instance since massive
-            // virtual mappings can fail to get allocated.
-            cfg.min_memories = cfg.min_memories.min(10);
-            cfg.max_memories = cfg.max_memories.min(10);
-
-            // Force this pooling allocator to always be able to accommodate the
-            // module that may be generated.
-            pooling.total_memories = cfg.max_memories as u32;
-            pooling.total_tables = cfg.max_tables as u32;
-        }
+        config
+            .wasmtime
+            .update_module_config(&mut config.module_config.config, u)?;
 
         Ok(config)
     }
@@ -502,6 +427,10 @@ pub struct WasmtimeConfig {
     /// Configuration for whether wasm is invoked in an async fashion and how
     /// it's cooperatively time-sliced.
     pub async_config: AsyncConfig,
+
+    /// Whether or not host trap handlers are enabled for this configuration,
+    /// aka whether signal handlers are supported.
+    host_trap_handlers: bool,
 }
 
 impl WasmtimeConfig {
@@ -526,6 +455,98 @@ impl WasmtimeConfig {
             // allocator.
             self.memory_config = other.memory_config.clone();
         }
+    }
+
+    /// Updates `config` to be compatible with `self` and the other way around
+    /// too.
+    pub fn update_module_config(
+        &mut self,
+        config: &mut wasm_smith::Config,
+        u: &mut Unstructured<'_>,
+    ) -> arbitrary::Result<()> {
+        // Winch doesn't support the same set of wasm proposal as Cranelift at
+        // this time, so if winch is selected be sure to disable wasm proposals
+        // in `Config` to ensure that Winch can compile the module that
+        // wasm-smith generates.
+        if let CompilerStrategy::Winch = self.compiler_strategy {
+            config.simd_enabled = false;
+            config.relaxed_simd_enabled = false;
+            config.gc_enabled = false;
+            config.threads_enabled = false;
+            config.tail_call_enabled = false;
+            config.exceptions_enabled = false;
+            config.reference_types_enabled = false;
+
+            // Winch requires host trap handlers to be enabled at this time.
+            self.host_trap_handlers = true;
+        }
+
+        // If using the pooling allocator, constrain the memory and module configurations
+        // to the module limits.
+        if let InstanceAllocationStrategy::Pooling(pooling) = &mut self.strategy {
+            // Forcibly don't use the `CustomUnaligned` memory configuration
+            // with the pooling allocator active.
+            if let MemoryConfig::CustomUnaligned = self.memory_config {
+                self.memory_config = MemoryConfig::Normal(u.arbitrary()?);
+            }
+
+            // If the pooling allocator is used, do not allow shared memory to
+            // be created. FIXME: see
+            // https://github.com/bytecodealliance/wasmtime/issues/4244.
+            config.threads_enabled = false;
+
+            // Ensure the pooling allocator can support the maximal size of
+            // memory, picking the smaller of the two to win.
+            let min_bytes = config
+                .max_memory32_bytes
+                // memory64_bytes is a u128, but since we are taking the min
+                // we can truncate it down to a u64.
+                .min(config.max_memory64_bytes.try_into().unwrap_or(u64::MAX));
+            let mut min = min_bytes.min(pooling.max_memory_size as u64);
+            if let MemoryConfig::Normal(cfg) = &self.memory_config {
+                min = min.min(cfg.static_memory_maximum_size.unwrap_or(0));
+            }
+            pooling.max_memory_size = min as usize;
+            config.max_memory32_bytes = min;
+            config.max_memory64_bytes = min as u128;
+
+            // If traps are disallowed then memories must have at least one page
+            // of memory so if we still are only allowing 0 pages of memory then
+            // increase that to one here.
+            if config.disallow_traps {
+                if pooling.max_memory_size < (1 << 16) {
+                    pooling.max_memory_size = 1 << 16;
+                    config.max_memory32_bytes = 1 << 16;
+                    config.max_memory64_bytes = 1 << 16;
+                    if let MemoryConfig::Normal(cfg) = &mut self.memory_config {
+                        match &mut cfg.static_memory_maximum_size {
+                            Some(size) => *size = (*size).max(pooling.max_memory_size as u64),
+                            size @ None => *size = Some(pooling.max_memory_size as u64),
+                        }
+                    }
+                }
+                // .. additionally update tables
+                if pooling.table_elements == 0 {
+                    pooling.table_elements = 1;
+                }
+            }
+
+            // Don't allow too many linear memories per instance since massive
+            // virtual mappings can fail to get allocated.
+            config.min_memories = config.min_memories.min(10);
+            config.max_memories = config.max_memories.min(10);
+
+            // Force this pooling allocator to always be able to accommodate the
+            // module that may be generated.
+            pooling.total_memories = config.max_memories as u32;
+            pooling.total_tables = config.max_tables as u32;
+        }
+
+        // TODO: should fix this
+        if !self.host_trap_handlers {
+            config.threads_enabled = false;
+        }
+        Ok(())
     }
 }
 

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -24,11 +24,9 @@ impl WasmtimeEngine {
         config: &mut generators::Config,
         compiler_strategy: CompilerStrategy,
     ) -> arbitrary::Result<Self> {
-        if let CompilerStrategy::Winch = compiler_strategy {
-            config.disable_unimplemented_winch_proposals();
-        }
         let mut new_config = u.arbitrary::<WasmtimeConfig>()?;
         new_config.compiler_strategy = compiler_strategy;
+        new_config.update_module_config(&mut config.module_config.config, u)?;
         new_config.make_compatible_with(&config.wasmtime);
 
         let config = generators::Config {

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -92,7 +92,7 @@ impl Engine {
         let (tunables, features) = config.validate()?;
 
         #[cfg(feature = "runtime")]
-        if tunables.host_trap_handlers {
+        if tunables.signals_based_traps {
             // Ensure that crate::runtime::vm's signal handlers are
             // configured. This is the per-program initialization required for
             // handling traps, such as configuring signals, vectored exception

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -88,8 +88,11 @@ impl Engine {
     /// to `true`, but explicitly disable these two compiler settings
     /// will cause errors.
     pub fn new(config: &Config) -> Result<Engine> {
+        let config = config.clone();
+        let (tunables, features) = config.validate()?;
+
         #[cfg(feature = "runtime")]
-        {
+        if tunables.host_trap_handlers {
             // Ensure that crate::runtime::vm's signal handlers are
             // configured. This is the per-program initialization required for
             // handling traps, such as configuring signals, vectored exception
@@ -98,9 +101,6 @@ impl Engine {
             #[cfg(feature = "debug-builtins")]
             crate::runtime::vm::debug_builtins::ensure_exported();
         }
-
-        let config = config.clone();
-        let (tunables, features) = config.validate()?;
 
         #[cfg(any(feature = "cranelift", feature = "winch"))]
         let (config, compiler) = config.build_compiler(&tunables, features)?;

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -370,7 +370,7 @@ impl Metadata<'_> {
             table_lazy_init,
             relaxed_simd_deterministic,
             winch_callable,
-
+            host_trap_handlers,
             // This doesn't affect compilation, it's just a runtime setting.
             dynamic_memory_growth_reserve: _,
 
@@ -435,6 +435,11 @@ impl Metadata<'_> {
             winch_callable,
             other.winch_callable,
             "Winch calling convention",
+        )?;
+        Self::check_bool(
+            host_trap_handlers,
+            other.host_trap_handlers,
+            "Host trap handlers",
         )?;
 
         Ok(())

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -370,7 +370,7 @@ impl Metadata<'_> {
             table_lazy_init,
             relaxed_simd_deterministic,
             winch_callable,
-            host_trap_handlers,
+            signals_based_traps,
             // This doesn't affect compilation, it's just a runtime setting.
             dynamic_memory_growth_reserve: _,
 
@@ -437,9 +437,9 @@ impl Metadata<'_> {
             "Winch calling convention",
         )?;
         Self::check_bool(
-            host_trap_handlers,
-            other.host_trap_handlers,
-            "Host trap handlers",
+            signals_based_traps,
+            other.signals_based_traps,
+            "Signals-based traps",
         )?;
 
         Ok(())

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -569,3 +569,9 @@ unsafe fn resource_enter_call(vmctx: *mut VMComponentContext) -> Result<()> {
 unsafe fn resource_exit_call(vmctx: *mut VMComponentContext) -> Result<()> {
     ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_exit_call())
 }
+
+unsafe fn trap(_vmctx: *mut VMComponentContext, code: u32) -> Result<()> {
+    Err(wasmtime_environ::Trap::from_u8(code.try_into().unwrap())
+        .unwrap()
+        .into())
+}

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -571,7 +571,5 @@ unsafe fn resource_exit_call(vmctx: *mut VMComponentContext) -> Result<()> {
 }
 
 unsafe fn trap(_vmctx: *mut VMComponentContext, code: u32) -> Result<()> {
-    Err(wasmtime_environ::Trap::from_u8(code.try_into().unwrap())
-        .unwrap()
-        .into())
+    Err(wasmtime_environ::Trap::from_u8(code.try_into().unwrap()).unwrap()).err2anyhow()
 }

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -27,6 +27,7 @@ macro_rules! signature {
     (@ty ptr_u8) => (*mut u8);
     (@ty ptr_u16) => (*mut u16);
     (@ty ptr_size) => (*mut usize);
+    (@ty u8) => (u8);
     (@ty u32) => (u32);
     (@ty u64) => (u64);
     (@ty vmctx) => (*mut VMComponentContext);
@@ -570,6 +571,6 @@ unsafe fn resource_exit_call(vmctx: *mut VMComponentContext) -> Result<()> {
     ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_exit_call())
 }
 
-unsafe fn trap(_vmctx: *mut VMComponentContext, code: u32) -> Result<()> {
-    Err(wasmtime_environ::Trap::from_u8(code.try_into().unwrap()).unwrap()).err2anyhow()
+unsafe fn trap(_vmctx: *mut VMComponentContext, code: u8) -> Result<()> {
+    Err(wasmtime_environ::Trap::from_u8(code).unwrap()).err2anyhow()
 }

--- a/crates/wasmtime/src/runtime/vm/gc/i31.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/i31.rs
@@ -2,6 +2,7 @@
 
 use super::VMGcRef;
 use core::fmt;
+use wasmtime_environ::Unsigned;
 
 /// A 31-bit integer for use with `i31ref`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -68,9 +69,8 @@ impl I31 {
     /// If the value doesn't fit in the bottom 31 bits, it is wrapped such that
     /// the wrapped value does.
     #[inline]
-    #[allow(clippy::cast_sign_loss)]
     pub fn wrapping_i32(value: i32) -> Self {
-        Self::wrapping_u32(value as u32)
+        Self::wrapping_u32(value.unsigned())
     }
 
     /// Get this `I31`'s value as an unsigned integer.

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -141,6 +141,7 @@ pub mod raw {
         (@ty i32) => (u32);
         (@ty i64) => (u64);
         (@ty f64) => (f64);
+        (@ty u8) => (u8);
         (@ty reference) => (u32);
         (@ty pointer) => (*mut u8);
         (@ty vmctx) => (*mut VMContext);
@@ -657,13 +658,12 @@ fn update_mem_size(instance: &mut Instance, num_pages: u32) {
     }
 }
 
-fn trap(_instance: &mut Instance, code: u32) -> Result<(), TrapReason> {
+fn trap(_instance: &mut Instance, code: u8) -> Result<(), TrapReason> {
     Err(TrapReason::Wasm(
-        wasmtime_environ::Trap::from_u8(code.try_into().unwrap()).unwrap(),
+        wasmtime_environ::Trap::from_u8(code).unwrap(),
     ))
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn f64_to_i64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
@@ -672,10 +672,10 @@ fn f64_to_i64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val <= -9223372036854777856.0 || val >= 9223372036854775808.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
-    Ok((val as i64).unsigned())
+    #[allow(clippy::cast_possible_truncation)]
+    return Ok((val as i64).unsigned());
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn f64_to_u64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
@@ -684,10 +684,10 @@ fn f64_to_u64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val <= -1.0 || val >= 18446744073709551616.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
-    Ok(val as u64)
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    return Ok(val as u64);
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn f64_to_i32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
@@ -696,10 +696,10 @@ fn f64_to_i32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val <= -2147483649.0 || val >= 2147483648.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
-    Ok((val as i32).unsigned())
+    #[allow(clippy::cast_possible_truncation)]
+    return Ok((val as i32).unsigned());
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn f64_to_u32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
@@ -708,7 +708,8 @@ fn f64_to_u32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val <= -1.0 || val >= 4294967296.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
-    Ok(val as u32)
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    return Ok(val as u32);
 }
 
 /// This module contains functions which are used for resolving relocations at

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -666,7 +666,7 @@ fn f64_to_i64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }
-    let val = val.trunc();
+    let val = relocs::truncf64(val);
     if val <= -9223372036854777856.0 || val >= 9223372036854775808.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
@@ -677,7 +677,7 @@ fn f64_to_u64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }
-    let val = val.trunc();
+    let val = relocs::truncf64(val);
     if val <= -1.0 || val >= 18446744073709551616.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
@@ -688,7 +688,7 @@ fn f64_to_i32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }
-    let val = val.trunc();
+    let val = relocs::truncf64(val);
     if val <= -2147483649.0 || val >= 2147483648.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
@@ -699,7 +699,7 @@ fn f64_to_u32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }
-    let val = val.trunc();
+    let val = relocs::truncf64(val);
     if val <= -1.0 || val >= 4294967296.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -60,6 +60,7 @@ use crate::runtime::vm::vmcontext::VMFuncRef;
 use crate::runtime::vm::{Instance, TrapReason, VMGcRef};
 #[cfg(feature = "threads")]
 use core::time::Duration;
+use wasmtime_environ::Unsigned;
 use wasmtime_environ::{DataIndex, ElemIndex, FuncIndex, MemoryIndex, TableIndex, Trap};
 #[cfg(feature = "wmemcheck")]
 use wasmtime_wmemcheck::AccessError::{
@@ -662,6 +663,7 @@ fn trap(_instance: &mut Instance, code: u32) -> Result<(), TrapReason> {
     ))
 }
 
+#[allow(clippy::cast_possible_truncation)]
 fn f64_to_i64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
@@ -670,9 +672,10 @@ fn f64_to_i64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val <= -9223372036854777856.0 || val >= 9223372036854775808.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
-    Ok(val as i64 as u64)
+    Ok((val as i64).unsigned())
 }
 
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn f64_to_u64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
@@ -684,6 +687,7 @@ fn f64_to_u64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     Ok(val as u64)
 }
 
+#[allow(clippy::cast_possible_truncation)]
 fn f64_to_i32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
@@ -692,9 +696,10 @@ fn f64_to_i32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val <= -2147483649.0 || val >= 2147483648.0 {
         return Err(TrapReason::Wasm(Trap::IntegerOverflow));
     }
-    Ok(val as i32 as u32)
+    Ok((val as i32).unsigned())
 }
 
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn f64_to_u32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -733,6 +733,7 @@ macro_rules! define_builtin_array {
     (@ty i32) => (u32);
     (@ty i64) => (u64);
     (@ty f64) => (f64);
+    (@ty u8) => (u8);
     (@ty reference) => (u32);
     (@ty pointer) => (*mut u8);
     (@ty vmctx) => (*mut VMContext);

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -732,6 +732,7 @@ macro_rules! define_builtin_array {
 
     (@ty i32) => (u32);
     (@ty i64) => (u64);
+    (@ty f64) => (f64);
     (@ty reference) => (u32);
     (@ty pointer) => (*mut u8);
     (@ty vmctx) => (*mut VMContext);

--- a/tests/disable_host_trap_handlers.rs
+++ b/tests/disable_host_trap_handlers.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use wasmtime::{Config, Engine, Instance, Module, Store, Trap};
+
+#[test]
+fn no_host_trap_handlers() -> Result<()> {
+    let mut config = Config::new();
+    config.host_trap_handlers(false);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (memory 1)
+
+                (func (export "load") (param i32) (result i32)
+                    (i32.load (local.get 0)))
+
+                (func (export "div") (param i32 i32) (result i32)
+                    (i32.div_s (local.get 0) (local.get 1)))
+
+                (func (export "unreachable") unreachable)
+                (func $oflow (export "overflow") call $oflow)
+            )
+        "#,
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let load = instance.get_typed_func::<i32, i32>(&mut store, "load")?;
+    let div = instance.get_typed_func::<(i32, i32), i32>(&mut store, "div")?;
+    let unreachable = instance.get_typed_func::<(), ()>(&mut store, "unreachable")?;
+    let overflow = instance.get_typed_func::<(), ()>(&mut store, "overflow")?;
+
+    let trap = load
+        .call(&mut store, 1 << 20)
+        .unwrap_err()
+        .downcast::<Trap>()?;
+    assert_eq!(trap, Trap::MemoryOutOfBounds);
+
+    let trap = div
+        .call(&mut store, (1, 0))
+        .unwrap_err()
+        .downcast::<Trap>()?;
+    assert_eq!(trap, Trap::IntegerDivisionByZero);
+
+    let trap = unreachable
+        .call(&mut store, ())
+        .unwrap_err()
+        .downcast::<Trap>()?;
+    assert_eq!(trap, Trap::UnreachableCodeReached);
+
+    let trap = overflow
+        .call(&mut store, ())
+        .unwrap_err()
+        .downcast::<Trap>()?;
+    assert_eq!(trap, Trap::StackOverflow);
+
+    assert_host_signal_handlers_are_unset();
+
+    Ok(())
+}
+
+fn assert_host_signal_handlers_are_unset() {
+    #[cfg(unix)]
+    unsafe {
+        let mut prev = std::mem::zeroed::<libc::sigaction>();
+        let rc = libc::sigaction(libc::SIGILL, std::ptr::null(), &mut prev);
+        assert_eq!(rc, 0);
+        assert_eq!(
+            prev.sa_sigaction,
+            libc::SIG_DFL,
+            "fault handler was installed when it shouldn't have been"
+        );
+    }
+}

--- a/tests/disable_host_trap_handlers.rs
+++ b/tests/disable_host_trap_handlers.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use wasmtime::{Config, Engine, Instance, Module, Store, Trap};
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn no_host_trap_handlers() -> Result<()> {
     let mut config = Config::new();
     config.signals_based_traps(false);

--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -127,6 +127,10 @@ macro_rules! declare_function_sig {
                 WasmValType::I32
             }
 
+            fn u8(&self) -> WasmValType {
+                WasmValType::I32
+            }
+
             fn f32(&self) -> WasmValType {
                 WasmValType::F32
             }


### PR DESCRIPTION
This commit introduces a new configuration option
`Config::host_trap_handlers` which enables disabling the reliance on host trap handlers (e.g. signal handlers on Unix) at runtime. This is intended to help increase portability in cases where signal handlers are otherwise difficult. This is achieved by plumbing the translation environment to more locations which now conditionally lowers to calls to a function to raise a trap instead of a trap instruction.

The caveats of this support are:

* This is not yet implemented for Winch
* This requires disabling spectre mitigations
* This does not yet support shared memories since it forces dynamic memories to be used.

These points are all possible to address but it might be best to see how this feature evolves over time. I'll also note that this is not an optimized implementation and likely has a fair bit of overhead. For example the solution in #6926 of a more optimized stub to jump-and-trap is not implemented yet.

Closes #6926

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
