### PR TITLE
Revert back to 1.78 as workspace MSRV

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -6,6 +6,18 @@ inputs:
     description: 'Default toolchan to install'
     required: false
     default: 'default'
+  msrv_range:
+    description: 'Versions later-than-latest-Rust the MSRV supports'
+    required: false
+    # Note that this is currently set to 3 as the MSRV is 1.78 and current
+    # stable is 1.81. Currently MSRV cannot be updated as it would break the
+    # build on OSS-Fuzz which hasn't updated its Rust compiler in quite some time.
+    #
+    # Updating OSS-Fuzz is being done in
+    # https://github.com/google/oss-fuzz/pull/12365 but it's taking some time,
+    # so for now this'll get bumped instead of MSRV while we wait for the update
+    # to happen.
+    default: '3'
 
 runs:
   using: composite
@@ -17,9 +29,10 @@ runs:
         # Determine MSRV as N in `1.N.0` by looking at the `rust-version`
         # located in the root `Cargo.toml`.
         msrv=$(grep 'rust-version.*1' Cargo.toml | sed 's/.*\.\([0-9]*\)\..*/\1/')
+        range=${{ inputs.msrv_range }}
 
         if [ "${{ inputs.toolchain }}" = "default" ]; then
-          echo "version=1.$((msrv+2)).0" >> "$GITHUB_OUTPUT"
+          echo "version=1.$((msrv+range)).0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.79.0"
+rust-version = "1.78.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -67,7 +67,7 @@ impl Mmap {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.memory.as_ptr().len()
+        unsafe { (*self.memory.as_ptr()).len() }
     }
 
     pub unsafe fn make_executable(
@@ -102,7 +102,7 @@ impl Drop for Mmap {
     fn drop(&mut self) {
         unsafe {
             let ptr = self.memory.as_ptr().cast();
-            let len = self.memory.as_ptr().len();
+            let len = (*self.memory.as_ptr()).len();
             if len == 0 {
                 return;
             }

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -68,7 +68,7 @@ impl Mmap {
     }
 
     pub fn len(&self) -> usize {
-        self.memory.as_ptr().len()
+        unsafe { (*self.memory.as_ptr()).len() }
     }
 
     pub unsafe fn make_executable(

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -104,7 +104,7 @@ impl Mmap {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.memory.as_ptr().len()
+        unsafe { (*self.memory.as_ptr()).len() }
     }
 
     pub unsafe fn make_executable(
@@ -149,7 +149,7 @@ impl Drop for Mmap {
     fn drop(&mut self) {
         unsafe {
             let ptr = self.memory.as_ptr().cast();
-            let len = self.memory.as_ptr().len();
+            let len = (*self.memory.as_ptr()).len();
             if len == 0 {
                 return;
             }

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -164,7 +164,7 @@ impl Mmap {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.memory.as_ptr().len()
+        unsafe { (*self.memory.as_ptr()).len() }
     }
 
     pub unsafe fn make_executable(


### PR DESCRIPTION
Last night's OSS-Fuzz build failed because the compiler used there hasn't been updated in quite some time. It's a nightly of 1.78 from the beginning of this year which means the bump to 1.79 recently for this workspace meant that Wasmtime stopped building there.

This commit reverts ac607ed2abdf0d51aedca302a78aa27d03451d2c and 1ad3da85ef8d161071b57aeed86effdd70cbc1ce and then updates our github action to say that we're 3 versions behind the latest Rust right now with some commentary as to why.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
