### PR TITLE
Add a `Signed` trait to match the `Unsigned` trait

### DIFF
--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -265,6 +265,7 @@ mod list;
 mod map;
 mod primary;
 mod set;
+mod signed;
 mod sparse;
 mod unsigned;
 
@@ -275,6 +276,7 @@ pub use self::list::{EntityList, ListPool};
 pub use self::map::SecondaryMap;
 pub use self::primary::PrimaryMap;
 pub use self::set::EntitySet;
+pub use self::signed::Signed;
 pub use self::sparse::{SparseMap, SparseMapValue, SparseSet};
 pub use self::unsigned::Unsigned;
 

--- a/cranelift/entity/src/signed.rs
+++ b/cranelift/entity/src/signed.rs
@@ -1,7 +1,7 @@
 /// Helper trait used to add `signed()` methods to primitive unsigned integer
 /// types.
 ///
-/// The purpose of this trait is to signal the intent that the sign bit of na
+/// The purpose of this trait is to signal the intent that the sign bit of an
 /// unsigned integer is intended to be discarded and the value is instead
 /// understood to be a "bag of bits" where the conversion to a signed number
 /// is intended to be lossless bit-wise. This can be used for example when

--- a/cranelift/entity/src/signed.rs
+++ b/cranelift/entity/src/signed.rs
@@ -1,0 +1,40 @@
+/// Helper trait used to add `signed()` methods to primitive unsigned integer
+/// types.
+///
+/// The purpose of this trait is to signal the intent that the sign bit of na
+/// unsigned integer is intended to be discarded and the value is instead
+/// understood to be a "bag of bits" where the conversion to a signed number
+/// is intended to be lossless bit-wise. This can be used for example when
+/// converting an unsigned integer into a signed integer for constrained reasons
+/// outside the scope of the code in question.
+pub trait Signed {
+    /// The signed integer for this type which has the same width.
+    type Signed;
+
+    /// View this unsigned integer as a signed integer of the same width.
+    ///
+    /// All bits are preserved.
+    fn signed(self) -> Self::Signed;
+}
+
+macro_rules! impls {
+    ($($unsigned:ident => $signed:ident)*) => {$(
+        impl Signed for $unsigned {
+            type Signed = $signed;
+
+            #[inline]
+            fn signed(self) -> $signed {
+                self as $signed
+            }
+        }
+    )*}
+}
+
+impls! {
+    u8 => i8
+    u16 => i16
+    u32 => i32
+    u64 => i64
+    u128 => i128
+    usize => isize
+}


### PR DESCRIPTION
I've wanted to use this every now and then but haven't gotten around to adding this so figured I'd go ahead and add it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
