### PR TITLE
Pulley: Allow configuring offsets and hexdumps in the disassembler

### DIFF
--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -19,6 +19,8 @@ pub struct Disassembler<'a> {
     disas: String,
     start: usize,
     temp: String,
+    offsets: bool,
+    hexdump: bool,
 }
 
 impl<'a> Disassembler<'a> {
@@ -38,7 +40,25 @@ impl<'a> Disassembler<'a> {
             disas: String::new(),
             start: 0,
             temp: String::new(),
+            offsets: true,
+            hexdump: true,
         }
+    }
+
+    /// Whether to prefix each instruction's disassembly with its offset.
+    ///
+    /// True by default.
+    pub fn offsets(&mut self, offsets: bool) -> &mut Self {
+        self.offsets = offsets;
+        self
+    }
+
+    /// Whether to include a hexdump of the bytecode in the disassembly.
+    ///
+    /// True by default.
+    pub fn hexdump(&mut self, hexdump: bool) -> &mut Self {
+        self.hexdump = hexdump;
+        self
     }
 
     /// Get the disassembly thus far.
@@ -176,18 +196,21 @@ macro_rules! impl_disas {
             }
 
             fn after_visit(&mut self) {
-                let size = self.bytecode.position() - self.start;
-
-                write!(&mut self.disas, "{:8x}: ", self.start).unwrap();
-                let mut need_space = false;
-                for byte in &self.raw_bytecode[self.start..][..size] {
-                    write!(&mut self.disas, "{}{byte:02x}", if need_space { " " } else { "" }).unwrap();
-                    need_space = true;
+                if self.offsets {
+                    write!(&mut self.disas, "{:8x}: ", self.start).unwrap();
                 }
-                for _ in 0..11_usize.saturating_sub(size) {
-                    write!(&mut self.disas, "   ").unwrap();
+                if self.hexdump {
+                    let size = self.bytecode.position() - self.start;
+                    let mut need_space = false;
+                    for byte in &self.raw_bytecode[self.start..][..size] {
+                        let space = if need_space { " " } else { "" };
+                        write!(&mut self.disas, "{}{byte:02x}", space).unwrap();
+                        need_space = true;
+                    }
+                    for _ in 0..11_usize.saturating_sub(size) {
+                        write!(&mut self.disas, "   ").unwrap();
+                    }
                 }
-
                 self.disas.push_str(&self.temp);
                 self.temp.clear();
 

--- a/pulley/tests/all/disas.rs
+++ b/pulley/tests/all/disas.rs
@@ -11,17 +11,23 @@ fn encoded(ops: &[Op]) -> Vec<u8> {
     encoded
 }
 
-fn assert_disas(ops: &[Op], expected: &str) {
+#[track_caller]
+fn assert_disas_with_disassembler(dis: &mut disas::Disassembler<'_>, expected: &str) {
     let expected = expected.trim();
     eprintln!("=== expected ===\n{expected}");
 
-    let bytecode = encoded(ops);
+    decode::Decoder::decode_all(dis).expect("decoding should succeed");
 
-    let actual = disas::Disassembler::disassemble_all(&bytecode).expect("decoding failed");
-    let actual = actual.trim();
+    let actual = dis.disas().trim();
     eprintln!("=== actual ===\n{actual}");
 
     assert_eq!(expected, actual);
+}
+
+#[track_caller]
+fn assert_disas(ops: &[Op], expected: &str) {
+    let bytecode = encoded(ops);
+    assert_disas_with_disassembler(&mut disas::Disassembler::new(&bytecode), expected);
 }
 
 #[test]
@@ -82,6 +88,95 @@ fn push_pop_many() {
        9: 36 1f 00 00 00                  xpop32_many x0, x1, x2, x3, x4
        e: 30                              pop_frame
        f: 00                              ret
+        "#,
+    );
+}
+
+#[test]
+fn no_offsets() {
+    let bytecode = encoded(&[
+        // Prologue.
+        Op::PushFrame(PushFrame {}),
+        // Function body.
+        Op::Xadd32(Xadd32 {
+            operands: BinaryOperands {
+                dst: XReg::x0,
+                src1: XReg::x0,
+                src2: XReg::x1,
+            },
+        }),
+        // Epilogue.
+        Op::PopFrame(PopFrame {}),
+        Op::Ret(Ret {}),
+    ]);
+
+    assert_disas_with_disassembler(
+        disas::Disassembler::new(&bytecode).offsets(false),
+        r#"
+2f                              push_frame
+12 00 04                        xadd32 x0, x0, x1
+30                              pop_frame
+00                              ret
+        "#,
+    );
+}
+
+#[test]
+fn no_hexdump() {
+    let bytecode = encoded(&[
+        // Prologue.
+        Op::PushFrame(PushFrame {}),
+        // Function body.
+        Op::Xadd32(Xadd32 {
+            operands: BinaryOperands {
+                dst: XReg::x0,
+                src1: XReg::x0,
+                src2: XReg::x1,
+            },
+        }),
+        // Epilogue.
+        Op::PopFrame(PopFrame {}),
+        Op::Ret(Ret {}),
+    ]);
+
+    assert_disas_with_disassembler(
+        disas::Disassembler::new(&bytecode).hexdump(false),
+        r#"
+       0: push_frame
+       1: xadd32 x0, x0, x1
+       4: pop_frame
+       5: ret
+        "#,
+    );
+}
+
+#[test]
+fn no_offsets_or_hexdump() {
+    let bytecode = encoded(&[
+        // Prologue.
+        Op::PushFrame(PushFrame {}),
+        // Function body.
+        Op::Xadd32(Xadd32 {
+            operands: BinaryOperands {
+                dst: XReg::x0,
+                src1: XReg::x0,
+                src2: XReg::x1,
+            },
+        }),
+        // Epilogue.
+        Op::PopFrame(PopFrame {}),
+        Op::Ret(Ret {}),
+    ]);
+
+    assert_disas_with_disassembler(
+        disas::Disassembler::new(&bytecode)
+            .offsets(false)
+            .hexdump(false),
+        r#"
+push_frame
+xadd32 x0, x0, x1
+pop_frame
+ret
         "#,
     );
 }


### PR DESCRIPTION
This is necessary Pulley `tests/disas` tests in the future.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
