### PR TITLE
Backport 9224 to release-25

### DIFF
--- a/crates/wasmtime/src/runtime/vm/helpers.c
+++ b/crates/wasmtime/src/runtime/vm/helpers.c
@@ -1,3 +1,8 @@
+// When using _FORTIFY_SOURCE with `longjmp` causes longjmp_chk to be used
+// instead. longjmp_chk ensures that the jump target is on the existing stack.
+// For our use case of jumping between stacks we need to disable it.
+#undef _FORTIFY_SOURCE
+
 #include <setjmp.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
Backport #9224 to the release branch. It's a very minor thing that getting out sooner unblocks some build tooling upgrades in Redpanda. Patching on our end would be a bit involved. I didn't add this to release notes because this would only effect C users that are setting rather advanced security parameters.
