### PR TITLE
Remove some job dependencies in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -338,7 +338,6 @@ jobs:
   # here isn't to run tests, mostly just serve as a double-check that Rust code
   # compiles and is likely to work everywhere else.
   micro_checks:
-    needs: determine
     name: Check ${{matrix.name}}
     strategy:
       fail-fast: true
@@ -421,7 +420,6 @@ jobs:
 
   # Checks for no_std support, ensure that crates can build on a no_std target
   no_std_checks:
-    needs: determine
     name: no_std checks
     runs-on: ubuntu-latest
     env:
@@ -445,7 +443,6 @@ jobs:
 
   # Check that Clippy lints are passing.
   clippy:
-    needs: determine
     name: Clippy
     runs-on: ubuntu-latest
     env:
@@ -469,7 +466,6 @@ jobs:
   # (e.g. Android NDK) and we haven't factored support for those things out into
   # a parallel jobs yet.
   monolith_checks:
-    needs: determine
     name: Monolith Checks
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
All of the `cargo check`-style jobs are always run on both PRs and merge so there's no need to gate on the `determine` step. That's only needed when the output of `determine` conditionally decides to run a job or not, but these are always unconditionally run. This will help a tiny bit with CI time where the `determine` job doesn't need to run, but otherwise cuts down a bit on the amount of configuration.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
