### PR TITLE
x64: Add support for the BMI2 `mulx` instruction

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -99,6 +99,21 @@
             (dst_lo WritableGpr)
             (dst_hi WritableGpr))
 
+       ;; Same as `Mul`, but for the BMI2 `mulx` instruction. This is different
+       ;; where the two `dst_*` registers can be arbitrary registers and it
+       ;; is always unsigned multiplication. Note that this instruction does
+       ;; not modify or read flags.
+       ;;
+       ;; Note that `dst_hi` here is always a valid register but `dst_lo`
+       ;; is allowed to be `invalid_reg` to indicate that only the high
+       ;; bits are desired. If `dst_lo` is invalid then the instruction itself
+       ;; will only define `dst_hi`.
+       (MulX (size OperandSize)
+             (src1 Gpr)
+             (src2 GprMem)
+             (dst_lo WritableGpr)
+             (dst_hi WritableGpr))
+
        ;; Same as `Mul` but the 16-bit multiplication result is stored in `AX`.
        (Mul8 (signed bool)
              (src1 Gpr)
@@ -2635,6 +2650,26 @@
             (size OperandSize (raw_operand_size_of_type ty))
             (_ Unit (emit (MInst.Mul size signed src1 src2 dst_lo dst_hi))))
         (value_gprs dst_lo dst_hi)))
+
+;; Special case the `mulx` pattern with the BMI2 instruction set.
+(rule 1 (x64_mul (ty_32_or_64 ty) $false src1 src2)
+  (if-let $true (use_bmi2))
+  (let ((dst_lo WritableGpr (temp_writable_gpr))
+        (dst_hi WritableGpr (temp_writable_gpr))
+        (size OperandSize (raw_operand_size_of_type ty))
+        (_ Unit (emit (MInst.MulX size src1 src2 dst_lo dst_hi))))
+    (value_gprs dst_lo dst_hi)))
+
+(decl x64_mulx_hi (Type Gpr GprMem) Gpr)
+(rule (x64_mulx_hi (ty_32_or_64 ty) src1 src2)
+  (let ((dst WritableGpr (temp_writable_gpr))
+        (size OperandSize (raw_operand_size_of_type ty))
+        (_ Unit (emit (MInst.MulX size src1 src2 (writable_invalid_gpr) dst))))
+    dst))
+
+;; Get the invalid register as writable
+(decl writable_invalid_gpr () WritableGpr)
+(extern constructor writable_invalid_gpr writable_invalid_gpr)
 
 ;; Helper for creating `mul` instructions or `imul` instructions (depending
 ;; on `signed`) for 8-bit operands.

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4354,6 +4354,14 @@
 (rule 1 (lower (umulhi a @ (value_type (ty_int_ref_16_to_64 ty)) b))
         (value_regs_get_gpr (x64_mul ty $false a b) 1))
 
+;; The BMI2 instruction set introduced `mulx` which defines two registers but
+;; if the two registers are the same then it only defines the upper bits. This
+;; helps slightly reduce register pressure by ensuring only one register here is
+;; clobbered.
+(rule 2 (lower (umulhi a @ (value_type (ty_32_or_64 ty)) b))
+        (if-let $true (use_bmi2))
+        (x64_mulx_hi ty a b))
+
 ;; Rules for `smulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 0 (lower (smulhi a @ (value_type $I8) b))

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -990,6 +990,11 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
         let mask = -1i128 as u128;
         self.emit_u128_le_const(mask ^ (0xff << (hole_idx * 8)))
     }
+
+    fn writable_invalid_gpr(&mut self) -> WritableGpr {
+        let reg = Gpr::new(self.invalid_reg()).unwrap();
+        WritableGpr::from_reg(reg)
+    }
 }
 
 impl IsleContext<'_, '_, MInst, X64Backend> {

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -252,6 +252,13 @@ pub(crate) fn check(
             dst_hi,
             ref src2,
             ..
+        }
+        | Inst::MulX {
+            size,
+            dst_lo,
+            dst_hi,
+            ref src2,
+            ..
         } => {
             match <&RegMem>::from(src2) {
                 RegMem::Mem { ref addr } => {

--- a/cranelift/filetests/filetests/isa/x64/bmi2.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmi2.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_llvm_abi_extensions=true
 target x86_64 has_bmi2
 
 function %sarx_i32(i32, i32) -> i32 {
@@ -342,6 +343,89 @@ block0(v0: i64, v1: i32):
 ; block1: ; offset 0x4
 ;   andl $0x1f, %esi
 ;   bzhil %esi, 0x14(%rdi), %eax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %extend_to_i128_mul_mulxq(i64, i64) -> i128 {
+block0(v0: i64, v1: i64):
+  v2 = uextend.i128 v0
+  v3 = uextend.i128 v1
+  v4 = imul v2, v3
+  return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rdx
+;   mulxq   %rdx, %rsi, %rax, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rdx
+;   mulxq %rsi, %rax, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umulhi_mulxl(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+  v2 = umulhi v0, v1
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rdx
+;   mulxl   %edx, %esi, %eax, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rdx
+;   mulxl %esi, %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umulhi_mulxq(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = umulhi v0, v1
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rdx
+;   mulxq   %rdx, %rsi, %rax, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rdx
+;   mulxq %rsi, %rax, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
@@ -4,6 +4,7 @@ set enable_llvm_abi_extensions=true
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_bmi2
 target riscv64
 target riscv64 has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/smul_overflow.clif
+++ b/cranelift/filetests/filetests/runtests/smul_overflow.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target x86_64
+target x86_64 has_bmi2
 target aarch64
 
 function %smulof_i64(i64, i64) -> i64, i8 {

--- a/cranelift/filetests/filetests/runtests/smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi.clif
@@ -2,6 +2,8 @@ test interpret
 test run
 target aarch64
 target s390x
+target x86_64
+target x86_64 has_bmi2
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64

--- a/cranelift/filetests/filetests/runtests/umul_overflow.clif
+++ b/cranelift/filetests/filetests/runtests/umul_overflow.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target x86_64
+target x86_64 has_bmi2
 target aarch64
 
 function %umulof_i64(i64, i64) -> i64, i8 {

--- a/cranelift/filetests/filetests/runtests/umulhi.clif
+++ b/cranelift/filetests/filetests/runtests/umulhi.clif
@@ -1,7 +1,9 @@
 test interpret
 test run
 target aarch64
+target x86_64
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_bmi2
 target s390x
 target riscv64
 target riscv64 has_c has_zcb


### PR DESCRIPTION
This commit adds backend support for the `mulx` instruction in the BMI2 instruction set which supports arbitrary destination registers. This instruction also doesn't read/clobber flags so it can help pipeline instructions in niche situations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
