### PR TITLE
Winch aarch64 dynamic heap

### DIFF
--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -34,7 +34,7 @@
 ;;       ldur    x1, [x9, #0x68]
 ;;       mov     w2, w0
 ;;       add     x2, x2, #4
-;;       b.vs    #0x134
+;;       b.hs    #0x134
 ;;   3c: cmp     x2, x1, uxtx
 ;;       b.hi    #0x138
 ;;   44: ldur    x3, [x9, #0x60]
@@ -48,7 +48,7 @@
 ;;       ldur    x2, [x9, #0x68]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.vs    #0x13c
+;;       b.hs    #0x13c
 ;;   74: cmp     x3, x2, uxtx
 ;;       b.hi    #0x140
 ;;   7c: ldur    x4, [x9, #0x60]
@@ -65,7 +65,7 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x4, x4, x16, uxtx
-;;       b.vs    #0x144
+;;       b.hs    #0x144
 ;;   b8: cmp     x4, x3, uxtx
 ;;       b.hi    #0x148
 ;;   c0: ldur    x5, [x9, #0x60]

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -34,34 +34,30 @@
 ;;       ldur    x1, [x9, #0x68]
 ;;       mov     w2, w0
 ;;       add     x2, x2, #4
-;;       b.vs    #0x14c
+;;       b.vs    #0x134
 ;;   3c: cmp     x2, x1, uxtx
-;;       b.hi    #0x150
+;;       b.hi    #0x138
 ;;   44: ldur    x3, [x9, #0x60]
 ;;       add     x3, x3, x0, uxtx
 ;;       mov     x16, #0
 ;;       mov     x4, x16
 ;;       cmp     x2, x1, uxtx
-;;       b.ls    #0x64
-;;       b       #0x60
-;;   60: mov     x3, x4
+;;       csel    x4, x4, x3, hi
 ;;       ldur    w0, [x3]
 ;;       ldur    w1, [x28, #0xc]
 ;;       ldur    x2, [x9, #0x68]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.vs    #0x154
-;;   7c: cmp     x3, x2, uxtx
-;;       b.hi    #0x158
-;;   84: ldur    x4, [x9, #0x60]
+;;       b.vs    #0x13c
+;;   74: cmp     x3, x2, uxtx
+;;       b.hi    #0x140
+;;   7c: ldur    x4, [x9, #0x60]
 ;;       add     x4, x4, x1, uxtx
 ;;       add     x4, x4, #4
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       b.ls    #0xa8
-;;       b       #0xa4
-;;   a4: mov     x4, x5
+;;       csel    x5, x5, x4, hi
 ;;       ldur    w1, [x4]
 ;;       ldur    w2, [x28, #0xc]
 ;;       ldur    x3, [x9, #0x68]
@@ -69,19 +65,17 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x4, x4, x16, uxtx
-;;       b.vs    #0x15c
-;;   c8: cmp     x4, x3, uxtx
-;;       b.hi    #0x160
-;;   d0: ldur    x5, [x9, #0x60]
+;;       b.vs    #0x144
+;;   b8: cmp     x4, x3, uxtx
+;;       b.hi    #0x148
+;;   c0: ldur    x5, [x9, #0x60]
 ;;       add     x5, x5, x2, uxtx
 ;;       orr     x16, xzr, #0xfffff
 ;;       add     x5, x5, x16, uxtx
 ;;       mov     x16, #0
 ;;       mov     x6, x16
 ;;       cmp     x4, x3, uxtx
-;;       b.ls    #0xf8
-;;       b       #0xf4
-;;   f4: mov     x5, x6
+;;       csel    x6, x6, x5, hi
 ;;       ldur    w2, [x5]
 ;;       sub     sp, sp, #4
 ;;       mov     x28, sp
@@ -103,9 +97,9 @@
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  14c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  150: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  154: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  158: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  15c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  160: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  134: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  138: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  13c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  140: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  144: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  148: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -1,0 +1,111 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = "-O static-memory-maximum-size=100 -O dynamic-memory-guard-size=0xffff"
+
+(module
+  (memory (export "memory") 17)
+  (func (export "run") (param i32) (result i32 i32 i32)
+    ;; Within the guard region.
+    local.get 0
+    i32.load offset=0
+    ;; Also within the guard region, bounds check should GVN with previous.
+    local.get 0
+    i32.load offset=4
+
+    ;; Outside the guard region, needs additional bounds checks.
+    local.get 0
+    i32.load offset=0x000fffff
+  )
+  (data (i32.const 0) "\45\00\00\00\a4\01\00\00")
+  (data (i32.const 0x000fffff) "\39\05\00\00")
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    w2, [x28, #0xc]
+;;       stur    x3, [x28]
+;;       ldur    w0, [x28, #0xc]
+;;       ldur    x1, [x9, #0x68]
+;;       mov     w2, w0
+;;       add     x2, x2, #4
+;;       b.vs    #0x14c
+;;   3c: cmp     x2, x1, uxtx
+;;       b.hi    #0x150
+;;   44: ldur    x3, [x9, #0x60]
+;;       add     x3, x3, x0, uxtx
+;;       mov     x16, #0
+;;       mov     x4, x16
+;;       cmp     x2, x1, uxtx
+;;       b.ls    #0x64
+;;       b       #0x60
+;;   60: mov     x3, x4
+;;       ldur    w0, [x3]
+;;       ldur    w1, [x28, #0xc]
+;;       ldur    x2, [x9, #0x68]
+;;       mov     w3, w1
+;;       add     x3, x3, #8
+;;       b.vs    #0x154
+;;   7c: cmp     x3, x2, uxtx
+;;       b.hi    #0x158
+;;   84: ldur    x4, [x9, #0x60]
+;;       add     x4, x4, x1, uxtx
+;;       add     x4, x4, #4
+;;       mov     x16, #0
+;;       mov     x5, x16
+;;       cmp     x3, x2, uxtx
+;;       b.ls    #0xa8
+;;       b       #0xa4
+;;   a4: mov     x4, x5
+;;       ldur    w1, [x4]
+;;       ldur    w2, [x28, #0xc]
+;;       ldur    x3, [x9, #0x68]
+;;       mov     w4, w2
+;;       mov     w16, #3
+;;       movk    w16, #0x10, lsl #16
+;;       add     x4, x4, x16, uxtx
+;;       b.vs    #0x15c
+;;   c8: cmp     x4, x3, uxtx
+;;       b.hi    #0x160
+;;   d0: ldur    x5, [x9, #0x60]
+;;       add     x5, x5, x2, uxtx
+;;       orr     x16, xzr, #0xfffff
+;;       add     x5, x5, x16, uxtx
+;;       mov     x16, #0
+;;       mov     x6, x16
+;;       cmp     x4, x3, uxtx
+;;       b.ls    #0xf8
+;;       b       #0xf4
+;;   f4: mov     x5, x6
+;;       ldur    w2, [x5]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w1, [x28]
+;;       mov     w0, w2
+;;       ldur    x1, [x28, #8]
+;;       ldur    w16, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x1]
+;;       ldur    w16, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x1, #4]
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;  14c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  150: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  154: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  158: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  15c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  160: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -23,13 +23,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x28, sp
-;;       mov     x9, x0
+;;       mov     x9, x1
 ;;       sub     sp, sp, #0x20
 ;;       mov     x28, sp
-;;       stur    x0, [x28, #0x18]
-;;       stur    x1, [x28, #0x10]
-;;       stur    w2, [x28, #0xc]
-;;       stur    x3, [x28]
+;;       stur    x1, [x28, #0x18]
+;;       stur    x2, [x28, #0x10]
+;;       stur    w3, [x28, #0xc]
+;;       stur    x0, [x28]
 ;;       ldur    w0, [x28, #0xc]
 ;;       ldur    x1, [x9, #0x68]
 ;;       mov     w2, w0
@@ -42,7 +42,7 @@
 ;;       mov     x16, #0
 ;;       mov     x4, x16
 ;;       cmp     x2, x1, uxtx
-;;       csel    x4, x4, x3, hi
+;;       csel    x3, x4, x4, hi
 ;;       ldur    w0, [x3]
 ;;       ldur    w1, [x28, #0xc]
 ;;       ldur    x2, [x9, #0x68]
@@ -57,7 +57,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x5, x5, x4, hi
+;;       csel    x4, x5, x5, hi
 ;;       ldur    w1, [x4]
 ;;       ldur    w2, [x28, #0xc]
 ;;       ldur    x3, [x9, #0x68]
@@ -75,7 +75,7 @@
 ;;       mov     x16, #0
 ;;       mov     x6, x16
 ;;       cmp     x4, x3, uxtx
-;;       csel    x6, x6, x5, hi
+;;       csel    x5, x6, x6, hi
 ;;       ldur    w2, [x5]
 ;;       sub     sp, sp, #4
 ;;       mov     x28, sp

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -37,7 +37,7 @@
 ;;       ldur    x2, [x9, #0x68]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #4
-;;       b.vs    #0x108
+;;       b.hs    #0x108
 ;;   48: cmp     x3, x2, uxtx
 ;;       b.hi    #0x10c
 ;;   50: ldur    x4, [x9, #0x60]
@@ -52,7 +52,7 @@
 ;;       ldur    x2, [x9, #0x68]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.vs    #0x110
+;;       b.hs    #0x110
 ;;   84: cmp     x3, x2, uxtx
 ;;       b.hi    #0x114
 ;;   8c: ldur    x4, [x9, #0x60]
@@ -70,7 +70,7 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x3, x3, x16, uxtx
-;;       b.vs    #0x118
+;;       b.hs    #0x118
 ;;   cc: cmp     x3, x2, uxtx
 ;;       b.hi    #0x11c
 ;;   d4: ldur    x4, [x9, #0x60]

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -37,35 +37,31 @@
 ;;       ldur    x2, [x9, #0x68]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #4
-;;       b.vs    #0x120
+;;       b.vs    #0x108
 ;;   48: cmp     x3, x2, uxtx
-;;       b.hi    #0x124
+;;       b.hi    #0x10c
 ;;   50: ldur    x4, [x9, #0x60]
 ;;       add     x4, x4, x1, uxtx
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       b.ls    #0x70
-;;       b       #0x6c
-;;   6c: mov     x4, x5
+;;       csel    x5, x5, x4, hi
 ;;       stur    w0, [x4]
 ;;       ldur    w0, [x28, #4]
 ;;       ldur    w1, [x28, #0xc]
 ;;       ldur    x2, [x9, #0x68]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.vs    #0x128
-;;   8c: cmp     x3, x2, uxtx
-;;       b.hi    #0x12c
-;;   94: ldur    x4, [x9, #0x60]
+;;       b.vs    #0x110
+;;   84: cmp     x3, x2, uxtx
+;;       b.hi    #0x114
+;;   8c: ldur    x4, [x9, #0x60]
 ;;       add     x4, x4, x1, uxtx
 ;;       add     x4, x4, #4
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       b.ls    #0xb8
-;;       b       #0xb4
-;;   b4: mov     x4, x5
+;;       csel    x5, x5, x4, hi
 ;;       stur    w0, [x4]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #0xc]
@@ -74,27 +70,25 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x3, x3, x16, uxtx
-;;       b.vs    #0x130
-;;   dc: cmp     x3, x2, uxtx
-;;       b.hi    #0x134
-;;   e4: ldur    x4, [x9, #0x60]
+;;       b.vs    #0x118
+;;   cc: cmp     x3, x2, uxtx
+;;       b.hi    #0x11c
+;;   d4: ldur    x4, [x9, #0x60]
 ;;       add     x4, x4, x1, uxtx
 ;;       orr     x16, xzr, #0xfffff
 ;;       add     x4, x4, x16, uxtx
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       b.ls    #0x10c
-;;       b       #0x108
-;;  108: mov     x4, x5
+;;       csel    x5, x5, x4, hi
 ;;       stur    w0, [x4]
 ;;       add     sp, sp, #0x20
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  120: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  124: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  128: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  12c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  130: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  134: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  108: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  10c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  110: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  114: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  118: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  11c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -1,0 +1,100 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = "-O static-memory-maximum-size=0 -O dynamic-memory-guard-size=0xffff"
+
+(module
+  (memory (export "memory") 1)
+  (func (export "run") (param i32 i32 i32 i32)
+    ;; Within the guard region.
+    local.get 0
+    local.get 1
+    i32.store offset=0
+    ;; Also within the guard region, bounds check should GVN with previous.
+    local.get 0
+    local.get 2
+    i32.store offset=4
+    ;; Outside the guard region, needs additional bounds checks.
+    local.get 0
+    local.get 3
+    i32.store offset=0x000fffff
+  )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    w2, [x28, #0xc]
+;;       stur    w3, [x28, #8]
+;;       stur    w4, [x28, #4]
+;;       stur    w5, [x28]
+;;       ldur    w0, [x28, #8]
+;;       ldur    w1, [x28, #0xc]
+;;       ldur    x2, [x9, #0x68]
+;;       mov     w3, w1
+;;       add     x3, x3, #4
+;;       b.vs    #0x120
+;;   48: cmp     x3, x2, uxtx
+;;       b.hi    #0x124
+;;   50: ldur    x4, [x9, #0x60]
+;;       add     x4, x4, x1, uxtx
+;;       mov     x16, #0
+;;       mov     x5, x16
+;;       cmp     x3, x2, uxtx
+;;       b.ls    #0x70
+;;       b       #0x6c
+;;   6c: mov     x4, x5
+;;       stur    w0, [x4]
+;;       ldur    w0, [x28, #4]
+;;       ldur    w1, [x28, #0xc]
+;;       ldur    x2, [x9, #0x68]
+;;       mov     w3, w1
+;;       add     x3, x3, #8
+;;       b.vs    #0x128
+;;   8c: cmp     x3, x2, uxtx
+;;       b.hi    #0x12c
+;;   94: ldur    x4, [x9, #0x60]
+;;       add     x4, x4, x1, uxtx
+;;       add     x4, x4, #4
+;;       mov     x16, #0
+;;       mov     x5, x16
+;;       cmp     x3, x2, uxtx
+;;       b.ls    #0xb8
+;;       b       #0xb4
+;;   b4: mov     x4, x5
+;;       stur    w0, [x4]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #0xc]
+;;       ldur    x2, [x9, #0x68]
+;;       mov     w3, w1
+;;       mov     w16, #3
+;;       movk    w16, #0x10, lsl #16
+;;       add     x3, x3, x16, uxtx
+;;       b.vs    #0x130
+;;   dc: cmp     x3, x2, uxtx
+;;       b.hi    #0x134
+;;   e4: ldur    x4, [x9, #0x60]
+;;       add     x4, x4, x1, uxtx
+;;       orr     x16, xzr, #0xfffff
+;;       add     x4, x4, x16, uxtx
+;;       mov     x16, #0
+;;       mov     x5, x16
+;;       cmp     x3, x2, uxtx
+;;       b.ls    #0x10c
+;;       b       #0x108
+;;  108: mov     x4, x5
+;;       stur    w0, [x4]
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;  120: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  124: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  128: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  12c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  130: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  134: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -45,7 +45,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x5, x5, x4, hi
+;;       csel    x4, x5, x5, hi
 ;;       stur    w0, [x4]
 ;;       ldur    w0, [x28, #4]
 ;;       ldur    w1, [x28, #0xc]
@@ -61,7 +61,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x5, x5, x4, hi
+;;       csel    x4, x5, x5, hi
 ;;       stur    w0, [x4]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #0xc]
@@ -80,7 +80,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x5, x5, x4, hi
+;;       csel    x4, x5, x5, hi
 ;;       stur    w0, [x4]
 ;;       add     sp, sp, #0x20
 ;;       mov     x28, sp

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -642,15 +642,6 @@ impl Assembler {
         });
     }
 
-    /// A conditional branch with resolved destination.
-    pub fn jmp_if_resolved(&mut self, kind: Cond, taken: i32) {
-        self.emit(Inst::CondBr {
-            taken: BranchTarget::ResolvedOffset(taken),
-            not_taken: BranchTarget::ResolvedOffset(4),
-            kind: CondBrKind::Cond(kind),
-        });
-    }
-
     /// Emits a jump table sequence.
     pub fn jmp_table(
         &mut self,
@@ -680,6 +671,17 @@ impl Assembler {
     pub fn cset(&mut self, rd: WritableReg, cond: Cond) {
         self.emit(Inst::CSet {
             rd: rd.map(Into::into),
+            cond,
+        });
+    }
+
+    // If the condition is true, Conditional Select writes rm to rd. If the condition is false,
+    // it writes rn to rd
+    pub fn csel(&mut self, rm: Reg, rn: Reg, rd: WritableReg, cond: Cond) {
+        self.emit(Inst::CSel {
+            rd: rd.map(Into::into),
+            rm: rm.into(),
+            rn: rn.into(),
             cond,
         });
     }

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -642,6 +642,15 @@ impl Assembler {
         });
     }
 
+    /// A conditional branch with resolved destination.
+    pub fn jmp_if_resolved(&mut self, kind: Cond, taken: i32) {
+        self.emit(Inst::CondBr {
+            taken: BranchTarget::ResolvedOffset(taken),
+            not_taken: BranchTarget::ResolvedOffset(4),
+            kind: CondBrKind::Cond(kind),
+        });
+    }
+
     /// Emits a jump table sequence.
     pub fn jmp_table(
         &mut self,

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -6,6 +6,7 @@ use crate::{
     masm::OperandSize,
     reg::{writable, Reg, WritableReg},
 };
+use cranelift_codegen::ir::TrapCode;
 use cranelift_codegen::isa::aarch64::inst::{
     BitOp, BranchTarget, Cond, CondBrKind, FPULeftShiftImm, FPUOp1, FPUOp2,
     FPUOpRI::{self, UShr32, UShr64},
@@ -697,6 +698,19 @@ impl Assembler {
     /// Bitwise AND (shifted register), setting flags.
     pub fn ands_rr(&mut self, rn: Reg, rm: Reg, size: OperandSize) {
         self.emit_alu_rrr(ALUOp::AndS, rm, rn, writable!(regs::zero()), size);
+    }
+
+    /// Permanently Undefined.
+    pub fn udf(&mut self, code: TrapCode) {
+        self.emit(Inst::Udf { trap_code: code });
+    }
+
+    /// Conditional trap.
+    pub fn trapif(&mut self, cc: Cond, code: TrapCode) {
+        self.emit(Inst::TrapIf {
+            kind: CondBrKind::Cond(cc),
+            trap_code: code,
+        });
     }
 
     // Helpers for ALU operations.

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -269,7 +269,7 @@ impl Masm for MacroAssembler {
         trap: TrapCode,
     ) {
         self.add(dst, lhs, rhs, size);
-        self.asm.trapif(Cond::Vs, trap);
+        self.asm.trapif(Cond::Hs, trap);
     }
 
     fn sub(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -632,7 +632,7 @@ impl Masm for MacroAssembler {
     }
 
     fn unreachable(&mut self) {
-        todo!()
+        self.asm.udf(TrapCode::UnreachableCodeReached);
     }
 
     fn jmp_table(&mut self, targets: &[MachLabel], index: Reg, tmp: Reg) {
@@ -647,16 +647,16 @@ impl Masm for MacroAssembler {
         self.asm.jmp_table(rest, default, index, tmp1, tmp);
     }
 
-    fn trap(&mut self, _code: TrapCode) {
-        todo!()
+    fn trap(&mut self, code: TrapCode) {
+        self.asm.udf(code);
     }
 
     fn trapz(&mut self, _src: Reg, _code: TrapCode) {
         todo!()
     }
 
-    fn trapif(&mut self, _cc: IntCmpKind, _code: TrapCode) {
-        todo!()
+    fn trapif(&mut self, cc: IntCmpKind, code: TrapCode) {
+        self.asm.trapif(cc.into(), code);
     }
 
     fn start_source_loc(&mut self, loc: RelSourceLoc) -> (CodeOffset, RelSourceLoc) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -238,9 +238,8 @@ impl Masm for MacroAssembler {
         }
     }
 
-    fn cmov(&mut self, dst: WritableReg, src: Reg, cc: IntCmpKind, size: OperandSize) {
-        self.asm.jmp_if_resolved(Cond::from(cc).invert(), 12);
-        self.asm.mov_rr(src, dst, size)
+    fn cmov(&mut self, dst: WritableReg, src: Reg, cc: IntCmpKind, _size: OperandSize) {
+        self.asm.csel(src, src, dst, Cond::from(cc));
     }
 
     fn add(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {


### PR DESCRIPTION
Hey 👋

This PR implements everything needed to run winch for aarch64 with dynamic heap. It implements the following macro instructions : `trap`, `trapif`, `cmov` and `checked_add`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
