### PR TITLE
Couple of cleanups to the ABI computation

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -109,7 +109,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         add_ret_area_ptr: bool,
         mut args: ArgsAccumulator,
     ) -> CodegenResult<(u32, Option<usize>)> {
-        let is_apple_cc = call_conv.extends_apple_aarch64();
+        let is_apple_cc = call_conv == isa::CallConv::AppleAarch64;
         let is_winch_return = call_conv == isa::CallConv::Winch && args_or_rets == ArgsOrRets::Rets;
 
         // See AArch64 ABI (https://github.com/ARM-software/abi-aa/blob/2021Q1/aapcs64/aapcs64.rst#64parameter-passing), sections 6.4.
@@ -594,7 +594,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     });
                 }
 
-                if flags.unwind_info() && call_conv.extends_apple_aarch64() {
+                if flags.unwind_info() && call_conv == isa::CallConv::AppleAarch64 {
                     // The macOS unwinder seems to require this.
                     insts.push(Inst::Unwind {
                         inst: UnwindInst::Aarch64SetPointerAuth {

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -28,16 +28,11 @@ pub enum CallConv {
     AppleAarch64,
     /// Specialized convention for the probestack function.
     Probestack,
-    /// Wasmtime equivalent of SystemV, not ABI-stable.
-    ///
-    /// FIXME: remove this when Wasmtime uses the "tail" calling convention for
-    /// all wasm functions.
-    WasmtimeSystemV,
     /// The winch calling convention, not ABI-stable.
     ///
-    /// The main difference to WasmtimeSystemV is that the winch calling
-    /// convention defines no callee-save registers, and restricts the number
-    /// of return registers to one integer, and one floating point.
+    /// The main difference to SystemV is that the winch calling convention
+    /// defines no callee-save registers, and restricts the number of return
+    /// registers to one integer, and one floating point.
     Winch,
 }
 
@@ -102,7 +97,6 @@ impl fmt::Display for CallConv {
             Self::WindowsFastcall => "windows_fastcall",
             Self::AppleAarch64 => "apple_aarch64",
             Self::Probestack => "probestack",
-            Self::WasmtimeSystemV => "wasmtime_system_v",
             Self::Winch => "winch",
         })
     }
@@ -119,7 +113,6 @@ impl str::FromStr for CallConv {
             "windows_fastcall" => Ok(Self::WindowsFastcall),
             "apple_aarch64" => Ok(Self::AppleAarch64),
             "probestack" => Ok(Self::Probestack),
-            "wasmtime_system_v" => Ok(Self::WasmtimeSystemV),
             "winch" => Ok(Self::Winch),
             _ => Err(()),
         }

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -69,22 +69,6 @@ impl CallConv {
             _ => false,
         }
     }
-
-    /// Is the calling convention extending the Windows Fastcall ABI?
-    pub fn extends_windows_fastcall(self) -> bool {
-        match self {
-            Self::WindowsFastcall => true,
-            _ => false,
-        }
-    }
-
-    /// Is the calling convention extending the Apple aarch64 ABI?
-    pub fn extends_apple_aarch64(self) -> bool {
-        match self {
-            Self::AppleAarch64 => true,
-            _ => false,
-        }
-    }
 }
 
 impl fmt::Display for CallConv {

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -133,7 +133,7 @@ where
                     ir::ArgumentExtension::None,
                     ir::ArgumentPurpose::Normal,
                 );
-                args.push(arg);
+                args.push_non_formal(arg);
             } else {
                 let arg = ABIArg::stack(
                     next_stack as i64,
@@ -141,7 +141,7 @@ where
                     ir::ArgumentExtension::None,
                     ir::ArgumentPurpose::Normal,
                 );
-                args.push(arg);
+                args.push_non_formal(arg);
                 next_stack += 8;
             }
             Some(args.args().len() - 1)

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -177,7 +177,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                     ir::ArgumentExtension::None,
                     ir::ArgumentPurpose::Normal,
                 );
-                args.push(arg);
+                args.push_non_formal(arg);
             } else {
                 let arg = ABIArg::stack(
                     next_stack as i64,
@@ -185,7 +185,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                     ir::ArgumentExtension::None,
                     ir::ArgumentPurpose::Normal,
                 );
-                args.push(arg);
+                args.push_non_formal(arg);
                 next_stack += 8;
             }
             Some(args.args().len() - 1)

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -1060,7 +1060,6 @@ impl IsleContext<'_, '_, MInst, S390xBackend> {
 #[inline]
 fn lane_order_for_call_conv(call_conv: CallConv) -> LaneOrder {
     match call_conv {
-        CallConv::WasmtimeSystemV => LaneOrder::LittleEndian,
         CallConv::Tail => LaneOrder::LittleEndian,
         _ => LaneOrder::BigEndian,
     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -580,12 +580,12 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     }
 
     fn gen_return(
-        call_conv: isa::CallConv,
+        call_conv: CallConv,
         _isa_flags: &x64_settings::Flags,
         frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
         // Emit return instruction.
-        let stack_bytes_to_pop = if call_conv == isa::CallConv::Tail {
+        let stack_bytes_to_pop = if call_conv == CallConv::Tail {
             frame_layout.tail_args_size
         } else {
             0
@@ -900,8 +900,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
     fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
         match call_conv_of_callee {
-            isa::CallConv::Winch => ALL_CLOBBERS,
-            isa::CallConv::WindowsFastcall => WINDOWS_CLOBBERS,
+            CallConv::Winch => ALL_CLOBBERS,
+            CallConv::WindowsFastcall => WINDOWS_CLOBBERS,
             _ => SYSV_CLOBBERS,
         }
     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -101,7 +101,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         add_ret_area_ptr: bool,
         mut args: ArgsAccumulator,
     ) -> CodegenResult<(u32, Option<usize>)> {
-        let is_fastcall = call_conv.extends_windows_fastcall();
+        let is_fastcall = call_conv == CallConv::WindowsFastcall;
 
         let mut next_gpr = 0;
         let mut next_vreg = 0;
@@ -199,7 +199,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 && args_or_rets == ArgsOrRets::Args
                 && is_fastcall
             {
-                let pointer = match get_intreg_for_arg(&call_conv, next_gpr, next_param_idx) {
+                let pointer = match get_intreg_for_arg(call_conv, next_gpr, next_param_idx) {
                     Some(reg) => {
                         next_gpr += 1;
                         ABIArgSlot::Reg {
@@ -238,8 +238,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             {
                 let mut slots = ABIArgSlotVec::new();
                 match (
-                    get_intreg_for_arg(&CallConv::SystemV, next_gpr, next_param_idx),
-                    get_intreg_for_arg(&CallConv::SystemV, next_gpr + 1, next_param_idx + 1),
+                    get_intreg_for_arg(CallConv::SystemV, next_gpr, next_param_idx),
+                    get_intreg_for_arg(CallConv::SystemV, next_gpr + 1, next_param_idx + 1),
                 ) {
                     (Some(reg1), Some(reg2)) => {
                         slots.push(ABIArgSlot::Reg {
@@ -292,19 +292,17 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 let intreg = *rc == RegClass::Int;
                 let nextreg = if intreg {
                     match args_or_rets {
-                        ArgsOrRets::Args => {
-                            get_intreg_for_arg(&call_conv, next_gpr, next_param_idx)
-                        }
+                        ArgsOrRets::Args => get_intreg_for_arg(call_conv, next_gpr, next_param_idx),
                         ArgsOrRets::Rets => {
-                            get_intreg_for_retval(&call_conv, flags, next_gpr, last_slot)
+                            get_intreg_for_retval(call_conv, flags, next_gpr, last_slot)
                         }
                     }
                 } else {
                     match args_or_rets {
                         ArgsOrRets::Args => {
-                            get_fltreg_for_arg(&call_conv, next_vreg, next_param_idx)
+                            get_fltreg_for_arg(call_conv, next_vreg, next_param_idx)
                         }
-                        ArgsOrRets::Rets => get_fltreg_for_retval(&call_conv, next_vreg, last_slot),
+                        ArgsOrRets::Rets => get_fltreg_for_retval(call_conv, next_vreg, last_slot),
                     }
                 };
                 next_param_idx += 1;
@@ -366,7 +364,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
         let extra_arg = if add_ret_area_ptr {
             debug_assert!(args_or_rets == ArgsOrRets::Args);
-            if let Some(reg) = get_intreg_for_arg(&call_conv, next_gpr, next_param_idx) {
+            if let Some(reg) = get_intreg_for_arg(call_conv, next_gpr, next_param_idx) {
                 args.push_non_formal(ABIArg::reg(
                     reg.to_real_reg().unwrap(),
                     types::I64,
@@ -836,9 +834,9 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         mut alloc_tmp: F,
     ) -> SmallVec<[Self::I; 8]> {
         let mut insts = SmallVec::new();
-        let arg0 = get_intreg_for_arg(&call_conv, 0, 0).unwrap();
-        let arg1 = get_intreg_for_arg(&call_conv, 1, 1).unwrap();
-        let arg2 = get_intreg_for_arg(&call_conv, 2, 2).unwrap();
+        let arg0 = get_intreg_for_arg(call_conv, 0, 0).unwrap();
+        let arg1 = get_intreg_for_arg(call_conv, 1, 1).unwrap();
+        let arg2 = get_intreg_for_arg(call_conv, 2, 2).unwrap();
         let temp = alloc_tmp(Self::word_type());
         let temp2 = alloc_tmp(Self::word_type());
         insts.push(Inst::imm(OperandSize::Size64, size as u64, temp));
@@ -903,7 +901,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
         match call_conv_of_callee {
             isa::CallConv::Winch => ALL_CLOBBERS,
-            _ if call_conv_of_callee.extends_windows_fastcall() => WINDOWS_CLOBBERS,
+            isa::CallConv::WindowsFastcall => WINDOWS_CLOBBERS,
             _ => SYSV_CLOBBERS,
         }
     }
@@ -1055,8 +1053,8 @@ impl From<StackAMode> for SyntheticAmode {
     }
 }
 
-fn get_intreg_for_arg(call_conv: &CallConv, idx: usize, arg_idx: usize) -> Option<Reg> {
-    let is_fastcall = call_conv.extends_windows_fastcall();
+fn get_intreg_for_arg(call_conv: CallConv, idx: usize, arg_idx: usize) -> Option<Reg> {
+    let is_fastcall = call_conv == CallConv::WindowsFastcall;
 
     // Fastcall counts by absolute argument number; SysV counts by argument of
     // this (integer) class.
@@ -1076,8 +1074,8 @@ fn get_intreg_for_arg(call_conv: &CallConv, idx: usize, arg_idx: usize) -> Optio
     }
 }
 
-fn get_fltreg_for_arg(call_conv: &CallConv, idx: usize, arg_idx: usize) -> Option<Reg> {
-    let is_fastcall = call_conv.extends_windows_fastcall();
+fn get_fltreg_for_arg(call_conv: CallConv, idx: usize, arg_idx: usize) -> Option<Reg> {
+    let is_fastcall = call_conv == CallConv::WindowsFastcall;
 
     // Fastcall counts by absolute argument number; SysV counts by argument of
     // this (floating-point) class.
@@ -1100,7 +1098,7 @@ fn get_fltreg_for_arg(call_conv: &CallConv, idx: usize, arg_idx: usize) -> Optio
 }
 
 fn get_intreg_for_retval(
-    call_conv: &CallConv,
+    call_conv: CallConv,
     flags: &settings::Flags,
     intreg_idx: usize,
     is_last: bool,
@@ -1142,7 +1140,7 @@ fn get_intreg_for_retval(
     }
 }
 
-fn get_fltreg_for_retval(call_conv: &CallConv, fltreg_idx: usize, is_last: bool) -> Option<Reg> {
+fn get_fltreg_for_retval(call_conv: CallConv, fltreg_idx: usize, is_last: bool) -> Option<Reg> {
     match call_conv {
         CallConv::Tail => match fltreg_idx {
             0 => Some(regs::xmm0()),

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -943,7 +943,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 .filter(|r| is_callee_save_fastcall(r.to_reg(), flags.enable_pinned_reg()))
                 .collect(),
             CallConv::Probestack => todo!("probestack?"),
-            CallConv::WasmtimeSystemV | CallConv::AppleAarch64 => unreachable!(),
+            CallConv::AppleAarch64 => unreachable!(),
         };
         // Sort registers for deterministic code output. We can do an unstable sort because the
         // registers will be unique (there are no dups).
@@ -1138,7 +1138,7 @@ fn get_intreg_for_retval(
             is_last.then(|| regs::rax())
         }
         CallConv::Probestack => todo!(),
-        CallConv::WasmtimeSystemV | CallConv::AppleAarch64 => unreachable!(),
+        CallConv::AppleAarch64 => unreachable!(),
     }
 }
 
@@ -1166,7 +1166,7 @@ fn get_fltreg_for_retval(call_conv: &CallConv, fltreg_idx: usize, is_last: bool)
         },
         CallConv::Winch => is_last.then(|| regs::xmm0()),
         CallConv::Probestack => todo!(),
-        CallConv::WasmtimeSystemV | CallConv::AppleAarch64 => unreachable!(),
+        CallConv::AppleAarch64 => unreachable!(),
     }
 }
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1126,7 +1126,6 @@ impl<M: ABIMachineSpec> Callee<M> {
                 || call_conv == isa::CallConv::Fast
                 || call_conv == isa::CallConv::Cold
                 || call_conv.extends_windows_fastcall()
-                || call_conv == isa::CallConv::WasmtimeSystemV
                 || call_conv == isa::CallConv::AppleAarch64
                 || call_conv == isa::CallConv::Winch,
             "Unsupported calling convention: {call_conv:?}"

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1125,7 +1125,7 @@ impl<M: ABIMachineSpec> Callee<M> {
                 || call_conv == isa::CallConv::Tail
                 || call_conv == isa::CallConv::Fast
                 || call_conv == isa::CallConv::Cold
-                || call_conv.extends_windows_fastcall()
+                || call_conv == isa::CallConv::WindowsFastcall
                 || call_conv == isa::CallConv::AppleAarch64
                 || call_conv == isa::CallConv::Winch,
             "Unsupported calling convention: {call_conv:?}"

--- a/cranelift/docs/ir.md
+++ b/cranelift/docs/ir.md
@@ -147,14 +147,14 @@ number, others don't care.
 - i64
 - i128
 
-Of these types, i32 and i64 are the most heavily-tested because of their use by 
-Wasmtime. There are no known bugs in i8, i16, and i128, but their use may not 
-be supported by all instructions in all backends (that is, they may cause 
+Of these types, i32 and i64 are the most heavily-tested because of their use by
+Wasmtime. There are no known bugs in i8, i16, and i128, but their use may not
+be supported by all instructions in all backends (that is, they may cause
 the compiler to crash during code generation with an error that an instruction
-is unsupported). 
+is unsupported).
 
-The function `valid_for_target` within the [fuzzgen function generator][fungen] 
-contains information about which instructions support which types. 
+The function `valid_for_target` within the [fuzzgen function generator][fungen]
+contains information about which instructions support which types.
 
 [fungen]: https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/fuzzgen/src/function_generator.rs
 
@@ -352,9 +352,7 @@ param        : type [paramext] [paramspecial]
 paramext     : "uext" | "sext"
 paramspecial : "sarg" ( num ) | "sret" | "vmctx" | "stack_limit"
 callconv     : "fast" | "cold" | "system_v" | "windows_fastcall"
-             | "wasmtime_system_v" | "wasmtime_fastcall"
-             | "apple_aarch64" | "wasmtime_apple_aarch64"
-             | "probestack"
+             | "apple_aarch64" | "probestack" | "winch"
 ```
 
 A function's calling convention determines exactly how arguments and return

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
@@ -50,7 +50,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   br %r14
 
 function %caller_be_to_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 {
-    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v
+    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 tail
 
 block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16x8, v7: i8x16, v8: i64x2, v9: i32x4, v10: i16x8, v11: i8x16):
     v12 = call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
@@ -58,30 +58,31 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 }
 
 ; VCode:
-;   stmg %r14, %r15, 112(%r15)
-;   aghi %r15, -288
-;   std %f8, 224(%r15)
-;   std %f9, 232(%r15)
-;   std %f10, 240(%r15)
-;   std %f11, 248(%r15)
-;   std %f12, 256(%r15)
-;   std %f13, 264(%r15)
-;   std %f14, 272(%r15)
-;   std %f15, 280(%r15)
+;   stmg %r6, %r15, 48(%r15)
+;   aghi %r15, -224
+;   std %f8, 160(%r15)
+;   std %f9, 168(%r15)
+;   std %f10, 176(%r15)
+;   std %f11, 184(%r15)
+;   std %f12, 192(%r15)
+;   std %f13, 200(%r15)
+;   std %f14, 208(%r15)
+;   std %f15, 216(%r15)
 ; block0:
-;   vl %v17, 448(%r15)
-;   vl %v19, 464(%r15)
-;   vl %v21, 480(%r15)
-;   vl %v23, 496(%r15)
+;   vl %v17, 384(%r15)
+;   vl %v19, 400(%r15)
+;   vl %v21, 416(%r15)
+;   vl %v23, 432(%r15)
+;   aghi %r15, -224
 ;   vpdi %v24, %v24, %v24, 4
 ;   vpdi %v0, %v25, %v25, 4
 ;   verllg %v25, %v0, 32
 ;   vpdi %v0, %v26, %v26, 4
-;   verllg %v1, %v0, 32
-;   verllf %v26, %v1, 16
-;   vpdi %v5, %v27, %v27, 4
-;   verllg %v7, %v5, 32
-;   verllf %v18, %v7, 16
+;   verllg %v2, %v0, 32
+;   verllf %v26, %v2, 16
+;   vpdi %v6, %v27, %v27, 4
+;   verllg %v16, %v6, 32
+;   verllf %v18, %v16, 16
 ;   verllh %v27, %v18, 8
 ;   vpdi %v28, %v28, %v28, 4
 ;   vpdi %v29, %v29, %v29, 4
@@ -89,65 +90,66 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vpdi %v30, %v30, %v30, 4
 ;   verllg %v30, %v30, 32
 ;   verllf %v30, %v30, 16
-;   vpdi %v1, %v31, %v31, 4
-;   verllg %v3, %v1, 32
-;   verllf %v5, %v3, 16
-;   verllh %v31, %v5, 8
-;   vpdi %v17, %v17, %v17, 4
-;   vst %v17, 160(%r15)
-;   vpdi %v20, %v19, %v19, 4
-;   verllg %v22, %v20, 32
-;   vst %v22, 176(%r15)
+;   vpdi %v2, %v31, %v31, 4
+;   verllg %v4, %v2, 32
+;   verllf %v6, %v4, 16
+;   verllh %v31, %v6, 8
+;   vpdi %v18, %v17, %v17, 4
+;   vst %v18, 160(%r15)
+;   vpdi %v22, %v19, %v19, 4
+;   verllg %v0, %v22, 32
+;   vst %v0, 176(%r15)
 ;   vpdi %v0, %v21, %v21, 4
 ;   verllg %v0, %v0, 32
 ;   verllf %v0, %v0, 16
 ;   vst %v0, 192(%r15)
-;   vpdi %v0, %v23, %v23, 4
-;   verllg %v2, %v0, 32
-;   verllf %v4, %v2, 16
-;   verllh %v6, %v4, 8
-;   vst %v6, 208(%r15)
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   vpdi %v21, %v24, %v24, 4
-;   verllg %v24, %v21, 32
-;   ld %f8, 224(%r15)
-;   ld %f9, 232(%r15)
-;   ld %f10, 240(%r15)
-;   ld %f11, 248(%r15)
-;   ld %f12, 256(%r15)
-;   ld %f13, 264(%r15)
-;   ld %f14, 272(%r15)
-;   ld %f15, 280(%r15)
-;   lmg %r14, %r15, 400(%r15)
+;   vpdi %v1, %v23, %v23, 4
+;   verllg %v3, %v1, 32
+;   verllf %v5, %v3, 16
+;   verllh %v7, %v5, 8
+;   vst %v7, 208(%r15)
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r5, 0(%r1)
+;   basr %r14, %r5 ; callee_pop_size 224
+;   vpdi %v22, %v24, %v24, 4
+;   verllg %v24, %v22, 32
+;   ld %f8, 160(%r15)
+;   ld %f9, 168(%r15)
+;   ld %f10, 176(%r15)
+;   ld %f11, 184(%r15)
+;   ld %f12, 192(%r15)
+;   ld %f13, 200(%r15)
+;   ld %f14, 208(%r15)
+;   ld %f15, 216(%r15)
+;   lmg %r6, %r15, 272(%r15)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stmg %r14, %r15, 0x70(%r15)
-;   aghi %r15, -0x120
-;   std %f8, 0xe0(%r15)
-;   std %f9, 0xe8(%r15)
-;   std %f10, 0xf0(%r15)
-;   std %f11, 0xf8(%r15)
-;   std %f12, 0x100(%r15)
-;   std %f13, 0x108(%r15)
-;   std %f14, 0x110(%r15)
-;   std %f15, 0x118(%r15)
+;   stmg %r6, %r15, 0x30(%r15)
+;   aghi %r15, -0xe0
+;   std %f8, 0xa0(%r15)
+;   std %f9, 0xa8(%r15)
+;   std %f10, 0xb0(%r15)
+;   std %f11, 0xb8(%r15)
+;   std %f12, 0xc0(%r15)
+;   std %f13, 0xc8(%r15)
+;   std %f14, 0xd0(%r15)
+;   std %f15, 0xd8(%r15)
 ; block1: ; offset 0x2a
-;   vl %v17, 0x1c0(%r15)
-;   vl %v19, 0x1d0(%r15)
-;   vl %v21, 0x1e0(%r15)
-;   vl %v23, 0x1f0(%r15)
+;   vl %v17, 0x180(%r15)
+;   vl %v19, 0x190(%r15)
+;   vl %v21, 0x1a0(%r15)
+;   vl %v23, 0x1b0(%r15)
+;   aghi %r15, -0xe0
 ;   vpdi %v24, %v24, %v24, 4
 ;   vpdi %v0, %v25, %v25, 4
 ;   verllg %v25, %v0, 0x20
 ;   vpdi %v0, %v26, %v26, 4
-;   verllg %v1, %v0, 0x20
-;   verllf %v26, %v1, 0x10
-;   vpdi %v5, %v27, %v27, 4
-;   verllg %v7, %v5, 0x20
-;   verllf %v18, %v7, 0x10
+;   verllg %v2, %v0, 0x20
+;   verllf %v26, %v2, 0x10
+;   vpdi %v6, %v27, %v27, 4
+;   verllg %v16, %v6, 0x20
+;   verllf %v18, %v16, 0x10
 ;   verllh %v27, %v18, 8
 ;   vpdi %v28, %v28, %v28, 4
 ;   vpdi %v29, %v29, %v29, 4
@@ -155,45 +157,45 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vpdi %v30, %v30, %v30, 4
 ;   verllg %v30, %v30, 0x20
 ;   verllf %v30, %v30, 0x10
-;   vpdi %v1, %v31, %v31, 4
-;   verllg %v3, %v1, 0x20
-;   verllf %v5, %v3, 0x10
-;   verllh %v31, %v5, 8
-;   vpdi %v17, %v17, %v17, 4
-;   vst %v17, 0xa0(%r15)
-;   vpdi %v20, %v19, %v19, 4
-;   verllg %v22, %v20, 0x20
-;   vst %v22, 0xb0(%r15)
+;   vpdi %v2, %v31, %v31, 4
+;   verllg %v4, %v2, 0x20
+;   verllf %v6, %v4, 0x10
+;   verllh %v31, %v6, 8
+;   vpdi %v18, %v17, %v17, 4
+;   vst %v18, 0xa0(%r15)
+;   vpdi %v22, %v19, %v19, 4
+;   verllg %v0, %v22, 0x20
+;   vst %v0, 0xb0(%r15)
 ;   vpdi %v0, %v21, %v21, 4
 ;   verllg %v0, %v0, 0x20
 ;   verllf %v0, %v0, 0x10
 ;   vst %v0, 0xc0(%r15)
-;   vpdi %v0, %v23, %v23, 4
-;   verllg %v2, %v0, 0x20
-;   verllf %v4, %v2, 0x10
-;   verllh %v6, %v4, 8
-;   vst %v6, 0xd0(%r15)
-;   bras %r1, 0x11a
+;   vpdi %v1, %v23, %v23, 4
+;   verllg %v3, %v1, 0x20
+;   verllf %v5, %v3, 0x10
+;   verllh %v7, %v5, 8
+;   vst %v7, 0xd0(%r15)
+;   bras %r1, 0x11e
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   vpdi %v21, %v24, %v24, 4
-;   verllg %v24, %v21, 0x20
-;   ld %f8, 0xe0(%r15)
-;   ld %f9, 0xe8(%r15)
-;   ld %f10, 0xf0(%r15)
-;   ld %f11, 0xf8(%r15)
-;   ld %f12, 0x100(%r15)
-;   ld %f13, 0x108(%r15)
-;   ld %f14, 0x110(%r15)
-;   ld %f15, 0x118(%r15)
-;   lmg %r14, %r15, 0x190(%r15)
+;   lg %r5, 0(%r1)
+;   basr %r14, %r5
+;   vpdi %v22, %v24, %v24, 4
+;   verllg %v24, %v22, 0x20
+;   ld %f8, 0xa0(%r15)
+;   ld %f9, 0xa8(%r15)
+;   ld %f10, 0xb0(%r15)
+;   ld %f11, 0xb8(%r15)
+;   ld %f12, 0xc0(%r15)
+;   ld %f13, 0xc8(%r15)
+;   ld %f14, 0xd0(%r15)
+;   ld %f15, 0xd8(%r15)
+;   lmg %r6, %r15, 0x110(%r15)
 ;   br %r14
 
-function %caller_le_to_be(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
+function %caller_le_to_be(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 tail {
     fn0 = %callee_be(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4
 
 block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16x8, v7: i8x16, v8: i64x2, v9: i32x4, v10: i16x8, v11: i8x16):
@@ -202,7 +204,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 }
 
 ; VCode:
-;   stmg %r14, %r15, 112(%r15)
+;   stmg %r14, %r15, 336(%r15)
 ;   aghi %r15, -288
 ;   std %f8, 224(%r15)
 ;   std %f9, 232(%r15)
@@ -251,8 +253,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   verllf %v4, %v2, 16
 ;   verllh %v6, %v4, 8
 ;   vst %v6, 208(%r15)
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r6, 0(%r1)
+;   basr %r14, %r6
 ;   vpdi %v21, %v24, %v24, 4
 ;   verllg %v24, %v21, 32
 ;   ld %f8, 224(%r15)
@@ -263,12 +265,13 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   ld %f13, 264(%r15)
 ;   ld %f14, 272(%r15)
 ;   ld %f15, 280(%r15)
-;   lmg %r14, %r15, 400(%r15)
+;   aghi %r15, 512
+;   lmg %r14, %r14, 112(%r15)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stmg %r14, %r15, 0x70(%r15)
+;   stmg %r14, %r15, 0x150(%r15)
 ;   aghi %r15, -0x120
 ;   std %f8, 0xe0(%r15)
 ;   std %f9, 0xe8(%r15)
@@ -322,8 +325,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   lg %r6, 0(%r1)
+;   basr %r14, %r6
 ;   vpdi %v21, %v24, %v24, 4
 ;   verllg %v24, %v21, 0x20
 ;   ld %f8, 0xe0(%r15)
@@ -334,11 +337,12 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   ld %f13, 0x108(%r15)
 ;   ld %f14, 0x110(%r15)
 ;   ld %f15, 0x118(%r15)
-;   lmg %r14, %r15, 0x190(%r15)
+;   aghi %r15, 0x200
+;   lmg %r14, %r14, 0x70(%r15)
 ;   br %r14
 
-function %caller_le_to_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
-    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v
+function %caller_le_to_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 tail {
+    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 tail
 
 block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16x8, v7: i8x16, v8: i64x2, v9: i32x4, v10: i16x8, v11: i8x16):
     v12 = call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
@@ -346,42 +350,46 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 }
 
 ; VCode:
-;   stmg %r14, %r15, 112(%r15)
-;   aghi %r15, -224
+;   stmg %r14, %r15, 336(%r15)
+;   aghi %r15, -160
 ; block0:
-;   vl %v17, 384(%r15)
-;   vl %v19, 400(%r15)
-;   vl %v21, 416(%r15)
-;   vl %v23, 432(%r15)
+;   vl %v17, 320(%r15)
+;   vl %v19, 336(%r15)
+;   vl %v21, 352(%r15)
+;   vl %v23, 368(%r15)
+;   aghi %r15, -224
 ;   vst %v17, 160(%r15)
 ;   vst %v19, 176(%r15)
 ;   vst %v21, 192(%r15)
 ;   vst %v23, 208(%r15)
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   lmg %r14, %r15, 336(%r15)
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r7, 0(%r1)
+;   basr %r14, %r7 ; callee_pop_size 224
+;   aghi %r15, 384
+;   lmg %r14, %r14, 112(%r15)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stmg %r14, %r15, 0x70(%r15)
-;   aghi %r15, -0xe0
+;   stmg %r14, %r15, 0x150(%r15)
+;   aghi %r15, -0xa0
 ; block1: ; offset 0xa
-;   vl %v17, 0x180(%r15)
-;   vl %v19, 0x190(%r15)
-;   vl %v21, 0x1a0(%r15)
-;   vl %v23, 0x1b0(%r15)
+;   vl %v17, 0x140(%r15)
+;   vl %v19, 0x150(%r15)
+;   vl %v21, 0x160(%r15)
+;   vl %v23, 0x170(%r15)
+;   aghi %r15, -0xe0
 ;   vst %v17, 0xa0(%r15)
 ;   vst %v19, 0xb0(%r15)
 ;   vst %v21, 0xc0(%r15)
 ;   vst %v23, 0xd0(%r15)
-;   bras %r1, 0x46
+;   bras %r1, 0x4a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   lmg %r14, %r15, 0x150(%r15)
+;   lg %r7, 0(%r1)
+;   basr %r14, %r7
+;   aghi %r15, 0x180
+;   lmg %r14, %r14, 0x70(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
@@ -983,7 +983,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkh %v24, %v7, %v19
 ;   br %r14
 
-function %iadd_pairwise_i32x4_le(i32x4, i32x4) -> i32x4 wasmtime_system_v {
+function %iadd_pairwise_i32x4_le(i32x4, i32x4) -> i32x4 tail {
 block0(v0: i32x4, v1: i32x4):
   v2 = iadd_pairwise.i32x4 v0, v1
   return v2
@@ -1009,7 +1009,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vpkg %v24, %v19, %v7
 ;   br %r14
 
-function %iadd_pairwise_i16x8_le(i16x8, i16x8) -> i16x8 wasmtime_system_v {
+function %iadd_pairwise_i16x8_le(i16x8, i16x8) -> i16x8 tail {
 block0(v0: i16x8, v1: i16x8):
   v2 = iadd_pairwise.i16x8 v0, v1
   return v2
@@ -1035,7 +1035,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vpkf %v24, %v19, %v7
 ;   br %r14
 
-function %iadd_pairwise_i8x16_le(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %iadd_pairwise_i8x16_le(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
   v2 = iadd_pairwise.i8x16 v0, v1
   return v2

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
@@ -39,7 +39,7 @@ block0(v0: i64x2):
 ;   verllg %v24, %v4, 0x20
 ;   br %r14
 
-function %bitcast_i64x2_i32x4(i64x2) -> i32x4 wasmtime_system_v {
+function %bitcast_i64x2_i32x4(i64x2) -> i32x4 tail {
 block0(v0: i64x2):
   v1 = bitcast.i32x4 big v0
   return v1
@@ -59,7 +59,7 @@ block0(v0: i64x2):
 ;   verllg %v24, %v4, 0x20
 ;   br %r14
 
-function %bitcast_i64x2_i32x4(i64x2) -> i32x4 wasmtime_system_v {
+function %bitcast_i64x2_i32x4(i64x2) -> i32x4 tail {
 block0(v0: i64x2):
   v1 = bitcast.i32x4 little v0
   return v1
@@ -101,7 +101,7 @@ block0(v0: i64x2):
 ; block0: ; offset 0x0
 ;   br %r14
 
-function %bitcast_i64x2_f64x2(i64x2) -> f64x2 wasmtime_system_v {
+function %bitcast_i64x2_f64x2(i64x2) -> f64x2 tail {
 block0(v0: i64x2):
   v1 = bitcast.f64x2 big v0
   return v1

--- a/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
@@ -1,7 +1,7 @@
 test compile precise-output
 target s390x
 
-function %vconst_i64x2_zero() -> i64x2 wasmtime_system_v {
+function %vconst_i64x2_zero() -> i64x2 tail {
 block0:
   v1 = vconst.i64x2 [0 0]
   return v1
@@ -17,7 +17,7 @@ block0:
 ;   vzero %v24
 ;   br %r14
 
-function %vconst_i64x2_splat1() -> i64x2 wasmtime_system_v {
+function %vconst_i64x2_splat1() -> i64x2 tail {
 block0:
   v1 = vconst.i64x2 [32767 32767]
   return v1
@@ -33,7 +33,7 @@ block0:
 ;   vrepig %v24, 0x7fff
 ;   br %r14
 
-function %vconst_i64x2_splat2() -> i64x2 wasmtime_system_v {
+function %vconst_i64x2_splat2() -> i64x2 tail {
 block0:
   v1 = vconst.i64x2 [-32768 -32768]
   return v1
@@ -49,7 +49,7 @@ block0:
 ;   vrepig %v24, -0x8000
 ;   br %r14
 
-function %vconst_i64x2_splat3() -> i64x2 wasmtime_system_v {
+function %vconst_i64x2_splat3() -> i64x2 tail {
 block0:
   v1 = vconst.i64x2 [32768 32768]
   return v1
@@ -71,7 +71,7 @@ block0:
 ;   ler %f0, %f5
 ;   br %r14
 
-function %vconst_i64x2_splat4() -> i64x2 wasmtime_system_v {
+function %vconst_i64x2_splat4() -> i64x2 tail {
 block0:
   v1 = vconst.i64x2 [-32769 -32769]
   return v1
@@ -93,7 +93,7 @@ block0:
 ;   ler %f0, %f5
 ;   br %r14
 
-function %vconst_i64x2_mixed() -> i64x2 wasmtime_system_v {
+function %vconst_i64x2_mixed() -> i64x2 tail {
 block0:
   v1 = vconst.i64x2 [1 2]
   return v1
@@ -118,7 +118,7 @@ block0:
 ;   vl %v24, 0(%r1)
 ;   br %r14
 
-function %vconst_i32x4_zero() -> i32x4 wasmtime_system_v {
+function %vconst_i32x4_zero() -> i32x4 tail {
 block0:
   v1 = vconst.i32x4 [0 0 0 0]
   return v1
@@ -134,7 +134,7 @@ block0:
 ;   vzero %v24
 ;   br %r14
 
-function %vconst_i32x4_splat1() -> i32x4 wasmtime_system_v {
+function %vconst_i32x4_splat1() -> i32x4 tail {
 block0:
   v1 = vconst.i32x4 [32767 32767 32767 32767]
   return v1
@@ -150,7 +150,7 @@ block0:
 ;   vrepif %v24, 0x7fff
 ;   br %r14
 
-function %vconst_i32x4_splat2() -> i32x4 wasmtime_system_v {
+function %vconst_i32x4_splat2() -> i32x4 tail {
 block0:
   v1 = vconst.i32x4 [-32768 -32768 -32768 -32768]
   return v1
@@ -166,7 +166,7 @@ block0:
 ;   vrepif %v24, -0x8000
 ;   br %r14
 
-function %vconst_i32x4_splat3() -> i32x4 wasmtime_system_v {
+function %vconst_i32x4_splat3() -> i32x4 tail {
 block0:
   v1 = vconst.i32x4 [32768 32768 32768 32768]
   return v1
@@ -186,7 +186,7 @@ block0:
 ;   ldr %f0, %f5
 ;   br %r14
 
-function %vconst_i32x4_splat4() -> i32x4 wasmtime_system_v {
+function %vconst_i32x4_splat4() -> i32x4 tail {
 block0:
   v1 = vconst.i32x4 [-32769 -32769 -32769 -32769]
   return v1
@@ -206,7 +206,7 @@ block0:
 ;   ldr %f0, %f5
 ;   br %r14
 
-function %vconst_i32x4_splat_i64() -> i32x4 wasmtime_system_v {
+function %vconst_i32x4_splat_i64() -> i32x4 tail {
 block0:
   v1 = vconst.i32x4 [1 2 1 2]
   return v1
@@ -227,7 +227,7 @@ block0:
 ;   vlrepg %v24, 0(%r1)
 ;   br %r14
 
-function %vconst_i32x4_mixed() -> i32x4 wasmtime_system_v {
+function %vconst_i32x4_mixed() -> i32x4 tail {
 block0:
   v1 = vconst.i32x4 [1 2 3 4]
   return v1
@@ -252,7 +252,7 @@ block0:
 ;   vl %v24, 0(%r1)
 ;   br %r14
 
-function %vconst_i16x8_zero() -> i16x8 wasmtime_system_v {
+function %vconst_i16x8_zero() -> i16x8 tail {
 block0:
   v1 = vconst.i16x8 [0 0 0 0 0 0 0 0]
   return v1
@@ -268,7 +268,7 @@ block0:
 ;   vzero %v24
 ;   br %r14
 
-function %vconst_i16x8_splat1() -> i16x8 wasmtime_system_v {
+function %vconst_i16x8_splat1() -> i16x8 tail {
 block0:
   v1 = vconst.i16x8 [32767 32767 32767 32767 32767 32767 32767 32767]
   return v1
@@ -284,7 +284,7 @@ block0:
 ;   vrepih %v24, 0x7fff
 ;   br %r14
 
-function %vconst_i16x8_splat2() -> i16x8 wasmtime_system_v {
+function %vconst_i16x8_splat2() -> i16x8 tail {
 block0:
   v1 = vconst.i16x8 [-32768 -32768 -32768 -32768 -32768 -32768 -32768 -32768]
   return v1
@@ -300,7 +300,7 @@ block0:
 ;   vrepih %v24, -0x8000
 ;   br %r14
 
-function %vconst_i16x8_mixed() -> i16x8 wasmtime_system_v {
+function %vconst_i16x8_mixed() -> i16x8 tail {
 block0:
   v1 = vconst.i16x8 [1 2 3 4 5 6 7 8]
   return v1
@@ -325,7 +325,7 @@ block0:
 ;   vl %v24, 0(%r1)
 ;   br %r14
 
-function %vconst_i8x16_zero() -> i8x16 wasmtime_system_v {
+function %vconst_i8x16_zero() -> i8x16 tail {
 block0:
   v1 = vconst.i8x16 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
   return v1
@@ -341,7 +341,7 @@ block0:
 ;   vzero %v24
 ;   br %r14
 
-function %vconst_i8x16_splat1() -> i8x16 wasmtime_system_v {
+function %vconst_i8x16_splat1() -> i8x16 tail {
 block0:
   v1 = vconst.i8x16 [127 127 127 127 127 127 127 127 127 127 127 127 127 127 127 127]
   return v1
@@ -357,7 +357,7 @@ block0:
 ;   vrepib %v24, 0x7f
 ;   br %r14
 
-function %vconst_i8x16_splat2() -> i8x16 wasmtime_system_v {
+function %vconst_i8x16_splat2() -> i8x16 tail {
 block0:
   v1 = vconst.i8x16 [-128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128]
   return v1
@@ -373,7 +373,7 @@ block0:
 ;   vrepib %v24, 0x80
 ;   br %r14
 
-function %vconst_i8x16_mixed() -> i8x16 wasmtime_system_v {
+function %vconst_i8x16_mixed() -> i8x16 tail {
 block0:
   v1 = vconst.i8x16 [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]
   return v1

--- a/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
@@ -1,7 +1,7 @@
 test compile precise-output
 target s390x
 
-function %snarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 wasmtime_system_v {
+function %snarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 tail {
 block0(v0: i64x2, v1: i64x2):
   v2 = snarrow.i64x2 v0, v1
   return v2
@@ -17,7 +17,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vpksg %v24, %v25, %v24
 ;   br %r14
 
-function %snarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 wasmtime_system_v {
+function %snarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 tail {
 block0(v0: i32x4, v1: i32x4):
   v2 = snarrow.i32x4 v0, v1
   return v2
@@ -33,7 +33,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vpksf %v24, %v25, %v24
 ;   br %r14
 
-function %snarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 wasmtime_system_v {
+function %snarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 tail {
 block0(v0: i16x8, v1: i16x8):
   v2 = snarrow.i16x8 v0, v1
   return v2
@@ -49,7 +49,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vpksh %v24, %v25, %v24
 ;   br %r14
 
-function %unarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 wasmtime_system_v {
+function %unarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 tail {
 block0(v0: i64x2, v1: i64x2):
   v2 = unarrow.i64x2 v0, v1
   return v2
@@ -71,7 +71,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vpklsg %v24, %v7, %v5
 ;   br %r14
 
-function %unarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 wasmtime_system_v {
+function %unarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 tail {
 block0(v0: i32x4, v1: i32x4):
   v2 = unarrow.i32x4 v0, v1
   return v2
@@ -93,7 +93,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vpklsf %v24, %v7, %v5
 ;   br %r14
 
-function %unarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 wasmtime_system_v {
+function %unarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 tail {
 block0(v0: i16x8, v1: i16x8):
   v2 = unarrow.i16x8 v0, v1
   return v2
@@ -115,7 +115,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vpklsh %v24, %v7, %v5
 ;   br %r14
 
-function %uunarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 wasmtime_system_v {
+function %uunarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 tail {
 block0(v0: i64x2, v1: i64x2):
   v2 = uunarrow.i64x2 v0, v1
   return v2
@@ -131,7 +131,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vpklsg %v24, %v25, %v24
 ;   br %r14
 
-function %uunarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 wasmtime_system_v {
+function %uunarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 tail {
 block0(v0: i32x4, v1: i32x4):
   v2 = uunarrow.i32x4 v0, v1
   return v2
@@ -147,7 +147,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vpklsf %v24, %v25, %v24
 ;   br %r14
 
-function %uunarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 wasmtime_system_v {
+function %uunarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 tail {
 block0(v0: i16x8, v1: i16x8):
   v2 = uunarrow.i16x8 v0, v1
   return v2
@@ -163,7 +163,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vpklsh %v24, %v25, %v24
 ;   br %r14
 
-function %swiden_low_i32x4_i64x2(i32x4) -> i64x2 wasmtime_system_v {
+function %swiden_low_i32x4_i64x2(i32x4) -> i64x2 tail {
 block0(v0: i32x4):
   v1 = swiden_low.i32x4 v0
   return v1
@@ -179,7 +179,7 @@ block0(v0: i32x4):
 ;   vuplf %v24, %v24
 ;   br %r14
 
-function %swiden_low_i16x8_i32x4(i16x8) -> i32x4 wasmtime_system_v {
+function %swiden_low_i16x8_i32x4(i16x8) -> i32x4 tail {
 block0(v0: i16x8):
   v1 = swiden_low.i16x8 v0
   return v1
@@ -195,7 +195,7 @@ block0(v0: i16x8):
 ;   vuplhw %v24, %v24
 ;   br %r14
 
-function %swiden_low_i8x16_i16x8(i8x16) -> i16x8 wasmtime_system_v {
+function %swiden_low_i8x16_i16x8(i8x16) -> i16x8 tail {
 block0(v0: i8x16):
   v1 = swiden_low.i8x16 v0
   return v1
@@ -211,7 +211,7 @@ block0(v0: i8x16):
 ;   vuplb %v24, %v24
 ;   br %r14
 
-function %swiden_high_i32x4_i64x2(i32x4) -> i64x2 wasmtime_system_v {
+function %swiden_high_i32x4_i64x2(i32x4) -> i64x2 tail {
 block0(v0: i32x4):
   v1 = swiden_high.i32x4 v0
   return v1
@@ -227,7 +227,7 @@ block0(v0: i32x4):
 ;   vuphf %v24, %v24
 ;   br %r14
 
-function %swiden_high_i16x8_i32x4(i16x8) -> i32x4 wasmtime_system_v {
+function %swiden_high_i16x8_i32x4(i16x8) -> i32x4 tail {
 block0(v0: i16x8):
   v1 = swiden_high.i16x8 v0
   return v1
@@ -243,7 +243,7 @@ block0(v0: i16x8):
 ;   vuphh %v24, %v24
 ;   br %r14
 
-function %swiden_high_i8x16_i16x8(i8x16) -> i16x8 wasmtime_system_v {
+function %swiden_high_i8x16_i16x8(i8x16) -> i16x8 tail {
 block0(v0: i8x16):
   v1 = swiden_high.i8x16 v0
   return v1
@@ -259,7 +259,7 @@ block0(v0: i8x16):
 ;   vuphb %v24, %v24
 ;   br %r14
 
-function %uwiden_low_i32x4_i64x2(i32x4) -> i64x2 wasmtime_system_v {
+function %uwiden_low_i32x4_i64x2(i32x4) -> i64x2 tail {
 block0(v0: i32x4):
   v1 = uwiden_low.i32x4 v0
   return v1
@@ -275,7 +275,7 @@ block0(v0: i32x4):
 ;   vupllf %v24, %v24
 ;   br %r14
 
-function %uwiden_low_i16x8_i32x4(i16x8) -> i32x4 wasmtime_system_v {
+function %uwiden_low_i16x8_i32x4(i16x8) -> i32x4 tail {
 block0(v0: i16x8):
   v1 = uwiden_low.i16x8 v0
   return v1
@@ -291,7 +291,7 @@ block0(v0: i16x8):
 ;   vupllh %v24, %v24
 ;   br %r14
 
-function %uwiden_low_i8x16_i16x8(i8x16) -> i16x8 wasmtime_system_v {
+function %uwiden_low_i8x16_i16x8(i8x16) -> i16x8 tail {
 block0(v0: i8x16):
   v1 = uwiden_low.i8x16 v0
   return v1
@@ -307,7 +307,7 @@ block0(v0: i8x16):
 ;   vupllb %v24, %v24
 ;   br %r14
 
-function %uwiden_high_i32x4_i64x2(i32x4) -> i64x2 wasmtime_system_v {
+function %uwiden_high_i32x4_i64x2(i32x4) -> i64x2 tail {
 block0(v0: i32x4):
   v1 = uwiden_high.i32x4 v0
   return v1
@@ -323,7 +323,7 @@ block0(v0: i32x4):
 ;   vuplhf %v24, %v24
 ;   br %r14
 
-function %uwiden_high_i16x8_i32x4(i16x8) -> i32x4 wasmtime_system_v {
+function %uwiden_high_i16x8_i32x4(i16x8) -> i32x4 tail {
 block0(v0: i16x8):
   v1 = uwiden_high.i16x8 v0
   return v1
@@ -339,7 +339,7 @@ block0(v0: i16x8):
 ;   vuplhh %v24, %v24
 ;   br %r14
 
-function %uwiden_high_i8x16_i16x8(i8x16) -> i16x8 wasmtime_system_v {
+function %uwiden_high_i8x16_i16x8(i8x16) -> i16x8 tail {
 block0(v0: i8x16):
   v1 = uwiden_high.i8x16 v0
   return v1

--- a/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
@@ -55,7 +55,7 @@ block0:
 ;   vl %v24, 0(%r1)
 ;   br %r14
 
-function %vconst_f32x4_mixed_le() -> f32x4 wasmtime_system_v {
+function %vconst_f32x4_mixed_le() -> f32x4 tail {
 block0:
   v1 = vconst.f32x4 [0x1.0 0x2.0 0x3.0 0x4.0]
   return v1
@@ -101,7 +101,7 @@ block0:
 ;   vl %v24, 0(%r1)
 ;   br %r14
 
-function %vconst_f64x2_mixed_le() -> f64x2 wasmtime_system_v {
+function %vconst_f64x2_mixed_le() -> f64x2 tail {
 block0:
   v1 = vconst.f64x2 [0x1.0 0x2.0]
   return v1
@@ -503,7 +503,7 @@ block0(v0: f32x4):
 ;   vldeb %v24, %v2
 ;   br %r14
 
-function %fvpromote_low_f32x4_le(f32x4) -> f64x2 wasmtime_system_v {
+function %fvpromote_low_f32x4_le(f32x4) -> f64x2 tail {
 block0(v0: f32x4):
   v1 = fvpromote_low v0
   return v1
@@ -543,7 +543,7 @@ block0(v0: f64x2):
 ;   vpkg %v24, %v4, %v6
 ;   br %r14
 
-function %fvdemote_f64x2_le(f64x2) -> f32x4 wasmtime_system_v {
+function %fvdemote_f64x2_le(f64x2) -> f32x4 tail {
 block0(v0: f64x2):
   v1 = fvdemote v0
   return v1
@@ -890,7 +890,7 @@ block0(v0: i32x4):
 ;   vcdgb %v24, %v3, 0, 4
 ;   br %r14
 
-function %fcvt_low_from_sint_i32x4_f64x2_le(i32x4) -> f64x2 wasmtime_system_v {
+function %fcvt_low_from_sint_i32x4_f64x2_le(i32x4) -> f64x2 tail {
 block0(v0: i32x4):
   v1 = swiden_low v0
   v2 = fcvt_from_sint.f64x2 v1

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane-arch13.clif
@@ -1,7 +1,7 @@
 test compile precise-output
 target s390x arch13
 
-function %insertlane_i64x2_mem_0(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_0(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 v1
     v3 = insertlane.i64x2 v0, v2, 0
@@ -18,7 +18,7 @@ block0(v0: i64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i64x2_mem_1(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_1(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 v1
     v3 = insertlane.i64x2 v0, v2, 1
@@ -35,7 +35,7 @@ block0(v0: i64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i64x2_mem_little_0(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_little_0(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 little v1
     v3 = insertlane.i64x2 v0, v2, 0
@@ -54,7 +54,7 @@ block0(v0: i64x2, v1: i64):
 ;   lr %r0, %r2
 ;   br %r14
 
-function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 little v1
     v3 = insertlane.i64x2 v0, v2, 1
@@ -73,7 +73,7 @@ block0(v0: i64x2, v1: i64):
 ;   .byte 0x08, 0x02
 ;   br %r14
 
-function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 v1
     v3 = insertlane.i32x4 v0, v2, 0
@@ -90,7 +90,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -107,7 +107,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i32x4_mem_little_0(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_little_0(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 little v1
     v3 = insertlane.i32x4 v0, v2, 0
@@ -126,7 +126,7 @@ block0(v0: i32x4, v1: i64):
 ;   ler %f0, %f3
 ;   br %r14
 
-function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 little v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -145,7 +145,7 @@ block0(v0: i32x4, v1: i64):
 ;   .byte 0x08, 0x03
 ;   br %r14
 
-function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 v1
     v3 = insertlane.i16x8 v0, v2, 0
@@ -162,7 +162,7 @@ block0(v0: i16x8, v1: i64):
 ;   vleh %v24, 0(%r2), 7 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i16x8_mem_7(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_7(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 v1
     v3 = insertlane.i16x8 v0, v2, 7
@@ -179,7 +179,7 @@ block0(v0: i16x8, v1: i64):
 ;   vleh %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i16x8_mem_little_0(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_little_0(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 little v1
     v3 = insertlane.i16x8 v0, v2, 0
@@ -197,7 +197,7 @@ block0(v0: i16x8, v1: i64):
 ;   lpdr %f0, %f0
 ;   le %f0, 0x7fe(%r1)
 
-function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 little v1
     v3 = insertlane.i16x8 v0, v2, 7
@@ -216,7 +216,7 @@ block0(v0: i16x8, v1: i64):
 ;   .byte 0x08, 0x01
 ;   br %r14
 
-function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 v1
     v3 = insertlane.i8x16 v0, v2, 0
@@ -233,7 +233,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i8x16_mem_15(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_15(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 v1
     v3 = insertlane.i8x16 v0, v2, 15
@@ -250,7 +250,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i8x16_mem_little_0(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_little_0(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 little v1
     v3 = insertlane.i8x16 v0, v2, 0
@@ -267,7 +267,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i8x16_mem_little_15(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_little_15(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 little v1
     v3 = insertlane.i8x16 v0, v2, 15
@@ -284,7 +284,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f64x2_mem_0(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_0(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 v1
     v3 = insertlane.f64x2 v0, v2, 0
@@ -301,7 +301,7 @@ block0(v0: f64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f64x2_mem_1(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_1(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 v1
     v3 = insertlane.f64x2 v0, v2, 1
@@ -318,7 +318,7 @@ block0(v0: f64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f64x2_mem_little_0(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_little_0(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 little v1
     v3 = insertlane.f64x2 v0, v2, 0
@@ -337,7 +337,7 @@ block0(v0: f64x2, v1: i64):
 ;   lr %r0, %r2
 ;   br %r14
 
-function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 little v1
     v3 = insertlane.f64x2 v0, v2, 1
@@ -356,7 +356,7 @@ block0(v0: f64x2, v1: i64):
 ;   .byte 0x08, 0x02
 ;   br %r14
 
-function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 tail {
 block0(v0: f32x4, v1: i64):
     v2 = load.f32 v1
     v3 = insertlane.f32x4 v0, v2, 0
@@ -373,7 +373,7 @@ block0(v0: f32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -390,7 +390,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f32x4_mem_little_0(f32x4, i64) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_mem_little_0(f32x4, i64) -> f32x4 tail {
 block0(v0: f32x4, v1: i64):
     v2 = load.f32 little v1
     v3 = insertlane.f32x4 v0, v2, 0
@@ -409,7 +409,7 @@ block0(v0: f32x4, v1: i64):
 ;   ler %f0, %f3
 ;   br %r14
 
-function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 little v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -428,7 +428,7 @@ block0(v0: i32x4, v1: i64):
 ;   .byte 0x08, 0x03
 ;   br %r14
 
-function %extractlane_i64x2_mem_0(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_0(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 0
     store v2, v1
@@ -445,7 +445,7 @@ block0(v0: i64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i64x2_mem_1(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_1(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 1
     store v2, v1
@@ -462,7 +462,7 @@ block0(v0: i64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i64x2_mem_little_0(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_little_0(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 0
     store little v2, v1
@@ -481,7 +481,7 @@ block0(v0: i64x2, v1: i64):
 ;   lr %r0, %r10
 ;   br %r14
 
-function %extractlane_i64x2_mem_little_1(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_little_1(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 1
     store little v2, v1
@@ -500,7 +500,7 @@ block0(v0: i64x2, v1: i64):
 ;   .byte 0x08, 0x0a
 ;   br %r14
 
-function %extractlane_i32x4_mem_0(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_0(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 0
     store v2, v1
@@ -517,7 +517,7 @@ block0(v0: i32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i32x4_mem_3(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_3(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 3
     store v2, v1
@@ -534,7 +534,7 @@ block0(v0: i32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i32x4_mem_little_0(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_little_0(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 0
     store little v2, v1
@@ -553,7 +553,7 @@ block0(v0: i32x4, v1: i64):
 ;   ler %f0, %f11
 ;   br %r14
 
-function %extractlane_i32x4_mem_little_3(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_little_3(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 3
     store little v2, v1
@@ -572,7 +572,7 @@ block0(v0: i32x4, v1: i64):
 ;   .byte 0x08, 0x0b
 ;   br %r14
 
-function %extractlane_i16x8_mem_0(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_0(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 0
     store v2, v1
@@ -589,7 +589,7 @@ block0(v0: i16x8, v1: i64):
 ;   vsteh %v24, 0(%r2), 7 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i16x8_mem_7(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_7(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 7
     store v2, v1
@@ -606,7 +606,7 @@ block0(v0: i16x8, v1: i64):
 ;   vsteh %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i16x8_mem_little_0(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_little_0(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 0
     store little v2, v1
@@ -624,7 +624,7 @@ block0(v0: i16x8, v1: i64):
 ;   lpdr %f0, %f0
 ;   le %f0, 0x7fe(%r9)
 
-function %extractlane_i16x8_mem_little_7(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_little_7(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 7
     store little v2, v1
@@ -643,7 +643,7 @@ block0(v0: i16x8, v1: i64):
 ;   .byte 0x08, 0x09
 ;   br %r14
 
-function %extractlane_i8x16_mem_0(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_0(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 0
     store v2, v1
@@ -660,7 +660,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i8x16_mem_15(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_15(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 15
     store v2, v1
@@ -677,7 +677,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i8x16_mem_little_0(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_little_0(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 0
     store little v2, v1
@@ -694,7 +694,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i8x16_mem_little_15(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_little_15(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 15
     store little v2, v1
@@ -711,7 +711,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f64x2_mem_0(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_0(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 0
     store v2, v1
@@ -728,7 +728,7 @@ block0(v0: f64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f64x2_mem_1(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_1(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 1
     store v2, v1
@@ -745,7 +745,7 @@ block0(v0: f64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f64x2_mem_little_0(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_little_0(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 0
     store little v2, v1
@@ -764,7 +764,7 @@ block0(v0: f64x2, v1: i64):
 ;   lr %r0, %r10
 ;   br %r14
 
-function %extractlane_f64x2_mem_little_1(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_little_1(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 1
     store little v2, v1
@@ -783,7 +783,7 @@ block0(v0: f64x2, v1: i64):
 ;   .byte 0x08, 0x0a
 ;   br %r14
 
-function %extractlane_f32x4_mem_0(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_0(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 0
     store v2, v1
@@ -800,7 +800,7 @@ block0(v0: f32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f32x4_mem_3(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_3(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 3
     store v2, v1
@@ -817,7 +817,7 @@ block0(v0: f32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f32x4_mem_little_0(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_little_0(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 0
     store little v2, v1
@@ -836,7 +836,7 @@ block0(v0: f32x4, v1: i64):
 ;   ler %f0, %f11
 ;   br %r14
 
-function %extractlane_f32x4_mem_little_3(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_little_3(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 3
     store little v2, v1
@@ -855,7 +855,7 @@ block0(v0: f32x4, v1: i64):
 ;   .byte 0x08, 0x0b
 ;   br %r14
 
-function %splat_i64x2_mem(i64) -> i64x2 wasmtime_system_v {
+function %splat_i64x2_mem(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 v0
     v2 = splat.i64x2 v1
@@ -872,7 +872,7 @@ block0(v0: i64):
 ;   vlrepg %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i64x2_mem_little(i64) -> i64x2 wasmtime_system_v {
+function %splat_i64x2_mem_little(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 little v0
     v2 = splat.i64x2 v1
@@ -891,7 +891,7 @@ block0(v0: i64):
 ;   ler %f0, %f5
 ;   br %r14
 
-function %splat_i32x4_mem(i64) -> i32x4 wasmtime_system_v {
+function %splat_i32x4_mem(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 v0
     v2 = splat.i32x4 v1
@@ -908,7 +908,7 @@ block0(v0: i64):
 ;   vlrepf %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i32x4_mem_little(i64) -> i32x4 wasmtime_system_v {
+function %splat_i32x4_mem_little(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 little v0
     v2 = splat.i32x4 v1
@@ -927,7 +927,7 @@ block0(v0: i64):
 ;   ldr %f0, %f5
 ;   br %r14
 
-function %splat_i16x8_mem(i64) -> i16x8 wasmtime_system_v {
+function %splat_i16x8_mem(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 v0
     v2 = splat.i16x8 v1
@@ -944,7 +944,7 @@ block0(v0: i64):
 ;   vlreph %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i16x8_mem_little(i64) -> i16x8 wasmtime_system_v {
+function %splat_i16x8_mem_little(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 little v0
     v2 = splat.i16x8 v1
@@ -963,7 +963,7 @@ block0(v0: i64):
 ;   lr %r0, %r5
 ;   br %r14
 
-function %splat_i8x16_mem(i64) -> i8x16 wasmtime_system_v {
+function %splat_i8x16_mem(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 v0
     v2 = splat.i8x16 v1
@@ -980,7 +980,7 @@ block0(v0: i64):
 ;   vlrepb %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i8x16_mem_little(i64) -> i8x16 wasmtime_system_v {
+function %splat_i8x16_mem_little(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 little v0
     v2 = splat.i8x16 v1
@@ -997,7 +997,7 @@ block0(v0: i64):
 ;   vlrepb %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_f64x2_mem(i64) -> f64x2 wasmtime_system_v {
+function %splat_f64x2_mem(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 v0
     v2 = splat.f64x2 v1
@@ -1014,7 +1014,7 @@ block0(v0: i64):
 ;   vlrepg %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_f64x2_mem_little(i64) -> f64x2 wasmtime_system_v {
+function %splat_f64x2_mem_little(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 little v0
     v2 = splat.f64x2 v1
@@ -1033,7 +1033,7 @@ block0(v0: i64):
 ;   ler %f0, %f5
 ;   br %r14
 
-function %splat_f32x4_mem(i64) -> f32x4 wasmtime_system_v {
+function %splat_f32x4_mem(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 v0
     v2 = splat.f32x4 v1
@@ -1050,7 +1050,7 @@ block0(v0: i64):
 ;   vlrepf %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_f32x4_mem_little(i64) -> f32x4 wasmtime_system_v {
+function %splat_f32x4_mem_little(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 little v0
     v2 = splat.f32x4 v1
@@ -1069,7 +1069,7 @@ block0(v0: i64):
 ;   ldr %f0, %f5
 ;   br %r14
 
-function %scalar_to_vector_i64x2_mem(i64) -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2_mem(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 v0
     v2 = scalar_to_vector.i64x2 v1
@@ -1088,7 +1088,7 @@ block0(v0: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i64x2_mem_little(i64) -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2_mem_little(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 little v0
     v2 = scalar_to_vector.i64x2 v1
@@ -1109,7 +1109,7 @@ block0(v0: i64):
 ;   lr %r0, %r2
 ;   br %r14
 
-function %scalar_to_vector_i32x4_mem(i64) -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4_mem(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 v0
     v2 = scalar_to_vector.i32x4 v1
@@ -1128,7 +1128,7 @@ block0(v0: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i32x4_mem_little(i64) -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4_mem_little(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 little v0
     v2 = scalar_to_vector.i32x4 v1
@@ -1149,7 +1149,7 @@ block0(v0: i64):
 ;   ler %f0, %f3
 ;   br %r14
 
-function %scalar_to_vector_i16x8_mem(i64) -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8_mem(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 v0
     v2 = scalar_to_vector.i16x8 v1
@@ -1168,7 +1168,7 @@ block0(v0: i64):
 ;   vleh %v24, 0(%r2), 7 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i16x8_mem_little(i64) -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8_mem_little(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 little v0
     v2 = scalar_to_vector.i16x8 v1
@@ -1188,7 +1188,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   le %f0, 0x7fe(%r1)
 
-function %scalar_to_vector_i8x16_mem(i64) -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16_mem(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 v0
     v2 = scalar_to_vector.i8x16 v1
@@ -1207,7 +1207,7 @@ block0(v0: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i8x16_mem_little(i64) -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16_mem_little(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 little v0
     v2 = scalar_to_vector.i8x16 v1
@@ -1226,7 +1226,7 @@ block0(v0: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_f64x2_mem(i64) -> f64x2 wasmtime_system_v {
+function %scalar_to_vector_f64x2_mem(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 v0
     v2 = scalar_to_vector.f64x2 v1
@@ -1245,7 +1245,7 @@ block0(v0: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_f64x2_mem_little(i64) -> f64x2 wasmtime_system_v {
+function %scalar_to_vector_f64x2_mem_little(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 little v0
     v2 = scalar_to_vector.f64x2 v1
@@ -1266,7 +1266,7 @@ block0(v0: i64):
 ;   lr %r0, %r2
 ;   br %r14
 
-function %scalar_to_vector_f32x4_mem(i64) -> f32x4 wasmtime_system_v {
+function %scalar_to_vector_f32x4_mem(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 v0
     v2 = scalar_to_vector.f32x4 v1
@@ -1285,7 +1285,7 @@ block0(v0: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_f32x4_mem_little(i64) -> f32x4 wasmtime_system_v {
+function %scalar_to_vector_f32x4_mem_little(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 little v0
     v2 = scalar_to_vector.f32x4 v1

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
@@ -1,7 +1,7 @@
 test compile precise-output
 target s390x
 
-function %insertlane_i64x2_0(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_0(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = insertlane.i64x2 v0, v1, 0
     return v2
@@ -17,7 +17,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
 
-function %insertlane_i64x2_1(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_1(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = insertlane.i64x2 v0, v1, 1
     return v2
@@ -33,7 +33,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
 
-function %insertlane_i64x2_imm_0(i64x2) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_imm_0(i64x2) -> i64x2 tail {
 block0(v0: i64x2):
     v1 = iconst.i64 123
     v2 = insertlane.i64x2 v0, v1, 0
@@ -50,7 +50,7 @@ block0(v0: i64x2):
 ;   vleig %v24, 0x7b, 1
 ;   br %r14
 
-function %insertlane_i64x2_imm_1(i64x2) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_imm_1(i64x2) -> i64x2 tail {
 block0(v0: i64x2):
     v1 = iconst.i64 123
     v2 = insertlane.i64x2 v0, v1, 1
@@ -67,7 +67,7 @@ block0(v0: i64x2):
 ;   vleig %v24, 0x7b, 0
 ;   br %r14
 
-function %insertlane_i64x2_lane_0_0(i64x2, i64x2) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_lane_0_0(i64x2, i64x2) -> i64x2 tail {
 block0(v0: i64x2, v1: i64x2):
     v2 = extractlane.i64x2 v1, 0
     v3 = insertlane.i64x2 v0, v2, 0
@@ -84,7 +84,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
 
-function %insertlane_i64x2_lane_0_1(i64x2, i64x2) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_lane_0_1(i64x2, i64x2) -> i64x2 tail {
 block0(v0: i64x2, v1: i64x2):
     v2 = extractlane.i64x2 v1, 0
     v3 = insertlane.i64x2 v0, v2, 1
@@ -101,7 +101,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
 
-function %insertlane_i64x2_lane_1_0(i64x2, i64x2) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_lane_1_0(i64x2, i64x2) -> i64x2 tail {
 block0(v0: i64x2, v1: i64x2):
     v2 = extractlane.i64x2 v1, 1
     v3 = insertlane.i64x2 v0, v2, 0
@@ -118,7 +118,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
 
-function %insertlane_i64x2_lane_1_1(i64x2, i64x2) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_lane_1_1(i64x2, i64x2) -> i64x2 tail {
 block0(v0: i64x2, v1: i64x2):
     v2 = extractlane.i64x2 v1, 1
     v3 = insertlane.i64x2 v0, v2, 1
@@ -135,7 +135,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
 
-function %insertlane_i64x2_mem_0(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_0(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 v1
     v3 = insertlane.i64x2 v0, v2, 0
@@ -152,7 +152,7 @@ block0(v0: i64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i64x2_mem_1(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_1(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 v1
     v3 = insertlane.i64x2 v0, v2, 1
@@ -169,7 +169,7 @@ block0(v0: i64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i64x2_mem_little_0(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_little_0(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 little v1
     v3 = insertlane.i64x2 v0, v2, 0
@@ -188,7 +188,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
 
-function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 wasmtime_system_v {
+function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 tail {
 block0(v0: i64x2, v1: i64):
     v2 = load.i64 little v1
     v3 = insertlane.i64x2 v0, v2, 1
@@ -207,7 +207,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
 
-function %insertlane_i32x4_0(i32x4, i32) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_0(i32x4, i32) -> i32x4 tail {
 block0(v0: i32x4, v1: i32):
     v2 = insertlane.i32x4 v0, v1, 0
     return v2
@@ -223,7 +223,7 @@ block0(v0: i32x4, v1: i32):
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
 
-function %insertlane_i32x4_3(i32x4, i32) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_3(i32x4, i32) -> i32x4 tail {
 block0(v0: i32x4, v1: i32):
     v2 = insertlane.i32x4 v0, v1, 3
     return v2
@@ -239,7 +239,7 @@ block0(v0: i32x4, v1: i32):
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
 
-function %insertlane_i32x4_imm_0(i32x4) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_imm_0(i32x4) -> i32x4 tail {
 block0(v0: i32x4):
     v1 = iconst.i32 123
     v2 = insertlane.i32x4 v0, v1, 0
@@ -256,7 +256,7 @@ block0(v0: i32x4):
 ;   vleif %v24, 0x7b, 3
 ;   br %r14
 
-function %insertlane_i32x4_imm_3(i32x4) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_imm_3(i32x4) -> i32x4 tail {
 block0(v0: i32x4):
     v1 = iconst.i32 123
     v2 = insertlane.i32x4 v0, v1, 3
@@ -273,7 +273,7 @@ block0(v0: i32x4):
 ;   vleif %v24, 0x7b, 0
 ;   br %r14
 
-function %insertlane_i32x4_lane_0_0(i32x4, i32x4) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_lane_0_0(i32x4, i32x4) -> i32x4 tail {
 block0(v0: i32x4, v1: i32x4):
     v2 = extractlane.i32x4 v1, 0
     v3 = insertlane.i32x4 v0, v2, 0
@@ -292,7 +292,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_i32x4_lane_0_3(i32x4, i32x4) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_lane_0_3(i32x4, i32x4) -> i32x4 tail {
 block0(v0: i32x4, v1: i32x4):
     v2 = extractlane.i32x4 v1, 0
     v3 = insertlane.i32x4 v0, v2, 3
@@ -313,7 +313,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_i32x4_lane_3_0(i32x4, i32x4) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_lane_3_0(i32x4, i32x4) -> i32x4 tail {
 block0(v0: i32x4, v1: i32x4):
     v2 = extractlane.i32x4 v1, 3
     v3 = insertlane.i32x4 v0, v2, 0
@@ -334,7 +334,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_i32x4_lane_3_3(i32x4, i32x4) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_lane_3_3(i32x4, i32x4) -> i32x4 tail {
 block0(v0: i32x4, v1: i32x4):
     v2 = extractlane.i32x4 v1, 3
     v3 = insertlane.i32x4 v0, v2, 3
@@ -353,7 +353,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 v1
     v3 = insertlane.i32x4 v0, v2, 0
@@ -370,7 +370,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -387,7 +387,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i32x4_mem_little_0(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_little_0(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 little v1
     v3 = insertlane.i32x4 v0, v2, 0
@@ -406,7 +406,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
 
-function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 little v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -425,7 +425,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
 
-function %insertlane_i16x8_0(i16x8, i16) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_0(i16x8, i16) -> i16x8 tail {
 block0(v0: i16x8, v1: i16):
     v2 = insertlane.i16x8 v0, v1, 0
     return v2
@@ -441,7 +441,7 @@ block0(v0: i16x8, v1: i16):
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
 
-function %insertlane_i16x8_7(i16x8, i16) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_7(i16x8, i16) -> i16x8 tail {
 block0(v0: i16x8, v1: i16):
     v2 = insertlane.i16x8 v0, v1, 7
     return v2
@@ -457,7 +457,7 @@ block0(v0: i16x8, v1: i16):
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
 
-function %insertlane_i16x8_imm_0(i16x8) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_imm_0(i16x8) -> i16x8 tail {
 block0(v0: i16x8):
     v1 = iconst.i16 123
     v2 = insertlane.i16x8 v0, v1, 0
@@ -474,7 +474,7 @@ block0(v0: i16x8):
 ;   vleih %v24, 0x7b, 7
 ;   br %r14
 
-function %insertlane_i16x8_imm_7(i16x8) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_imm_7(i16x8) -> i16x8 tail {
 block0(v0: i16x8):
     v1 = iconst.i16 123
     v2 = insertlane.i16x8 v0, v1, 7
@@ -491,7 +491,7 @@ block0(v0: i16x8):
 ;   vleih %v24, 0x7b, 0
 ;   br %r14
 
-function %insertlane_i16x8_lane_0_0(i16x8, i16x8) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_lane_0_0(i16x8, i16x8) -> i16x8 tail {
 block0(v0: i16x8, v1: i16x8):
     v2 = extractlane.i16x8 v1, 0
     v3 = insertlane.i16x8 v0, v2, 0
@@ -510,7 +510,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_i16x8_lane_0_7(i16x8, i16x8) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_lane_0_7(i16x8, i16x8) -> i16x8 tail {
 block0(v0: i16x8, v1: i16x8):
     v2 = extractlane.i16x8 v1, 0
     v3 = insertlane.i16x8 v0, v2, 7
@@ -531,7 +531,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_i16x8_lane_7_0(i16x8, i16x8) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_lane_7_0(i16x8, i16x8) -> i16x8 tail {
 block0(v0: i16x8, v1: i16x8):
     v2 = extractlane.i16x8 v1, 7
     v3 = insertlane.i16x8 v0, v2, 0
@@ -552,7 +552,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_i16x8_lane_7_7(i16x8, i16x8) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_lane_7_7(i16x8, i16x8) -> i16x8 tail {
 block0(v0: i16x8, v1: i16x8):
     v2 = extractlane.i16x8 v1, 7
     v3 = insertlane.i16x8 v0, v2, 7
@@ -571,7 +571,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 v1
     v3 = insertlane.i16x8 v0, v2, 0
@@ -588,7 +588,7 @@ block0(v0: i16x8, v1: i64):
 ;   vleh %v24, 0(%r2), 7 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i16x8_mem_7(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_7(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 v1
     v3 = insertlane.i16x8 v0, v2, 7
@@ -605,7 +605,7 @@ block0(v0: i16x8, v1: i64):
 ;   vleh %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i16x8_mem_little_0(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_little_0(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 little v1
     v3 = insertlane.i16x8 v0, v2, 0
@@ -624,7 +624,7 @@ block0(v0: i16x8, v1: i64):
 ;   vlvgh %v24, %r5, 7
 ;   br %r14
 
-function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 wasmtime_system_v {
+function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 tail {
 block0(v0: i16x8, v1: i64):
     v2 = load.i16 little v1
     v3 = insertlane.i16x8 v0, v2, 7
@@ -643,7 +643,7 @@ block0(v0: i16x8, v1: i64):
 ;   vlvgh %v24, %r5, 0
 ;   br %r14
 
-function %insertlane_i8x16_0(i8x16, i8) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_0(i8x16, i8) -> i8x16 tail {
 block0(v0: i8x16, v1: i8):
     v2 = insertlane.i8x16 v0, v1, 0
     return v2
@@ -659,7 +659,7 @@ block0(v0: i8x16, v1: i8):
 ;   vlvgb %v24, %r2, 0xf
 ;   br %r14
 
-function %insertlane_i8x16_15(i8x16, i8) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_15(i8x16, i8) -> i8x16 tail {
 block0(v0: i8x16, v1: i8):
     v2 = insertlane.i8x16 v0, v1, 15
     return v2
@@ -675,7 +675,7 @@ block0(v0: i8x16, v1: i8):
 ;   vlvgb %v24, %r2, 0
 ;   br %r14
 
-function %insertlane_i8x16_imm_0(i8x16) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_imm_0(i8x16) -> i8x16 tail {
 block0(v0: i8x16):
     v1 = iconst.i8 123
     v2 = insertlane.i8x16 v0, v1, 0
@@ -692,7 +692,7 @@ block0(v0: i8x16):
 ;   vleib %v24, 0x7b, 0xf
 ;   br %r14
 
-function %insertlane_i8x16_imm_15(i8x16) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_imm_15(i8x16) -> i8x16 tail {
 block0(v0: i8x16):
     v1 = iconst.i8 123
     v2 = insertlane.i8x16 v0, v1, 15
@@ -709,7 +709,7 @@ block0(v0: i8x16):
 ;   vleib %v24, 0x7b, 0
 ;   br %r14
 
-function %insertlane_i8x16_lane_0_0(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_lane_0_0(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = extractlane.i8x16 v1, 0
     v3 = insertlane.i8x16 v0, v2, 0
@@ -728,7 +728,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_i8x16_lane_0_15(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_lane_0_15(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = extractlane.i8x16 v1, 0
     v3 = insertlane.i8x16 v0, v2, 15
@@ -749,7 +749,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_i8x16_lane_15_0(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_lane_15_0(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = extractlane.i8x16 v1, 15
     v3 = insertlane.i8x16 v0, v2, 0
@@ -770,7 +770,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_i8x16_lane_15_15(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_lane_15_15(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = extractlane.i8x16 v1, 15
     v3 = insertlane.i8x16 v0, v2, 15
@@ -789,7 +789,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 v1
     v3 = insertlane.i8x16 v0, v2, 0
@@ -806,7 +806,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i8x16_mem_15(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_15(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 v1
     v3 = insertlane.i8x16 v0, v2, 15
@@ -823,7 +823,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i8x16_mem_little_0(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_little_0(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 little v1
     v3 = insertlane.i8x16 v0, v2, 0
@@ -840,7 +840,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i8x16_mem_little_15(i8x16, i64) -> i8x16 wasmtime_system_v {
+function %insertlane_i8x16_mem_little_15(i8x16, i64) -> i8x16 tail {
 block0(v0: i8x16, v1: i64):
     v2 = load.i8 little v1
     v3 = insertlane.i8x16 v0, v2, 15
@@ -857,7 +857,7 @@ block0(v0: i8x16, v1: i64):
 ;   vleb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f64x2_0(f64x2, f64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_0(f64x2, f64) -> f64x2 tail {
 block0(v0: f64x2, v1: f64):
     v2 = insertlane.f64x2 v0, v1, 0
     return v2
@@ -873,7 +873,7 @@ block0(v0: f64x2, v1: f64):
 ;   vpdi %v24, %v24, %v0, 0
 ;   br %r14
 
-function %insertlane_f64x2_1(f64x2, f64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_1(f64x2, f64) -> f64x2 tail {
 block0(v0: f64x2, v1: f64):
     v2 = insertlane.f64x2 v0, v1, 1
     return v2
@@ -889,7 +889,7 @@ block0(v0: f64x2, v1: f64):
 ;   vpdi %v24, %v0, %v24, 1
 ;   br %r14
 
-function %insertlane_f64x2_lane_0_0(f64x2, f64x2) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_lane_0_0(f64x2, f64x2) -> f64x2 tail {
 block0(v0: f64x2, v1: f64x2):
     v2 = extractlane.f64x2 v1, 0
     v3 = insertlane.f64x2 v0, v2, 0
@@ -906,7 +906,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
 
-function %insertlane_f64x2_lane_0_1(f64x2, f64x2) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_lane_0_1(f64x2, f64x2) -> f64x2 tail {
 block0(v0: f64x2, v1: f64x2):
     v2 = extractlane.f64x2 v1, 0
     v3 = insertlane.f64x2 v0, v2, 1
@@ -923,7 +923,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
 
-function %insertlane_f64x2_lane_1_0(f64x2, f64x2) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_lane_1_0(f64x2, f64x2) -> f64x2 tail {
 block0(v0: f64x2, v1: f64x2):
     v2 = extractlane.f64x2 v1, 1
     v3 = insertlane.f64x2 v0, v2, 0
@@ -940,7 +940,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
 
-function %insertlane_f64x2_lane_1_1(f64x2, f64x2) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_lane_1_1(f64x2, f64x2) -> f64x2 tail {
 block0(v0: f64x2, v1: f64x2):
     v2 = extractlane.f64x2 v1, 1
     v3 = insertlane.f64x2 v0, v2, 1
@@ -957,7 +957,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
 
-function %insertlane_f64x2_mem_0(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_0(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 v1
     v3 = insertlane.f64x2 v0, v2, 0
@@ -974,7 +974,7 @@ block0(v0: f64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f64x2_mem_1(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_1(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 v1
     v3 = insertlane.f64x2 v0, v2, 1
@@ -991,7 +991,7 @@ block0(v0: f64x2, v1: i64):
 ;   vleg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f64x2_mem_little_0(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_little_0(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 little v1
     v3 = insertlane.f64x2 v0, v2, 0
@@ -1010,7 +1010,7 @@ block0(v0: f64x2, v1: i64):
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
 
-function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 wasmtime_system_v {
+function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 tail {
 block0(v0: f64x2, v1: i64):
     v2 = load.f64 little v1
     v3 = insertlane.f64x2 v0, v2, 1
@@ -1029,7 +1029,7 @@ block0(v0: f64x2, v1: i64):
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
 
-function %insertlane_f32x4_0(f32x4, f32) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_0(f32x4, f32) -> f32x4 tail {
 block0(v0: f32x4, v1: f32):
     v2 = insertlane.f32x4 v0, v1, 0
     return v2
@@ -1049,7 +1049,7 @@ block0(v0: f32x4, v1: f32):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_f32x4_3(f32x4, f32) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_3(f32x4, f32) -> f32x4 tail {
 block0(v0: f32x4, v1: f32):
     v2 = insertlane.f32x4 v0, v1, 3
     return v2
@@ -1067,7 +1067,7 @@ block0(v0: f32x4, v1: f32):
 ;   vsel %v24, %v0, %v24, %v3
 ;   br %r14
 
-function %insertlane_f32x4_lane_0_0(f32x4, f32x4) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_lane_0_0(f32x4, f32x4) -> f32x4 tail {
 block0(v0: f32x4, v1: f32x4):
     v2 = extractlane.f32x4 v1, 0
     v3 = insertlane.f32x4 v0, v2, 0
@@ -1086,7 +1086,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_f32x4_lane_0_3(f32x4, f32x4) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_lane_0_3(f32x4, f32x4) -> f32x4 tail {
 block0(v0: f32x4, v1: f32x4):
     v2 = extractlane.f32x4 v1, 0
     v3 = insertlane.f32x4 v0, v2, 3
@@ -1107,7 +1107,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_f32x4_lane_3_0(f32x4, f32x4) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_lane_3_0(f32x4, f32x4) -> f32x4 tail {
 block0(v0: f32x4, v1: f32x4):
     v2 = extractlane.f32x4 v1, 3
     v3 = insertlane.f32x4 v0, v2, 0
@@ -1128,7 +1128,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
-function %insertlane_f32x4_lane_3_3(f32x4, f32x4) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_lane_3_3(f32x4, f32x4) -> f32x4 tail {
 block0(v0: f32x4, v1: f32x4):
     v2 = extractlane.f32x4 v1, 3
     v3 = insertlane.f32x4 v0, v2, 3
@@ -1147,7 +1147,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
-function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 tail {
 block0(v0: f32x4, v1: i64):
     v2 = load.f32 v1
     v3 = insertlane.f32x4 v0, v2, 0
@@ -1164,7 +1164,7 @@ block0(v0: f32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -1181,7 +1181,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %insertlane_f32x4_mem_little_0(f32x4, i64) -> f32x4 wasmtime_system_v {
+function %insertlane_f32x4_mem_little_0(f32x4, i64) -> f32x4 tail {
 block0(v0: f32x4, v1: i64):
     v2 = load.f32 little v1
     v3 = insertlane.f32x4 v0, v2, 0
@@ -1200,7 +1200,7 @@ block0(v0: f32x4, v1: i64):
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
 
-function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
+function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 tail {
 block0(v0: i32x4, v1: i64):
     v2 = load.i32 little v1
     v3 = insertlane.i32x4 v0, v2, 3
@@ -1219,7 +1219,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
 
-function %extractlane_i64x2_0(i64x2) -> i64 wasmtime_system_v {
+function %extractlane_i64x2_0(i64x2) -> i64 tail {
 block0(v0: i64x2):
     v1 = extractlane.i64x2 v0, 0
     return v1
@@ -1235,7 +1235,7 @@ block0(v0: i64x2):
 ;   vlgvg %r2, %v24, 1
 ;   br %r14
 
-function %extractlane_i64x2_1(i64x2) -> i64 wasmtime_system_v {
+function %extractlane_i64x2_1(i64x2) -> i64 tail {
 block0(v0: i64x2):
     v1 = extractlane.i64x2 v0, 1
     return v1
@@ -1251,7 +1251,7 @@ block0(v0: i64x2):
 ;   vlgvg %r2, %v24, 0
 ;   br %r14
 
-function %extractlane_i64x2_mem_0(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_0(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 0
     store v2, v1
@@ -1268,7 +1268,7 @@ block0(v0: i64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i64x2_mem_1(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_1(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 1
     store v2, v1
@@ -1285,7 +1285,7 @@ block0(v0: i64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i64x2_mem_little_0(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_little_0(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 0
     store little v2, v1
@@ -1304,7 +1304,7 @@ block0(v0: i64x2, v1: i64):
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i64x2_mem_little_1(i64x2, i64) wasmtime_system_v {
+function %extractlane_i64x2_mem_little_1(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
     v2 = extractlane.i64x2 v0, 1
     store little v2, v1
@@ -1323,7 +1323,7 @@ block0(v0: i64x2, v1: i64):
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i32x4_0(i32x4) -> i32 wasmtime_system_v {
+function %extractlane_i32x4_0(i32x4) -> i32 tail {
 block0(v0: i32x4):
     v1 = extractlane.i32x4 v0, 0
     return v1
@@ -1339,7 +1339,7 @@ block0(v0: i32x4):
 ;   vlgvf %r2, %v24, 3
 ;   br %r14
 
-function %extractlane_i32x4_3(i32x4) -> i32 wasmtime_system_v {
+function %extractlane_i32x4_3(i32x4) -> i32 tail {
 block0(v0: i32x4):
     v1 = extractlane.i32x4 v0, 3
     return v1
@@ -1355,7 +1355,7 @@ block0(v0: i32x4):
 ;   vlgvf %r2, %v24, 0
 ;   br %r14
 
-function %extractlane_i32x4_mem_0(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_0(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 0
     store v2, v1
@@ -1372,7 +1372,7 @@ block0(v0: i32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i32x4_mem_3(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_3(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 3
     store v2, v1
@@ -1389,7 +1389,7 @@ block0(v0: i32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i32x4_mem_little_0(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_little_0(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 0
     store little v2, v1
@@ -1408,7 +1408,7 @@ block0(v0: i32x4, v1: i64):
 ;   strv %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i32x4_mem_little_3(i32x4, i64) wasmtime_system_v {
+function %extractlane_i32x4_mem_little_3(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
     v2 = extractlane.i32x4 v0, 3
     store little v2, v1
@@ -1427,7 +1427,7 @@ block0(v0: i32x4, v1: i64):
 ;   strv %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i16x8_0(i16x8) -> i16 wasmtime_system_v {
+function %extractlane_i16x8_0(i16x8) -> i16 tail {
 block0(v0: i16x8):
     v1 = extractlane.i16x8 v0, 0
     return v1
@@ -1443,7 +1443,7 @@ block0(v0: i16x8):
 ;   vlgvh %r2, %v24, 7
 ;   br %r14
 
-function %extractlane_i16x8_7(i16x8) -> i16 wasmtime_system_v {
+function %extractlane_i16x8_7(i16x8) -> i16 tail {
 block0(v0: i16x8):
     v1 = extractlane.i16x8 v0, 7
     return v1
@@ -1459,7 +1459,7 @@ block0(v0: i16x8):
 ;   vlgvh %r2, %v24, 0
 ;   br %r14
 
-function %extractlane_i16x8_mem_0(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_0(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 0
     store v2, v1
@@ -1476,7 +1476,7 @@ block0(v0: i16x8, v1: i64):
 ;   vsteh %v24, 0(%r2), 7 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i16x8_mem_7(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_7(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 7
     store v2, v1
@@ -1493,7 +1493,7 @@ block0(v0: i16x8, v1: i64):
 ;   vsteh %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i16x8_mem_little_0(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_little_0(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 0
     store little v2, v1
@@ -1512,7 +1512,7 @@ block0(v0: i16x8, v1: i64):
 ;   strvh %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i16x8_mem_little_7(i16x8, i64) wasmtime_system_v {
+function %extractlane_i16x8_mem_little_7(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
     v2 = extractlane.i16x8 v0, 7
     store little v2, v1
@@ -1531,7 +1531,7 @@ block0(v0: i16x8, v1: i64):
 ;   strvh %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i8x16_0(i8x16) -> i8 wasmtime_system_v {
+function %extractlane_i8x16_0(i8x16) -> i8 tail {
 block0(v0: i8x16):
     v1 = extractlane.i8x16 v0, 0
     return v1
@@ -1547,7 +1547,7 @@ block0(v0: i8x16):
 ;   vlgvb %r2, %v24, 0xf
 ;   br %r14
 
-function %extractlane_i8x16_15(i8x16) -> i8 wasmtime_system_v {
+function %extractlane_i8x16_15(i8x16) -> i8 tail {
 block0(v0: i8x16):
     v1 = extractlane.i8x16 v0, 15
     return v1
@@ -1563,7 +1563,7 @@ block0(v0: i8x16):
 ;   vlgvb %r2, %v24, 0
 ;   br %r14
 
-function %extractlane_i8x16_mem_0(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_0(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 0
     store v2, v1
@@ -1580,7 +1580,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i8x16_mem_15(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_15(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 15
     store v2, v1
@@ -1597,7 +1597,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i8x16_mem_little_0(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_little_0(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 0
     store little v2, v1
@@ -1614,7 +1614,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_i8x16_mem_little_15(i8x16, i64) wasmtime_system_v {
+function %extractlane_i8x16_mem_little_15(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
     v2 = extractlane.i8x16 v0, 15
     store little v2, v1
@@ -1631,7 +1631,7 @@ block0(v0: i8x16, v1: i64):
 ;   vsteb %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f64x2_0(f64x2) -> f64 wasmtime_system_v {
+function %extractlane_f64x2_0(f64x2) -> f64 tail {
 block0(v0: f64x2):
     v1 = extractlane.f64x2 v0, 0
     return v1
@@ -1647,7 +1647,7 @@ block0(v0: f64x2):
 ;   vrepg %v0, %v24, 1
 ;   br %r14
 
-function %extractlane_f64x2_1(f64x2) -> f64 wasmtime_system_v {
+function %extractlane_f64x2_1(f64x2) -> f64 tail {
 block0(v0: f64x2):
     v1 = extractlane.f64x2 v0, 1
     return v1
@@ -1663,7 +1663,7 @@ block0(v0: f64x2):
 ;   vrepg %v0, %v24, 0
 ;   br %r14
 
-function %extractlane_f64x2_mem_0(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_0(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 0
     store v2, v1
@@ -1680,7 +1680,7 @@ block0(v0: f64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f64x2_mem_1(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_1(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 1
     store v2, v1
@@ -1697,7 +1697,7 @@ block0(v0: f64x2, v1: i64):
 ;   vsteg %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f64x2_mem_little_0(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_little_0(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 0
     store little v2, v1
@@ -1716,7 +1716,7 @@ block0(v0: f64x2, v1: i64):
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f64x2_mem_little_1(f64x2, i64) wasmtime_system_v {
+function %extractlane_f64x2_mem_little_1(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
     v2 = extractlane.f64x2 v0, 1
     store little v2, v1
@@ -1735,7 +1735,7 @@ block0(v0: f64x2, v1: i64):
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f32x4_0(f32x4) -> f32 wasmtime_system_v {
+function %extractlane_f32x4_0(f32x4) -> f32 tail {
 block0(v0: f32x4):
     v1 = extractlane.f32x4 v0, 0
     return v1
@@ -1751,7 +1751,7 @@ block0(v0: f32x4):
 ;   vrepf %v0, %v24, 3
 ;   br %r14
 
-function %extractlane_f32x4_3(f32x4) -> f32 wasmtime_system_v {
+function %extractlane_f32x4_3(f32x4) -> f32 tail {
 block0(v0: f32x4):
     v1 = extractlane.f32x4 v0, 3
     return v1
@@ -1767,7 +1767,7 @@ block0(v0: f32x4):
 ;   vrepf %v0, %v24, 0
 ;   br %r14
 
-function %extractlane_f32x4_mem_0(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_0(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 0
     store v2, v1
@@ -1784,7 +1784,7 @@ block0(v0: f32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f32x4_mem_3(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_3(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 3
     store v2, v1
@@ -1801,7 +1801,7 @@ block0(v0: f32x4, v1: i64):
 ;   vstef %v24, 0(%r2), 0 ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f32x4_mem_little_0(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_little_0(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 0
     store little v2, v1
@@ -1820,7 +1820,7 @@ block0(v0: f32x4, v1: i64):
 ;   strv %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %extractlane_f32x4_mem_little_3(f32x4, i64) wasmtime_system_v {
+function %extractlane_f32x4_mem_little_3(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
     v2 = extractlane.f32x4 v0, 3
     store little v2, v1
@@ -1839,7 +1839,7 @@ block0(v0: f32x4, v1: i64):
 ;   strv %r5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i64x2(i64) -> i64x2 wasmtime_system_v {
+function %splat_i64x2(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = splat.i64x2 v0
     return v1
@@ -1857,7 +1857,7 @@ block0(v0: i64):
 ;   vrepg %v24, %v2, 0
 ;   br %r14
 
-function %splat_i64x2_imm() -> i64x2 wasmtime_system_v {
+function %splat_i64x2_imm() -> i64x2 tail {
 block0:
     v0 = iconst.i64 123
     v1 = splat.i64x2 v0
@@ -1874,7 +1874,7 @@ block0:
 ;   vrepig %v24, 0x7b
 ;   br %r14
 
-function %splat_i64x2_lane_0(i64x2) -> i64x2 wasmtime_system_v {
+function %splat_i64x2_lane_0(i64x2) -> i64x2 tail {
 block0(v0: i64x2):
     v1 = extractlane.i64x2 v0, 0
     v2 = splat.i64x2 v1
@@ -1891,7 +1891,7 @@ block0(v0: i64x2):
 ;   vrepg %v24, %v24, 1
 ;   br %r14
 
-function %splat_i64x2_lane_1(i64x2) -> i64x2 wasmtime_system_v {
+function %splat_i64x2_lane_1(i64x2) -> i64x2 tail {
 block0(v0: i64x2):
     v1 = extractlane.i64x2 v0, 1
     v2 = splat.i64x2 v1
@@ -1908,7 +1908,7 @@ block0(v0: i64x2):
 ;   vrepg %v24, %v24, 0
 ;   br %r14
 
-function %splat_i64x2_mem(i64) -> i64x2 wasmtime_system_v {
+function %splat_i64x2_mem(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 v0
     v2 = splat.i64x2 v1
@@ -1925,7 +1925,7 @@ block0(v0: i64):
 ;   vlrepg %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i64x2_mem_little(i64) -> i64x2 wasmtime_system_v {
+function %splat_i64x2_mem_little(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 little v0
     v2 = splat.i64x2 v1
@@ -1946,7 +1946,7 @@ block0(v0: i64):
 ;   vrepg %v24, %v4, 0
 ;   br %r14
 
-function %splat_i32x4(i32) -> i32x4 wasmtime_system_v {
+function %splat_i32x4(i32) -> i32x4 tail {
 block0(v0: i32):
     v1 = splat.i32x4 v0
     return v1
@@ -1964,7 +1964,7 @@ block0(v0: i32):
 ;   vrepf %v24, %v2, 0
 ;   br %r14
 
-function %splat_i32x4_imm() -> i32x4 wasmtime_system_v {
+function %splat_i32x4_imm() -> i32x4 tail {
 block0:
     v0 = iconst.i32 123
     v1 = splat.i32x4 v0
@@ -1981,7 +1981,7 @@ block0:
 ;   vrepif %v24, 0x7b
 ;   br %r14
 
-function %splat_i32x4_lane_0(i32x4) -> i32x4 wasmtime_system_v {
+function %splat_i32x4_lane_0(i32x4) -> i32x4 tail {
 block0(v0: i32x4):
     v1 = extractlane.i32x4 v0, 0
     v2 = splat.i32x4 v1
@@ -1998,7 +1998,7 @@ block0(v0: i32x4):
 ;   vrepf %v24, %v24, 3
 ;   br %r14
 
-function %splat_i32x4_lane_3(i32x4) -> i32x4 wasmtime_system_v {
+function %splat_i32x4_lane_3(i32x4) -> i32x4 tail {
 block0(v0: i32x4):
     v1 = extractlane.i32x4 v0, 3
     v2 = splat.i32x4 v1
@@ -2015,7 +2015,7 @@ block0(v0: i32x4):
 ;   vrepf %v24, %v24, 0
 ;   br %r14
 
-function %splat_i32x4_mem(i64) -> i32x4 wasmtime_system_v {
+function %splat_i32x4_mem(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 v0
     v2 = splat.i32x4 v1
@@ -2032,7 +2032,7 @@ block0(v0: i64):
 ;   vlrepf %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i32x4_mem_little(i64) -> i32x4 wasmtime_system_v {
+function %splat_i32x4_mem_little(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 little v0
     v2 = splat.i32x4 v1
@@ -2053,7 +2053,7 @@ block0(v0: i64):
 ;   vrepf %v24, %v4, 0
 ;   br %r14
 
-function %splat_i16x8(i16) -> i16x8 wasmtime_system_v {
+function %splat_i16x8(i16) -> i16x8 tail {
 block0(v0: i16):
     v1 = splat.i16x8 v0
     return v1
@@ -2071,7 +2071,7 @@ block0(v0: i16):
 ;   vreph %v24, %v2, 0
 ;   br %r14
 
-function %splat_i16x8_imm() -> i16x8 wasmtime_system_v {
+function %splat_i16x8_imm() -> i16x8 tail {
 block0:
     v0 = iconst.i16 123
     v1 = splat.i16x8 v0
@@ -2088,7 +2088,7 @@ block0:
 ;   vrepih %v24, 0x7b
 ;   br %r14
 
-function %splat_i16x8_lane_0(i16x8) -> i16x8 wasmtime_system_v {
+function %splat_i16x8_lane_0(i16x8) -> i16x8 tail {
 block0(v0: i16x8):
     v1 = extractlane.i16x8 v0, 0
     v2 = splat.i16x8 v1
@@ -2105,7 +2105,7 @@ block0(v0: i16x8):
 ;   vreph %v24, %v24, 7
 ;   br %r14
 
-function %splat_i16x8_lane_7(i16x8) -> i16x8 wasmtime_system_v {
+function %splat_i16x8_lane_7(i16x8) -> i16x8 tail {
 block0(v0: i16x8):
     v1 = extractlane.i16x8 v0, 7
     v2 = splat.i16x8 v1
@@ -2122,7 +2122,7 @@ block0(v0: i16x8):
 ;   vreph %v24, %v24, 0
 ;   br %r14
 
-function %splat_i16x8_mem(i64) -> i16x8 wasmtime_system_v {
+function %splat_i16x8_mem(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 v0
     v2 = splat.i16x8 v1
@@ -2139,7 +2139,7 @@ block0(v0: i64):
 ;   vlreph %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i16x8_mem_little(i64) -> i16x8 wasmtime_system_v {
+function %splat_i16x8_mem_little(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 little v0
     v2 = splat.i16x8 v1
@@ -2160,7 +2160,7 @@ block0(v0: i64):
 ;   vreph %v24, %v4, 0
 ;   br %r14
 
-function %splat_i8x16(i8) -> i8x16 wasmtime_system_v {
+function %splat_i8x16(i8) -> i8x16 tail {
 block0(v0: i8):
     v1 = splat.i8x16 v0
     return v1
@@ -2178,7 +2178,7 @@ block0(v0: i8):
 ;   vrepb %v24, %v2, 0
 ;   br %r14
 
-function %splat_i8x16_imm() -> i8x16 wasmtime_system_v {
+function %splat_i8x16_imm() -> i8x16 tail {
 block0:
     v0 = iconst.i8 123
     v1 = splat.i8x16 v0
@@ -2195,7 +2195,7 @@ block0:
 ;   vrepib %v24, 0x7b
 ;   br %r14
 
-function %splat_i8x16_lane_0(i8x16) -> i8x16 wasmtime_system_v {
+function %splat_i8x16_lane_0(i8x16) -> i8x16 tail {
 block0(v0: i8x16):
     v1 = extractlane.i8x16 v0, 0
     v2 = splat.i8x16 v1
@@ -2212,7 +2212,7 @@ block0(v0: i8x16):
 ;   vrepb %v24, %v24, 0xf
 ;   br %r14
 
-function %splat_i8x16_lane_15(i8x16) -> i8x16 wasmtime_system_v {
+function %splat_i8x16_lane_15(i8x16) -> i8x16 tail {
 block0(v0: i8x16):
     v1 = extractlane.i8x16 v0, 15
     v2 = splat.i8x16 v1
@@ -2229,7 +2229,7 @@ block0(v0: i8x16):
 ;   vrepb %v24, %v24, 0
 ;   br %r14
 
-function %splat_i8x16_mem(i64) -> i8x16 wasmtime_system_v {
+function %splat_i8x16_mem(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 v0
     v2 = splat.i8x16 v1
@@ -2246,7 +2246,7 @@ block0(v0: i64):
 ;   vlrepb %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_i8x16_mem_little(i64) -> i8x16 wasmtime_system_v {
+function %splat_i8x16_mem_little(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 little v0
     v2 = splat.i8x16 v1
@@ -2263,7 +2263,7 @@ block0(v0: i64):
 ;   vlrepb %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_f64x2(f64) -> f64x2 wasmtime_system_v {
+function %splat_f64x2(f64) -> f64x2 tail {
 block0(v0: f64):
     v1 = splat.f64x2 v0
     return v1
@@ -2279,7 +2279,7 @@ block0(v0: f64):
 ;   vrepg %v24, %v0, 0
 ;   br %r14
 
-function %splat_f64x2_lane_0(f64x2) -> f64x2 wasmtime_system_v {
+function %splat_f64x2_lane_0(f64x2) -> f64x2 tail {
 block0(v0: f64x2):
     v1 = extractlane.f64x2 v0, 0
     v2 = splat.f64x2 v1
@@ -2296,7 +2296,7 @@ block0(v0: f64x2):
 ;   vrepg %v24, %v24, 1
 ;   br %r14
 
-function %splat_f64x2_lane_1(f64x2) -> f64x2 wasmtime_system_v {
+function %splat_f64x2_lane_1(f64x2) -> f64x2 tail {
 block0(v0: f64x2):
     v1 = extractlane.f64x2 v0, 1
     v2 = splat.f64x2 v1
@@ -2313,7 +2313,7 @@ block0(v0: f64x2):
 ;   vrepg %v24, %v24, 0
 ;   br %r14
 
-function %splat_f64x2_mem(i64) -> f64x2 wasmtime_system_v {
+function %splat_f64x2_mem(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 v0
     v2 = splat.f64x2 v1
@@ -2330,7 +2330,7 @@ block0(v0: i64):
 ;   vlrepg %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_f64x2_mem_little(i64) -> f64x2 wasmtime_system_v {
+function %splat_f64x2_mem_little(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 little v0
     v2 = splat.f64x2 v1
@@ -2351,7 +2351,7 @@ block0(v0: i64):
 ;   vrepg %v24, %v4, 0
 ;   br %r14
 
-function %splat_f32x4(f32) -> f32x4 wasmtime_system_v {
+function %splat_f32x4(f32) -> f32x4 tail {
 block0(v0: f32):
     v1 = splat.f32x4 v0
     return v1
@@ -2367,7 +2367,7 @@ block0(v0: f32):
 ;   vrepf %v24, %v0, 0
 ;   br %r14
 
-function %splat_f32x4_lane_0(f32x4) -> f32x4 wasmtime_system_v {
+function %splat_f32x4_lane_0(f32x4) -> f32x4 tail {
 block0(v0: f32x4):
     v1 = extractlane.f32x4 v0, 0
     v2 = splat.f32x4 v1
@@ -2384,7 +2384,7 @@ block0(v0: f32x4):
 ;   vrepf %v24, %v24, 3
 ;   br %r14
 
-function %splat_i32x4_lane_3(i32x4) -> i32x4 wasmtime_system_v {
+function %splat_i32x4_lane_3(i32x4) -> i32x4 tail {
 block0(v0: i32x4):
     v1 = extractlane.i32x4 v0, 3
     v2 = splat.i32x4 v1
@@ -2401,7 +2401,7 @@ block0(v0: i32x4):
 ;   vrepf %v24, %v24, 0
 ;   br %r14
 
-function %splat_f32x4_mem(i64) -> f32x4 wasmtime_system_v {
+function %splat_f32x4_mem(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 v0
     v2 = splat.f32x4 v1
@@ -2418,7 +2418,7 @@ block0(v0: i64):
 ;   vlrepf %v24, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %splat_f32x4_mem_little(i64) -> f32x4 wasmtime_system_v {
+function %splat_f32x4_mem_little(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 little v0
     v2 = splat.f32x4 v1
@@ -2439,7 +2439,7 @@ block0(v0: i64):
 ;   vrepf %v24, %v4, 0
 ;   br %r14
 
-function %scalar_to_vector_i64x2(i64) -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = scalar_to_vector.i64x2 v0
     return v1
@@ -2457,7 +2457,7 @@ block0(v0: i64):
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
 
-function %scalar_to_vector_i64x2_imm() -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2_imm() -> i64x2 tail {
 block0:
     v0 = iconst.i64 123
     v1 = scalar_to_vector.i64x2 v0
@@ -2476,7 +2476,7 @@ block0:
 ;   vleig %v24, 0x7b, 1
 ;   br %r14
 
-function %scalar_to_vector_i64x2_lane_0(i64x2) -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2_lane_0(i64x2) -> i64x2 tail {
 block0(v0: i64x2):
     v1 = extractlane.i64x2 v0, 0
     v2 = scalar_to_vector.i64x2 v1
@@ -2495,7 +2495,7 @@ block0(v0: i64x2):
 ;   vpdi %v24, %v2, %v24, 1
 ;   br %r14
 
-function %scalar_to_vector_i64x2_lane_1(i64x2) -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2_lane_1(i64x2) -> i64x2 tail {
 block0(v0: i64x2):
     v1 = extractlane.i64x2 v0, 1
     v2 = scalar_to_vector.i64x2 v1
@@ -2514,7 +2514,7 @@ block0(v0: i64x2):
 ;   vpdi %v24, %v2, %v24, 0
 ;   br %r14
 
-function %scalar_to_vector_i64x2_mem(i64) -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2_mem(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 v0
     v2 = scalar_to_vector.i64x2 v1
@@ -2533,7 +2533,7 @@ block0(v0: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i64x2_mem_little(i64) -> i64x2 wasmtime_system_v {
+function %scalar_to_vector_i64x2_mem_little(i64) -> i64x2 tail {
 block0(v0: i64):
     v1 = load.i64 little v0
     v2 = scalar_to_vector.i64x2 v1
@@ -2543,18 +2543,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vgbm %v24, 0
-;   lrvg %r2, 0(%r2)
-;   vlvgg %v24, %r2, 1
+;   lrvg %r6, 0(%r2)
+;   vlvgg %v24, %r6, 1
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
-;   lrvg %r2, 0(%r2) ; trap: heap_oob
-;   vlvgg %v24, %r2, 1
+;   lrvg %r6, 0(%r2) ; trap: heap_oob
+;   vlvgg %v24, %r6, 1
 ;   br %r14
 
-function %scalar_to_vector_i32x4(i32) -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4(i32) -> i32x4 tail {
 block0(v0: i32):
     v1 = scalar_to_vector.i32x4 v0
     return v1
@@ -2572,7 +2572,7 @@ block0(v0: i32):
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
 
-function %scalar_to_vector_i32x4_imm() -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4_imm() -> i32x4 tail {
 block0:
     v0 = iconst.i32 123
     v1 = scalar_to_vector.i32x4 v0
@@ -2591,7 +2591,7 @@ block0:
 ;   vleif %v24, 0x7b, 3
 ;   br %r14
 
-function %scalar_to_vector_i32x4_lane_0(i32x4) -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4_lane_0(i32x4) -> i32x4 tail {
 block0(v0: i32x4):
     v1 = extractlane.i32x4 v0, 0
     v2 = scalar_to_vector.i32x4 v1
@@ -2610,7 +2610,7 @@ block0(v0: i32x4):
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
-function %scalar_to_vector_i32x4_lane_3(i32x4) -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4_lane_3(i32x4) -> i32x4 tail {
 block0(v0: i32x4):
     v1 = extractlane.i32x4 v0, 3
     v2 = scalar_to_vector.i32x4 v1
@@ -2631,7 +2631,7 @@ block0(v0: i32x4):
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
-function %scalar_to_vector_i32x4_mem(i64) -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4_mem(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 v0
     v2 = scalar_to_vector.i32x4 v1
@@ -2650,7 +2650,7 @@ block0(v0: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i32x4_mem_little(i64) -> i32x4 wasmtime_system_v {
+function %scalar_to_vector_i32x4_mem_little(i64) -> i32x4 tail {
 block0(v0: i64):
     v1 = load.i32 little v0
     v2 = scalar_to_vector.i32x4 v1
@@ -2660,18 +2660,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vgbm %v24, 0
-;   lrv %r2, 0(%r2)
-;   vlvgf %v24, %r2, 3
+;   lrv %r6, 0(%r2)
+;   vlvgf %v24, %r6, 3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
-;   lrv %r2, 0(%r2) ; trap: heap_oob
-;   vlvgf %v24, %r2, 3
+;   lrv %r6, 0(%r2) ; trap: heap_oob
+;   vlvgf %v24, %r6, 3
 ;   br %r14
 
-function %scalar_to_vector_i16x8(i16) -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8(i16) -> i16x8 tail {
 block0(v0: i16):
     v1 = scalar_to_vector.i16x8 v0
     return v1
@@ -2689,7 +2689,7 @@ block0(v0: i16):
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
 
-function %scalar_to_vector_i16x8_imm() -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8_imm() -> i16x8 tail {
 block0:
     v0 = iconst.i16 123
     v1 = scalar_to_vector.i16x8 v0
@@ -2708,7 +2708,7 @@ block0:
 ;   vleih %v24, 0x7b, 7
 ;   br %r14
 
-function %scalar_to_vector_i16x8_lane_0(i16x8) -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8_lane_0(i16x8) -> i16x8 tail {
 block0(v0: i16x8):
     v1 = extractlane.i16x8 v0, 0
     v2 = scalar_to_vector.i16x8 v1
@@ -2727,7 +2727,7 @@ block0(v0: i16x8):
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
-function %scalar_to_vector_i16x8_lane_7(i16x8) -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8_lane_7(i16x8) -> i16x8 tail {
 block0(v0: i16x8):
     v1 = extractlane.i16x8 v0, 7
     v2 = scalar_to_vector.i16x8 v1
@@ -2748,7 +2748,7 @@ block0(v0: i16x8):
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
-function %scalar_to_vector_i16x8_mem(i64) -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8_mem(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 v0
     v2 = scalar_to_vector.i16x8 v1
@@ -2767,7 +2767,7 @@ block0(v0: i64):
 ;   vleh %v24, 0(%r2), 7 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i16x8_mem_little(i64) -> i16x8 wasmtime_system_v {
+function %scalar_to_vector_i16x8_mem_little(i64) -> i16x8 tail {
 block0(v0: i64):
     v1 = load.i16 little v0
     v2 = scalar_to_vector.i16x8 v1
@@ -2777,18 +2777,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vgbm %v24, 0
-;   lrvh %r2, 0(%r2)
-;   vlvgh %v24, %r2, 7
+;   lrvh %r6, 0(%r2)
+;   vlvgh %v24, %r6, 7
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
-;   lrvh %r2, 0(%r2) ; trap: heap_oob
-;   vlvgh %v24, %r2, 7
+;   lrvh %r6, 0(%r2) ; trap: heap_oob
+;   vlvgh %v24, %r6, 7
 ;   br %r14
 
-function %scalar_to_vector_i8x16(i8) -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16(i8) -> i8x16 tail {
 block0(v0: i8):
     v1 = scalar_to_vector.i8x16 v0
     return v1
@@ -2806,7 +2806,7 @@ block0(v0: i8):
 ;   vlvgb %v24, %r2, 0xf
 ;   br %r14
 
-function %scalar_to_vector_i8x16_imm() -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16_imm() -> i8x16 tail {
 block0:
     v0 = iconst.i8 123
     v1 = scalar_to_vector.i8x16 v0
@@ -2825,7 +2825,7 @@ block0:
 ;   vleib %v24, 0x7b, 0xf
 ;   br %r14
 
-function %scalar_to_vector_i8x16_lane_0(i8x16) -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16_lane_0(i8x16) -> i8x16 tail {
 block0(v0: i8x16):
     v1 = extractlane.i8x16 v0, 0
     v2 = scalar_to_vector.i8x16 v1
@@ -2844,7 +2844,7 @@ block0(v0: i8x16):
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
-function %scalar_to_vector_i8x16_lane_15(i8x16) -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16_lane_15(i8x16) -> i8x16 tail {
 block0(v0: i8x16):
     v1 = extractlane.i8x16 v0, 15
     v2 = scalar_to_vector.i8x16 v1
@@ -2865,7 +2865,7 @@ block0(v0: i8x16):
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
-function %scalar_to_vector_i8x16_mem(i64) -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16_mem(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 v0
     v2 = scalar_to_vector.i8x16 v1
@@ -2884,7 +2884,7 @@ block0(v0: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_i8x16_mem_little(i64) -> i8x16 wasmtime_system_v {
+function %scalar_to_vector_i8x16_mem_little(i64) -> i8x16 tail {
 block0(v0: i64):
     v1 = load.i8 little v0
     v2 = scalar_to_vector.i8x16 v1
@@ -2903,7 +2903,7 @@ block0(v0: i64):
 ;   vleb %v24, 0(%r2), 0xf ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_f64x2(f64) -> f64x2 wasmtime_system_v {
+function %scalar_to_vector_f64x2(f64) -> f64x2 tail {
 block0(v0: f64):
     v1 = scalar_to_vector.f64x2 v0
     return v1
@@ -2921,7 +2921,7 @@ block0(v0: f64):
 ;   vpdi %v24, %v2, %v0, 0
 ;   br %r14
 
-function %scalar_to_vector_f64x2_lane_0(f64x2) -> f64x2 wasmtime_system_v {
+function %scalar_to_vector_f64x2_lane_0(f64x2) -> f64x2 tail {
 block0(v0: f64x2):
     v1 = extractlane.f64x2 v0, 0
     v2 = scalar_to_vector.f64x2 v1
@@ -2940,7 +2940,7 @@ block0(v0: f64x2):
 ;   vpdi %v24, %v2, %v24, 1
 ;   br %r14
 
-function %scalar_to_vector_f64x2_lane_1(f64x2) -> f64x2 wasmtime_system_v {
+function %scalar_to_vector_f64x2_lane_1(f64x2) -> f64x2 tail {
 block0(v0: f64x2):
     v1 = extractlane.f64x2 v0, 1
     v2 = scalar_to_vector.f64x2 v1
@@ -2959,7 +2959,7 @@ block0(v0: f64x2):
 ;   vpdi %v24, %v2, %v24, 0
 ;   br %r14
 
-function %scalar_to_vector_f64x2_mem(i64) -> f64x2 wasmtime_system_v {
+function %scalar_to_vector_f64x2_mem(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 v0
     v2 = scalar_to_vector.f64x2 v1
@@ -2978,7 +2978,7 @@ block0(v0: i64):
 ;   vleg %v24, 0(%r2), 1 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_f64x2_mem_little(i64) -> f64x2 wasmtime_system_v {
+function %scalar_to_vector_f64x2_mem_little(i64) -> f64x2 tail {
 block0(v0: i64):
     v1 = load.f64 little v0
     v2 = scalar_to_vector.f64x2 v1
@@ -2988,18 +2988,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vgbm %v24, 0
-;   lrvg %r2, 0(%r2)
-;   vlvgg %v24, %r2, 1
+;   lrvg %r6, 0(%r2)
+;   vlvgg %v24, %r6, 1
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
-;   lrvg %r2, 0(%r2) ; trap: heap_oob
-;   vlvgg %v24, %r2, 1
+;   lrvg %r6, 0(%r2) ; trap: heap_oob
+;   vlvgg %v24, %r6, 1
 ;   br %r14
 
-function %scalar_to_vector_f32x4(f32) -> f32x4 wasmtime_system_v {
+function %scalar_to_vector_f32x4(f32) -> f32x4 tail {
 block0(v0: f32):
     v1 = scalar_to_vector.f32x4 v0
     return v1
@@ -3019,7 +3019,7 @@ block0(v0: f32):
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
-function %scalar_to_vector_f32x4_lane_0(f32x4) -> f32x4 wasmtime_system_v {
+function %scalar_to_vector_f32x4_lane_0(f32x4) -> f32x4 tail {
 block0(v0: f32x4):
     v1 = extractlane.f32x4 v0, 0
     v2 = scalar_to_vector.f32x4 v1
@@ -3038,7 +3038,7 @@ block0(v0: f32x4):
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
-function %scalar_to_vector_f32x4_lane_3(f32x4) -> f32x4 wasmtime_system_v {
+function %scalar_to_vector_f32x4_lane_3(f32x4) -> f32x4 tail {
 block0(v0: f32x4):
     v1 = extractlane.f32x4 v0, 3
     v2 = scalar_to_vector.f32x4 v1
@@ -3059,7 +3059,7 @@ block0(v0: f32x4):
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
-function %scalar_to_vector_f32x4_mem(i64) -> f32x4 wasmtime_system_v {
+function %scalar_to_vector_f32x4_mem(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 v0
     v2 = scalar_to_vector.f32x4 v1
@@ -3078,7 +3078,7 @@ block0(v0: i64):
 ;   vlef %v24, 0(%r2), 3 ; trap: heap_oob
 ;   br %r14
 
-function %scalar_to_vector_f32x4_mem_little(i64) -> f32x4 wasmtime_system_v {
+function %scalar_to_vector_f32x4_mem_little(i64) -> f32x4 tail {
 block0(v0: i64):
     v1 = load.f32 little v0
     v2 = scalar_to_vector.f32x4 v1
@@ -3088,14 +3088,14 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vgbm %v24, 0
-;   lrv %r2, 0(%r2)
-;   vlvgf %v24, %r2, 3
+;   lrv %r6, 0(%r2)
+;   vlvgf %v24, %r6, 3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
-;   lrv %r2, 0(%r2) ; trap: heap_oob
-;   vlvgf %v24, %r2, 3
+;   lrv %r6, 0(%r2) ; trap: heap_oob
+;   vlvgf %v24, %r6, 3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
@@ -1130,7 +1130,7 @@ block0(v0: i8x16):
 ;   lgdr %r2, %f4
 ;   br %r14
 
-function %vhigh_bits_le(i64x2) -> i64 wasmtime_system_v {
+function %vhigh_bits_le(i64x2) -> i64 tail {
 block0(v0: i64x2):
   v1 = vhigh_bits.i64 v0
   return v1
@@ -1159,7 +1159,7 @@ block0(v0: i64x2):
 ;   lgdr %r2, %f4
 ;   br %r14
 
-function %vhigh_bits_le(i32x4) -> i64 wasmtime_system_v {
+function %vhigh_bits_le(i32x4) -> i64 tail {
 block0(v0: i32x4):
   v1 = vhigh_bits.i64 v0
   return v1
@@ -1189,7 +1189,7 @@ block0(v0: i32x4):
 ;   lgdr %r2, %f4
 ;   br %r14
 
-function %vhigh_bits_le(i16x8) -> i64 wasmtime_system_v {
+function %vhigh_bits_le(i16x8) -> i64 tail {
 block0(v0: i16x8):
   v1 = vhigh_bits.i64 v0
   return v1
@@ -1217,7 +1217,7 @@ block0(v0: i16x8):
 ;   lgdr %r2, %f4
 ;   br %r14
 
-function %vhigh_bits_le(i8x16) -> i64 wasmtime_system_v {
+function %vhigh_bits_le(i8x16) -> i64 tail {
 block0(v0: i8x16):
   v1 = vhigh_bits.i64 v0
   return v1

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
@@ -1,7 +1,7 @@
 test compile precise-output
 target s390x
 
-function %swizzle(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %swizzle(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = swizzle v0, v1
     return v2
@@ -25,7 +25,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vperm %v24, %v3, %v24, %v17
 ;   br %r14
 
-function %shuffle_0(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_0(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
     return v2
@@ -43,7 +43,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 
-function %shuffle_1(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_1(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [3 0 31 26 4 6 12 11 23 13 24 4 2 15 17 5]
     return v2
@@ -70,7 +70,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 
-function %shuffle_vmrhg_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhg_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 25 26 27 28 29 30 31 8 9 10 11 12 13 14 15]
     return v2
@@ -86,7 +86,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhg %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrhf_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhf_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 25 26 27 8 9 10 11 28 29 30 31 12 13 14 15]
     return v2
@@ -102,7 +102,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhf %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrhh_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhh_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 25 8 9 26 27 10 11 28 29 12 13 30 31 14 15]
     return v2
@@ -118,7 +118,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhh %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrhb_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhb_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 8 25 9 26 10 27 11 28 12 29 13 30 14 31 15]
     return v2
@@ -134,7 +134,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhb %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrhg_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhg_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 9 10 11 12 13 14 15 24 25 26 27 28 29 30 31]
     return v2
@@ -150,7 +150,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhg %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrhf_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhf_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 9 10 11 24 25 26 27 12 13 14 15 28 29 30 31]
     return v2
@@ -166,7 +166,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhf %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrhh_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhh_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 9 24 25 10 11 26 27 12 13 28 29 14 15 30 31]
     return v2
@@ -182,7 +182,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhh %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrhb_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhb_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 24 9 25 10 26 11 27 12 28 13 29 14 30 15 31]
     return v2
@@ -198,7 +198,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhb %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrhg_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhg_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 9 10 11 12 13 14 15 8 9 10 11 12 13 14 15]
     return v2
@@ -214,7 +214,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhg %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrhf_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhf_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 9 10 11 8 9 10 11 12 13 14 15 12 13 14 15]
     return v2
@@ -230,7 +230,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhf %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrhh_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhh_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 9 8 9 10 11 10 11 12 13 12 13 14 15 14 15]
     return v2
@@ -246,7 +246,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhh %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrhb_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhb_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [8 8 9 9 10 10 11 11 12 12 13 13 14 14 15 15]
     return v2
@@ -262,7 +262,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhb %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrhg_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhg_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 25 26 27 28 29 30 31 24 25 26 27 28 29 30 31]
     return v2
@@ -278,7 +278,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhg %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vmrhf_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhf_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 25 26 27 24 25 26 27 28 29 30 31 28 29 30 31]
     return v2
@@ -294,7 +294,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhf %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vmrhh_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhh_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 25 24 25 26 27 26 27 28 29 28 29 30 31 30 31]
     return v2
@@ -310,7 +310,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhh %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vmrhb_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrhb_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [24 24 25 25 26 26 27 27 28 28 29 29 30 30 31 31]
     return v2
@@ -326,7 +326,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrhb %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vmrlg_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlg_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 18 19 20 21 22 23 0 1 2 3 4 5 6 7]
     return v2
@@ -342,7 +342,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlg %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrlf_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlf_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 18 19 0 1 2 3 20 21 22 23 4 5 6 7]
     return v2
@@ -358,7 +358,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlf %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrlh_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlh_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 0 1 18 19 2 3 20 21 4 5 22 23 6 7]
     return v2
@@ -374,7 +374,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlh %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrlb_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlb_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 0 17 1 18 2 19 3 20 4 21 5 22 6 23 7]
     return v2
@@ -390,7 +390,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlb %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vmrlg_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlg_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23]
     return v2
@@ -406,7 +406,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlg %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrlf_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlf_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 2 3 16 17 18 19 4 5 6 7 20 21 22 23]
     return v2
@@ -422,7 +422,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlf %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrlh_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlh_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 16 17 2 3 18 19 4 5 20 21 6 7 22 23]
     return v2
@@ -438,7 +438,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlh %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrlb_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlb_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 16 1 17 2 18 3 19 4 20 5 21 6 22 7 23]
     return v2
@@ -454,7 +454,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlb %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vmrlg_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlg_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7]
     return v2
@@ -470,7 +470,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlg %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrlf_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlf_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 2 3 0 1 2 3 4 5 6 7 4 5 6 7]
     return v2
@@ -486,7 +486,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlf %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrlh_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlh_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 0 1 2 3 2 3 4 5 4 5 6 7 6 7]
     return v2
@@ -502,7 +502,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlh %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrlb_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlb_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7]
     return v2
@@ -518,7 +518,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlb %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vmrlg_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlg_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 18 19 20 21 22 23 16 17 18 19 20 21 22 23]
     return v2
@@ -534,7 +534,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlg %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vmrlf_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlf_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 18 19 16 17 18 19 20 21 22 23 20 21 22 23]
     return v2
@@ -550,7 +550,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlf %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vmrlh_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlh_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 16 17 18 19 18 19 20 21 20 21 22 23 22 23]
     return v2
@@ -566,7 +566,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmrlh %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vmrlb_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vmrlb_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 16 17 17 18 18 19 19 20 20 21 21 22 22 23 23]
     return v2
@@ -583,7 +583,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   br %r14
 
 ;; Special patterns that can be implemented via PACK.
-function %shuffle_vpkg_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkg_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 18 19 24 25 26 27 0 1 2 3 8 9 10 11]
     return v2
@@ -599,7 +599,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkg %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vpkf_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkf_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 20 21 24 25 28 29 0 1 4 5 8 9 12 13]
     return v2
@@ -615,7 +615,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkf %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vpkh_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkh_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 18 20 22 24 26 28 30 0 2 4 6 8 10 12 14]
     return v2
@@ -631,7 +631,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkh %v24, %v24, %v25
 ;   br %r14
 
-function %shuffle_vpkg_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkg_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 2 3 8 9 10 11 16 17 18 19 24 25 26 27]
     return v2
@@ -647,7 +647,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkg %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vpkf_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkf_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 4 5 8 9 12 13 16 17 20 21 24 25 28 29]
     return v2
@@ -663,7 +663,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkf %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vpkh_yx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkh_yx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30]
     return v2
@@ -679,7 +679,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkh %v24, %v25, %v24
 ;   br %r14
 
-function %shuffle_vpkg_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkg_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 2 3 8 9 10 11 0 1 2 3 8 9 10 11]
     return v2
@@ -695,7 +695,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkg %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vpkf_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkf_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 1 4 5 8 9 12 13 0 1 4 5 8 9 12 13]
     return v2
@@ -711,7 +711,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkf %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vpkh_xx(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkh_xx(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [0 2 4 6 8 10 12 14 0 2 4 6 8 10 12 14]
     return v2
@@ -727,7 +727,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkh %v24, %v24, %v24
 ;   br %r14
 
-function %shuffle_vpkg_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkg_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 18 19 24 25 26 27 16 17 18 19 24 25 26 27]
     return v2
@@ -743,7 +743,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkg %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vpkf_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkf_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 17 20 21 24 25 28 29 16 17 20 21 24 25 28 29]
     return v2
@@ -759,7 +759,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vpkf %v24, %v25, %v25
 ;   br %r14
 
-function %shuffle_vpkh_yy(i8x16, i8x16) -> i8x16 wasmtime_system_v {
+function %shuffle_vpkh_yy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):
     v2 = shuffle v0, v1, [16 18 20 22 24 26 28 30 16 18 20 22 24 26 28 30]
     return v2

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane-arch13.clif
@@ -1,7 +1,7 @@
 test compile precise-output
 target s390x arch13
 
-function %uload8x8_big(i64) -> i16x8 wasmtime_system_v {
+function %uload8x8_big(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = uload8x8 big v0
   return v1
@@ -21,7 +21,7 @@ block0(v0: i64):
 ;   vuplhb %v24, %v2
 ;   br %r14
 
-function %uload16x4_big(i64) -> i32x4 wasmtime_system_v {
+function %uload16x4_big(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = uload16x4 big v0
   return v1
@@ -43,7 +43,7 @@ block0(v0: i64):
 ;   vuplhh %v24, %v4
 ;   br %r14
 
-function %uload32x2_big(i64) -> i64x2 wasmtime_system_v {
+function %uload32x2_big(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = uload32x2 big v0
   return v1
@@ -63,7 +63,7 @@ block0(v0: i64):
 ;   vuplhf %v24, %v4
 ;   br %r14
 
-function %sload8x8_big(i64) -> i16x8 wasmtime_system_v {
+function %sload8x8_big(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = sload8x8 big v0
   return v1
@@ -83,7 +83,7 @@ block0(v0: i64):
 ;   vuphb %v24, %v2
 ;   br %r14
 
-function %sload16x4_big(i64) -> i32x4 wasmtime_system_v {
+function %sload16x4_big(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = sload16x4 big v0
   return v1
@@ -105,7 +105,7 @@ block0(v0: i64):
 ;   vuphh %v24, %v4
 ;   br %r14
 
-function %sload32x2_big(i64) -> i64x2 wasmtime_system_v {
+function %sload32x2_big(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = sload32x2 big v0
   return v1
@@ -125,7 +125,7 @@ block0(v0: i64):
 ;   vuphf %v24, %v4
 ;   br %r14
 
-function %load_i8x16_big(i64) -> i8x16 wasmtime_system_v {
+function %load_i8x16_big(i64) -> i8x16 tail {
 block0(v0: i64):
   v1 = load.i8x16 big v0
   return v1
@@ -142,7 +142,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r6)
 
-function %load_i16x8_big(i64) -> i16x8 wasmtime_system_v {
+function %load_i16x8_big(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = load.i16x8 big v0
   return v1
@@ -160,7 +160,7 @@ block0(v0: i64):
 ;   lr %r0, %r7
 ;   br %r14
 
-function %load_i32x4_big(i64) -> i32x4 wasmtime_system_v {
+function %load_i32x4_big(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = load.i32x4 big v0
   return v1
@@ -178,7 +178,7 @@ block0(v0: i64):
 ;   ldr %f0, %f7
 ;   br %r14
 
-function %load_i64x2_big(i64) -> i64x2 wasmtime_system_v {
+function %load_i64x2_big(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = load.i64x2 big v0
   return v1
@@ -196,7 +196,7 @@ block0(v0: i64):
 ;   ler %f0, %f7
 ;   br %r14
 
-function %load_f32x4_big(i64) -> f32x4 wasmtime_system_v {
+function %load_f32x4_big(i64) -> f32x4 tail {
 block0(v0: i64):
   v1 = load.f32x4 big v0
   return v1
@@ -214,7 +214,7 @@ block0(v0: i64):
 ;   ldr %f0, %f7
 ;   br %r14
 
-function %load_f64x2_big(i64) -> f64x2 wasmtime_system_v {
+function %load_f64x2_big(i64) -> f64x2 tail {
 block0(v0: i64):
   v1 = load.f64x2 big v0
   return v1
@@ -232,7 +232,7 @@ block0(v0: i64):
 ;   ler %f0, %f7
 ;   br %r14
 
-function %store_i8x16_big(i8x16, i64) wasmtime_system_v {
+function %store_i8x16_big(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
   store.i8x16 big v0, v1
   return
@@ -249,7 +249,7 @@ block0(v0: i8x16, v1: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r14)
 
-function %store_i16x8_big(i16x8, i64) wasmtime_system_v {
+function %store_i16x8_big(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
   store.i16x8 big v0, v1
   return
@@ -267,7 +267,7 @@ block0(v0: i16x8, v1: i64):
 ;   lr %r0, %r15
 ;   br %r14
 
-function %store_i32x4_big(i32x4, i64) wasmtime_system_v {
+function %store_i32x4_big(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
   store.i32x4 big v0, v1
   return
@@ -285,7 +285,7 @@ block0(v0: i32x4, v1: i64):
 ;   ldr %f0, %f15
 ;   br %r14
 
-function %store_i64x2_big(i64x2, i64) wasmtime_system_v {
+function %store_i64x2_big(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
   store.i64x2 big v0, v1
   return
@@ -303,7 +303,7 @@ block0(v0: i64x2, v1: i64):
 ;   ler %f0, %f15
 ;   br %r14
 
-function %store_f32x4_big(f32x4, i64) wasmtime_system_v {
+function %store_f32x4_big(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
   store.f32x4 big v0, v1
   return
@@ -321,7 +321,7 @@ block0(v0: f32x4, v1: i64):
 ;   ldr %f0, %f15
 ;   br %r14
 
-function %store_f64x2_big(f64x2, i64) wasmtime_system_v {
+function %store_f64x2_big(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
   store.f64x2 big v0, v1
   return
@@ -339,7 +339,7 @@ block0(v0: f64x2, v1: i64):
 ;   ler %f0, %f15
 ;   br %r14
 
-function %uload8x8_little(i64) -> i16x8 wasmtime_system_v {
+function %uload8x8_little(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = uload8x8 little v0
   return v1
@@ -359,7 +359,7 @@ block0(v0: i64):
 ;   vuplhb %v24, %v2
 ;   br %r14
 
-function %uload16x4_little(i64) -> i32x4 wasmtime_system_v {
+function %uload16x4_little(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = uload16x4 little v0
   return v1
@@ -379,7 +379,7 @@ block0(v0: i64):
 ;   vuplhh %v24, %v2
 ;   br %r14
 
-function %uload32x2_little(i64) -> i64x2 wasmtime_system_v {
+function %uload32x2_little(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = uload32x2 little v0
   return v1
@@ -399,7 +399,7 @@ block0(v0: i64):
 ;   vuplhf %v24, %v2
 ;   br %r14
 
-function %sload8x8_little(i64) -> i16x8 wasmtime_system_v {
+function %sload8x8_little(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = sload8x8 little v0
   return v1
@@ -419,7 +419,7 @@ block0(v0: i64):
 ;   vuphb %v24, %v2
 ;   br %r14
 
-function %sload16x4_little(i64) -> i32x4 wasmtime_system_v {
+function %sload16x4_little(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = sload16x4 little v0
   return v1
@@ -439,7 +439,7 @@ block0(v0: i64):
 ;   vuphh %v24, %v2
 ;   br %r14
 
-function %sload32x2_little(i64) -> i64x2 wasmtime_system_v {
+function %sload32x2_little(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = sload32x2 little v0
   return v1
@@ -459,7 +459,7 @@ block0(v0: i64):
 ;   vuphf %v24, %v2
 ;   br %r14
 
-function %load_i8x16_little(i64) -> i8x16 wasmtime_system_v {
+function %load_i8x16_little(i64) -> i8x16 tail {
 block0(v0: i64):
   v1 = load.i8x16 little v0
   return v1
@@ -476,7 +476,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r6)
 
-function %load_i16x8_little(i64) -> i16x8 wasmtime_system_v {
+function %load_i16x8_little(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = load.i16x8 little v0
   return v1
@@ -493,7 +493,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r6)
 
-function %load_i32x4_little(i64) -> i32x4 wasmtime_system_v {
+function %load_i32x4_little(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = load.i32x4 little v0
   return v1
@@ -510,7 +510,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r6)
 
-function %load_i64x2_little(i64) -> i64x2 wasmtime_system_v {
+function %load_i64x2_little(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = load.i64x2 little v0
   return v1
@@ -527,7 +527,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r6)
 
-function %load_f32x4_little(i64) -> f32x4 wasmtime_system_v {
+function %load_f32x4_little(i64) -> f32x4 tail {
 block0(v0: i64):
   v1 = load.f32x4 little v0
   return v1
@@ -544,7 +544,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r6)
 
-function %load_f64x2_little(i64) -> f64x2 wasmtime_system_v {
+function %load_f64x2_little(i64) -> f64x2 tail {
 block0(v0: i64):
   v1 = load.f64x2 little v0
   return v1
@@ -561,7 +561,7 @@ block0(v0: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r6)
 
-function %store_i8x16_little(i8x16, i64) wasmtime_system_v {
+function %store_i8x16_little(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
   store.i8x16 little v0, v1
   return
@@ -578,7 +578,7 @@ block0(v0: i8x16, v1: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r14)
 
-function %store_i16x8_little(i16x8, i64) wasmtime_system_v {
+function %store_i16x8_little(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
   store.i16x8 little v0, v1
   return
@@ -595,7 +595,7 @@ block0(v0: i16x8, v1: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r14)
 
-function %store_i32x4_little(i32x4, i64) wasmtime_system_v {
+function %store_i32x4_little(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
   store.i32x4 little v0, v1
   return
@@ -612,7 +612,7 @@ block0(v0: i32x4, v1: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r14)
 
-function %store_i64x2_little(i64x2, i64) wasmtime_system_v {
+function %store_i64x2_little(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
   store.i64x2 little v0, v1
   return
@@ -629,7 +629,7 @@ block0(v0: i64x2, v1: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r14)
 
-function %store_f32x4_little(f32x4, i64) wasmtime_system_v {
+function %store_f32x4_little(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
   store.f32x4 little v0, v1
   return
@@ -646,7 +646,7 @@ block0(v0: f32x4, v1: i64):
 ;   lpdr %f0, %f0
 ;   lh %r0, 0x7fe(%r14)
 
-function %store_f64x2_little(f64x2, i64) wasmtime_system_v {
+function %store_f64x2_little(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
   store.f64x2 little v0, v1
   return

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
@@ -1,7 +1,7 @@
 test compile precise-output
 target s390x
 
-function %uload8x8_big(i64) -> i16x8 wasmtime_system_v {
+function %uload8x8_big(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = uload8x8 big v0
   return v1
@@ -21,7 +21,7 @@ block0(v0: i64):
 ;   vuplhb %v24, %v4
 ;   br %r14
 
-function %uload16x4_big(i64) -> i32x4 wasmtime_system_v {
+function %uload16x4_big(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = uload16x4 big v0
   return v1
@@ -43,7 +43,7 @@ block0(v0: i64):
 ;   vuplhh %v24, %v6
 ;   br %r14
 
-function %uload32x2_big(i64) -> i64x2 wasmtime_system_v {
+function %uload32x2_big(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = uload32x2 big v0
   return v1
@@ -63,7 +63,7 @@ block0(v0: i64):
 ;   vuplhf %v24, %v4
 ;   br %r14
 
-function %sload8x8_big(i64) -> i16x8 wasmtime_system_v {
+function %sload8x8_big(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = sload8x8 big v0
   return v1
@@ -83,7 +83,7 @@ block0(v0: i64):
 ;   vuphb %v24, %v4
 ;   br %r14
 
-function %sload16x4_big(i64) -> i32x4 wasmtime_system_v {
+function %sload16x4_big(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = sload16x4 big v0
   return v1
@@ -105,7 +105,7 @@ block0(v0: i64):
 ;   vuphh %v24, %v6
 ;   br %r14
 
-function %sload32x2_big(i64) -> i64x2 wasmtime_system_v {
+function %sload32x2_big(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = sload32x2 big v0
   return v1
@@ -125,7 +125,7 @@ block0(v0: i64):
 ;   vuphf %v24, %v4
 ;   br %r14
 
-function %load_i8x16_big(i64) -> i8x16 wasmtime_system_v {
+function %load_i8x16_big(i64) -> i8x16 tail {
 block0(v0: i64):
   v1 = load.i8x16 big v0
   return v1
@@ -134,18 +134,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
-;   lrvg %r2, 8(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
-;   lrvg %r2, 8(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %load_i16x8_big(i64) -> i16x8 wasmtime_system_v {
+function %load_i16x8_big(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = load.i16x8 big v0
   return v1
@@ -167,7 +167,7 @@ block0(v0: i64):
 ;   verllf %v24, %v6, 0x10
 ;   br %r14
 
-function %load_i32x4_big(i64) -> i32x4 wasmtime_system_v {
+function %load_i32x4_big(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = load.i32x4 big v0
   return v1
@@ -187,7 +187,7 @@ block0(v0: i64):
 ;   verllg %v24, %v4, 0x20
 ;   br %r14
 
-function %load_i64x2_big(i64) -> i64x2 wasmtime_system_v {
+function %load_i64x2_big(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = load.i64x2 big v0
   return v1
@@ -205,7 +205,7 @@ block0(v0: i64):
 ;   vpdi %v24, %v2, %v2, 4
 ;   br %r14
 
-function %load_f32x4_big(i64) -> f32x4 wasmtime_system_v {
+function %load_f32x4_big(i64) -> f32x4 tail {
 block0(v0: i64):
   v1 = load.f32x4 big v0
   return v1
@@ -225,7 +225,7 @@ block0(v0: i64):
 ;   verllg %v24, %v4, 0x20
 ;   br %r14
 
-function %load_f64x2_big(i64) -> f64x2 wasmtime_system_v {
+function %load_f64x2_big(i64) -> f64x2 tail {
 block0(v0: i64):
   v1 = load.f64x2 big v0
   return v1
@@ -243,7 +243,7 @@ block0(v0: i64):
 ;   vpdi %v24, %v2, %v2, 4
 ;   br %r14
 
-function %store_i8x16_big(i8x16, i64) wasmtime_system_v {
+function %store_i8x16_big(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
   store.i8x16 big v0, v1
   return
@@ -252,20 +252,20 @@ block0(v0: i8x16, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   strvg %r7, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   strvg %r7, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_i16x8_big(i16x8, i64) wasmtime_system_v {
+function %store_i16x8_big(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
   store.i16x8 big v0, v1
   return
@@ -287,7 +287,7 @@ block0(v0: i16x8, v1: i64):
 ;   vst %v7, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_i32x4_big(i32x4, i64) wasmtime_system_v {
+function %store_i32x4_big(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
   store.i32x4 big v0, v1
   return
@@ -307,7 +307,7 @@ block0(v0: i32x4, v1: i64):
 ;   vst %v5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_i64x2_big(i64x2, i64) wasmtime_system_v {
+function %store_i64x2_big(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
   store.i64x2 big v0, v1
   return
@@ -325,7 +325,7 @@ block0(v0: i64x2, v1: i64):
 ;   vst %v3, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_f32x4_big(f32x4, i64) wasmtime_system_v {
+function %store_f32x4_big(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
   store.f32x4 big v0, v1
   return
@@ -345,7 +345,7 @@ block0(v0: f32x4, v1: i64):
 ;   vst %v5, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_f64x2_big(f64x2, i64) wasmtime_system_v {
+function %store_f64x2_big(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
   store.f64x2 big v0, v1
   return
@@ -363,7 +363,7 @@ block0(v0: f64x2, v1: i64):
 ;   vst %v3, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %uload8x8_little(i64) -> i16x8 wasmtime_system_v {
+function %uload8x8_little(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = uload8x8 little v0
   return v1
@@ -383,7 +383,7 @@ block0(v0: i64):
 ;   vuplhb %v24, %v4
 ;   br %r14
 
-function %uload16x4_little(i64) -> i32x4 wasmtime_system_v {
+function %uload16x4_little(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = uload16x4 little v0
   return v1
@@ -403,7 +403,7 @@ block0(v0: i64):
 ;   vuplhh %v24, %v4
 ;   br %r14
 
-function %uload32x2_little(i64) -> i64x2 wasmtime_system_v {
+function %uload32x2_little(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = uload32x2 little v0
   return v1
@@ -423,7 +423,7 @@ block0(v0: i64):
 ;   vuplhf %v24, %v4
 ;   br %r14
 
-function %sload8x8_little(i64) -> i16x8 wasmtime_system_v {
+function %sload8x8_little(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = sload8x8 little v0
   return v1
@@ -443,7 +443,7 @@ block0(v0: i64):
 ;   vuphb %v24, %v4
 ;   br %r14
 
-function %sload16x4_little(i64) -> i32x4 wasmtime_system_v {
+function %sload16x4_little(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = sload16x4 little v0
   return v1
@@ -463,7 +463,7 @@ block0(v0: i64):
 ;   vuphh %v24, %v4
 ;   br %r14
 
-function %sload32x2_little(i64) -> i64x2 wasmtime_system_v {
+function %sload32x2_little(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = sload32x2 little v0
   return v1
@@ -483,7 +483,7 @@ block0(v0: i64):
 ;   vuphf %v24, %v4
 ;   br %r14
 
-function %load_i8x16_little(i64) -> i8x16 wasmtime_system_v {
+function %load_i8x16_little(i64) -> i8x16 tail {
 block0(v0: i64):
   v1 = load.i8x16 little v0
   return v1
@@ -492,18 +492,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
-;   lrvg %r2, 8(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
-;   lrvg %r2, 8(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %load_i16x8_little(i64) -> i16x8 wasmtime_system_v {
+function %load_i16x8_little(i64) -> i16x8 tail {
 block0(v0: i64):
   v1 = load.i16x8 little v0
   return v1
@@ -512,18 +512,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
-;   lrvg %r2, 8(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
-;   lrvg %r2, 8(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %load_i32x4_little(i64) -> i32x4 wasmtime_system_v {
+function %load_i32x4_little(i64) -> i32x4 tail {
 block0(v0: i64):
   v1 = load.i32x4 little v0
   return v1
@@ -532,18 +532,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
-;   lrvg %r2, 8(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
-;   lrvg %r2, 8(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %load_i64x2_little(i64) -> i64x2 wasmtime_system_v {
+function %load_i64x2_little(i64) -> i64x2 tail {
 block0(v0: i64):
   v1 = load.i64x2 little v0
   return v1
@@ -552,18 +552,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
-;   lrvg %r2, 8(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
-;   lrvg %r2, 8(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %load_f32x4_little(i64) -> f32x4 wasmtime_system_v {
+function %load_f32x4_little(i64) -> f32x4 tail {
 block0(v0: i64):
   v1 = load.f32x4 little v0
   return v1
@@ -572,18 +572,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
-;   lrvg %r2, 8(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
-;   lrvg %r2, 8(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %load_f64x2_little(i64) -> f64x2 wasmtime_system_v {
+function %load_f64x2_little(i64) -> f64x2 tail {
 block0(v0: i64):
   v1 = load.f64x2 little v0
   return v1
@@ -592,18 +592,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
-;   lrvg %r2, 8(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
-;   lrvg %r2, 8(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 8(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %load_f64x2_sum_little(i64, i64) -> f64x2 wasmtime_system_v {
+function %load_f64x2_sum_little(i64, i64) -> f64x2 tail {
 block0(v0: i64, v1: i64):
   v2 = iadd.i64 v0, v1
   v3 = load.f64x2 little v2
@@ -613,18 +613,18 @@ block0(v0: i64, v1: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r5, 0(%r3,%r2)
-;   lrvg %r3, 8(%r3,%r2)
-;   vlvgp %v24, %r3, %r5
+;   lrvg %r7, 8(%r3,%r2)
+;   vlvgp %v24, %r7, %r5
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r3, %r2) ; trap: heap_oob
-;   lrvg %r3, 8(%r3, %r2) ; trap: heap_oob
-;   vlvgp %v24, %r3, %r5
+;   lrvg %r7, 8(%r3, %r2) ; trap: heap_oob
+;   vlvgp %v24, %r7, %r5
 ;   br %r14
 
-function %load_f64x2_off_little(i64) -> f64x2 wasmtime_system_v {
+function %load_f64x2_off_little(i64) -> f64x2 tail {
 block0(v0: i64):
   v1 = load.f64x2 little v0+128
   return v1
@@ -633,18 +633,18 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   lrvg %r4, 128(%r2)
-;   lrvg %r2, 136(%r2)
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 136(%r2)
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0x80(%r2) ; trap: heap_oob
-;   lrvg %r2, 0x88(%r2) ; trap: heap_oob
-;   vlvgp %v24, %r2, %r4
+;   lrvg %r6, 0x88(%r2) ; trap: heap_oob
+;   vlvgp %v24, %r6, %r4
 ;   br %r14
 
-function %store_i8x16_little(i8x16, i64) wasmtime_system_v {
+function %store_i8x16_little(i8x16, i64) tail {
 block0(v0: i8x16, v1: i64):
   store.i8x16 little v0, v1
   return
@@ -653,20 +653,20 @@ block0(v0: i8x16, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   strvg %r7, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   strvg %r7, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_i16x8_little(i16x8, i64) wasmtime_system_v {
+function %store_i16x8_little(i16x8, i64) tail {
 block0(v0: i16x8, v1: i64):
   store.i16x8 little v0, v1
   return
@@ -675,20 +675,20 @@ block0(v0: i16x8, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   strvg %r7, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   strvg %r7, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_i32x4_little(i32x4, i64) wasmtime_system_v {
+function %store_i32x4_little(i32x4, i64) tail {
 block0(v0: i32x4, v1: i64):
   store.i32x4 little v0, v1
   return
@@ -697,20 +697,20 @@ block0(v0: i32x4, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   strvg %r7, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   strvg %r7, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_i64x2_little(i64x2, i64) wasmtime_system_v {
+function %store_i64x2_little(i64x2, i64) tail {
 block0(v0: i64x2, v1: i64):
   store.i64x2 little v0, v1
   return
@@ -719,20 +719,20 @@ block0(v0: i64x2, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   strvg %r7, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   strvg %r7, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_f32x4_little(f32x4, i64) wasmtime_system_v {
+function %store_f32x4_little(f32x4, i64) tail {
 block0(v0: f32x4, v1: i64):
   store.f32x4 little v0, v1
   return
@@ -741,20 +741,20 @@ block0(v0: f32x4, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   strvg %r7, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   strvg %r7, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_f64x2_little(f64x2, i64) wasmtime_system_v {
+function %store_f64x2_little(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
   store.f64x2 little v0, v1
   return
@@ -763,20 +763,20 @@ block0(v0: f64x2, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   strvg %r7, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   strvg %r7, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_f64x2_sum_little(f64x2, i64, i64) wasmtime_system_v {
+function %store_f64x2_sum_little(f64x2, i64, i64) tail {
 block0(v0: f64x2, v1: i64, v2: i64):
   v3 = iadd.i64 v1, v2
   store.f64x2 little v0, v3
@@ -785,21 +785,21 @@ block0(v0: f64x2, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   vlgvg %r5, %v24, 1
+;   vlgvg %r6, %v24, 1
 ;   vlgvg %r4, %v24, 0
-;   strvg %r5, 0(%r3,%r2)
+;   strvg %r6, 0(%r3,%r2)
 ;   strvg %r4, 8(%r3,%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   vlgvg %r5, %v24, 1
+;   vlgvg %r6, %v24, 1
 ;   vlgvg %r4, %v24, 0
-;   strvg %r5, 0(%r3, %r2) ; trap: heap_oob
+;   strvg %r6, 0(%r3, %r2) ; trap: heap_oob
 ;   strvg %r4, 8(%r3, %r2) ; trap: heap_oob
 ;   br %r14
 
-function %store_f64x2_off_little(f64x2, i64) wasmtime_system_v {
+function %store_f64x2_off_little(f64x2, i64) tail {
 block0(v0: f64x2, v1: i64):
   store.f64x2 little v0, v1+128
   return
@@ -808,16 +808,16 @@ block0(v0: f64x2, v1: i64):
 ; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 128(%r2)
-;   strvg %r3, 136(%r2)
+;   strvg %r7, 136(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r7, %v24, 0
 ;   strvg %r5, 0x80(%r2) ; trap: heap_oob
-;   strvg %r3, 0x88(%r2) ; trap: heap_oob
+;   strvg %r7, 0x88(%r2) ; trap: heap_oob
 ;   br %r14
 

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -88,7 +88,7 @@ pub(crate) enum LookupError {
 /// convention and the rest, if any, via a return pointer.
 #[derive(Copy, Clone, Debug)]
 pub enum CallingConvention {
-    /// See [cranelift_codegen::isa::CallConv::WasmtimeSystemV]
+    /// See [cranelift_codegen::isa::CallConv::SystemV]
     SystemV,
     /// See [cranelift_codegen::isa::CallConv::WindowsFastcall]
     WindowsFastcall,
@@ -101,7 +101,7 @@ pub enum CallingConvention {
 }
 
 impl CallingConvention {
-    /// Returns true if the current calling convention is `WasmtimeFastcall`.
+    /// Returns true if the current calling convention is `WindowsFastcall`.
     fn is_fastcall(&self) -> bool {
         match &self {
             CallingConvention::WindowsFastcall => true,
@@ -109,7 +109,7 @@ impl CallingConvention {
         }
     }
 
-    /// Returns true if the current calling convention is `WasmtimeSystemV`.
+    /// Returns true if the current calling convention is `SystemV`.
     fn is_systemv(&self) -> bool {
         match &self {
             CallingConvention::SystemV => true,
@@ -117,7 +117,7 @@ impl CallingConvention {
         }
     }
 
-    /// Returns true if the current calling convention is `WasmtimeAppleAarch64`.
+    /// Returns true if the current calling convention is `AppleAarch64`.
     fn is_apple_aarch64(&self) -> bool {
         match &self {
             CallingConvention::AppleAarch64 => true,


### PR DESCRIPTION
This also removes the `WasmtimeSystemV` call conv as it is no longer used anywhere.