### PR TITLE
Don't limit core instances/memories/tables by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2704,7 +2704,7 @@ impl PoolingAllocationConfig {
     }
 
     /// The maximum number of core instances a single component may contain
-    /// (default is `20`).
+    /// (default is unlimited).
     ///
     /// This method (along with
     /// [`PoolingAllocationConfig::max_memories_per_component`],
@@ -2720,7 +2720,7 @@ impl PoolingAllocationConfig {
     }
 
     /// The maximum number of Wasm linear memories that a single component may
-    /// transitively contain (default is `20`).
+    /// transitively contain (default is unlimited).
     ///
     /// This method (along with
     /// [`PoolingAllocationConfig::max_core_instances_per_component`],
@@ -2736,7 +2736,7 @@ impl PoolingAllocationConfig {
     }
 
     /// The maximum number of tables that a single component may transitively
-    /// contain (default is `20`).
+    /// contain (default is unlimited).
     ///
     /// This method (along with
     /// [`PoolingAllocationConfig::max_core_instances_per_component`],

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -153,9 +153,9 @@ impl Default for InstanceLimits {
             total_component_instances: 1000,
             component_instance_size: 1 << 20, // 1 MiB
             total_core_instances: 1000,
-            max_core_instances_per_component: 20,
-            max_memories_per_component: 20,
-            max_tables_per_component: 20,
+            max_core_instances_per_component: u32::MAX,
+            max_memories_per_component: u32::MAX,
+            max_tables_per_component: u32::MAX,
             total_memories: 1000,
             total_tables: 1000,
             #[cfg(feature = "async")]


### PR DESCRIPTION
This commit updates the defaults of `PoolingAllocationConfig` to allow unlimited core instances/memories/tables per component instead of the previous default of 20. The limits here are somewhat restrictive and more tailored for high-scale use cases which aren't always the best defaults for a general purpose tool like the `wasmtime` CLI. The CLI for example uses the pooling allocator by default with `serve` and this helps accept a wider breadth of components by default instead of artificially limiting the shape of input components.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
