### PR TITLE
Stop special-casing `i31ref` accesses in many places

### DIFF
--- a/crates/cranelift/src/gc.rs
+++ b/crates/cranelift/src/gc.rs
@@ -26,39 +26,6 @@ pub fn gc_compiler(func_env: &FuncEnvironment<'_>) -> Box<dyn GcCompiler> {
     imp::gc_compiler(func_env)
 }
 
-/// Load a `*mut VMGcRef` into a virtual register, without any GC barriers.
-///
-/// The resulting value is an instance of the function environment's type for
-/// GC-managed references, aka `i32`. Note that a `VMGcRef` is always 4-bytes
-/// large, even when targeting 64-bit architectures.
-pub fn unbarriered_load_gc_ref(
-    func_env: &FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder<'_>,
-    ty: WasmHeapType,
-    src: ir::Value,
-    flags: ir::MemFlags,
-) -> WasmResult<ir::Value> {
-    imp::unbarriered_load_gc_ref(func_env, builder, ty, src, flags)
-}
-
-/// Store `*dst = gc_ref`, without any GC barriers.
-///
-/// `dst` is a `*mut VMGcRef`.
-///
-/// `gc_ref` is an instance of the function environment's type for GC-managed
-/// references, aka `i32`. Note that a `VMGcRef` is always 4-bytes large, even
-/// when targeting 64-bit architectures.
-pub fn unbarriered_store_gc_ref(
-    func_env: &FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder<'_>,
-    ty: WasmHeapType,
-    dst: ir::Value,
-    gc_ref: ir::Value,
-    flags: ir::MemFlags,
-) -> WasmResult<()> {
-    imp::unbarriered_store_gc_ref(func_env, builder, ty, dst, gc_ref, flags)
-}
-
 /// Get the index and signature of the built-in function for doing `table.grow`
 /// on GC reference tables.
 pub fn gc_ref_table_grow_builtin(

--- a/crates/cranelift/src/gc/disabled.rs
+++ b/crates/cranelift/src/gc/disabled.rs
@@ -12,33 +12,6 @@ pub fn gc_compiler(_: &FuncEnvironment<'_>) -> Box<dyn GcCompiler> {
     Box::new(DisabledGcCompiler)
 }
 
-pub fn unbarriered_load_gc_ref(
-    _func_env: &FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder,
-    ty: WasmHeapType,
-    _ptr_to_gc_ref: ir::Value,
-    _flags: ir::MemFlags,
-) -> WasmResult<ir::Value> {
-    Err(wasm_unsupported!(
-        "support for `{ty}` references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
-}
-
-pub fn unbarriered_store_gc_ref(
-    _func_env: &FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder<'_>,
-    ty: WasmHeapType,
-    _dst: ir::Value,
-    _gc_ref: ir::Value,
-    _flags: ir::MemFlags,
-) -> WasmResult<()> {
-    Err(wasm_unsupported!(
-        "support for `{ty}` references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
-}
-
 pub fn gc_ref_table_grow_builtin(
     ty: WasmHeapType,
     _func_env: &mut FuncEnvironment<'_>,


### PR DESCRIPTION
Consolidate all `i31ref` special casing into the `translate_{read,write}_gc_reference` methods, which already emit more or less inline GC barriers depending on the reference's heap type, so it makes sense to also handle `i31ref` there.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
