### PR TITLE
Rename the `wasmtime::runtime::vm::Instance::module` method to `env_module`

### DIFF
--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -1013,7 +1013,7 @@ impl SharedMemory {
     ) -> Self {
         #[cfg_attr(not(feature = "threads"), allow(unused_variables, unreachable_code))]
         crate::runtime::vm::Instance::from_vmctx(wasmtime_export.vmctx, |handle| {
-            let memory_index = handle.module().memory_index(wasmtime_export.index);
+            let memory_index = handle.env_module().memory_index(wasmtime_export.index);
             let page_size = handle.memory_page_size(memory_index);
             debug_assert!(page_size.is_power_of_two());
             let page_size_log2 = u8::try_from(page_size.ilog2()).unwrap();

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -572,7 +572,7 @@ impl<T> Store<T> {
             let shim = ModuleRuntimeInfo::bare(module);
             let allocator = OnDemandInstanceAllocator::default();
             allocator
-                .validate_module(shim.module(), shim.offsets())
+                .validate_module(shim.env_module(), shim.offsets())
                 .unwrap();
             let mut instance = unsafe {
                 allocator

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -204,7 +204,7 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
     ) -> Result<(MemoryAllocationIndex, Memory)> {
         #[cfg(debug_assertions)]
         {
-            let module = request.runtime_info.module();
+            let module = request.runtime_info.env_module();
             let offsets = request.runtime_info.offsets();
             self.validate_module_impl(module, offsets)
                 .expect("should have already validated the module before allocating memory");

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -217,7 +217,7 @@ impl ModuleRuntimeInfo {
     }
 
     /// The underlying Module.
-    pub(crate) fn module(&self) -> &Arc<wasmtime_environ::Module> {
+    pub(crate) fn env_module(&self) -> &Arc<wasmtime_environ::Module> {
         match self {
             ModuleRuntimeInfo::Module(m) => m.env_module(),
             ModuleRuntimeInfo::Bare(b) => &b.module,

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -11,7 +11,7 @@ static mut VMCTX_AND_MEMORY: (*mut VMContext, usize) = (std::ptr::null_mut(), 0)
 pub unsafe extern "C" fn resolve_vmctx_memory(ptr: usize) -> *const u8 {
     Instance::from_vmctx(VMCTX_AND_MEMORY.0, |handle| {
         assert!(
-            VMCTX_AND_MEMORY.1 < handle.module().memory_plans.len(),
+            VMCTX_AND_MEMORY.1 < handle.env_module().memory_plans.len(),
             "memory index for debugger is out of bounds"
         );
         let index = MemoryIndex::new(VMCTX_AND_MEMORY.1);
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
     );
     Instance::from_vmctx(VMCTX_AND_MEMORY.0, |handle| {
         assert!(
-            VMCTX_AND_MEMORY.1 < handle.module().memory_plans.len(),
+            VMCTX_AND_MEMORY.1 < handle.env_module().memory_plans.len(),
             "memory index for debugger is out of bounds"
         );
         let index = MemoryIndex::new(VMCTX_AND_MEMORY.1);

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -372,7 +372,7 @@ pub trait InstanceAllocator: InstanceAllocatorImpl {
         &self,
         mut request: InstanceAllocationRequest,
     ) -> Result<InstanceHandle> {
-        let module = request.runtime_info.module();
+        let module = request.runtime_info.env_module();
 
         #[cfg(debug_assertions)]
         InstanceAllocatorImpl::validate_module_impl(self, module, request.runtime_info.offsets())
@@ -438,7 +438,7 @@ pub trait InstanceAllocator: InstanceAllocatorImpl {
         request: &mut InstanceAllocationRequest,
         memories: &mut PrimaryMap<DefinedMemoryIndex, (MemoryAllocationIndex, Memory)>,
     ) -> Result<()> {
-        let module = request.runtime_info.module();
+        let module = request.runtime_info.env_module();
 
         #[cfg(debug_assertions)]
         InstanceAllocatorImpl::validate_module_impl(self, module, request.runtime_info.offsets())
@@ -490,7 +490,7 @@ pub trait InstanceAllocator: InstanceAllocatorImpl {
         request: &mut InstanceAllocationRequest,
         tables: &mut PrimaryMap<DefinedTableIndex, (TableAllocationIndex, Table)>,
     ) -> Result<()> {
-        let module = request.runtime_info.module();
+        let module = request.runtime_info.env_module();
 
         #[cfg(debug_assertions)]
         InstanceAllocatorImpl::validate_module_impl(self, module, request.runtime_info.offsets())
@@ -636,7 +636,7 @@ fn get_memory_init_start(
     let mut context = ConstEvalContext::new(instance, module);
     let mut const_evaluator = ConstExprEvaluator::default();
     unsafe { const_evaluator.eval(&mut context, &init.offset) }.map(|v| {
-        match instance.module().memory_plans[init.memory_index]
+        match instance.env_module().memory_plans[init.memory_index]
             .memory
             .idx_type
         {
@@ -706,7 +706,10 @@ fn initialize_memories(instance: &mut Instance, module: &Module) -> Result<()> {
             let val = unsafe { self.const_evaluator.eval(&mut context, expr) }
                 .expect("const expression should be valid");
             Some(
-                match self.instance.module().memory_plans[memory].memory.idx_type {
+                match self.instance.env_module().memory_plans[memory]
+                    .memory
+                    .idx_type
+                {
                     wasmtime_environ::IndexType::I32 => val.get_u32().into(),
                     wasmtime_environ::IndexType::I64 => val.get_u64(),
                 },


### PR DESCRIPTION
Because it returns the `wasmtime_environ::Module`.

This paves the way for a new method to get the `wasmtime::Module`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
