### PR TITLE
wit-bindgen: Don't trace values containing lists by default.

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -110,6 +110,7 @@ impl Parse for Config {
                         inline = Some(s.value());
                     }
                     Opt::Tracing(val) => opts.tracing = val,
+                    Opt::VerboseTracing(val) => opts.verbose_tracing = val,
                     Opt::Async(val, span) => {
                         if async_configured {
                             return Err(Error::new(span, "cannot specify second async config"));
@@ -232,6 +233,7 @@ mod kw {
     syn::custom_keyword!(inline);
     syn::custom_keyword!(path);
     syn::custom_keyword!(tracing);
+    syn::custom_keyword!(verbose_tracing);
     syn::custom_keyword!(trappable_error_type);
     syn::custom_keyword!(world);
     syn::custom_keyword!(ownership);
@@ -254,6 +256,7 @@ enum Opt {
     Path(syn::LitStr),
     Inline(syn::LitStr),
     Tracing(bool),
+    VerboseTracing(bool),
     Async(AsyncConfig, Span),
     TrappableErrorType(Vec<TrappableError>),
     Ownership(Ownership),
@@ -288,6 +291,10 @@ impl Parse for Opt {
             input.parse::<kw::tracing>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::Tracing(input.parse::<syn::LitBool>()?.value))
+        } else if l.peek(kw::verbose_tracing) {
+            input.parse::<kw::verbose_tracing>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Opt::VerboseTracing(input.parse::<syn::LitBool>()?.value))
         } else if l.peek(Token![async]) {
             let span = input.parse::<Token![async]>()?.span;
             input.parse::<Token![:]>()?;

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -16,6 +16,7 @@ macro_rules! gentest {
                 wasmtime::component::bindgen!({
                     path: $path,
                     tracing: true,
+                    verbose_tracing: true,
                     ownership: Borrowing {
                         duplicate_if_necessary: true
                     }

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -527,7 +527,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -556,7 +556,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -585,7 +585,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -614,7 +614,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -643,7 +643,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -672,7 +672,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -701,7 +701,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -730,7 +730,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -759,7 +759,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -788,7 +788,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -817,8 +817,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_u8_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -840,8 +840,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_u16_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -863,8 +863,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_u32_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -886,8 +886,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_u64_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -909,8 +909,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_s8_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -932,8 +932,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_s16_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -955,8 +955,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_s32_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -978,8 +978,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_s64_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1001,8 +1001,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_float32_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1024,8 +1024,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_float64_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1047,14 +1047,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::tuple_list(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1082,7 +1082,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, a = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, a = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -1111,8 +1111,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::string_list_ret(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1140,14 +1140,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::tuple_string_list(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1175,14 +1175,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::string_list(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1204,14 +1204,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::record_list(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1233,14 +1233,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::record_list_reverse(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1262,14 +1262,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::variant_list(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -1291,14 +1291,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, a = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, a = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::load_store_everything(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -1045,7 +1045,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -1080,7 +1080,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, x = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, x = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -1109,8 +1109,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::list_result(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -255,7 +255,7 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, l = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, l = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
@@ -284,8 +284,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::simple_list2(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -313,14 +313,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, a = tracing::field::debug(& arg0), b
-                                    = tracing::field::debug(& arg1), "call"
+                                    tracing::Level::TRACE, a = tracing::field::debug("..."), b =
+                                    tracing::field::debug("..."), "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::simple_list3(host, arg0, arg1).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }
@@ -348,14 +348,14 @@ pub mod foo {
                         wasmtime::component::__internal::Box::new(
                             async move {
                                 tracing::event!(
-                                    tracing::Level::TRACE, l = tracing::field::debug(& arg0),
+                                    tracing::Level::TRACE, l = tracing::field::debug("..."),
                                     "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::simple_list4(host, arg0).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -868,8 +868,8 @@ pub mod foo {
                                     tracing::Level::TRACE, a = tracing::field::debug(& arg0), b
                                     = tracing::field::debug(& arg1), c = tracing::field::debug(&
                                     arg2), d = tracing::field::debug(& arg3), e =
-                                    tracing::field::debug(& arg4), f = tracing::field::debug(&
-                                    arg5), "call"
+                                    tracing::field::debug(& arg4), f =
+                                    tracing::field::debug("..."), "call"
                                 );
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::result_arg(
@@ -906,8 +906,8 @@ pub mod foo {
                                 let host = &mut host_getter(caller.data_mut());
                                 let r = Host::result_result(host).await;
                                 tracing::event!(
-                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
-                                    "return"
+                                    tracing::Level::TRACE, result =
+                                    tracing::field::debug("..."), "return"
                                 );
                                 Ok((r,))
                             }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -241,10 +241,18 @@ pub(crate) use self::store::ComponentStoreData;
 ///     ",
 ///
 ///     // Add calls to `tracing::span!` before each import or export is called
-///     // to log arguments and return values.
+///     // to log most arguments and return values. By default values
+///     // containing lists are excluded; enable `verbose_tracing` to include
+///     // them.
 ///     //
 ///     // This option defaults to `false`.
 ///     tracing: true,
+///
+///     // Include all arguments and return values in the tracing output,
+///     // including values containing lists, which may be very large.
+///     //
+///     // This option defaults to `false`.
+///     verbose_tracing: false,
 ///
 ///     // Imports will be async functions through #[async_trait] and exports
 ///     // are also invoked as async functions. Requires `Config::async_support`

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -3022,26 +3022,10 @@ fn type_contains_lists(ty: Type, resolve: &Resolve) -> bool {
                 .iter()
                 .any(|case| option_type_contains_lists(case.ty, resolve)),
             TypeDefKind::Type(ty) => type_contains_lists(*ty, resolve),
-            TypeDefKind::Future(ty) => {
-                if let Some(ty) = ty {
-                    if type_contains_lists(*ty, resolve) {
-                        return true;
-                    }
-                }
-                false
-            }
+            TypeDefKind::Future(ty) => option_type_contains_lists(*ty, resolve),
             TypeDefKind::Stream(Stream { element, end }) => {
-                if let Some(element) = element {
-                    if type_contains_lists(*element, resolve) {
-                        return true;
-                    }
-                }
-                if let Some(end) = end {
-                    if type_contains_lists(*end, resolve) {
-                        return true;
-                    }
-                }
-                false
+                option_type_contains_lists(*element, resolve)
+                    || option_type_contains_lists(*end, resolve)
             }
             TypeDefKind::List(_) => true,
         },


### PR DESCRIPTION
`list` values in Wit interfaces can represent things like HTTP bodies which can be very large. To enable tracing without spamming logfiles with all this data, put printing of values containing `list`s behind a separate `verbose_tracing` option.

This is a coarse-grained approach; but it seems like a pretty good default for tracing, and enabling full tracing when one needs it is straightforward.

In the future, we may want to refine the option by implementing the `Valuable` trait and using `tracing::field::valuable`, which could allow us to do things like print non-`list` fields of records that otherwise contain `list`s.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
