### PR TITLE
Couple of improvements to the abi handling code (part 3)

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -351,7 +351,14 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
         let extra_arg = if add_ret_area_ptr {
             debug_assert!(args_or_rets == ArgsOrRets::Args);
-            if call_conv == isa::CallConv::Tail {
+            if call_conv != isa::CallConv::Tail && call_conv != isa::CallConv::Winch {
+                args.push_non_formal(ABIArg::reg(
+                    xreg(8).to_real_reg().unwrap(),
+                    I64,
+                    ir::ArgumentExtension::None,
+                    ir::ArgumentPurpose::Normal,
+                ));
+            } else if call_conv == isa::CallConv::Tail {
                 args.push_non_formal(ABIArg::reg(
                     xreg_preg(0).into(),
                     I64,

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -11,7 +11,7 @@ use crate::isa::unwind::UnwindInst;
 use crate::isa::winch;
 use crate::machinst::*;
 use crate::settings;
-use crate::{CodegenError, CodegenResult};
+use crate::CodegenResult;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use regalloc2::{MachineEnv, PReg, PRegSet};
@@ -26,11 +26,6 @@ pub(crate) type AArch64Callee = Callee<AArch64MachineDeps>;
 
 /// Support for the AArch64 ABI from the caller side (at a callsite).
 pub(crate) type AArch64CallSite = CallSite<AArch64MachineDeps>;
-
-/// This is the limit for the size of argument and return-value areas on the
-/// stack. We place a reasonable limit here to avoid integer overflow issues
-/// with 32-bit arithmetic: for now, 128 MB.
-static STACK_ARG_RET_SIZE_LIMIT: u32 = 128 * 1024 * 1024;
 
 impl Into<AMode> for StackAMode {
     fn into(self) -> AMode {
@@ -91,6 +86,11 @@ impl ABIMachineSpec for AArch64MachineDeps {
     type I = Inst;
 
     type F = aarch64_settings::Flags;
+
+    /// This is the limit for the size of argument and return-value areas on the
+    /// stack. We place a reasonable limit here to avoid integer overflow issues
+    /// with 32-bit arithmetic: for now, 128 MB.
+    const STACK_ARG_RET_SIZE_LIMIT: u32 = 128 * 1024 * 1024;
 
     fn word_bits() -> u32 {
         64
@@ -386,12 +386,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
 
         next_stack = align_to(next_stack, 16);
-
-        // To avoid overflow issues, limit the arg/return size to something
-        // reasonable -- here, 128 MB.
-        if next_stack > STACK_ARG_RET_SIZE_LIMIT {
-            return Err(CodegenError::ImplLimitExceeded);
-        }
 
         Ok((next_stack, extra_arg))
     }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -111,6 +111,12 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         // Stack space.
         let mut next_stack: u32 = 0;
 
+        // In the SystemV ABI, the return area pointer is the first argument,
+        // so we need to leave room for it if required.
+        if add_ret_area_ptr && call_conv != CallConv::Tail && call_conv != CallConv::Winch {
+            next_x_reg += 1;
+        }
+
         for param in params {
             if let ir::ArgumentPurpose::StructArgument(_) = param.purpose {
                 panic!(
@@ -163,7 +169,16 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         }
         let pos: Option<usize> = if add_ret_area_ptr {
             assert!(ArgsOrRets::Args == args_or_rets);
-            if next_x_reg <= x_end {
+            if call_conv != CallConv::Tail && call_conv != CallConv::Winch {
+                // In the SystemV ABI, the return area pointer is the first argument.
+                let arg = ABIArg::reg(
+                    x_reg(x_start).to_real_reg().unwrap(),
+                    I64,
+                    ir::ArgumentExtension::None,
+                    ir::ArgumentPurpose::Normal,
+                );
+                args.push_non_formal(arg);
+            } else if next_x_reg <= x_end {
                 let arg = ABIArg::reg(
                     x_reg(next_x_reg).to_real_reg().unwrap(),
                     I64,

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -121,6 +121,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // so we need to leave room for it if required.
         if add_ret_area_ptr && call_conv != CallConv::Tail && call_conv != CallConv::Winch {
             next_gpr += 1;
+            next_param_idx += 1;
         }
 
         // If any param uses extension, the winch calling convention will not pack its results

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -814,11 +814,7 @@ impl SigSet {
 
     /// Get the already-interned ABI signature id for the given `ir::SigRef`.
     pub fn abi_sig_for_sig_ref(&self, sig_ref: ir::SigRef) -> Sig {
-        self.ir_sig_ref_to_abi_sig
-            .get(sig_ref)
-            // Should have a secondary map entry...
-            .expect("must call `make_abi_sig_from_ir_sig_ref` before `get_abi_sig_for_sig_ref`")
-            // ...and that entry should be initialized.
+        self.ir_sig_ref_to_abi_sig[sig_ref]
             .expect("must call `make_abi_sig_from_ir_sig_ref` before `get_abi_sig_for_sig_ref`")
     }
 

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -82,7 +82,9 @@ impl Reg {
 
 impl std::fmt::Debug for Reg {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if let Some(rreg) = self.to_real_reg() {
+        if self.0 == VReg::invalid() {
+            write!(f, "<invalid>")
+        } else if let Some(rreg) = self.to_real_reg() {
             let preg: PReg = rreg.into();
             write!(f, "{preg}")
         } else if let Some(vreg) = self.to_virtual_reg() {

--- a/cranelift/codegen/src/machinst/valueregs.rs
+++ b/cranelift/codegen/src/machinst/valueregs.rs
@@ -21,9 +21,25 @@ const VALUE_REGS_PARTS: usize = 2;
 /// values (`Reg::invalid()`) to avoid the need to carry a separate length. This
 /// allows the struct to be `Copy` (no heap or drop overhead) and be only 16 or
 /// 8 bytes, which is important for compiler performance.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ValueRegs<R: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel> {
     parts: [R; VALUE_REGS_PARTS],
+}
+
+impl<R: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel> Debug for ValueRegs<R> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut f = f.debug_tuple("ValueRegs");
+        let mut last_valid = true;
+        for part in self.parts {
+            if part.is_invalid_sentinel() {
+                last_valid = false;
+            } else {
+                debug_assert!(last_valid);
+                f.field(&part);
+            }
+        }
+        f.finish()
+    }
 }
 
 /// A type with an "invalid" sentinel value.

--- a/cranelift/filetests/filetests/egraph/unordered.clif
+++ b/cranelift/filetests/filetests/egraph/unordered.clif
@@ -4,7 +4,7 @@ target x86_64
 
 ; https://github.com/bytecodealliance/wasmtime/issues/6126
 ;
-; In this example, iconst defines v2, and later an identical iconst defines v1. 
+; In this example, iconst defines v2, and later an identical iconst defines v1.
 ; In between, v2 is used in an iadd instruction that's added to the GVN map.
 ; Finally, v1 is used in another iadd which should unify with the first one.
 function %unordered(i32) -> i32, i32 {

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -182,7 +182,7 @@ block0(v0: i8):
 ; VCode:
 ; block0:
 ;   movz w7, #42
-;   strb w0, [x1]
+;   strb w0, [x8]
 ;   mov x0, x7
 ;   mov x1, x7
 ;   mov x2, x7
@@ -195,7 +195,7 @@ block0(v0: i8):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w7, #0x2a
-;   sturb w0, [x1]
+;   sturb w0, [x8]
 ;   mov x0, x7
 ;   mov x1, x7
 ;   mov x2, x7

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -825,20 +825,24 @@ block0(v0: i64):
 ;   ret
 
 function %f18(i64) -> i64 {
-    fn0 = %g(i64 sret) -> i64
+    fn0 = %g(i64 sret)
 
 block0(v0: i64):
-    v1 = call fn0(v0)
-    return v1
+    call fn0(v0)
+    return v0
 }
 
 ; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
+;   str x24, [sp, #-16]!
 ; block0:
-;   load_ext_name x3, TestCase(%g)+0
-;   mov x8, x0
-;   blr x3
+;   mov x24, x0
+;   load_ext_name x2, TestCase(%g)+0
+;   mov x8, x24
+;   blr x2
+;   mov x0, x24
+;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
 ;
@@ -846,13 +850,17 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block1: ; offset 0x8
-;   ldr x3, #0x10
-;   b #0x18
+;   str x24, [sp, #-0x10]!
+; block1: ; offset 0xc
+;   mov x24, x0
+;   ldr x2, #0x18
+;   b #0x20
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   mov x8, x0
-;   blr x3
+;   mov x8, x24
+;   blr x2
+;   mov x0, x24
+;   ldr x24, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/bitcast-scalar-vector.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitcast-scalar-vector.clif
@@ -50,20 +50,20 @@ block0(v0: i128):
 
 ; VCode:
 ; block0:
-;   vmv.s.x v12,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.s.x v12,a2 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv1r.v v14,v12
-;   vslide1up.vx v14,v12,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslide1up.vx v14,v12,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0xe6, 0x05, 0x42
+;   .byte 0x57, 0x66, 0x06, 0x42
 ;   .byte 0x57, 0x37, 0xc0, 0x9e
-;   .byte 0x57, 0x67, 0xc5, 0x3a
+;   .byte 0x57, 0xe7, 0xc5, 0x3a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ret
 
 function %bitcast_vec_to_i64(i32x2) -> i64 {
@@ -110,16 +110,16 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vmv.s.x v11,a0 #avl=1, #vtype=(e64, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=8, #vtype=(e8, m1, ta, ma)
+;   vmv.s.x v11,a1 #avl=1, #vtype=(e64, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=8, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0xf0, 0x80, 0xcd
-;   .byte 0xd7, 0x65, 0x05, 0x42
+;   .byte 0xd7, 0xe5, 0x05, 0x42
 ;   .byte 0x57, 0x70, 0x04, 0xcc
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %bitcast_vec_to_f64(i32x2) -> f64 {

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -236,15 +236,15 @@ block0(v0: i8):
 ; block0:
 ;   mv a5,a1
 ;   li a1,42
+;   sw a1,0(a0)
+;   sw a1,8(a0)
+;   sw a1,16(a0)
+;   sw a1,24(a0)
+;   sw a1,32(a0)
+;   sw a1,40(a0)
 ;   mv a2,a5
-;   sw a1,0(a2)
-;   sw a1,8(a2)
-;   sw a1,16(a2)
-;   sw a1,24(a2)
-;   sw a1,32(a2)
-;   sw a1,40(a2)
-;   slli a4,a0,56; srai a4,a4,56
-;   sd a0,48(a2)
+;   slli a4,a2,56; srai a4,a4,56
+;   sd a2,48(a0)
 ;   mv a0,a1
 ;   ret
 ;
@@ -252,16 +252,16 @@ block0(v0: i8):
 ; block0: ; offset 0x0
 ;   mv a5, a1
 ;   addi a1, zero, 0x2a
+;   sw a1, 0(a0)
+;   sw a1, 8(a0)
+;   sw a1, 0x10(a0)
+;   sw a1, 0x18(a0)
+;   sw a1, 0x20(a0)
+;   sw a1, 0x28(a0)
 ;   mv a2, a5
-;   sw a1, 0(a2)
-;   sw a1, 8(a2)
-;   sw a1, 0x10(a2)
-;   sw a1, 0x18(a2)
-;   sw a1, 0x20(a2)
-;   sw a1, 0x28(a2)
-;   slli a4, a0, 0x38
+;   slli a4, a2, 0x38
 ;   srai a4, a4, 0x38
-;   sd a0, 0x30(a2)
+;   sd a2, 0x30(a0)
 ;   mv a0, a1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
@@ -125,99 +125,100 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   mv fp,sp
 ;   addi sp,sp,-384
 ; block0:
+;   mv a7,a0
 ;   vle8.v v10,-64(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v13,-48(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v15,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a0,0
-;   li a2,0
-;   sd a0,0(slot)
-;   sd a2,8(slot)
-;   sd a0,16(slot)
-;   sd a2,24(slot)
-;   sd a0,32(slot)
-;   sd a2,40(slot)
-;   sd a0,48(slot)
-;   sd a2,56(slot)
-;   sd a0,64(slot)
-;   sd a2,72(slot)
-;   sd a0,80(slot)
-;   sd a2,88(slot)
-;   sd a0,96(slot)
-;   sd a2,104(slot)
+;   li a1,0
+;   li a3,0
+;   sd a1,0(slot)
+;   sd a3,8(slot)
+;   sd a1,16(slot)
+;   sd a3,24(slot)
+;   sd a1,32(slot)
+;   sd a3,40(slot)
+;   sd a1,48(slot)
+;   sd a3,56(slot)
+;   sd a1,64(slot)
+;   sd a3,72(slot)
+;   sd a1,80(slot)
+;   sd a3,88(slot)
+;   sd a1,96(slot)
+;   sd a3,104(slot)
 ;   sd zero,112(slot)
 ;   sw zero,120(slot)
 ;   sh zero,124(slot)
-;   sd a0,128(slot)
-;   sd a2,136(slot)
-;   sd a0,144(slot)
-;   sd a2,152(slot)
-;   sd a0,160(slot)
-;   sd a2,168(slot)
-;   sd a0,176(slot)
-;   sd a2,184(slot)
-;   sd a0,192(slot)
-;   sd a2,200(slot)
-;   sd a0,208(slot)
-;   sd a2,216(slot)
-;   sd a0,224(slot)
-;   sd a2,232(slot)
+;   sd a1,128(slot)
+;   sd a3,136(slot)
+;   sd a1,144(slot)
+;   sd a3,152(slot)
+;   sd a1,160(slot)
+;   sd a3,168(slot)
+;   sd a1,176(slot)
+;   sd a3,184(slot)
+;   sd a1,192(slot)
+;   sd a3,200(slot)
+;   sd a1,208(slot)
+;   sd a3,216(slot)
+;   sd a1,224(slot)
+;   sd a3,232(slot)
 ;   sd zero,240(slot)
 ;   sw zero,248(slot)
 ;   sh zero,252(slot)
-;   sd a0,256(slot)
-;   sd a2,264(slot)
-;   sd a0,272(slot)
-;   sd a2,280(slot)
-;   sd a0,288(slot)
-;   sd a2,296(slot)
-;   sd a0,304(slot)
-;   sd a2,312(slot)
-;   sd a0,320(slot)
-;   sd a2,328(slot)
-;   sd a0,336(slot)
-;   sd a2,344(slot)
-;   sd a0,352(slot)
-;   sd a2,360(slot)
+;   sd a1,256(slot)
+;   sd a3,264(slot)
+;   sd a1,272(slot)
+;   sd a3,280(slot)
+;   sd a1,288(slot)
+;   sd a3,296(slot)
+;   sd a1,304(slot)
+;   sd a3,312(slot)
+;   sd a1,320(slot)
+;   sd a3,328(slot)
+;   sd a1,336(slot)
+;   sd a3,344(slot)
+;   sd a1,352(slot)
+;   sd a3,360(slot)
 ;   sd zero,368(slot)
 ;   sw zero,376(slot)
 ;   sh zero,380(slot)
-;   sext.w a2,a1
-;   select v12,v15,v15##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v12,v12##condition=(a2 ne zero)
+;   sext.w a3,a2
+;   select v12,v15,v15##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v12,v12,v12##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v12,v12##condition=(a3 ne zero)
 ;   vfsqrt.v v11,v10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   lui a2,4095
-;   slli a3,a2,39
+;   lui a1,4095
+;   slli a3,a1,39
 ;   fmv.d.x fa5,a3
 ;   vfmv.v.f v12,fa5 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmfne.vv v0,v11,v11 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vvm v15,v11,v12,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vfsqrt.v v11,v15 #avl=2, #vtype=(e64, m1, ta, ma)
-;   lui a2,4095
-;   slli a3,a2,39
+;   lui a1,4095
+;   slli a3,a1,39
 ;   fmv.d.x fa5,a3
 ;   vfmv.v.f v15,fa5 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmfne.vv v0,v11,v11 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vvm v12,v11,v15,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v14,v14,v14##condition=(a2 ne zero)
-;   addw a3,a1,a1
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   sext.w a3,a2
+;   select v14,v14,v14##condition=(a3 ne zero)
+;   addw a3,a2,a2
 ;   select v11,v14,v14##condition=(a3 ne zero)
 ;   select v11,v11,v11##condition=(a3 ne zero)
 ;   select v11,v11,v11##condition=(a3 ne zero)
@@ -228,9 +229,9 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   load_addr a4,3(slot)
 ;   addi a4,a4,0
 ;   andi a1,a4,3
-;   slli a1,a1,3
-;   andi a2,a4,-4
-;   atomic_rmw.i8 and a0,a5,(a2)##t0=a4 offset=a1
+;   slli a5,a1,3
+;   andi a1,a4,-4
+;   atomic_rmw.i8 and a0,a6,(a1)##t0=a4 offset=a5
 ;   select v10,v13,v13##condition=(a3 ne zero)
 ;   select v10,v10,v10##condition=(a3 ne zero)
 ;   select v10,v10,v10##condition=(a3 ne zero)
@@ -265,13 +266,14 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   select v11,v11,v11##condition=(a3 ne zero)
 ;   select v11,v11,v11##condition=(a3 ne zero)
 ;   select v11,v11,v11##condition=(a3 ne zero)
-;   vse8.v v12,0(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,16(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v12,32(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,48(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,64(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,80(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,96(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   mv a1,a7
+;   vse8.v v12,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,16(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,32(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,48(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,64(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,80(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,96(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   addi sp,sp,384
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -286,6 +288,7 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   mv s0, sp
 ;   addi sp, sp, -0x180
 ; block1: ; offset 0x14
+;   mv a7, a0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x190
 ;   .byte 0x07, 0x85, 0x0f, 0x02
@@ -293,92 +296,92 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   .byte 0x87, 0x86, 0x0f, 0x02
 ;   addi t6, sp, 0x1c0
 ;   .byte 0x87, 0x87, 0x0f, 0x02
-;   mv a0, zero
-;   mv a2, zero
-;   sd a0, 0(sp)
-;   sd a2, 8(sp)
-;   sd a0, 0x10(sp)
-;   sd a2, 0x18(sp)
-;   sd a0, 0x20(sp)
-;   sd a2, 0x28(sp)
-;   sd a0, 0x30(sp)
-;   sd a2, 0x38(sp)
-;   sd a0, 0x40(sp)
-;   sd a2, 0x48(sp)
-;   sd a0, 0x50(sp)
-;   sd a2, 0x58(sp)
-;   sd a0, 0x60(sp)
-;   sd a2, 0x68(sp)
+;   mv a1, zero
+;   mv a3, zero
+;   sd a1, 0(sp)
+;   sd a3, 8(sp)
+;   sd a1, 0x10(sp)
+;   sd a3, 0x18(sp)
+;   sd a1, 0x20(sp)
+;   sd a3, 0x28(sp)
+;   sd a1, 0x30(sp)
+;   sd a3, 0x38(sp)
+;   sd a1, 0x40(sp)
+;   sd a3, 0x48(sp)
+;   sd a1, 0x50(sp)
+;   sd a3, 0x58(sp)
+;   sd a1, 0x60(sp)
+;   sd a3, 0x68(sp)
 ;   sd zero, 0x70(sp)
 ;   sw zero, 0x78(sp)
 ;   sh zero, 0x7c(sp)
-;   sd a0, 0x80(sp)
-;   sd a2, 0x88(sp)
-;   sd a0, 0x90(sp)
-;   sd a2, 0x98(sp)
-;   sd a0, 0xa0(sp)
-;   sd a2, 0xa8(sp)
-;   sd a0, 0xb0(sp)
-;   sd a2, 0xb8(sp)
-;   sd a0, 0xc0(sp)
-;   sd a2, 0xc8(sp)
-;   sd a0, 0xd0(sp)
-;   sd a2, 0xd8(sp)
-;   sd a0, 0xe0(sp)
-;   sd a2, 0xe8(sp)
+;   sd a1, 0x80(sp)
+;   sd a3, 0x88(sp)
+;   sd a1, 0x90(sp)
+;   sd a3, 0x98(sp)
+;   sd a1, 0xa0(sp)
+;   sd a3, 0xa8(sp)
+;   sd a1, 0xb0(sp)
+;   sd a3, 0xb8(sp)
+;   sd a1, 0xc0(sp)
+;   sd a3, 0xc8(sp)
+;   sd a1, 0xd0(sp)
+;   sd a3, 0xd8(sp)
+;   sd a1, 0xe0(sp)
+;   sd a3, 0xe8(sp)
 ;   sd zero, 0xf0(sp)
 ;   sw zero, 0xf8(sp)
 ;   sh zero, 0xfc(sp)
-;   sd a0, 0x100(sp)
-;   sd a2, 0x108(sp)
-;   sd a0, 0x110(sp)
-;   sd a2, 0x118(sp)
-;   sd a0, 0x120(sp)
-;   sd a2, 0x128(sp)
-;   sd a0, 0x130(sp)
-;   sd a2, 0x138(sp)
-;   sd a0, 0x140(sp)
-;   sd a2, 0x148(sp)
-;   sd a0, 0x150(sp)
-;   sd a2, 0x158(sp)
-;   sd a0, 0x160(sp)
-;   sd a2, 0x168(sp)
+;   sd a1, 0x100(sp)
+;   sd a3, 0x108(sp)
+;   sd a1, 0x110(sp)
+;   sd a3, 0x118(sp)
+;   sd a1, 0x120(sp)
+;   sd a3, 0x128(sp)
+;   sd a1, 0x130(sp)
+;   sd a3, 0x138(sp)
+;   sd a1, 0x140(sp)
+;   sd a3, 0x148(sp)
+;   sd a1, 0x150(sp)
+;   sd a3, 0x158(sp)
+;   sd a1, 0x160(sp)
+;   sd a3, 0x168(sp)
 ;   sd zero, 0x170(sp)
 ;   sw zero, 0x178(sp)
 ;   sh zero, 0x17c(sp)
-;   sext.w a2, a1
+;   sext.w a3, a2
 ;   .byte 0x57, 0x36, 0xf0, 0x9e
-;   bnez a2, 8
+;   bnez a3, 8
 ;   .byte 0x57, 0x36, 0xf0, 0x9e
-;   sext.w a2, a1
-;   sext.w a2, a1
+;   sext.w a3, a2
+;   sext.w a3, a2
 ;   .byte 0x57, 0x37, 0xc0, 0x9e
-;   bnez a2, 8
+;   bnez a3, 8
 ;   .byte 0x57, 0x37, 0xc0, 0x9e
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0x15, 0xa0, 0x4e
-;   lui a2, 0xfff
-;   slli a3, a2, 0x27
+;   lui a1, 0xfff
+;   slli a3, a1, 0x27
 ;   fmv.d.x fa5, a3
 ;   .byte 0x57, 0xd6, 0x07, 0x5e
 ;   .byte 0x57, 0x90, 0xb5, 0x72
 ;   .byte 0xd7, 0x07, 0xb6, 0x5c
 ;   .byte 0xd7, 0x15, 0xf0, 0x4e
-;   lui a2, 0xfff
-;   slli a3, a2, 0x27
+;   lui a1, 0xfff
+;   slli a3, a1, 0x27
 ;   fmv.d.x fa5, a3
 ;   .byte 0xd7, 0xd7, 0x07, 0x5e
 ;   .byte 0x57, 0x90, 0xb5, 0x72
 ;   .byte 0x57, 0x86, 0xb7, 0x5c
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   addw a3, a1, a1
+;   sext.w a3, a2
+;   sext.w a3, a2
+;   sext.w a3, a2
+;   sext.w a3, a2
+;   sext.w a3, a2
+;   sext.w a3, a2
+;   sext.w a3, a2
+;   sext.w a3, a2
+;   addw a3, a2, a2
 ;   .byte 0xd7, 0x35, 0xe0, 0x9e
 ;   bnez a3, 8
 ;   .byte 0xd7, 0x35, 0xe0, 0x9e
@@ -392,21 +395,21 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   addi a4, sp, 3
 ;   mv a4, a4
 ;   andi a1, a4, 3
-;   slli a1, a1, 3
-;   andi a2, a4, -4
-;   lr.w.aqrl a0, (a2) ; trap: heap_oob
-;   srl a0, a0, a1
+;   slli a5, a1, 3
+;   andi a1, a4, -4
+;   lr.w.aqrl a0, (a1) ; trap: heap_oob
+;   srl a0, a0, a5
 ;   andi a0, a0, 0xff
-;   and a4, a0, a5
-;   lr.w.aqrl t5, (a2) ; trap: heap_oob
+;   and a4, a0, a6
+;   lr.w.aqrl t5, (a1) ; trap: heap_oob
 ;   addi t6, zero, 0xff
-;   sll t6, t6, a1
+;   sll t6, t6, a5
 ;   not t6, t6
 ;   and t5, t5, t6
 ;   andi t6, a4, 0xff
-;   sll t6, t6, a1
+;   sll t6, t6, a5
 ;   or t5, t5, t6
-;   sc.w.aqrl a4, t5, (a2) ; trap: heap_oob
+;   sc.w.aqrl a4, t5, (a1) ; trap: heap_oob
 ;   bnez a4, -0x34
 ;   .byte 0x57, 0x35, 0xd0, 0x9e
 ;   bnez a3, 8
@@ -416,19 +419,20 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   bnez a3, 8
 ;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   mv a1, a7
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x06, 0x08, 0x02
-;   addi t6, a6, 0x10
+;   .byte 0x27, 0x86, 0x05, 0x02
+;   addi t6, a1, 0x10
 ;   .byte 0xa7, 0x85, 0x0f, 0x02
-;   addi t6, a6, 0x20
+;   addi t6, a1, 0x20
 ;   .byte 0x27, 0x86, 0x0f, 0x02
-;   addi t6, a6, 0x30
+;   addi t6, a1, 0x30
 ;   .byte 0xa7, 0x85, 0x0f, 0x02
-;   addi t6, a6, 0x40
+;   addi t6, a1, 0x40
 ;   .byte 0xa7, 0x85, 0x0f, 0x02
-;   addi t6, a6, 0x50
+;   addi t6, a1, 0x50
 ;   .byte 0xa7, 0x85, 0x0f, 0x02
-;   addi t6, a6, 0x60
+;   addi t6, a1, 0x60
 ;   .byte 0xa7, 0x85, 0x0f, 0x02
 ;   addi sp, sp, 0x180
 ;   ld ra, 8(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
@@ -345,8 +345,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vand.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -362,8 +362,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x26
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x26
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -383,8 +383,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vand.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -401,9 +401,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x26
+;   .byte 0xd7, 0xc6, 0x95, 0x26
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -423,8 +423,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vand.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -441,9 +441,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x26
+;   .byte 0xd7, 0xc6, 0x95, 0x26
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -463,8 +463,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vand.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -481,9 +481,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x26
+;   .byte 0xd7, 0xc6, 0x95, 0x26
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -504,10 +504,10 @@ block0(v0: f32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   fmv.w.x fa1,a0
+;   fmv.w.x fa1,a1
 ;   vfmv.v.f v15,fa1 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vand.vv v15,v9,v15 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -523,12 +523,12 @@ block0(v0: f32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   fmv.w.x fa1, a0
+;   fmv.w.x fa1, a1
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0xd7, 0x05, 0x5e
 ;   .byte 0xd7, 0x87, 0x97, 0x26
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -549,10 +549,10 @@ block0(v0: f64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   fmv.d.x fa1,a0
+;   fmv.d.x fa1,a1
 ;   vfmv.v.f v15,fa1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vand.vv v15,v9,v15 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -568,12 +568,12 @@ block0(v0: f64x2, v1: i64):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   fmv.d.x fa1, a0
+;   fmv.d.x fa1, a1
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0xd7, 0x05, 0x5e
 ;   .byte 0xd7, 0x87, 0x97, 0x26
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
@@ -345,8 +345,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vor.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vor.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -362,8 +362,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x2a
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x2a
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -383,8 +383,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vor.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vor.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -401,9 +401,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x2a
+;   .byte 0xd7, 0xc6, 0x95, 0x2a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -423,8 +423,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vor.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vor.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -441,9 +441,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x2a
+;   .byte 0xd7, 0xc6, 0x95, 0x2a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -463,8 +463,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vor.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vor.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -481,9 +481,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x2a
+;   .byte 0xd7, 0xc6, 0x95, 0x2a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -504,10 +504,10 @@ block0(v0: f32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   fmv.w.x fa1,a0
+;   fmv.w.x fa1,a1
 ;   vfmv.v.f v15,fa1 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vor.vv v15,v9,v15 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -523,12 +523,12 @@ block0(v0: f32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   fmv.w.x fa1, a0
+;   fmv.w.x fa1, a1
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0xd7, 0x05, 0x5e
 ;   .byte 0xd7, 0x87, 0x97, 0x2a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -549,10 +549,10 @@ block0(v0: f64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   fmv.d.x fa1,a0
+;   fmv.d.x fa1,a1
 ;   vfmv.v.f v15,fa1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vor.vv v15,v9,v15 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -568,12 +568,12 @@ block0(v0: f64x2, v1: i64):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   fmv.d.x fa1, a0
+;   fmv.d.x fa1, a1
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0xd7, 0x05, 0x5e
 ;   .byte 0xd7, 0x87, 0x97, 0x2a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
@@ -345,8 +345,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vxor.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vxor.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -362,8 +362,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x2e
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x2e
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -383,8 +383,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vxor.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vxor.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -401,9 +401,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x2e
+;   .byte 0xd7, 0xc6, 0x95, 0x2e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -423,8 +423,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vxor.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vxor.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -441,9 +441,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x2e
+;   .byte 0xd7, 0xc6, 0x95, 0x2e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -463,8 +463,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vxor.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vxor.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -481,9 +481,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x2e
+;   .byte 0xd7, 0xc6, 0x95, 0x2e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -504,10 +504,10 @@ block0(v0: f32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   fmv.w.x fa1,a0
+;   fmv.w.x fa1,a1
 ;   vfmv.v.f v15,fa1 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vxor.vv v15,v9,v15 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -523,12 +523,12 @@ block0(v0: f32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   fmv.w.x fa1, a0
+;   fmv.w.x fa1, a1
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0xd7, 0x05, 0x5e
 ;   .byte 0xd7, 0x87, 0x97, 0x2e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -549,10 +549,10 @@ block0(v0: f64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   fmv.d.x fa1,a0
+;   fmv.d.x fa1,a1
 ;   vfmv.v.f v15,fa1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vxor.vv v15,v9,v15 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -568,12 +568,12 @@ block0(v0: f64x2, v1: i64):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   fmv.d.x fa1, a0
+;   fmv.d.x fa1, a1
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0xd7, 0x05, 0x5e
 ;   .byte 0xd7, 0x87, 0x97, 0x2e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
@@ -17,8 +17,8 @@ block0(v0: i16x8, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwadd.wx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -35,9 +35,9 @@ block0(v0: i16x8, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xd6
+;   .byte 0xd7, 0xe6, 0x95, 0xd6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -58,8 +58,8 @@ block0(v0: i32x4, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwadd.wx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -76,9 +76,9 @@ block0(v0: i32x4, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xd6
+;   .byte 0xd7, 0xe6, 0x95, 0xd6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -99,8 +99,8 @@ block0(v0: i64x2, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwadd.wx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -117,9 +117,9 @@ block0(v0: i64x2, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xd6
+;   .byte 0xd7, 0xe6, 0x95, 0xd6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -140,8 +140,8 @@ block0(v0: i16x8, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwaddu.wx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -158,9 +158,9 @@ block0(v0: i16x8, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xd2
+;   .byte 0xd7, 0xe6, 0x95, 0xd2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -181,8 +181,8 @@ block0(v0: i32x4, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwaddu.wx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -199,9 +199,9 @@ block0(v0: i32x4, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xd2
+;   .byte 0xd7, 0xe6, 0x95, 0xd2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -222,8 +222,8 @@ block0(v0: i64x2, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwaddu.wx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -240,9 +240,9 @@ block0(v0: i64x2, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xd2
+;   .byte 0xd7, 0xe6, 0x95, 0xd2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
@@ -165,8 +165,8 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,2 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vwadd.vx v15,v13,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v15,v13,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -185,9 +185,9 @@ block0(v0: i32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0x36, 0x91, 0x3e
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x67, 0xd5, 0xc6
+;   .byte 0xd7, 0xe7, 0xd5, 0xc6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -210,8 +210,8 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,4 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vwadd.vx v15,v13,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v15,v13,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -230,9 +230,9 @@ block0(v0: i16x8, v1: i16):
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0xd7, 0x36, 0x92, 0x3e
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xc6
+;   .byte 0xd7, 0xe7, 0xd5, 0xc6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -255,8 +255,8 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,8 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwadd.vx v15,v13,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v15,v13,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -274,9 +274,9 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0xd7, 0x36, 0x94, 0x3e
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xc6
+;   .byte 0xd7, 0xe7, 0xd5, 0xc6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
@@ -150,8 +150,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwadd.vx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -168,9 +168,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xc6
+;   .byte 0xd7, 0xe6, 0x95, 0xc6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -192,8 +192,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwadd.vx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -210,9 +210,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xc6
+;   .byte 0xd7, 0xe6, 0x95, 0xc6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -234,8 +234,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwadd.vx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -252,9 +252,9 @@ block0(v0: i8x16, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xc6
+;   .byte 0xd7, 0xe6, 0x95, 0xc6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
@@ -166,8 +166,8 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,2 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vwaddu.vx v15,v13,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v15,v13,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -186,9 +186,9 @@ block0(v0: i32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0x36, 0x91, 0x3e
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x67, 0xd5, 0xc2
+;   .byte 0xd7, 0xe7, 0xd5, 0xc2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -211,8 +211,8 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,4 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vwaddu.vx v15,v13,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v15,v13,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -231,9 +231,9 @@ block0(v0: i16x8, v1: i16):
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0xd7, 0x36, 0x92, 0x3e
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xc2
+;   .byte 0xd7, 0xe7, 0xd5, 0xc2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -256,8 +256,8 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,8 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwaddu.vx v15,v13,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v15,v13,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -275,9 +275,9 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0xd7, 0x36, 0x94, 0x3e
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xc2
+;   .byte 0xd7, 0xe7, 0xd5, 0xc2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
@@ -151,8 +151,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwaddu.vx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -169,9 +169,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xc2
+;   .byte 0xd7, 0xe6, 0x95, 0xc2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -193,8 +193,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwaddu.vx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -211,9 +211,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xc2
+;   .byte 0xd7, 0xe6, 0x95, 0xc2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -235,8 +235,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwaddu.vx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -253,9 +253,9 @@ block0(v0: i8x16, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xc2
+;   .byte 0xd7, 0xe6, 0x95, 0xc2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
@@ -345,8 +345,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vadd.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -362,8 +362,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x02
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -383,8 +383,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vadd.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -401,9 +401,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x02
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -423,8 +423,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vadd.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -441,9 +441,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x02
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -463,8 +463,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vadd.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -481,9 +481,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x02
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-eq.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmseq.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmseq.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x62
+;   .byte 0x57, 0xc0, 0x95, 0x62
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,10 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmseq.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmseq.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -262,11 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x62
+;   .byte 0x57, 0xc0, 0x95, 0x62
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ne.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsne.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsne.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x66
+;   .byte 0x57, 0xc0, 0x95, 0x66
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,10 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsne.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsne.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -262,11 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x66
+;   .byte 0x57, 0xc0, 0x95, 0x66
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
@@ -198,11 +198,11 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v8,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmsle.vv v0,v8,v9 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -219,12 +219,12 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
+;   .byte 0x57, 0xc4, 0x05, 0x5e
 ;   .byte 0x57, 0x80, 0x84, 0x76
 ;   .byte 0x57, 0x34, 0x00, 0x5e
 ;   .byte 0x57, 0xb5, 0x8f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0x27, 0x05, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -244,10 +244,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsle.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsle.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -264,11 +264,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x76
+;   .byte 0x57, 0xc0, 0x95, 0x76
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsgt.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsgt.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x7e
+;   .byte 0x57, 0xc0, 0x95, 0x7e
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,10 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmslt.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmslt.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -262,11 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x6e
+;   .byte 0x57, 0xc0, 0x95, 0x6e
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sle.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsle.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsle.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x76
+;   .byte 0x57, 0xc0, 0x95, 0x76
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,11 +242,11 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v8,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmsle.vv v0,v8,v9 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -263,12 +263,12 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
+;   .byte 0x57, 0xc4, 0x05, 0x5e
 ;   .byte 0x57, 0x80, 0x84, 0x76
 ;   .byte 0x57, 0x34, 0x00, 0x5e
 ;   .byte 0x57, 0xb5, 0x8f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0x27, 0x05, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmslt.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmslt.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x6e
+;   .byte 0x57, 0xc0, 0x95, 0x6e
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,10 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsgt.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsgt.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -262,11 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x7e
+;   .byte 0x57, 0xc0, 0x95, 0x7e
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
@@ -198,11 +198,11 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v8,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmsleu.vv v0,v8,v9 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -219,12 +219,12 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
+;   .byte 0x57, 0xc4, 0x05, 0x5e
 ;   .byte 0x57, 0x80, 0x84, 0x72
 ;   .byte 0x57, 0x34, 0x00, 0x5e
 ;   .byte 0x57, 0xb5, 0x8f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0x27, 0x05, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -244,10 +244,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsleu.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsleu.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -264,11 +264,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x72
+;   .byte 0x57, 0xc0, 0x95, 0x72
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsgtu.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsgtu.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x7a
+;   .byte 0x57, 0xc0, 0x95, 0x7a
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,10 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsltu.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsltu.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -262,11 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x6a
+;   .byte 0x57, 0xc0, 0x95, 0x6a
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ule.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsleu.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsleu.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x72
+;   .byte 0x57, 0xc0, 0x95, 0x72
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,11 +242,11 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v8,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmsleu.vv v0,v8,v9 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -263,12 +263,12 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
+;   .byte 0x57, 0xc4, 0x05, 0x5e
 ;   .byte 0x57, 0x80, 0x84, 0x72
 ;   .byte 0x57, 0x34, 0x00, 0x5e
 ;   .byte 0x57, 0xb5, 0x8f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0x27, 0x05, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
@@ -198,10 +198,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsltu.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsltu.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,11 +218,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x6a
+;   .byte 0x57, 0xc0, 0x95, 0x6a
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -242,10 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmsgtu.vx v0,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmsgtu.vx v0,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v15,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v15,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -262,11 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x95, 0x7a
+;   .byte 0x57, 0xc0, 0x95, 0x7a
 ;   .byte 0xd7, 0x37, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0xff, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
@@ -65,9 +65,9 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ; block0:
 ;   vle8.v v9,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v11,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v15,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v15,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmacc.vv v15,v9,v11 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -86,10 +86,10 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ;   addi t6, sp, 0x20
 ;   .byte 0x87, 0x85, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x47, 0x05, 0x5e
+;   .byte 0xd7, 0xc7, 0x05, 0x5e
 ;   .byte 0xd7, 0xa7, 0x95, 0xb6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -159,9 +159,9 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ; block0:
 ;   vle8.v v9,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v11,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v15,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v15,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vnmsac.vv v15,v9,v11 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -180,10 +180,10 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ;   addi t6, sp, 0x20
 ;   .byte 0x87, 0x85, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x47, 0x05, 0x5e
+;   .byte 0xd7, 0xc7, 0x05, 0x5e
 ;   .byte 0xd7, 0xa7, 0x95, 0xbe
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -254,8 +254,8 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ;   vle8.v v9,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v11,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vmul.vv v8,v9,v11 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vsub.vx v8,v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v8,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v8,v8,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -275,9 +275,9 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ;   .byte 0x87, 0x85, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0xa4, 0x95, 0x96
-;   .byte 0x57, 0x44, 0x85, 0x0a
+;   .byte 0x57, 0xc4, 0x85, 0x0a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x84, 0x05, 0x02
+;   .byte 0x27, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
@@ -183,8 +183,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmul.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmul.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -200,8 +200,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x66, 0x95, 0x96
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xe6, 0x95, 0x96
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -221,8 +221,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmul.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmul.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -239,9 +239,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0x96
+;   .byte 0xd7, 0xe6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -261,8 +261,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmul.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmul.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -279,9 +279,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0x96
+;   .byte 0xd7, 0xe6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -301,8 +301,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmul.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmul.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -319,9 +319,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0x96
+;   .byte 0xd7, 0xe6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
@@ -17,8 +17,8 @@ block0(v0: i8x16, v1: i8):
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   lui a5,8
 ;   vmv.s.x v0,a5 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v10,v9,a0,v0.t #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v10,v9,a1,v0.t #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -38,8 +38,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0xe0, 0x07, 0x42
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x57, 0x45, 0x95, 0x5c
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0x57, 0xc5, 0x95, 0x5c
+;   .byte 0x27, 0x05, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -60,8 +60,8 @@ block0(v0: i16x8, v1: i16):
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   li a5,32
 ;   vmv.s.x v0,a5 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v10,v9,a0,v0.t #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v10,v9,a1,v0.t #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -81,9 +81,9 @@ block0(v0: i16x8, v1: i16):
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0xe0, 0x07, 0x42
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0x57, 0x45, 0x95, 0x5c
+;   .byte 0x57, 0xc5, 0x95, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0x27, 0x05, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -103,8 +103,8 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vmv.v.i v0,4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v15,v9,a0,v0.t #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v15,v9,a1,v0.t #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -123,9 +123,9 @@ block0(v0: i32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0x30, 0x02, 0x5e
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x47, 0x95, 0x5c
+;   .byte 0xd7, 0xc7, 0x95, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -145,8 +145,8 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v15,v9,a0,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v15,v9,a1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -164,9 +164,9 @@ block0(v0: i64x2, v1: i64):
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0xb0, 0x00, 0x5e
-;   .byte 0xd7, 0x47, 0x95, 0x5c
+;   .byte 0xd7, 0xc7, 0x95, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ishl.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ishl.clif
@@ -15,8 +15,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -32,8 +32,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x96
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x96
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -52,8 +52,8 @@ block0(v0: i8x16, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -69,8 +69,8 @@ block0(v0: i8x16, v1: i16):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x96
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x96
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -89,8 +89,8 @@ block0(v0: i8x16, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -106,8 +106,8 @@ block0(v0: i8x16, v1: i32):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x96
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x96
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -126,8 +126,8 @@ block0(v0: i8x16, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -143,8 +143,8 @@ block0(v0: i8x16, v1: i64):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x96
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x96
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -163,8 +163,8 @@ block0(v0: i8x16, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v14,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v14,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -180,8 +180,8 @@ block0(v0: i8x16, v1: i128):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0x57, 0x47, 0x95, 0x96
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x57, 0xc7, 0x95, 0x96
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -200,8 +200,8 @@ block0(v0: i16x8, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,9 +218,9 @@ block0(v0: i16x8, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -239,8 +239,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -257,9 +257,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -278,8 +278,8 @@ block0(v0: i16x8, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -296,9 +296,9 @@ block0(v0: i16x8, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -317,8 +317,8 @@ block0(v0: i16x8, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -335,9 +335,9 @@ block0(v0: i16x8, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -356,8 +356,8 @@ block0(v0: i16x8, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v14,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v14,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -374,9 +374,9 @@ block0(v0: i16x8, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0x57, 0x47, 0x95, 0x96
+;   .byte 0x57, 0xc7, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -395,8 +395,8 @@ block0(v0: i32x4, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -413,9 +413,9 @@ block0(v0: i32x4, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -434,8 +434,8 @@ block0(v0: i32x4, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -452,9 +452,9 @@ block0(v0: i32x4, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -473,8 +473,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -491,9 +491,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -512,8 +512,8 @@ block0(v0: i32x4, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -530,9 +530,9 @@ block0(v0: i32x4, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -551,8 +551,8 @@ block0(v0: i32x4, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v14,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v14,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -569,9 +569,9 @@ block0(v0: i32x4, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0x57, 0x47, 0x95, 0x96
+;   .byte 0x57, 0xc7, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -590,8 +590,8 @@ block0(v0: i64x2, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -608,9 +608,9 @@ block0(v0: i64x2, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -629,8 +629,8 @@ block0(v0: i64x2, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -647,9 +647,9 @@ block0(v0: i64x2, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -668,8 +668,8 @@ block0(v0: i64x2, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -686,9 +686,9 @@ block0(v0: i64x2, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -707,8 +707,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -725,9 +725,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x96
+;   .byte 0xd7, 0xc6, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -746,8 +746,8 @@ block0(v0: i64x2, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsll.vx v14,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsll.vx v14,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -764,9 +764,9 @@ block0(v0: i64x2, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x47, 0x95, 0x96
+;   .byte 0x57, 0xc7, 0x95, 0x96
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
@@ -17,8 +17,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vrsub.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -34,8 +34,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x0e
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x0e
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -55,8 +55,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vrsub.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -73,9 +73,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x0e
+;   .byte 0xd7, 0xc6, 0x95, 0x0e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -95,8 +95,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vrsub.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -113,9 +113,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x0e
+;   .byte 0xd7, 0xc6, 0x95, 0x0e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -135,8 +135,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vrsub.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -153,9 +153,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x0e
+;   .byte 0xd7, 0xc6, 0x95, 0x0e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -175,8 +175,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsub.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -192,8 +192,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x0a
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x0a
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -213,8 +213,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsub.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -231,9 +231,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x0a
+;   .byte 0xd7, 0xc6, 0x95, 0x0a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -253,8 +253,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsub.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -271,9 +271,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x0a
+;   .byte 0xd7, 0xc6, 0x95, 0x0a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -293,8 +293,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsub.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -311,9 +311,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x0a
+;   .byte 0xd7, 0xc6, 0x95, 0x0a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -660,8 +660,8 @@ block0(v0: i16x8, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsub.wx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -678,9 +678,9 @@ block0(v0: i16x8, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xde
+;   .byte 0xd7, 0xe6, 0x95, 0xde
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -701,8 +701,8 @@ block0(v0: i32x4, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsub.wx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -719,9 +719,9 @@ block0(v0: i32x4, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xde
+;   .byte 0xd7, 0xe6, 0x95, 0xde
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -742,8 +742,8 @@ block0(v0: i64x2, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsub.wx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -760,9 +760,9 @@ block0(v0: i64x2, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xde
+;   .byte 0xd7, 0xe6, 0x95, 0xde
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -783,8 +783,8 @@ block0(v0: i16x8, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsubu.wx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -801,9 +801,9 @@ block0(v0: i16x8, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xda
+;   .byte 0xd7, 0xe6, 0x95, 0xda
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -824,8 +824,8 @@ block0(v0: i32x4, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsubu.wx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -842,9 +842,9 @@ block0(v0: i32x4, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xda
+;   .byte 0xd7, 0xe6, 0x95, 0xda
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -865,8 +865,8 @@ block0(v0: i64x2, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsubu.wx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -883,9 +883,9 @@ block0(v0: i64x2, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xda
+;   .byte 0xd7, 0xe6, 0x95, 0xda
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
@@ -165,8 +165,8 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,2 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vwsub.vx v15,v13,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v15,v13,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -185,9 +185,9 @@ block0(v0: i32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0x36, 0x91, 0x3e
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x67, 0xd5, 0xce
+;   .byte 0xd7, 0xe7, 0xd5, 0xce
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -210,8 +210,8 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,4 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vwsub.vx v15,v13,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v15,v13,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -230,9 +230,9 @@ block0(v0: i16x8, v1: i16):
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0xd7, 0x36, 0x92, 0x3e
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xce
+;   .byte 0xd7, 0xe7, 0xd5, 0xce
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -255,8 +255,8 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,8 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsub.vx v15,v13,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v15,v13,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -274,9 +274,9 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0xd7, 0x36, 0x94, 0x3e
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xce
+;   .byte 0xd7, 0xe7, 0xd5, 0xce
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
@@ -150,8 +150,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsub.vx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -168,9 +168,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xce
+;   .byte 0xd7, 0xe6, 0x95, 0xce
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -192,8 +192,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsub.vx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -210,9 +210,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xce
+;   .byte 0xd7, 0xe6, 0x95, 0xce
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -234,8 +234,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsub.vx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -252,9 +252,9 @@ block0(v0: i8x16, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xce
+;   .byte 0xd7, 0xe6, 0x95, 0xce
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
@@ -165,8 +165,8 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,2 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vwsubu.vx v15,v13,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v15,v13,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -185,9 +185,9 @@ block0(v0: i32x4, v1: i32):
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0x36, 0x91, 0x3e
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x67, 0xd5, 0xca
+;   .byte 0xd7, 0xe7, 0xd5, 0xca
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -210,8 +210,8 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,4 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vwsubu.vx v15,v13,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v15,v13,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -230,9 +230,9 @@ block0(v0: i16x8, v1: i16):
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0xd7, 0x36, 0x92, 0x3e
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xca
+;   .byte 0xd7, 0xe7, 0xd5, 0xca
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -255,8 +255,8 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vslidedown.vi v13,v9,8 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsubu.vx v15,v13,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v15,v13,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -274,9 +274,9 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0xd7, 0x36, 0x94, 0x3e
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x67, 0xd5, 0xca
+;   .byte 0xd7, 0xe7, 0xd5, 0xca
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
@@ -150,8 +150,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsubu.vx v13,v9,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v13,v9,a1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -168,9 +168,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x71, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0xca
+;   .byte 0xd7, 0xe6, 0x95, 0xca
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -192,8 +192,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsubu.vx v13,v9,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v13,v9,a1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -210,9 +210,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0xf2, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xca
+;   .byte 0xd7, 0xe6, 0x95, 0xca
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -234,8 +234,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vwsubu.vx v13,v9,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v13,v9,a1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -252,9 +252,9 @@ block0(v0: i8x16, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x74, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0xca
+;   .byte 0xd7, 0xe6, 0x95, 0xca
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
@@ -183,8 +183,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsub.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -201,9 +201,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x0a
+;   .byte 0xd7, 0xc6, 0x95, 0x0a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -223,8 +223,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vrsub.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -241,9 +241,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x0e
+;   .byte 0xd7, 0xc6, 0x95, 0x0e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-load-extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-load-extend.clif
@@ -10,19 +10,19 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle64.v v11,0(a0) #avl=1, #vtype=(e64, m1, ta, ma)
+;   vle64.v v11,0(a1) #avl=1, #vtype=(e64, m1, ta, ma)
 ;   vzext.vf2 v13,v11 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0xf0, 0x80, 0xcd
-;   .byte 0x87, 0x75, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xf5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0xd7, 0x26, 0xb3, 0x4a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ret
 
 function %sload8x8(i64) -> i16x8 {
@@ -33,19 +33,19 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle64.v v11,0(a0) #avl=1, #vtype=(e64, m1, ta, ma)
+;   vle64.v v11,0(a1) #avl=1, #vtype=(e64, m1, ta, ma)
 ;   vsext.vf2 v13,v11 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0xf0, 0x80, 0xcd
-;   .byte 0x87, 0x75, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xf5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0xd7, 0xa6, 0xb3, 0x4a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ret
 
 function %uload16x4(i64) -> i32x4 {
@@ -56,19 +56,19 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle64.v v11,0(a0) #avl=1, #vtype=(e64, m1, ta, ma)
+;   vle64.v v11,0(a1) #avl=1, #vtype=(e64, m1, ta, ma)
 ;   vzext.vf2 v13,v11 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0xf0, 0x80, 0xcd
-;   .byte 0x87, 0x75, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xf5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0x26, 0xb3, 0x4a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ret
 
 function %sload16x4(i64) -> i32x4 {
@@ -79,19 +79,19 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle64.v v11,0(a0) #avl=1, #vtype=(e64, m1, ta, ma)
+;   vle64.v v11,0(a1) #avl=1, #vtype=(e64, m1, ta, ma)
 ;   vsext.vf2 v13,v11 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0xf0, 0x80, 0xcd
-;   .byte 0x87, 0x75, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xf5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0xd7, 0xa6, 0xb3, 0x4a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ret
 
 function %uload32x2(i64) -> i64x2 {
@@ -102,19 +102,19 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle64.v v11,0(a0) #avl=1, #vtype=(e64, m1, ta, ma)
+;   vle64.v v11,0(a1) #avl=1, #vtype=(e64, m1, ta, ma)
 ;   vzext.vf2 v13,v11 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0xf0, 0x80, 0xcd
-;   .byte 0x87, 0x75, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xf5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0x26, 0xb3, 0x4a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ret
 
 function %sload32x2(i64) -> i64x2 {
@@ -125,18 +125,18 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle64.v v11,0(a0) #avl=1, #vtype=(e64, m1, ta, ma)
+;   vle64.v v11,0(a1) #avl=1, #vtype=(e64, m1, ta, ma)
 ;   vsext.vf2 v13,v11 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0xf0, 0x80, 0xcd
-;   .byte 0x87, 0x75, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xf5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0xa6, 0xb3, 0x4a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-load-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-load-splat.clif
@@ -11,17 +11,17 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lb a4,0(a0)
+;   lb a4,0(a1)
 ;   vmv.v.x v12,a4 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v12,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lb a4, 0(a0) ; trap: heap_oob
+;   lb a4, 0(a1) ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   .byte 0x57, 0x46, 0x07, 0x5e
-;   .byte 0x27, 0x86, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ret
 
 function %load_splat_i16x8(i64) -> i16x8 {
@@ -33,18 +33,18 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lh a4,0(a0)
+;   lh a4,0(a1)
 ;   vmv.v.x v12,a4 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v12,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lh a4, 0(a0) ; trap: heap_oob
+;   lh a4, 0(a1) ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0x57, 0x46, 0x07, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x86, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ret
 
 function %load_splat_i32x4(i64) -> i32x4 {
@@ -56,18 +56,18 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lw a4,0(a0)
+;   lw a4,0(a1)
 ;   vmv.v.x v12,a4 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v12,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lw a4, 0(a0) ; trap: heap_oob
+;   lw a4, 0(a1) ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0x57, 0x46, 0x07, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x86, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ret
 
 function %load_splat_i64x2(i64) -> i64x2 {
@@ -79,18 +79,18 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   ld a4,0(a0)
+;   ld a4,0(a1)
 ;   vmv.v.x v12,a4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v12,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ld a4, 0(a0) ; trap: heap_oob
+;   ld a4, 0(a1) ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0x46, 0x07, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x86, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ret
 
 function %load_splat_f32x4(i64) -> f32x4 {
@@ -102,18 +102,18 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   flw fa4,0(a0)
+;   flw fa4,0(a1)
 ;   vfmv.v.f v12,fa4 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v12,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   flw fa4, 0(a0) ; trap: heap_oob
+;   flw fa4, 0(a1) ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0x57, 0x56, 0x07, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x86, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ret
 
 function %load_splat_f64x2(i64) -> f64x2 {
@@ -125,17 +125,17 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   fld fa4,0(a0)
+;   fld fa4,0(a1)
 ;   vfmv.v.f v12,fa4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v12,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fld fa4, 0(a0) ; trap: heap_oob
+;   fld fa4, 0(a1) ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0x56, 0x07, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x86, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-loads.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-loads.clif
@@ -11,15 +11,15 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x87, 0x05, 0x05, 0x02 ; trap: heap_oob
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0x87, 0x85, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %load_i16x8(i64) -> i16x8 {
@@ -30,16 +30,16 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle16.v v11,0(a0) #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle16.v v11,0(a1) #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0x87, 0x55, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xd5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %load_i32x4(i64) -> i32x4 {
@@ -50,16 +50,16 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle32.v v11,0(a0) #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle32.v v11,0(a1) #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0x87, 0x65, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xe5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %load_i64x2(i64) -> i64x2 {
@@ -70,15 +70,15 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vle64.v v11,0(a0) #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle64.v v11,0(a1) #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x87, 0x75, 0x05, 0x02 ; trap: heap_oob
+;   .byte 0x87, 0xf5, 0x05, 0x02 ; trap: heap_oob
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
@@ -345,8 +345,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsadd.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsadd.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -362,8 +362,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x86
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x86
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -383,8 +383,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsadd.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsadd.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -401,9 +401,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x86
+;   .byte 0xd7, 0xc6, 0x95, 0x86
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -423,8 +423,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsadd.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsadd.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -441,9 +441,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x86
+;   .byte 0xd7, 0xc6, 0x95, 0x86
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -463,8 +463,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsadd.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsadd.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -481,9 +481,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x86
+;   .byte 0xd7, 0xc6, 0x95, 0x86
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-scalartovector.clif
@@ -12,8 +12,8 @@ block0(v0: i8):
 ; block0:
 ;   vmv.v.x v11,zero #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v15,v11,a0,v0.t #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v15,v11,a1,v0.t #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -23,8 +23,8 @@ block0(v0: i8):
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0xb0, 0x00, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xd7, 0x47, 0xb5, 0x5c
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xd7, 0xc7, 0xb5, 0x5c
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ret
 
 function %scalartovector_i16(i16) -> i16x8 {
@@ -37,8 +37,8 @@ block0(v0: i16):
 ; block0:
 ;   vmv.v.x v11,zero #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v15,v11,a0,v0.t #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v15,v11,a1,v0.t #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -48,9 +48,9 @@ block0(v0: i16):
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0xb0, 0x00, 0x5e
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x47, 0xb5, 0x5c
+;   .byte 0xd7, 0xc7, 0xb5, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ret
 
 function %scalartovector_i32(i32) -> i32x4 {
@@ -63,8 +63,8 @@ block0(v0: i32):
 ; block0:
 ;   vmv.v.x v11,zero #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v15,v11,a0,v0.t #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v15,v11,a1,v0.t #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -74,9 +74,9 @@ block0(v0: i32):
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0xb0, 0x00, 0x5e
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x47, 0xb5, 0x5c
+;   .byte 0xd7, 0xc7, 0xb5, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ret
 
 function %scalartovector_i64(i64) -> i64x2 {
@@ -89,8 +89,8 @@ block0(v0: i64):
 ; block0:
 ;   vmv.v.x v11,zero #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vxm v15,v11,a0,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmerge.vxm v15,v11,a1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -98,9 +98,9 @@ block0(v0: i64):
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0x45, 0x00, 0x5e
 ;   .byte 0x57, 0xb0, 0x00, 0x5e
-;   .byte 0xd7, 0x47, 0xb5, 0x5c
+;   .byte 0xd7, 0xc7, 0xb5, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ret
 
 function %scalartovector_f32(f32) -> f32x4 {
@@ -169,7 +169,7 @@ block0(v0: i8):
 ;   vmv.v.x v10,zero #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v14,v10,7,v0.t #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v14,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -180,7 +180,7 @@ block0(v0: i8):
 ;   .byte 0x57, 0xb0, 0x00, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   .byte 0x57, 0xb7, 0xa3, 0x5c
-;   .byte 0x27, 0x87, 0x05, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ret
 
 function %scalartovector_i16_imm(i16) -> i16x8 {
@@ -195,7 +195,7 @@ block0(v0: i16):
 ;   vmv.v.x v10,zero #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v14,v10,7,v0.t #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v14,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -207,7 +207,7 @@ block0(v0: i16):
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0x57, 0xb7, 0xa3, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x87, 0x05, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ret
 
 function %scalartovector_i32_imm(i32) -> i32x4 {
@@ -222,7 +222,7 @@ block0(v0: i32):
 ;   vmv.v.x v10,zero #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v14,v10,7,v0.t #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v14,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -234,7 +234,7 @@ block0(v0: i32):
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0x57, 0xb7, 0xa3, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x87, 0x05, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ret
 
 function %scalartovector_i64_imm(i64) -> i64x2 {
@@ -249,7 +249,7 @@ block0(v0: i64):
 ;   vmv.v.x v10,zero #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v14,v10,7,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v14,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
@@ -259,6 +259,6 @@ block0(v0: i64):
 ;   .byte 0x57, 0xb0, 0x00, 0x5e
 ;   .byte 0x57, 0xb7, 0xa3, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x87, 0x05, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-select.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-select.clif
@@ -16,8 +16,8 @@ block0(v0: i64, v1: i64x2, v2: i64x2):
 ; block0:
 ;   vle8.v v10,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   select v15,v10,v12##condition=(a0 ne zero)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   select v15,v10,v12##condition=(a1 ne zero)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -36,9 +36,9 @@ block0(v0: i64, v1: i64x2, v2: i64x2):
 ;   addi t6, sp, 0x20
 ;   .byte 0x07, 0x86, 0x0f, 0x02
 ;   .byte 0xd7, 0x37, 0xa0, 0x9e
-;   bnez a0, 8
+;   bnez a1, 8
 ;   .byte 0xd7, 0x37, 0xc0, 0x9e
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -58,9 +58,9 @@ block0(v0: i32, v1: i32x4, v2: i32x4):
 ; block0:
 ;   vle8.v v10,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   sext.w a2,a0
-;   select v9,v10,v12##condition=(a2 ne zero)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   sext.w a1,a1
+;   select v9,v10,v12##condition=(a1 ne zero)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -78,11 +78,11 @@ block0(v0: i32, v1: i32x4, v2: i32x4):
 ;   .byte 0x07, 0x85, 0x0f, 0x02
 ;   addi t6, sp, 0x20
 ;   .byte 0x07, 0x86, 0x0f, 0x02
-;   sext.w a2, a0
+;   sext.w a1, a1
 ;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   bnez a2, 8
+;   bnez a1, 8
 ;   .byte 0xd7, 0x34, 0xc0, 0x9e
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -102,10 +102,10 @@ block0(v0: i16, v1: i16x8, v2: i16x8):
 ; block0:
 ;   vle8.v v10,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   slli a2,a0,48
-;   srai a3,a2,48
+;   slli a1,a1,48
+;   srai a3,a1,48
 ;   select v11,v10,v12##condition=(a3 ne zero)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -123,12 +123,12 @@ block0(v0: i16, v1: i16x8, v2: i16x8):
 ;   .byte 0x07, 0x85, 0x0f, 0x02
 ;   addi t6, sp, 0x20
 ;   .byte 0x07, 0x86, 0x0f, 0x02
-;   slli a2, a0, 0x30
-;   srai a3, a2, 0x30
+;   slli a1, a1, 0x30
+;   srai a3, a1, 0x30
 ;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   bnez a3, 8
 ;   .byte 0xd7, 0x35, 0xc0, 0x9e
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -148,9 +148,9 @@ block0(v0: i8, v1: i8x16, v2: i8x16):
 ; block0:
 ;   vle8.v v10,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   andi a2,a0,255
-;   select v9,v10,v12##condition=(a2 ne zero)
-;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   andi a1,a1,255
+;   select v9,v10,v12##condition=(a1 ne zero)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -168,11 +168,11 @@ block0(v0: i8, v1: i8x16, v2: i8x16):
 ;   .byte 0x07, 0x85, 0x0f, 0x02
 ;   addi t6, sp, 0x20
 ;   .byte 0x07, 0x86, 0x0f, 0x02
-;   andi a2, a0, 0xff
+;   andi a1, a1, 0xff
 ;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   bnez a2, 8
+;   bnez a1, 8
 ;   .byte 0xd7, 0x34, 0xc0, 0x9e
-;   .byte 0xa7, 0x84, 0x05, 0x02
+;   .byte 0xa7, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -192,8 +192,8 @@ block0(v0: i64, v1: f64x2, v2: f64x2):
 ; block0:
 ;   vle8.v v10,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   select v15,v10,v12##condition=(a0 ne zero)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   select v15,v10,v12##condition=(a1 ne zero)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -212,9 +212,9 @@ block0(v0: i64, v1: f64x2, v2: f64x2):
 ;   addi t6, sp, 0x20
 ;   .byte 0x07, 0x86, 0x0f, 0x02
 ;   .byte 0xd7, 0x37, 0xa0, 0x9e
-;   bnez a0, 8
+;   bnez a1, 8
 ;   .byte 0xd7, 0x37, 0xc0, 0x9e
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -234,8 +234,8 @@ block0(v0: i64, v1: f32x4, v2: f32x4):
 ; block0:
 ;   vle8.v v10,-32(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   select v15,v10,v12##condition=(a0 ne zero)
-;   vse8.v v15,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   select v15,v10,v12##condition=(a1 ne zero)
+;   vse8.v v15,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -254,9 +254,9 @@ block0(v0: i64, v1: f32x4, v2: f32x4):
 ;   addi t6, sp, 0x20
 ;   .byte 0x07, 0x86, 0x0f, 0x02
 ;   .byte 0xd7, 0x37, 0xa0, 0x9e
-;   bnez a0, 8
+;   bnez a1, 8
 ;   .byte 0xd7, 0x37, 0xc0, 0x9e
-;   .byte 0xa7, 0x87, 0x05, 0x02
+;   .byte 0xa7, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
@@ -353,8 +353,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmax.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmax.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -370,8 +370,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x1e
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x1e
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -391,8 +391,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmax.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmax.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -409,9 +409,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x1e
+;   .byte 0xd7, 0xc6, 0x95, 0x1e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -431,8 +431,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmax.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmax.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -449,9 +449,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x1e
+;   .byte 0xd7, 0xc6, 0x95, 0x1e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -471,8 +471,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmax.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmax.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -489,9 +489,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x1e
+;   .byte 0xd7, 0xc6, 0x95, 0x1e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
@@ -353,8 +353,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmin.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmin.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -370,8 +370,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x16
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x16
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -391,8 +391,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmin.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmin.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -409,9 +409,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x16
+;   .byte 0xd7, 0xc6, 0x95, 0x16
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -431,8 +431,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmin.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmin.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -449,9 +449,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x16
+;   .byte 0xd7, 0xc6, 0x95, 0x16
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -471,8 +471,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmin.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmin.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -489,9 +489,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x16
+;   .byte 0xd7, 0xc6, 0x95, 0x16
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
@@ -183,8 +183,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulh.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulh.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -200,8 +200,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x66, 0x95, 0x9e
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xe6, 0x95, 0x9e
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -221,8 +221,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulh.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulh.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -239,9 +239,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0x9e
+;   .byte 0xd7, 0xe6, 0x95, 0x9e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -261,8 +261,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulh.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulh.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -279,9 +279,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0x9e
+;   .byte 0xd7, 0xe6, 0x95, 0x9e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -301,8 +301,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulh.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulh.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -319,9 +319,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0x9e
+;   .byte 0xd7, 0xe6, 0x95, 0x9e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
@@ -10,15 +10,15 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   vmv.v.x v11,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.x v11,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xd7, 0x45, 0x05, 0x5e
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xd7, 0xc5, 0x05, 0x5e
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %splat_i16x8(i16) -> i16x8 {
@@ -29,16 +29,16 @@ block0(v0: i16):
 
 ; VCode:
 ; block0:
-;   vmv.v.x v11,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.x v11,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x45, 0x05, 0x5e
+;   .byte 0xd7, 0xc5, 0x05, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %splat_i32x4(i32) -> i32x4 {
@@ -49,16 +49,16 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   vmv.v.x v11,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.x v11,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x45, 0x05, 0x5e
+;   .byte 0xd7, 0xc5, 0x05, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %splat_i64x2(i64) -> i64x2 {
@@ -69,16 +69,16 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   vmv.v.x v11,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v11,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.x v11,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v11,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x45, 0x05, 0x5e
+;   .byte 0xd7, 0xc5, 0x05, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x05, 0x05, 0x02
 ;   ret
 
 function %splat_const_i8x16() -> i8x16 {

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sqmulroundsat.clif
@@ -100,8 +100,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsmul.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsmul.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -118,9 +118,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x9e
+;   .byte 0xd7, 0xc6, 0x95, 0x9e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -140,8 +140,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsmul.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsmul.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -158,9 +158,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x9e
+;   .byte 0xd7, 0xc6, 0x95, 0x9e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sshr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sshr.clif
@@ -15,8 +15,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -32,8 +32,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa6
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -52,8 +52,8 @@ block0(v0: i8x16, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -69,8 +69,8 @@ block0(v0: i8x16, v1: i16):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa6
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -89,8 +89,8 @@ block0(v0: i8x16, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -106,8 +106,8 @@ block0(v0: i8x16, v1: i32):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa6
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -126,8 +126,8 @@ block0(v0: i8x16, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -143,8 +143,8 @@ block0(v0: i8x16, v1: i64):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa6
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -163,8 +163,8 @@ block0(v0: i8x16, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v14,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v14,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -180,8 +180,8 @@ block0(v0: i8x16, v1: i128):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0x57, 0x47, 0x95, 0xa6
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x57, 0xc7, 0x95, 0xa6
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -200,8 +200,8 @@ block0(v0: i16x8, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,9 +218,9 @@ block0(v0: i16x8, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -239,8 +239,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -257,9 +257,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -278,8 +278,8 @@ block0(v0: i16x8, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -296,9 +296,9 @@ block0(v0: i16x8, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -317,8 +317,8 @@ block0(v0: i16x8, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -335,9 +335,9 @@ block0(v0: i16x8, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -356,8 +356,8 @@ block0(v0: i16x8, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v14,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v14,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -374,9 +374,9 @@ block0(v0: i16x8, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0x57, 0x47, 0x95, 0xa6
+;   .byte 0x57, 0xc7, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -395,8 +395,8 @@ block0(v0: i32x4, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -413,9 +413,9 @@ block0(v0: i32x4, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -434,8 +434,8 @@ block0(v0: i32x4, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -452,9 +452,9 @@ block0(v0: i32x4, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -473,8 +473,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -491,9 +491,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -512,8 +512,8 @@ block0(v0: i32x4, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -530,9 +530,9 @@ block0(v0: i32x4, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -551,8 +551,8 @@ block0(v0: i32x4, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v14,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v14,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -569,9 +569,9 @@ block0(v0: i32x4, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0x57, 0x47, 0x95, 0xa6
+;   .byte 0x57, 0xc7, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -590,8 +590,8 @@ block0(v0: i64x2, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -608,9 +608,9 @@ block0(v0: i64x2, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -629,8 +629,8 @@ block0(v0: i64x2, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -647,9 +647,9 @@ block0(v0: i64x2, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -668,8 +668,8 @@ block0(v0: i64x2, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -686,9 +686,9 @@ block0(v0: i64x2, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -707,8 +707,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -725,9 +725,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa6
+;   .byte 0xd7, 0xc6, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -746,8 +746,8 @@ block0(v0: i64x2, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsra.vx v14,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsra.vx v14,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -764,9 +764,9 @@ block0(v0: i64x2, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x47, 0x95, 0xa6
+;   .byte 0x57, 0xc7, 0x95, 0xa6
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
@@ -353,8 +353,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vssub.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vssub.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -370,8 +370,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x8e
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x8e
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -391,8 +391,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vssub.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vssub.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -409,9 +409,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x8e
+;   .byte 0xd7, 0xc6, 0x95, 0x8e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -431,8 +431,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vssub.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vssub.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -449,9 +449,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x8e
+;   .byte 0xd7, 0xc6, 0x95, 0x8e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -471,9 +471,9 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v14,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v14,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vssub.vv v14,v14,v9 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v14,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -490,10 +490,10 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x47, 0x05, 0x5e
+;   .byte 0x57, 0xc7, 0x05, 0x5e
 ;   .byte 0x57, 0x87, 0xe4, 0x8e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x87, 0x05, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-swizzle.clif
@@ -56,8 +56,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vrgather.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrgather.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -73,8 +73,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x32
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x32
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
@@ -345,8 +345,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsaddu.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsaddu.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -362,8 +362,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x82
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x82
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -383,8 +383,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsaddu.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsaddu.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -401,9 +401,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x82
+;   .byte 0xd7, 0xc6, 0x95, 0x82
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -423,8 +423,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsaddu.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsaddu.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -441,9 +441,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x82
+;   .byte 0xd7, 0xc6, 0x95, 0x82
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -463,8 +463,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsaddu.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsaddu.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -481,9 +481,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x82
+;   .byte 0xd7, 0xc6, 0x95, 0x82
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
@@ -352,8 +352,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmaxu.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmaxu.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -369,8 +369,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x1a
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x1a
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -390,8 +390,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmaxu.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmaxu.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -408,9 +408,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x1a
+;   .byte 0xd7, 0xc6, 0x95, 0x1a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -430,8 +430,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmaxu.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmaxu.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -448,9 +448,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x1a
+;   .byte 0xd7, 0xc6, 0x95, 0x1a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -470,8 +470,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmaxu.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmaxu.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -488,9 +488,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x1a
+;   .byte 0xd7, 0xc6, 0x95, 0x1a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
@@ -353,8 +353,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vminu.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vminu.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -370,8 +370,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x12
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x12
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -391,8 +391,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vminu.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vminu.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -409,9 +409,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x12
+;   .byte 0xd7, 0xc6, 0x95, 0x12
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -431,8 +431,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vminu.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vminu.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -449,9 +449,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x12
+;   .byte 0xd7, 0xc6, 0x95, 0x12
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -471,8 +471,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vminu.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vminu.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -489,9 +489,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x12
+;   .byte 0xd7, 0xc6, 0x95, 0x12
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
@@ -183,8 +183,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulhu.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulhu.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -200,8 +200,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x66, 0x95, 0x92
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xe6, 0x95, 0x92
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -221,8 +221,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulhu.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulhu.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -239,9 +239,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x66, 0x95, 0x92
+;   .byte 0xd7, 0xe6, 0x95, 0x92
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -261,8 +261,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulhu.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulhu.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -279,9 +279,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0x92
+;   .byte 0xd7, 0xe6, 0x95, 0x92
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -301,8 +301,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmulhu.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmulhu.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -319,9 +319,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x66, 0x95, 0x92
+;   .byte 0xd7, 0xe6, 0x95, 0x92
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ushr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ushr.clif
@@ -15,8 +15,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -32,8 +32,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa2
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -52,8 +52,8 @@ block0(v0: i8x16, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -69,8 +69,8 @@ block0(v0: i8x16, v1: i16):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa2
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -89,8 +89,8 @@ block0(v0: i8x16, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -106,8 +106,8 @@ block0(v0: i8x16, v1: i32):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa2
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -126,8 +126,8 @@ block0(v0: i8x16, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -143,8 +143,8 @@ block0(v0: i8x16, v1: i64):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0xa2
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -163,8 +163,8 @@ block0(v0: i8x16, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v14,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v14,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -180,8 +180,8 @@ block0(v0: i8x16, v1: i128):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0x57, 0x47, 0x95, 0xa2
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x57, 0xc7, 0x95, 0xa2
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -200,8 +200,8 @@ block0(v0: i16x8, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -218,9 +218,9 @@ block0(v0: i16x8, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -239,8 +239,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -257,9 +257,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -278,8 +278,8 @@ block0(v0: i16x8, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -296,9 +296,9 @@ block0(v0: i16x8, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -317,8 +317,8 @@ block0(v0: i16x8, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -335,9 +335,9 @@ block0(v0: i16x8, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -356,8 +356,8 @@ block0(v0: i16x8, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v14,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v14,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -374,9 +374,9 @@ block0(v0: i16x8, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0x57, 0x47, 0x95, 0xa2
+;   .byte 0x57, 0xc7, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -395,8 +395,8 @@ block0(v0: i32x4, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -413,9 +413,9 @@ block0(v0: i32x4, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -434,8 +434,8 @@ block0(v0: i32x4, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -452,9 +452,9 @@ block0(v0: i32x4, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -473,8 +473,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -491,9 +491,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -512,8 +512,8 @@ block0(v0: i32x4, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -530,9 +530,9 @@ block0(v0: i32x4, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -551,8 +551,8 @@ block0(v0: i32x4, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v14,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v14,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -569,9 +569,9 @@ block0(v0: i32x4, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0x57, 0x47, 0x95, 0xa2
+;   .byte 0x57, 0xc7, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -590,8 +590,8 @@ block0(v0: i64x2, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -608,9 +608,9 @@ block0(v0: i64x2, v1: i8):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -629,8 +629,8 @@ block0(v0: i64x2, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -647,9 +647,9 @@ block0(v0: i64x2, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -668,8 +668,8 @@ block0(v0: i64x2, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -686,9 +686,9 @@ block0(v0: i64x2, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -707,8 +707,8 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v13,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v13,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -725,9 +725,9 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0xa2
+;   .byte 0xd7, 0xc6, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -746,8 +746,8 @@ block0(v0: i64x2, v1: i128):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vsrl.vx v14,v9,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v14,0(a2) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsrl.vx v14,v9,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -764,9 +764,9 @@ block0(v0: i64x2, v1: i128):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x47, 0x95, 0xa2
+;   .byte 0x57, 0xc7, 0x95, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x07, 0x06, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
@@ -353,8 +353,8 @@ block0(v0: i8x16, v1: i8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vssubu.vx v13,v9,a0 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vssubu.vx v13,v9,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -370,8 +370,8 @@ block0(v0: i8x16, v1: i8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   .byte 0xd7, 0x46, 0x95, 0x8a
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xd7, 0xc6, 0x95, 0x8a
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -391,8 +391,8 @@ block0(v0: i16x8, v1: i16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vssubu.vx v13,v9,a0 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vssubu.vx v13,v9,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -409,9 +409,9 @@ block0(v0: i16x8, v1: i16):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0x46, 0x95, 0x8a
+;   .byte 0xd7, 0xc6, 0x95, 0x8a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -431,8 +431,8 @@ block0(v0: i32x4, v1: i32):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vssubu.vx v13,v9,a0 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vssubu.vx v13,v9,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -449,9 +449,9 @@ block0(v0: i32x4, v1: i32):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0x46, 0x95, 0x8a
+;   .byte 0xd7, 0xc6, 0x95, 0x8a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x86, 0x05, 0x02
+;   .byte 0xa7, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -471,9 +471,9 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,-16(incoming_arg) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v14,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.x v14,a1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vssubu.vv v14,v14,v9 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v14,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -490,10 +490,10 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, sp, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x47, 0x05, 0x5e
+;   .byte 0x57, 0xc7, 0x05, 0x5e
 ;   .byte 0x57, 0x87, 0xe4, 0x8a
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x87, 0x05, 0x02
+;   .byte 0x27, 0x07, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
@@ -145,26 +145,26 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   fsd fs0,112(sp)
 ;   fsd fs2,104(sp)
 ; block0:
-;   mv s2,a4
-;   sb a0,0(slot)
-;   mv s1,a0
-;   sh a1,8(slot)
-;   mv s9,a1
-;   sw a2,16(slot)
-;   mv s4,a2
+;   mv s2,a0
+;   sb a1,0(slot)
+;   mv s1,a1
+;   sh a2,8(slot)
+;   mv s9,a2
+;   sw a3,16(slot)
+;   mv s4,a3
 ;   fsw fa0,20(slot)
 ;   fmv.d fs2,fa0
-;   sd a3,24(slot)
-;   mv s3,a3
+;   sd a4,24(slot)
+;   mv s3,a4
 ;   fsd fa1,32(slot)
 ;   fmv.d fs0,fa1
 ;   call userextname0
 ;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
-;   mv a2,s4
-;   mv a4,s2
-;   sw a2,0(a4)
-;   mv a3,s3
-;   sd a3,8(a4)
+;   mv a0,s2
+;   mv a3,s4
+;   sw a3,0(a0)
+;   mv a4,s3
+;   sd a4,8(a0)
 ;   mv a0,s1
 ;   mv a1,s9
 ;   fmv.d fa0,fs2
@@ -197,26 +197,26 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   fsd fs0, 0x70(sp)
 ;   fsd fs2, 0x68(sp)
 ; block1: ; offset 0x30
-;   mv s2, a4
-;   sb a0, 0(sp)
-;   mv s1, a0
-;   sh a1, 8(sp)
-;   mv s9, a1
-;   sw a2, 0x10(sp)
-;   mv s4, a2
+;   mv s2, a0
+;   sb a1, 0(sp)
+;   mv s1, a1
+;   sh a2, 8(sp)
+;   mv s9, a2
+;   sw a3, 0x10(sp)
+;   mv s4, a3
 ;   fsw fa0, 0x14(sp)
 ;   fmv.d fs2, fa0
-;   sd a3, 0x18(sp)
-;   mv s3, a3
+;   sd a4, 0x18(sp)
+;   mv s3, a4
 ;   fsd fa1, 0x20(sp)
 ;   fmv.d fs0, fa1
 ;   auipc ra, 0 ; reloc_external RiscvCallPlt u0:0 0
 ;   jalr ra
-;   mv a2, s4
-;   mv a4, s2
-;   sw a2, 0(a4)
-;   mv a3, s3
-;   sd a3, 8(a4)
+;   mv a0, s2
+;   mv a3, s4
+;   sw a3, 0(a0)
+;   mv a4, s3
+;   sd a4, 8(a0)
 ;   mv a0, s1
 ;   mv a1, s9
 ;   fmv.d fa0, fs2

--- a/cranelift/filetests/filetests/isa/s390x/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/user_stack_maps.clif
@@ -95,7 +95,7 @@ block0:
 ;   lmg %r6, %r15, 0xe0(%r15)
 ;   br %r14
 
-function %different_types(i8, i16, i32, i64, f32, f64) -> i8, i16, i32, i64, f32, f64 {
+function %different_types(i8, i16, i32, i64, f32, f64) -> i8, i16, i32, i64, f32, f64 fast {
     ss0 = explicit_slot 1
     ss1 = explicit_slot 2, align = 2
     ss2 = explicit_slot 8, align = 4

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1244,16 +1244,15 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, 0(%rdx)
-;   movq    %rdi, 8(%rdx)
-;   movq    %rsi, 16(%rdx)
-;   movq    %rdi, 24(%rdx)
-;   movq    %rdi, 32(%rdx)
-;   movq    %rsi, 40(%rdx)
-;   movq    %rdi, 48(%rdx)
-;   movq    %rsi, 56(%rdx)
-;   movq    %rdi, %rcx
-;   movq    %rsi, %rdx
+;   movq    %rdx, 0(%rdi)
+;   movq    %rsi, 8(%rdi)
+;   movq    %rdx, 16(%rdi)
+;   movq    %rsi, 24(%rdi)
+;   movq    %rsi, 32(%rdi)
+;   movq    %rdx, 40(%rdi)
+;   movq    %rsi, 48(%rdi)
+;   movq    %rdx, 56(%rdi)
+;   movq    %rsi, %rcx
 ;   movq    %rcx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1264,16 +1263,15 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, (%rdx)
-;   movq %rdi, 8(%rdx)
-;   movq %rsi, 0x10(%rdx)
-;   movq %rdi, 0x18(%rdx)
-;   movq %rdi, 0x20(%rdx)
-;   movq %rsi, 0x28(%rdx)
-;   movq %rdi, 0x30(%rdx)
-;   movq %rsi, 0x38(%rdx)
-;   movq %rdi, %rcx
-;   movq %rsi, %rdx
+;   movq %rdx, (%rdi)
+;   movq %rsi, 8(%rdi)
+;   movq %rdx, 0x10(%rdi)
+;   movq %rsi, 0x18(%rdi)
+;   movq %rsi, 0x20(%rdi)
+;   movq %rdx, 0x28(%rdi)
+;   movq %rsi, 0x30(%rdi)
+;   movq %rdx, 0x38(%rdi)
+;   movq %rsi, %rcx
 ;   movq %rcx, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1292,13 +1290,13 @@ block0(v0: i128, v1: i128):
 ;   subq    %rsp, $32, %rsp
 ;   movq    %r13, 16(%rsp)
 ; block0:
-;   movq    %r8, %r13
-;   lea     0(%rsp), %r8
+;   movq    %rdi, %r13
+;   lea     0(%rsp), %rdi
 ;   load_ext_name %g+0, %r9
 ;   call    *%r9
 ;   movq    0(%rsp), %r8
-;   movq    %r13, %r10
-;   movq    %r8, 0(%r10)
+;   movq    %r13, %rdi
+;   movq    %r8, 0(%rdi)
 ;   movq    16(%rsp), %r13
 ;   addq    %rsp, $32, %rsp
 ;   movq    %rbp, %rsp
@@ -1312,13 +1310,13 @@ block0(v0: i128, v1: i128):
 ;   subq $0x20, %rsp
 ;   movq %r13, 0x10(%rsp)
 ; block1: ; offset 0xd
-;   movq %r8, %r13
-;   leaq (%rsp), %r8
+;   movq %rdi, %r13
+;   leaq (%rsp), %rdi
 ;   movabsq $0, %r9 ; reloc_external Abs8 %g 0
 ;   callq *%r9
 ;   movq (%rsp), %r8
-;   movq %r13, %r10
-;   movq %r8, (%r10)
+;   movq %r13, %rdi
+;   movq %r8, (%rdi)
 ;   movq 0x10(%rsp), %r13
 ;   addq $0x20, %rsp
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot.clif
@@ -20,7 +20,7 @@ block0(v0: i64):
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   movq    %rdi, %r10
+;   movq    %rsi, %r10
 ;   addq    %r10, $48, %r10
 ;   cmpq    %rsp, %r10
 ;   jnbe #trap=stk_ovf
@@ -30,8 +30,8 @@ block0(v0: i64):
 ;   lea     rsp(16 + virtual offset), %rdx
 ;   lea     rsp(32 + virtual offset), %r8
 ;   lea     rsp(40 + virtual offset), %r9
-;   movq    %r8, 0(%rsi)
-;   movq    %r9, 8(%rsi)
+;   movq    %r8, 0(%rdi)
+;   movq    %r9, 8(%rdi)
 ;   addq    %rsp, $48, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -41,7 +41,7 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   movq %rdi, %r10
+;   movq %rsi, %r10
 ;   addq $0x30, %r10
 ;   cmpq %rsp, %r10
 ;   ja 0x3b
@@ -51,8 +51,8 @@ block0(v0: i64):
 ;   leaq 0x10(%rsp), %rdx
 ;   leaq 0x20(%rsp), %r8
 ;   leaq 0x28(%rsp), %r9
-;   movq %r8, (%rsi)
-;   movq %r9, 8(%rsi)
+;   movq %r8, (%rdi)
+;   movq %r9, 8(%rdi)
 ;   addq $0x30, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -30,21 +30,26 @@ block0(v0: i64):
 ;   retq
 
 function %f1(i64, i64) -> i64 {
-    fn0 = %f2(i64 sret) -> i64
+    fn0 = %f2(i64 sret)
 
 block0(v0: i64, v1: i64):
-    v2 = call fn0(v1)
-    return v2
+    call fn0(v1)
+    return v1
 }
 
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %r15, 0(%rsp)
 ; block0:
-;   load_ext_name %f2+0, %rcx
-;   movq    %rsi, %rdi
-;   call    *%rcx
-;   movq    %rdx, %rax
+;   movq    %rsi, %r15
+;   load_ext_name %f2+0, %rax
+;   movq    %r15, %rdi
+;   call    *%rax
+;   movq    %r15, %rax
+;   movq    0(%rsp), %r15
+;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -53,11 +58,16 @@ block0(v0: i64, v1: i64):
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block1: ; offset 0x4
-;   movabsq $0, %rcx ; reloc_external Abs8 %f2 0
-;   movq %rsi, %rdi
-;   callq *%rcx
-;   movq %rdx, %rax
+;   subq $0x10, %rsp
+;   movq %r15, (%rsp)
+; block1: ; offset 0xc
+;   movq %rsi, %r15
+;   movabsq $0, %rax ; reloc_external Abs8 %f2 0
+;   movq %r15, %rdi
+;   callq *%rax
+;   movq %r15, %rax
+;   movq (%rsp), %r15
+;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
@@ -143,32 +143,32 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   movq    %r14, 152(%rsp)
 ;   movq    %r15, 160(%rsp)
 ; block0:
-;   movq    %r8, %r13
-;   lea     rsp(0 + virtual offset), %r8
-;   movb    %dil, 0(%r8)
-;   movq    %rdi, %r15
-;   lea     rsp(8 + virtual offset), %r8
-;   movw    %si, 0(%r8)
-;   movq    %rsi, %r12
+;   movq    %rdi, %r13
+;   lea     rsp(0 + virtual offset), %r9
+;   movb    %sil, 0(%r9)
+;   movq    %rsi, %r15
+;   lea     rsp(8 + virtual offset), %r9
+;   movw    %dx, 0(%r9)
+;   movq    %rdx, %r12
 ;   lea     rsp(16 + virtual offset), %r9
-;   movl    %edx, 0(%r9)
-;   movq    %rdx, %rbx
+;   movl    %ecx, 0(%r9)
+;   movq    %rcx, %rbx
 ;   lea     rsp(20 + virtual offset), %r10
 ;   movss   %xmm0, 0(%r10)
 ;   movdqu  %xmm0, rsp(96 + virtual offset)
 ;   lea     rsp(24 + virtual offset), %r11
-;   movq    %rcx, 0(%r11)
-;   movq    %rcx, %r14
+;   movq    %r8, 0(%r11)
+;   movq    %r8, %r14
 ;   lea     rsp(32 + virtual offset), %rsi
 ;   movsd   %xmm1, 0(%rsi)
 ;   movdqu  %xmm1, rsp(112 + virtual offset)
 ;   call    User(userextname0)
 ;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
-;   movq    %rbx, %rdx
-;   movq    %r13, %r8
-;   movl    %edx, 0(%r8)
-;   movq    %r14, %rcx
-;   movq    %rcx, 8(%r8)
+;   movq    %rbx, %rcx
+;   movq    %r13, %rdi
+;   movl    %ecx, 0(%rdi)
+;   movq    %r14, %r8
+;   movq    %r8, 8(%rdi)
 ;   movq    %r15, %rax
 ;   movq    %r12, %rdx
 ;   movdqu  rsp(96 + virtual offset), %xmm0
@@ -194,31 +194,31 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   movq %r14, 0x98(%rsp)
 ;   movq %r15, 0xa0(%rsp)
 ; block1: ; offset 0x33
-;   movq %r8, %r13
-;   leaq (%rsp), %r8
-;   movb %dil, (%r8)
-;   movq %rdi, %r15
-;   leaq 8(%rsp), %r8
-;   movw %si, (%r8)
-;   movq %rsi, %r12
+;   movq %rdi, %r13
+;   leaq (%rsp), %r9
+;   movb %sil, (%r9)
+;   movq %rsi, %r15
+;   leaq 8(%rsp), %r9
+;   movw %dx, (%r9)
+;   movq %rdx, %r12
 ;   leaq 0x10(%rsp), %r9
-;   movl %edx, (%r9)
-;   movq %rdx, %rbx
+;   movl %ecx, (%r9)
+;   movq %rcx, %rbx
 ;   leaq 0x14(%rsp), %r10
 ;   movss %xmm0, (%r10)
 ;   movdqu %xmm0, 0x60(%rsp)
 ;   leaq 0x18(%rsp), %r11
-;   movq %rcx, (%r11)
-;   movq %rcx, %r14
+;   movq %r8, (%r11)
+;   movq %r8, %r14
 ;   leaq 0x20(%rsp), %rsi
 ;   movsd %xmm1, (%rsi)
 ;   movdqu %xmm1, 0x70(%rsp)
 ;   callq 0x86 ; reloc_external CallPCRel4 u0:0 -4
-;   movq %rbx, %rdx
-;   movq %r13, %r8
-;   movl %edx, (%r8)
-;   movq %r14, %rcx
-;   movq %rcx, 8(%r8)
+;   movq %rbx, %rcx
+;   movq %r13, %rdi
+;   movl %ecx, (%rdi)
+;   movq %r14, %r8
+;   movq %r8, 8(%rdi)
 ;   movq %r15, %rax
 ;   movq %r12, %rdx
 ;   movdqu 0x60(%rsp), %xmm0


### PR DESCRIPTION
The first commit adds a couple of assertions against misuse of StructReturn. The next two commits are minor cleanups. And the last commit is a partial ABI fix for multi-value returns.

Helps with https://github.com/bytecodealliance/wasmtime/issues/9250