### PR TITLE
Add a `runtime_module` method to get the `wasmtime::Module` associated with a `wasmtime::runtime::vm::Instance`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -259,8 +259,16 @@ impl Instance {
             .cast()
     }
 
-    pub(crate) fn env_module(&self) -> &Arc<Module> {
+    pub(crate) fn env_module(&self) -> &Arc<wasmtime_environ::Module> {
         self.runtime_info.env_module()
+    }
+
+    #[allow(dead_code)] // TODO: used in forthcoming patches
+    pub(crate) fn runtime_module(&self) -> Option<&crate::Module> {
+        match &self.runtime_info {
+            ModuleRuntimeInfo::Module(m) => Some(m),
+            ModuleRuntimeInfo::Bare(_) => None,
+        }
     }
 
     /// Translate a module-level interned type index into an engine-level


### PR DESCRIPTION

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
