### PR TITLE
Fix a multiplication overflow found during fuzzing

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -122,7 +122,7 @@ impl ResourceLimiter for StoreLimits {
         desired: usize,
         _maximum: Option<usize>,
     ) -> Result<bool> {
-        let delta = (desired - current) * std::mem::size_of::<usize>();
+        let delta = (desired - current).saturating_mul(std::mem::size_of::<usize>());
         Ok(self.alloc(delta))
     }
 }


### PR DESCRIPTION
With table64 support it's now possible that the number of desired table elements can overflow the address space when multiplied by the size of a pointer, so account for this when handling resource limits while fuzzing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
