### PR TITLE
Add the `GcRuntime::alloc_raw` trait method

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -20,6 +20,7 @@ pub use i31::*;
 
 use crate::prelude::*;
 use crate::runtime::vm::GcHeapAllocationIndex;
+use core::alloc::Layout;
 use core::ptr;
 use core::{any::Any, num::NonZeroUsize};
 use wasmtime_environ::{GcArrayLayout, GcStructLayout, StackMap, VMGcKind, VMSharedTypeIndex};
@@ -271,11 +272,17 @@ unsafe impl GcHeap for DisabledGcHeap {
     fn alloc_externref(&mut self, _host_data: ExternRefHostDataId) -> Result<Option<VMExternRef>> {
         bail!(
             "GC support disabled either in the `Config` or at compile time \
-                 because the `gc` cargo feature was not enabled"
+             because the `gc` cargo feature was not enabled"
         )
     }
     fn externref_host_data(&self, _externref: &VMExternRef) -> ExternRefHostDataId {
         unreachable!()
+    }
+    fn alloc_raw(&mut self, _header: VMGcHeader, _layout: Layout) -> Result<Option<VMGcRef>> {
+        bail!(
+            "GC support disabled either in the `Config` or at compile time \
+             because the `gc` cargo feature was not enabled"
+        )
     }
     fn alloc_uninit_struct(
         &mut self,
@@ -284,7 +291,7 @@ unsafe impl GcHeap for DisabledGcHeap {
     ) -> Result<Option<VMStructRef>> {
         bail!(
             "GC support disabled either in the `Config` or at compile time \
-                 because the `gc` cargo feature was not enabled"
+             because the `gc` cargo feature was not enabled"
         )
     }
     fn dealloc_uninit_struct(&mut self, _structref: VMStructRef) {
@@ -301,7 +308,7 @@ unsafe impl GcHeap for DisabledGcHeap {
     ) -> Result<Option<VMArrayRef>> {
         bail!(
             "GC support disabled either in the `Config` or at compile time \
-                 because the `gc` cargo feature was not enabled"
+             because the `gc` cargo feature was not enabled"
         )
     }
     fn dealloc_uninit_array(&mut self, _structref: VMArrayRef) {


### PR DESCRIPTION
And do some minor refactors to the DRC collector to build other allocation methods on top of that one internally.

This method will be used in forthcoming PRs implementing the `struct.new[_default]` instructions, where a libcall does the actual allocation, but Wasm code performs field initialization inline.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
