### PR TITLE
Implement the `struct.*` GC instructions

### DIFF
--- a/cranelift/wasm/src/environ/mod.rs
+++ b/cranelift/wasm/src/environ/mod.rs
@@ -4,5 +4,5 @@
 mod spec;
 
 pub use crate::environ::spec::{
-    FuncEnvironment, GlobalVariable, ModuleEnvironment, TargetEnvironment,
+    FuncEnvironment, GlobalVariable, ModuleEnvironment, StructFieldsVec, TargetEnvironment,
 };

--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -39,7 +39,9 @@ mod state;
 mod table;
 mod translation_utils;
 
-pub use crate::environ::{FuncEnvironment, GlobalVariable, ModuleEnvironment, TargetEnvironment};
+pub use crate::environ::{
+    FuncEnvironment, GlobalVariable, ModuleEnvironment, StructFieldsVec, TargetEnvironment,
+};
 pub use crate::func_translator::FuncTranslator;
 pub use crate::heap::{Heap, HeapData, HeapStyle};
 pub use crate::module_translator::translate_module;

--- a/crates/cranelift/src/gc/disabled.rs
+++ b/crates/cranelift/src/gc/disabled.rs
@@ -20,7 +20,7 @@ fn disabled<T>() -> WasmResult<T> {
 }
 
 pub fn gc_ref_table_grow_builtin(
-    ty: WasmHeapType,
+    _ty: WasmHeapType,
     _func_env: &mut FuncEnvironment<'_>,
     _func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {
@@ -28,7 +28,7 @@ pub fn gc_ref_table_grow_builtin(
 }
 
 pub fn gc_ref_table_fill_builtin(
-    ty: WasmHeapType,
+    _ty: WasmHeapType,
     _func_env: &mut FuncEnvironment<'_>,
     _func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {

--- a/crates/cranelift/src/gc/disabled.rs
+++ b/crates/cranelift/src/gc/disabled.rs
@@ -12,15 +12,19 @@ pub fn gc_compiler(_: &FuncEnvironment<'_>) -> Box<dyn GcCompiler> {
     Box::new(DisabledGcCompiler)
 }
 
+fn disabled<T>() -> WasmResult<T> {
+    Err(wasm_unsupported!(
+        "support for Wasm GC disabled at compile time because the `gc` cargo \
+         feature was not enabled"
+    ))
+}
+
 pub fn gc_ref_table_grow_builtin(
     ty: WasmHeapType,
     _func_env: &mut FuncEnvironment<'_>,
     _func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {
-    Err(wasm_unsupported!(
-        "support for `{ty}` references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 pub fn gc_ref_table_fill_builtin(
@@ -28,10 +32,7 @@ pub fn gc_ref_table_fill_builtin(
     _func_env: &mut FuncEnvironment<'_>,
     _func: &mut ir::Function,
 ) -> WasmResult<ir::FuncRef> {
-    Err(wasm_unsupported!(
-        "support for `{ty}` references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 pub fn translate_struct_new(
@@ -40,10 +41,7 @@ pub fn translate_struct_new(
     _struct_type_index: TypeIndex,
     _fields: &[ir::Value],
 ) -> WasmResult<ir::Value> {
-    Err(wasm_unsupported!(
-        "support for GC references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 pub fn translate_struct_new_default(
@@ -51,10 +49,7 @@ pub fn translate_struct_new_default(
     _builder: &mut FunctionBuilder<'_>,
     _struct_type_index: TypeIndex,
 ) -> WasmResult<ir::Value> {
-    Err(wasm_unsupported!(
-        "support for GC references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 pub fn translate_struct_get(
@@ -64,10 +59,7 @@ pub fn translate_struct_get(
     _field_index: u32,
     _struct_ref: ir::Value,
 ) -> WasmResult<ir::Value> {
-    Err(wasm_unsupported!(
-        "support for GC references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 pub fn translate_struct_get_s(
@@ -77,10 +69,7 @@ pub fn translate_struct_get_s(
     _field_index: u32,
     _struct_ref: ir::Value,
 ) -> WasmResult<ir::Value> {
-    Err(wasm_unsupported!(
-        "support for GC references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 pub fn translate_struct_get_u(
@@ -90,10 +79,7 @@ pub fn translate_struct_get_u(
     _field_index: u32,
     _struct_ref: ir::Value,
 ) -> WasmResult<ir::Value> {
-    Err(wasm_unsupported!(
-        "support for GC references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 pub fn translate_struct_set(
@@ -104,10 +90,7 @@ pub fn translate_struct_set(
     _struct_ref: ir::Value,
     _new_val: ir::Value,
 ) -> WasmResult<()> {
-    Err(wasm_unsupported!(
-        "support for GC references disabled at compile time because the `gc` cargo \
-         feature was not enabled"
-    ))
+    disabled()
 }
 
 struct DisabledGcCompiler;
@@ -127,38 +110,29 @@ impl GcCompiler for DisabledGcCompiler {
         _struct_type_index: TypeIndex,
         _fields: &[ir::Value],
     ) -> WasmResult<ir::Value> {
-        Err(wasm_unsupported!(
-            "support for GC types disabled at compile time because the `gc` cargo \
-             feature was not enabled"
-        ))
+        disabled()
     }
 
     fn translate_read_gc_reference(
         &mut self,
         _func_env: &mut FuncEnvironment<'_>,
         _builder: &mut FunctionBuilder,
-        ty: WasmRefType,
+        _ty: WasmRefType,
         _src: ir::Value,
         _flags: ir::MemFlags,
     ) -> WasmResult<ir::Value> {
-        Err(wasm_unsupported!(
-            "support for `{ty}` disabled at compile time because the `gc` cargo \
-             feature was not enabled"
-        ))
+        disabled()
     }
 
     fn translate_write_gc_reference(
         &mut self,
         _func_env: &mut FuncEnvironment<'_>,
         _builder: &mut FunctionBuilder,
-        ty: WasmRefType,
+        _ty: WasmRefType,
         _dst: ir::Value,
         _new_val: ir::Value,
         _flags: ir::MemFlags,
     ) -> WasmResult<()> {
-        Err(wasm_unsupported!(
-            "support for `{ty}` disabled at compile time because the `gc` cargo \
-             feature was not enabled"
-        ))
+        disabled()
     }
 }

--- a/crates/cranelift/src/gc/disabled.rs
+++ b/crates/cranelift/src/gc/disabled.rs
@@ -5,7 +5,7 @@ use crate::func_environ::FuncEnvironment;
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 use cranelift_wasm::{wasm_unsupported, WasmHeapType, WasmRefType, WasmResult};
-use wasmtime_environ::GcTypeLayouts;
+use wasmtime_environ::{GcTypeLayouts, TypeIndex};
 
 /// Get the default GC compiler.
 pub fn gc_compiler(_: &FuncEnvironment<'_>) -> Box<dyn GcCompiler> {
@@ -34,6 +34,82 @@ pub fn gc_ref_table_fill_builtin(
     ))
 }
 
+pub fn translate_struct_new(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _struct_type_index: TypeIndex,
+    _fields: &[ir::Value],
+) -> WasmResult<ir::Value> {
+    Err(wasm_unsupported!(
+        "support for GC references disabled at compile time because the `gc` cargo \
+         feature was not enabled"
+    ))
+}
+
+pub fn translate_struct_new_default(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _struct_type_index: TypeIndex,
+) -> WasmResult<ir::Value> {
+    Err(wasm_unsupported!(
+        "support for GC references disabled at compile time because the `gc` cargo \
+         feature was not enabled"
+    ))
+}
+
+pub fn translate_struct_get(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _struct_type_index: TypeIndex,
+    _field_index: u32,
+    _struct_ref: ir::Value,
+) -> WasmResult<ir::Value> {
+    Err(wasm_unsupported!(
+        "support for GC references disabled at compile time because the `gc` cargo \
+         feature was not enabled"
+    ))
+}
+
+pub fn translate_struct_get_s(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _struct_type_index: TypeIndex,
+    _field_index: u32,
+    _struct_ref: ir::Value,
+) -> WasmResult<ir::Value> {
+    Err(wasm_unsupported!(
+        "support for GC references disabled at compile time because the `gc` cargo \
+         feature was not enabled"
+    ))
+}
+
+pub fn translate_struct_get_u(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _struct_type_index: TypeIndex,
+    _field_index: u32,
+    _struct_ref: ir::Value,
+) -> WasmResult<ir::Value> {
+    Err(wasm_unsupported!(
+        "support for GC references disabled at compile time because the `gc` cargo \
+         feature was not enabled"
+    ))
+}
+
+pub fn translate_struct_set(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _struct_type_index: TypeIndex,
+    _field_index: u32,
+    _struct_ref: ir::Value,
+    _new_val: ir::Value,
+) -> WasmResult<()> {
+    Err(wasm_unsupported!(
+        "support for GC references disabled at compile time because the `gc` cargo \
+         feature was not enabled"
+    ))
+}
+
 struct DisabledGcCompiler;
 
 impl GcCompiler for DisabledGcCompiler {
@@ -42,6 +118,19 @@ impl GcCompiler for DisabledGcCompiler {
             "support for GC types disabled at compile time because the `gc` cargo \
              feature was not enabled"
         )
+    }
+
+    fn alloc_struct(
+        &mut self,
+        _func_env: &mut FuncEnvironment<'_>,
+        _builder: &mut FunctionBuilder<'_>,
+        _struct_type_index: TypeIndex,
+        _fields: &[ir::Value],
+    ) -> WasmResult<ir::Value> {
+        Err(wasm_unsupported!(
+            "support for GC types disabled at compile time because the `gc` cargo \
+             feature was not enabled"
+        ))
     }
 
     fn translate_read_gc_reference(

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -79,6 +79,17 @@ macro_rules! foreach_builtin_function {
             #[cfg(feature = "gc")]
             gc(vmctx: vmctx, root: reference) -> reference;
 
+            // Allocate a new, uninitialized GC object and return a reference to
+            // it.
+            #[cfg(feature = "gc")]
+            gc_alloc_raw(
+                vmctx: vmctx,
+                kind: i32,
+                module_interned_type_index: i32,
+                size: i32,
+                align: i32
+            ) -> reference;
+
             // Returns an index for Wasm's `table.grow` instruction for GC references.
             #[cfg(feature = "gc")]
             table_grow_gc_ref(vmctx: vmctx, table: i32, delta: i64, init: reference) -> pointer;

--- a/crates/environ/src/gc.rs
+++ b/crates/environ/src/gc.rs
@@ -14,7 +14,7 @@ pub mod drc;
 
 use crate::prelude::*;
 use core::alloc::Layout;
-use wasmtime_types::{WasmArrayType, WasmStructType};
+use wasmtime_types::{WasmArrayType, WasmStorageType, WasmStructType, WasmValType};
 
 /// Discriminant to check whether GC reference is an `i31ref` or not.
 pub const I31_DISCRIMINANT: u64 = 1;
@@ -22,6 +22,20 @@ pub const I31_DISCRIMINANT: u64 = 1;
 /// A mask that can be used to check for non-null and non-i31ref GC references
 /// with a single bitwise-and operation.
 pub const NON_NULL_NON_I31_MASK: u64 = !I31_DISCRIMINANT;
+
+/// Get the byte size of the given Wasm type when it is stored inside the GC
+/// heap.
+pub fn byte_size_of_wasm_ty_in_gc_heap(ty: &WasmStorageType) -> u32 {
+    match ty {
+        WasmStorageType::I8 => 1,
+        WasmStorageType::I16 => 2,
+        WasmStorageType::Val(ty) => match ty {
+            WasmValType::I32 | WasmValType::F32 | WasmValType::Ref(_) => 4,
+            WasmValType::I64 | WasmValType::F64 => 8,
+            WasmValType::V128 => 16,
+        },
+    }
+}
 
 /// A trait for getting the layout of a Wasm GC struct or array inside a
 /// particular collector.
@@ -141,14 +155,14 @@ impl GcArrayLayout {
 /// header (for example) is included in the offset.
 #[derive(Clone, Debug)]
 pub struct GcStructLayout {
-    /// The size of this struct.
+    /// The size (in bytes) of this struct.
     pub size: u32,
 
-    /// The alignment of this struct.
+    /// The alignment (in bytes) of this struct.
     pub align: u32,
 
     /// The fields of this struct. The `i`th entry is the `i`th struct field's
-    /// offset in the struct.
+    /// offset (in bytes) in the struct.
     pub fields: Vec<u32>,
 }
 
@@ -213,13 +227,13 @@ impl VMGcKind {
     pub fn from_high_bits_of_u32(val: u32) -> VMGcKind {
         let masked = val & Self::MASK;
         match masked {
-            x if x == Self::ExternRef as u32 => Self::ExternRef,
-            x if x == Self::ExternOfAnyRef as u32 => Self::ExternOfAnyRef,
-            x if x == Self::AnyRef as u32 => Self::AnyRef,
-            x if x == Self::AnyOfExternRef as u32 => Self::AnyOfExternRef,
-            x if x == Self::EqRef as u32 => Self::EqRef,
-            x if x == Self::ArrayRef as u32 => Self::ArrayRef,
-            x if x == Self::StructRef as u32 => Self::StructRef,
+            x if x == Self::ExternRef.as_u32() => Self::ExternRef,
+            x if x == Self::ExternOfAnyRef.as_u32() => Self::ExternOfAnyRef,
+            x if x == Self::AnyRef.as_u32() => Self::AnyRef,
+            x if x == Self::AnyOfExternRef.as_u32() => Self::AnyOfExternRef,
+            x if x == Self::EqRef.as_u32() => Self::EqRef,
+            x if x == Self::ArrayRef.as_u32() => Self::ArrayRef,
+            x if x == Self::StructRef.as_u32() => Self::StructRef,
             _ => panic!("invalid `VMGcKind`: {masked:#032b}"),
         }
     }
@@ -227,8 +241,15 @@ impl VMGcKind {
     /// Does this kind match the other kind?
     ///
     /// That is, is this kind a subtype of the other kind?
+    #[inline]
     pub fn matches(self, other: Self) -> bool {
-        (self as u32) & (other as u32) == (other as u32)
+        (self.as_u32() & other.as_u32()) == other.as_u32()
+    }
+
+    /// TODO FITZGEN
+    #[inline]
+    pub fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/environ/src/gc.rs
+++ b/crates/environ/src/gc.rs
@@ -246,7 +246,7 @@ impl VMGcKind {
         (self.as_u32() & other.as_u32()) == other.as_u32()
     }
 
-    /// TODO FITZGEN
+    /// Get this `VMGcKind` as a raw `u32`.
     #[inline]
     pub fn as_u32(self) -> u32 {
         self as u32

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -180,6 +180,11 @@ impl GcStore {
         self.host_data_table.get_mut(host_data_id)
     }
 
+    /// Allocate a raw object with the given header and layout.
+    pub fn alloc_raw(&mut self, header: VMGcHeader, layout: Layout) -> Result<Option<VMGcRef>> {
+        self.gc_heap.alloc_raw(header, layout)
+    }
+
     /// Allocate an uninitialized struct with the given type index and layout.
     ///
     /// This does NOT check that the index is currently allocated in the types

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -29,6 +29,7 @@ use wasmtime_environ::{VMGcKind, VMSharedTypeIndex};
 /// }
 /// ```
 #[repr(align(8))]
+#[derive(Debug, Clone, Copy)]
 pub struct VMGcHeader(u64);
 
 unsafe impl GcHeapObject for VMGcHeader {

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -263,7 +263,6 @@ impl Instance {
         self.runtime_info.env_module()
     }
 
-    #[allow(dead_code)] // TODO: used in forthcoming patches
     pub(crate) fn runtime_module(&self) -> Option<&crate::Module> {
         match &self.runtime_info {
             ModuleRuntimeInfo::Module(m) => Some(m),

--- a/crates/wast/src/core.rs
+++ b/crates/wast/src/core.rs
@@ -22,6 +22,14 @@ pub fn val<T>(store: &mut Store<T>, v: &WastArgCore<'_>) -> Result<Val> {
             ty: AbstractHeapType::Func,
             shared: false,
         }) => Val::FuncRef(None),
+        RefNull(HeapType::Abstract {
+            ty: AbstractHeapType::Any,
+            shared: false,
+        }) => Val::AnyRef(None),
+        RefNull(HeapType::Abstract {
+            shared: false,
+            ty: AbstractHeapType::None,
+        }) => Val::AnyRef(None),
         RefExtern(x) => Val::ExternRef(Some(ExternRef::new(store, *x)?)),
         other => bail!("couldn't convert {:?} to a runtime value", other),
     })
@@ -105,11 +113,19 @@ pub fn match_val<T>(store: &Store<T>, actual: &Val, expected: &WastRetCore) -> R
             }
         }
 
+        (Val::AnyRef(Some(_)), WastRetCore::RefAny) => Ok(()),
         (Val::AnyRef(Some(x)), WastRetCore::RefI31) => {
             if x.is_i31(store)? {
                 Ok(())
             } else {
                 bail!("expected a `(ref i31)`, found {x:?}");
+            }
+        }
+        (Val::AnyRef(Some(x)), WastRetCore::RefStruct) => {
+            if x.is_struct(store)? {
+                Ok(())
+            } else {
+                bail!("expected a struct reference, found {x:?}")
             }
         }
 

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -388,6 +388,8 @@ where
             || (expected.contains("uninitialized element 2") && actual.contains("uninitialized element"))
             // function references call_ref
             || (expected.contains("null function") && (actual.contains("uninitialized element") || actual.contains("null reference")))
+            // GC tests say "null $kind reference" but we just say "null reference".
+            || (expected.contains("null") && expected.contains("reference") && actual.contains("null reference"))
         {
             return Ok(());
         }

--- a/tests/disas/gc/struct-get.wat
+++ b/tests/disas/gc/struct-get.wat
@@ -1,0 +1,231 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc"
+;;! test = "optimize"
+
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (param (ref null $ty)) (result f32)
+    (struct.get $ty 0 (local.get 0))
+  )
+
+  (func (param (ref null $ty)) (result i32)
+    (struct.get_s $ty 1 (local.get 0))
+  )
+
+  (func (param (ref null $ty)) (result i32)
+    (struct.get_u $ty 1 (local.get 0))
+  )
+
+  (func (param (ref null $ty)) (result anyref)
+    (struct.get $ty 2 (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0033                               brif v2, block3, block2
+;;
+;;                                 block2 cold:
+;; @0033                               trap null_reference
+;;
+;;                                 block3:
+;; @0033                               v7 = uextend.i64 v2
+;; @0033                               v8 = iconst.i64 16
+;; @0033                               v9 = uadd_overflow_trap v7, v8, user65535  ; v8 = 16
+;; @0033                               v10 = iconst.i64 4
+;; @0033                               v11 = uadd_overflow_trap v9, v10, user65535  ; v10 = 4
+;; @0033                               v6 = load.i64 notrap aligned readonly v0+48
+;; @0033                               v12 = icmp ult v11, v6
+;; @0033                               brif v12, block5, block4
+;;
+;;                                 block4 cold:
+;; @0033                               trap user65535
+;;
+;;                                 block5:
+;; @0033                               v5 = load.i64 notrap aligned readonly v0+40
+;; @0033                               v13 = iadd v5, v9
+;; @0033                               v14 = load.f32 notrap aligned v13
+;; @0037                               jump block1
+;;
+;;                                 block1:
+;; @0037                               return v14
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @003c                               brif v2, block3, block2
+;;
+;;                                 block2 cold:
+;; @003c                               trap null_reference
+;;
+;;                                 block3:
+;; @003c                               v7 = uextend.i64 v2
+;; @003c                               v8 = iconst.i64 20
+;; @003c                               v9 = uadd_overflow_trap v7, v8, user65535  ; v8 = 20
+;; @003c                               v10 = iconst.i64 1
+;; @003c                               v11 = uadd_overflow_trap v9, v10, user65535  ; v10 = 1
+;; @003c                               v6 = load.i64 notrap aligned readonly v0+48
+;; @003c                               v12 = icmp ult v11, v6
+;; @003c                               brif v12, block5, block4
+;;
+;;                                 block4 cold:
+;; @003c                               trap user65535
+;;
+;;                                 block5:
+;; @003c                               v5 = load.i64 notrap aligned readonly v0+40
+;; @003c                               v13 = iadd v5, v9
+;; @003c                               v14 = load.i8 notrap aligned v13
+;; @0040                               jump block1
+;;
+;;                                 block1:
+;; @003c                               v15 = sextend.i32 v14
+;; @0040                               return v15
+;; }
+;;
+;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0045                               brif v2, block3, block2
+;;
+;;                                 block2 cold:
+;; @0045                               trap null_reference
+;;
+;;                                 block3:
+;; @0045                               v7 = uextend.i64 v2
+;; @0045                               v8 = iconst.i64 20
+;; @0045                               v9 = uadd_overflow_trap v7, v8, user65535  ; v8 = 20
+;; @0045                               v10 = iconst.i64 1
+;; @0045                               v11 = uadd_overflow_trap v9, v10, user65535  ; v10 = 1
+;; @0045                               v6 = load.i64 notrap aligned readonly v0+48
+;; @0045                               v12 = icmp ult v11, v6
+;; @0045                               brif v12, block5, block4
+;;
+;;                                 block4 cold:
+;; @0045                               trap user65535
+;;
+;;                                 block5:
+;; @0045                               v5 = load.i64 notrap aligned readonly v0+40
+;; @0045                               v13 = iadd v5, v9
+;; @0045                               v14 = load.i8 notrap aligned v13
+;; @0049                               jump block1
+;;
+;;                                 block1:
+;; @0045                               v15 = uextend.i32 v14
+;; @0049                               return v15
+;; }
+;;
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     fn0 = colocated u1:26 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @004e                               brif v2, block7, block6
+;;
+;;                                 block6 cold:
+;; @004e                               trap null_reference
+;;
+;;                                 block7:
+;; @004e                               v7 = uextend.i64 v2
+;; @004e                               v8 = iconst.i64 24
+;; @004e                               v9 = uadd_overflow_trap v7, v8, user65535  ; v8 = 24
+;; @004e                               v10 = iconst.i64 4
+;; @004e                               v11 = uadd_overflow_trap v9, v10, user65535  ; v10 = 4
+;; @004e                               v6 = load.i64 notrap aligned readonly v0+48
+;; @004e                               v12 = icmp ult v11, v6
+;; @004e                               brif v12, block9, block8
+;;
+;;                                 block8 cold:
+;; @004e                               trap user65535
+;;
+;;                                 block9:
+;; @004e                               v5 = load.i64 notrap aligned readonly v0+40
+;; @004e                               v13 = iadd v5, v9
+;; @004e                               v14 = load.i32 notrap aligned v13
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     store notrap v14, v54
+;; @004e                               v15 = iconst.i32 -2
+;; @004e                               v16 = band v14, v15  ; v15 = -2
+;;                                     v56 = iconst.i32 0
+;; @004e                               v17 = icmp eq v16, v56  ; v56 = 0
+;; @004e                               brif v17, block5, block2
+;;
+;;                                 block2:
+;; @004e                               v19 = load.i64 notrap aligned v0+56
+;; @004e                               v20 = load.i64 notrap aligned v19
+;; @004e                               v21 = load.i64 notrap aligned v19+8
+;; @004e                               v22 = icmp eq v20, v21
+;; @004e                               brif v22, block3, block4
+;;
+;;                                 block4:
+;; @004e                               v26 = uextend.i64 v14
+;; @004e                               v27 = iconst.i64 8
+;; @004e                               v28 = uadd_overflow_trap v26, v27, user65535  ; v27 = 8
+;; @004e                               v30 = uadd_overflow_trap v28, v27, user65535  ; v27 = 8
+;; @004e                               v31 = icmp ult v30, v6
+;; @004e                               brif v31, block11, block10
+;;
+;;                                 block10 cold:
+;; @004e                               trap user65535
+;;
+;;                                 block11:
+;; @004e                               v32 = iadd.i64 v5, v28
+;; @004e                               v33 = load.i64 notrap aligned v32
+;;                                     v51 = load.i32 notrap v54
+;; @004e                               v38 = uextend.i64 v51
+;;                                     v64 = iconst.i64 8
+;; @004e                               v40 = uadd_overflow_trap v38, v64, user65535  ; v64 = 8
+;; @004e                               v42 = uadd_overflow_trap v40, v64, user65535  ; v64 = 8
+;; @004e                               v43 = icmp ult v42, v6
+;; @004e                               brif v43, block13, block12
+;;
+;;                                 block12 cold:
+;; @004e                               trap user65535
+;;
+;;                                 block13:
+;;                                     v58 = iconst.i64 1
+;; @004e                               v34 = iadd.i64 v33, v58  ; v58 = 1
+;; @004e                               v44 = iadd.i64 v5, v40
+;; @004e                               store notrap aligned v34, v44
+;;                                     v50 = load.i32 notrap v54
+;; @004e                               store notrap aligned v50, v20
+;;                                     v65 = iconst.i64 4
+;;                                     v66 = iadd.i64 v20, v65  ; v65 = 4
+;; @004e                               store notrap aligned v66, v19
+;; @004e                               jump block5
+;;
+;;                                 block3 cold:
+;; @004e                               v47 = call fn0(v0, v14), stack_map=[i32 @ ss0+0]
+;; @004e                               jump block5
+;;
+;;                                 block5:
+;;                                     v48 = load.i32 notrap v54
+;; @0052                               jump block1
+;;
+;;                                 block1:
+;; @0052                               return v48
+;; }

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -1,0 +1,107 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc"
+;;! test = "optimize"
+
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (result (ref $ty))
+    (struct.new_default $ty)
+  )
+)
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     fn0 = colocated u1:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @0021                               v7 = iconst.i32 -1476395008
+;; @0021                               v4 = iconst.i32 0
+;; @0021                               v9 = iconst.i32 32
+;; @0021                               v10 = iconst.i32 8
+;; @0021                               v11 = call fn0(v0, v7, v4, v9, v10)  ; v7 = -1476395008, v4 = 0, v9 = 32, v10 = 8
+;; @0021                               v15 = uextend.i64 v11
+;; @0021                               v16 = iconst.i64 16
+;; @0021                               v17 = uadd_overflow_trap v15, v16, user65535  ; v16 = 16
+;; @0021                               v18 = iconst.i64 4
+;; @0021                               v19 = uadd_overflow_trap v17, v18, user65535  ; v18 = 4
+;; @0021                               v14 = load.i64 notrap aligned readonly v0+48
+;; @0021                               v20 = icmp ult v19, v14
+;; @0021                               brif v20, block5, block4
+;;
+;;                                 block4 cold:
+;; @0021                               trap user65535
+;;
+;;                                 block5:
+;; @0021                               v3 = f32const 0.0
+;; @0021                               v13 = load.i64 notrap aligned readonly v0+40
+;; @0021                               v21 = iadd v13, v17
+;; @0021                               store notrap aligned v3, v21  ; v3 = 0.0
+;; @0021                               v26 = iconst.i64 20
+;; @0021                               v27 = uadd_overflow_trap.i64 v15, v26, user65535  ; v26 = 20
+;; @0021                               v28 = iconst.i64 1
+;; @0021                               v29 = uadd_overflow_trap v27, v28, user65535  ; v28 = 1
+;; @0021                               v30 = icmp ult v29, v14
+;; @0021                               brif v30, block7, block6
+;;
+;;                                 block6 cold:
+;; @0021                               trap user65535
+;;
+;;                                 block7:
+;;                                     v83 = iconst.i32 0
+;; @0021                               v31 = iadd.i64 v13, v27
+;; @0021                               istore8 notrap aligned v83, v31  ; v83 = 0
+;; @0021                               v36 = iconst.i64 24
+;; @0021                               v37 = uadd_overflow_trap.i64 v15, v36, user65535  ; v36 = 24
+;;                                     v84 = iconst.i64 4
+;; @0021                               v39 = uadd_overflow_trap v37, v84, user65535  ; v84 = 4
+;; @0021                               v40 = icmp ult v39, v14
+;; @0021                               brif v40, block9, block8
+;;
+;;                                 block8 cold:
+;; @0021                               trap user65535
+;;
+;;                                 block9:
+;;                                     v75 = iconst.i8 1
+;; @0021                               brif v75, block3, block2  ; v75 = 1
+;;
+;;                                 block2:
+;;                                     v82 = iconst.i64 0
+;; @0021                               v49 = iconst.i64 8
+;; @0021                               v50 = uadd_overflow_trap v82, v49, user65535  ; v82 = 0, v49 = 8
+;; @0021                               v52 = uadd_overflow_trap v50, v49, user65535  ; v49 = 8
+;; @0021                               v53 = icmp ult v52, v14
+;; @0021                               brif v53, block11, block10
+;;
+;;                                 block10 cold:
+;; @0021                               trap user65535
+;;
+;;                                 block11:
+;; @0021                               v54 = iadd.i64 v13, v50
+;; @0021                               v55 = load.i64 notrap aligned v54
+;; @0021                               brif.i8 v53, block13, block12
+;;
+;;                                 block12 cold:
+;; @0021                               trap user65535
+;;
+;;                                 block13:
+;;                                     v85 = iconst.i64 1
+;;                                     v86 = iadd.i64 v55, v85  ; v85 = 1
+;; @0021                               store notrap aligned v86, v54
+;; @0021                               jump block3
+;;
+;;                                 block3:
+;;                                     v87 = iconst.i32 0
+;; @0021                               v41 = iadd.i64 v13, v37
+;; @0021                               store notrap aligned v87, v41  ; v87 = 0
+;; @0024                               jump block1
+;;
+;;                                 block1:
+;; @0024                               return v11
+;; }

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -1,0 +1,119 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc"
+;;! test = "optimize"
+
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (param f32 i32 anyref) (result (ref $ty))
+    (struct.new $ty (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     fn0 = colocated u1:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
+;;                                     v71 = stack_addr.i64 ss0
+;;                                     store notrap v4, v71
+;; @002a                               v7 = iconst.i32 -1476395008
+;; @002a                               v8 = iconst.i32 0
+;; @002a                               v9 = iconst.i32 32
+;; @002a                               v10 = iconst.i32 8
+;; @002a                               v11 = call fn0(v0, v7, v8, v9, v10), stack_map=[i32 @ ss0+0]  ; v7 = -1476395008, v8 = 0, v9 = 32, v10 = 8
+;; @002a                               v15 = uextend.i64 v11
+;; @002a                               v16 = iconst.i64 16
+;; @002a                               v17 = uadd_overflow_trap v15, v16, user65535  ; v16 = 16
+;; @002a                               v18 = iconst.i64 4
+;; @002a                               v19 = uadd_overflow_trap v17, v18, user65535  ; v18 = 4
+;; @002a                               v14 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v20 = icmp ult v19, v14
+;; @002a                               brif v20, block5, block4
+;;
+;;                                 block4 cold:
+;; @002a                               trap user65535
+;;
+;;                                 block5:
+;; @002a                               v13 = load.i64 notrap aligned readonly v0+40
+;; @002a                               v21 = iadd v13, v17
+;; @002a                               store.f32 notrap aligned v2, v21
+;; @002a                               v26 = iconst.i64 20
+;; @002a                               v27 = uadd_overflow_trap.i64 v15, v26, user65535  ; v26 = 20
+;; @002a                               v28 = iconst.i64 1
+;; @002a                               v29 = uadd_overflow_trap v27, v28, user65535  ; v28 = 1
+;; @002a                               v30 = icmp ult v29, v14
+;; @002a                               brif v30, block7, block6
+;;
+;;                                 block6 cold:
+;; @002a                               trap user65535
+;;
+;;                                 block7:
+;; @002a                               v31 = iadd.i64 v13, v27
+;; @002a                               istore8.i32 notrap aligned v3, v31
+;; @002a                               v36 = iconst.i64 24
+;; @002a                               v37 = uadd_overflow_trap.i64 v15, v36, user65535  ; v36 = 24
+;;                                     v78 = iconst.i64 4
+;; @002a                               v39 = uadd_overflow_trap v37, v78, user65535  ; v78 = 4
+;; @002a                               v40 = icmp ult v39, v14
+;; @002a                               brif v40, block9, block8
+;;
+;;                                 block8 cold:
+;; @002a                               trap user65535
+;;
+;;                                 block9:
+;;                                     v70 = load.i32 notrap v71
+;; @002a                               v42 = iconst.i32 -2
+;; @002a                               v43 = band v70, v42  ; v42 = -2
+;;                                     v79 = iconst.i32 0
+;;                                     v80 = icmp eq v43, v79  ; v79 = 0
+;; @002a                               brif v80, block3, block2
+;;
+;;                                 block2:
+;; @002a                               v48 = uextend.i64 v70
+;; @002a                               v49 = iconst.i64 8
+;; @002a                               v50 = uadd_overflow_trap v48, v49, user65535  ; v49 = 8
+;; @002a                               v52 = uadd_overflow_trap v50, v49, user65535  ; v49 = 8
+;; @002a                               v53 = icmp ult v52, v14
+;; @002a                               brif v53, block11, block10
+;;
+;;                                 block10 cold:
+;; @002a                               trap user65535
+;;
+;;                                 block11:
+;; @002a                               v54 = iadd.i64 v13, v50
+;; @002a                               v55 = load.i64 notrap aligned v54
+;;                                     v68 = load.i32 notrap v71
+;; @002a                               v60 = uextend.i64 v68
+;;                                     v81 = iconst.i64 8
+;; @002a                               v62 = uadd_overflow_trap v60, v81, user65535  ; v81 = 8
+;; @002a                               v64 = uadd_overflow_trap v62, v81, user65535  ; v81 = 8
+;; @002a                               v65 = icmp ult v64, v14
+;; @002a                               brif v65, block13, block12
+;;
+;;                                 block12 cold:
+;; @002a                               trap user65535
+;;
+;;                                 block13:
+;;                                     v82 = iconst.i64 1
+;;                                     v83 = iadd.i64 v55, v82  ; v82 = 1
+;; @002a                               v66 = iadd.i64 v13, v62
+;; @002a                               store notrap aligned v83, v66
+;; @002a                               jump block3
+;;
+;;                                 block3:
+;;                                     v67 = load.i32 notrap v71
+;; @002a                               v41 = iadd.i64 v13, v37
+;; @002a                               store notrap aligned v67, v41
+;; @002d                               jump block1
+;;
+;;                                 block1:
+;; @002d                               return v11
+;; }

--- a/tests/disas/gc/struct-set.wat
+++ b/tests/disas/gc/struct-set.wat
@@ -1,0 +1,205 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc"
+;;! test = "optimize"
+
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (param (ref null $ty) f32)
+    (struct.set $ty 0 (local.get 0) (local.get 1))
+  )
+
+  (func (param (ref null $ty) i32)
+    (struct.set $ty 1 (local.get 0) (local.get 1))
+  )
+
+  (func (param (ref null $ty) anyref)
+    (struct.set $ty 2 (local.get 0) (local.get 1))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, f32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
+;; @0034                               brif v2, block3, block2
+;;
+;;                                 block2 cold:
+;; @0034                               trap null_reference
+;;
+;;                                 block3:
+;; @0034                               v7 = uextend.i64 v2
+;; @0034                               v8 = iconst.i64 16
+;; @0034                               v9 = uadd_overflow_trap v7, v8, user65535  ; v8 = 16
+;; @0034                               v10 = iconst.i64 4
+;; @0034                               v11 = uadd_overflow_trap v9, v10, user65535  ; v10 = 4
+;; @0034                               v6 = load.i64 notrap aligned readonly v0+48
+;; @0034                               v12 = icmp ult v11, v6
+;; @0034                               brif v12, block5, block4
+;;
+;;                                 block4 cold:
+;; @0034                               trap user65535
+;;
+;;                                 block5:
+;; @0034                               v5 = load.i64 notrap aligned readonly v0+40
+;; @0034                               v13 = iadd v5, v9
+;; @0034                               store.f32 notrap aligned v3, v13
+;; @0038                               jump block1
+;;
+;;                                 block1:
+;; @0038                               return
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @003f                               brif v2, block3, block2
+;;
+;;                                 block2 cold:
+;; @003f                               trap null_reference
+;;
+;;                                 block3:
+;; @003f                               v7 = uextend.i64 v2
+;; @003f                               v8 = iconst.i64 20
+;; @003f                               v9 = uadd_overflow_trap v7, v8, user65535  ; v8 = 20
+;; @003f                               v10 = iconst.i64 1
+;; @003f                               v11 = uadd_overflow_trap v9, v10, user65535  ; v10 = 1
+;; @003f                               v6 = load.i64 notrap aligned readonly v0+48
+;; @003f                               v12 = icmp ult v11, v6
+;; @003f                               brif v12, block5, block4
+;;
+;;                                 block4 cold:
+;; @003f                               trap user65535
+;;
+;;                                 block5:
+;; @003f                               v5 = load.i64 notrap aligned readonly v0+40
+;; @003f                               v13 = iadd v5, v9
+;; @003f                               istore8.i32 notrap aligned v3, v13
+;; @0043                               jump block1
+;;
+;;                                 block1:
+;; @0043                               return
+;; }
+;;
+;; function u0:2(i64 vmctx, i64, i32, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     fn0 = colocated u1:25 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @004a                               brif v2, block9, block8
+;;
+;;                                 block8 cold:
+;; @004a                               trap null_reference
+;;
+;;                                 block9:
+;; @004a                               v7 = uextend.i64 v2
+;; @004a                               v8 = iconst.i64 24
+;; @004a                               v9 = uadd_overflow_trap v7, v8, user65535  ; v8 = 24
+;; @004a                               v10 = iconst.i64 4
+;; @004a                               v11 = uadd_overflow_trap v9, v10, user65535  ; v10 = 4
+;; @004a                               v6 = load.i64 notrap aligned readonly v0+48
+;; @004a                               v12 = icmp ult v11, v6
+;; @004a                               brif v12, block11, block10
+;;
+;;                                 block10 cold:
+;; @004a                               trap user65535
+;;
+;;                                 block11:
+;; @004a                               v5 = load.i64 notrap aligned readonly v0+40
+;; @004a                               v13 = iadd v5, v9
+;; @004a                               v14 = load.i32 notrap aligned v13
+;; @004a                               v15 = iconst.i32 -2
+;; @004a                               v16 = band.i32 v3, v15  ; v15 = -2
+;;                                     v67 = iconst.i32 0
+;; @004a                               v17 = icmp eq v16, v67  ; v67 = 0
+;; @004a                               brif v17, block3, block2
+;;
+;;                                 block2:
+;; @004a                               v21 = uextend.i64 v3
+;; @004a                               v47 = iconst.i64 8
+;; @004a                               v23 = uadd_overflow_trap v21, v47, user65535  ; v47 = 8
+;; @004a                               v25 = uadd_overflow_trap v23, v47, user65535  ; v47 = 8
+;; @004a                               v26 = icmp ult v25, v6
+;; @004a                               brif v26, block13, block12
+;;
+;;                                 block12 cold:
+;; @004a                               trap user65535
+;;
+;;                                 block13:
+;; @004a                               v27 = iadd.i64 v5, v23
+;; @004a                               v28 = load.i64 notrap aligned v27
+;; @004a                               brif.i8 v26, block15, block14
+;;
+;;                                 block14 cold:
+;; @004a                               trap user65535
+;;
+;;                                 block15:
+;;                                     v68 = iconst.i64 1
+;; @004a                               v29 = iadd.i64 v28, v68  ; v68 = 1
+;; @004a                               store notrap aligned v29, v27
+;; @004a                               jump block3
+;;
+;;                                 block3:
+;; @004a                               store.i32 notrap aligned v3, v13
+;;                                     v72 = iconst.i32 -2
+;;                                     v73 = band.i32 v14, v72  ; v72 = -2
+;;                                     v74 = iconst.i32 0
+;;                                     v75 = icmp eq v73, v74  ; v74 = 0
+;; @004a                               brif v75, block7, block4
+;;
+;;                                 block4:
+;; @004a                               v46 = uextend.i64 v14
+;;                                     v76 = iconst.i64 8
+;; @004a                               v48 = uadd_overflow_trap v46, v76, user65535  ; v76 = 8
+;; @004a                               v50 = uadd_overflow_trap v48, v76, user65535  ; v76 = 8
+;; @004a                               v51 = icmp ult v50, v6
+;; @004a                               brif v51, block17, block16
+;;
+;;                                 block16 cold:
+;; @004a                               trap user65535
+;;
+;;                                 block17:
+;; @004a                               v52 = iadd.i64 v5, v48
+;; @004a                               v53 = load.i64 notrap aligned v52
+;;                                     v70 = iconst.i64 -1
+;; @004a                               v54 = iadd v53, v70  ; v70 = -1
+;;                                     v71 = iconst.i64 0
+;; @004a                               v55 = icmp eq v54, v71  ; v71 = 0
+;; @004a                               brif v55, block5, block6
+;;
+;;                                 block5 cold:
+;; @004a                               call fn0(v0, v14)
+;; @004a                               jump block7
+;;
+;;                                 block6:
+;; @004a                               brif.i8 v51, block19, block18
+;;
+;;                                 block18 cold:
+;; @004a                               trap user65535
+;;
+;;                                 block19:
+;;                                     v77 = iadd.i64 v53, v70  ; v70 = -1
+;; @004a                               store notrap aligned v77, v52
+;; @004a                               jump block7
+;;
+;;                                 block7:
+;; @004e                               jump block1
+;;
+;;                                 block1:
+;; @004e                               return
+;; }

--- a/tests/misc_testsuite/gc/struct-instructions.wast
+++ b/tests/misc_testsuite/gc/struct-instructions.wast
@@ -1,0 +1,131 @@
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (global $g (mut (ref null $ty)) (ref.null $ty))
+
+  ;; Constructors.
+
+  (func $new (param f32 i32 anyref) (result (ref $ty))
+    (struct.new $ty (local.get 0) (local.get 1) (local.get 2))
+  )
+  (func (export "new") (param f32 i32 anyref)
+    (global.set $g (call $new (local.get 0) (local.get 1) (local.get 2)))
+  )
+
+  (func $new-default (result (ref $ty))
+    (struct.new_default $ty)
+  )
+  (func (export "new-default")
+    (global.set $g (call $new-default))
+  )
+
+  ;; Getters.
+
+  (func $get-f32 (param (ref null $ty)) (result f32)
+    (struct.get $ty 0 (local.get 0))
+  )
+  (func (export "get-f32") (result f32)
+    (call $get-f32 (global.get $g))
+  )
+
+  (func $get-s-i8 (param (ref null $ty)) (result i32)
+    (struct.get_s $ty 1 (local.get 0))
+  )
+  (func (export "get-s-i8") (result i32)
+    (call $get-s-i8 (global.get $g))
+  )
+
+  (func $get-u-i8 (param (ref null $ty)) (result i32)
+    (struct.get_u $ty 1 (local.get 0))
+  )
+  (func (export "get-u-i8") (result i32)
+    (call $get-u-i8 (global.get $g))
+  )
+
+  (func $get-anyref (param (ref null $ty)) (result anyref)
+    (struct.get $ty 2 (local.get 0))
+  )
+  (func (export "get-anyref") (result anyref)
+    (call $get-anyref (global.get $g))
+  )
+
+  ;; Setters.
+
+  (func $set-f32 (param (ref null $ty) f32)
+    (struct.set $ty 0 (local.get 0) (local.get 1))
+  )
+  (func (export "set-f32") (param f32)
+    (call $set-f32 (global.get $g) (local.get 0))
+  )
+
+  (func $set-i8 (param (ref null $ty) i32)
+    (struct.set $ty 1 (local.get 0) (local.get 1))
+  )
+  (func (export "set-i8") (param i32)
+    (call $set-i8 (global.get $g) (local.get 0))
+  )
+
+  (func $set-anyref (param (ref null $ty) anyref)
+    (struct.set $ty 2 (local.get 0) (local.get 1))
+  )
+  (func (export "set-anyref") (param anyref)
+    (call $set-anyref (global.get $g) (local.get 0))
+  )
+
+  (func (export "set-anyref-non-null")
+    (call $set-anyref (global.get $g) (struct.new_default $ty))
+  )
+)
+
+(assert_return (invoke "new" (f32.const 1) (i32.const -1) (ref.null any)))
+(assert_return (invoke "get-f32") (f32.const 1))
+(assert_return (invoke "get-s-i8") (i32.const -1))
+(assert_return (invoke "get-u-i8") (i32.const 255))
+(assert_return (invoke "get-anyref") (ref.null any))
+
+(assert_return (invoke "new-default"))
+(assert_return (invoke "get-f32") (f32.const 0))
+(assert_return (invoke "get-s-i8") (i32.const 0))
+(assert_return (invoke "get-u-i8") (i32.const 0))
+(assert_return (invoke "get-anyref") (ref.null any))
+
+(assert_return (invoke "set-f32" (f32.const 2)))
+(assert_return (invoke "get-f32") (f32.const 2))
+
+(assert_return (invoke "set-i8" (i32.const -1)))
+(assert_return (invoke "get-s-i8") (i32.const -1))
+(assert_return (invoke "get-u-i8") (i32.const 255))
+
+(assert_return (invoke "set-anyref-non-null"))
+(assert_return (invoke "get-anyref") (ref.struct))
+(assert_return (invoke "set-anyref" (ref.null any)))
+(assert_return (invoke "get-anyref") (ref.null any))
+
+;; Null dereference
+
+(module
+  (type $t (struct (field (mut i32) (mut i16))))
+
+  (func (export "struct.get-null") (param (ref null $t))
+    (drop (struct.get $t 0 (local.get 0)))
+  )
+
+  (func (export "struct.get_s-null") (param (ref null $t))
+    (drop (struct.get_s $t 1 (local.get 0)))
+  )
+
+  (func (export "struct.get_u-null") (param (ref null $t))
+    (drop (struct.get_u $t 1 (local.get 0)))
+  )
+
+  (func (export "struct.set-null") (param (ref null $t))
+    (struct.set $t 0 (local.get 0) (i32.const 0))
+  )
+)
+
+(assert_trap (invoke "struct.get-null" (ref.null none)) "null structure reference")
+(assert_trap (invoke "struct.get_s-null" (ref.null none)) "null structure reference")
+(assert_trap (invoke "struct.get_u-null" (ref.null none)) "null structure reference")
+(assert_trap (invoke "struct.set-null" (ref.null none)) "null structure reference")


### PR DESCRIPTION
This commit implements the `struct.*` instructions for the GC proposal.  These instructions allow allocating new structs and getting and setting their fields.

The implemented instructions are:

* `struct.new`
* `struct.new_default`
* `struct.get`
* `struct.get_s`
* `struct.get_u`
* `struct.set`

The `struct.new*` instructions are also allowed in constant expressions, but support for that is not yet implemented.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
