### PR TITLE
wasi-sockets: Add `network-error-code`

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -340,6 +340,8 @@ wasmtime_option_group! {
         pub tcp: Option<bool>,
         /// Indicates whether `wasi:sockets` UDP support is enabled or not.
         pub udp: Option<bool>,
+        /// Enable WASI APIs marked as: @unstable(feature = network-error-code)
+        pub network_error_code: Option<bool>,
         /// Allows imports from the `wasi_unstable` core wasm module.
         pub preview0: Option<bool>,
         /// Inherit all environment variables from the parent process.

--- a/src/common.rs
+++ b/src/common.rs
@@ -337,6 +337,7 @@ impl RunCommon {
     pub fn compute_wasi_features(&self) -> LinkOptions {
         let mut options = LinkOptions::default();
         options.cli_exit_with_code(self.common.wasi.cli_exit_with_code.unwrap_or(false));
+        options.network_error_code(self.common.wasi.network_error_code.unwrap_or(false));
         options
     }
 }


### PR DESCRIPTION
Implements https://github.com/WebAssembly/wasi-sockets/pull/105

This function downcasts a stream error to a network-related error.
Similar to the existing `filesystem-error-code` and `http-error-code` functions.

Unit test is missing because I couldn't figure out a reliable way to fail a TCP stream mid-connection. Suggestions are welcome.