### PR TITLE
Refactor the `wasmtime::runtime::vm::Store` trait

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2424,6 +2424,14 @@ impl AsyncCx {
 }
 
 unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
+    fn store_opaque(&self) -> &StoreOpaque {
+        &self.inner
+    }
+
+    fn store_opaque_mut(&mut self) -> &mut StoreOpaque {
+        &mut self.inner
+    }
+
     fn vmruntime_limits(&self) -> *mut VMRuntimeLimits {
         <StoreOpaque>::vmruntime_limits(self)
     }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -102,7 +102,6 @@ use core::num::NonZeroU64;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::ptr;
-use core::sync::atomic::AtomicU64;
 use core::task::{Context, Poll};
 
 mod context;
@@ -2430,10 +2429,6 @@ unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
 
     fn store_opaque_mut(&mut self) -> &mut StoreOpaque {
         &mut self.inner
-    }
-
-    fn epoch_ptr(&self) -> *const AtomicU64 {
-        self.engine.epoch_counter() as *const _
     }
 
     fn maybe_gc_store(&mut self) -> Option<&mut GcStore> {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2431,10 +2431,6 @@ unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
         &mut self.inner
     }
 
-    fn maybe_gc_store(&mut self) -> Option<&mut GcStore> {
-        self.gc_store.as_mut()
-    }
-
     fn memory_growing(
         &mut self,
         current: usize,

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2432,10 +2432,6 @@ unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
         &mut self.inner
     }
 
-    fn vmruntime_limits(&self) -> *mut VMRuntimeLimits {
-        <StoreOpaque>::vmruntime_limits(self)
-    }
-
     fn epoch_ptr(&self) -> *const AtomicU64 {
         self.engine.epoch_counter() as *const _
     }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -593,8 +593,8 @@ impl<T> Store<T> {
             // throughout Wasmtime.
             unsafe {
                 let traitobj = mem::transmute::<
-                    *mut (dyn crate::runtime::vm::Store + '_),
-                    *mut (dyn crate::runtime::vm::Store + 'static),
+                    *mut (dyn crate::runtime::vm::VMStore + '_),
+                    *mut (dyn crate::runtime::vm::VMStore + 'static),
                 >(&mut *inner);
                 instance.set_store(traitobj);
             }
@@ -1883,7 +1883,7 @@ impl StoreOpaque {
         self.default_caller.vmctx()
     }
 
-    pub fn traitobj(&self) -> *mut dyn crate::runtime::vm::Store {
+    pub fn traitobj(&self) -> *mut dyn crate::runtime::vm::VMStore {
         self.default_caller.store()
     }
 
@@ -2423,7 +2423,7 @@ impl AsyncCx {
     }
 }
 
-unsafe impl<T> crate::runtime::vm::Store for StoreInner<T> {
+unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
     fn vmruntime_limits(&self) -> *mut VMRuntimeLimits {
         <StoreOpaque>::vmruntime_limits(self)
     }

--- a/crates/wasmtime/src/runtime/store/context.rs
+++ b/crates/wasmtime/src/runtime/store/context.rs
@@ -32,7 +32,7 @@ impl<'a, T> StoreContextMut<'a, T> {
     /// Unfortunately there's not a ton of debug asserts we can add here, so we
     /// rely on testing to largely help show that this is correctly used.
     pub(crate) unsafe fn from_raw(
-        store: *mut dyn crate::runtime::vm::Store,
+        store: *mut dyn crate::runtime::vm::VMStore,
     ) -> StoreContextMut<'a, T> {
         StoreContextMut(&mut *(store as *mut StoreInner<T>))
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -102,13 +102,6 @@ pub unsafe trait VMStore {
     /// Get an exclusive borrow of this store's `StoreOpaque`.
     fn store_opaque_mut(&mut self) -> &mut StoreOpaque;
 
-    /// Returns the raw pointer in memory where this store's shared
-    /// `VMRuntimeLimits` structure is located.
-    ///
-    /// Used to configure `VMContext` initialization and store the right pointer
-    /// in the `VMContext`.
-    fn vmruntime_limits(&self) -> *mut VMRuntimeLimits;
-
     /// Returns a pointer to the global epoch counter.
     ///
     /// Used to configure the `VMContext` on initialization.

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -8,6 +8,8 @@ use crate::store::StoreOpaque;
 use alloc::sync::Arc;
 use core::fmt;
 use core::mem;
+use core::ops::Deref;
+use core::ops::DerefMut;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use wasmtime_environ::{
@@ -175,6 +177,20 @@ pub unsafe trait VMStore {
     /// Metadata required for resources for the component model.
     #[cfg(feature = "component-model")]
     fn component_calls(&mut self) -> &mut component::CallContexts;
+}
+
+impl Deref for dyn VMStore {
+    type Target = StoreOpaque;
+
+    fn deref(&self) -> &Self::Target {
+        self.store_opaque()
+    }
+}
+
+impl DerefMut for dyn VMStore {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.store_opaque_mut()
+    }
 }
 
 /// Functionality required by this crate for a particular module. This

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -92,7 +92,7 @@ pub use crate::runtime::vm::cow::{MemoryImage, MemoryImageSlot, ModuleMemoryImag
 /// lifetime of this store or the Send/Sync-ness of this store. All of that must
 /// be respected by embedders (e.g. the `wasmtime::Store` structure). The theory
 /// is that `wasmtime::Store` handles all this correctly.
-pub unsafe trait Store {
+pub unsafe trait VMStore {
     /// Returns the raw pointer in memory where this store's shared
     /// `VMRuntimeLimits` structure is located.
     ///

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -103,7 +103,7 @@ pub unsafe trait VMStore {
     fn store_opaque_mut(&mut self) -> &mut StoreOpaque;
 
     /// Get this store's GC heap.
-    fn gc_store(&mut self) -> &mut GcStore {
+    fn unwrap_gc_store_mut(&mut self) -> &mut GcStore {
         self.maybe_gc_store()
             .expect("attempt to access the GC store before it has been allocated")
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -102,15 +102,6 @@ pub unsafe trait VMStore {
     /// Get an exclusive borrow of this store's `StoreOpaque`.
     fn store_opaque_mut(&mut self) -> &mut StoreOpaque;
 
-    /// Get this store's GC heap.
-    fn unwrap_gc_store_mut(&mut self) -> &mut GcStore {
-        self.maybe_gc_store()
-            .expect("attempt to access the GC store before it has been allocated")
-    }
-
-    /// Get this store's GC heap, if it has been allocated.
-    fn maybe_gc_store(&mut self) -> Option<&mut GcStore>;
-
     /// Callback invoked to allow the store's resource limiter to reject a
     /// memory grow operation.
     fn memory_growing(

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -11,7 +11,7 @@ use core::mem;
 use core::ops::Deref;
 use core::ops::DerefMut;
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use wasmtime_environ::{
     DefinedFuncIndex, DefinedMemoryIndex, HostPtr, ModuleInternedTypeIndex, VMOffsets,
     VMSharedTypeIndex,
@@ -101,11 +101,6 @@ pub unsafe trait VMStore {
 
     /// Get an exclusive borrow of this store's `StoreOpaque`.
     fn store_opaque_mut(&mut self) -> &mut StoreOpaque;
-
-    /// Returns a pointer to the global epoch counter.
-    ///
-    /// Used to configure the `VMContext` on initialization.
-    fn epoch_ptr(&self) -> *const AtomicU64;
 
     /// Get this store's GC heap.
     fn gc_store(&mut self) -> &mut GcStore {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -4,6 +4,7 @@
 #![warn(clippy::cast_sign_loss)]
 
 use crate::prelude::*;
+use crate::store::StoreOpaque;
 use alloc::sync::Arc;
 use core::fmt;
 use core::mem;
@@ -93,6 +94,12 @@ pub use crate::runtime::vm::cow::{MemoryImage, MemoryImageSlot, ModuleMemoryImag
 /// be respected by embedders (e.g. the `wasmtime::Store` structure). The theory
 /// is that `wasmtime::Store` handles all this correctly.
 pub unsafe trait VMStore {
+    /// Get a shared borrow of this store's `StoreOpaque`.
+    fn store_opaque(&self) -> &StoreOpaque;
+
+    /// Get an exclusive borrow of this store's `StoreOpaque`.
+    fn store_opaque_mut(&mut self) -> &mut StoreOpaque;
+
     /// Returns the raw pointer in memory where this store's shared
     /// `VMRuntimeLimits` structure is located.
     ///

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -8,8 +8,8 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::{
-    SendSyncPtr, Store, VMArrayCallFunction, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition,
-    VMOpaqueContext, VMWasmCallFunction, ValRaw,
+    SendSyncPtr, VMArrayCallFunction, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition,
+    VMOpaqueContext, VMStore, VMWasmCallFunction, ValRaw,
 };
 use alloc::alloc::Layout;
 use alloc::sync::Arc;
@@ -189,7 +189,7 @@ impl ComponentInstance {
         offsets: VMComponentOffsets<HostPtr>,
         runtime_info: Arc<dyn ComponentRuntimeInfo>,
         resource_types: Arc<dyn Any + Send + Sync>,
-        store: *mut dyn Store,
+        store: *mut dyn VMStore,
     ) {
         assert!(alloc_size >= Self::alloc_layout(&offsets).size());
 
@@ -253,9 +253,9 @@ impl ComponentInstance {
     }
 
     /// Returns the store that this component was created with.
-    pub fn store(&self) -> *mut dyn Store {
+    pub fn store(&self) -> *mut dyn VMStore {
         unsafe {
-            let ret = *self.vmctx_plus_offset::<*mut dyn Store>(self.offsets.store());
+            let ret = *self.vmctx_plus_offset::<*mut dyn VMStore>(self.offsets.store());
             assert!(!ret.is_null());
             ret
         }
@@ -435,7 +435,7 @@ impl ComponentInstance {
         }
     }
 
-    unsafe fn initialize_vmctx(&mut self, store: *mut dyn Store) {
+    unsafe fn initialize_vmctx(&mut self, store: *mut dyn VMStore) {
         *self.vmctx_plus_offset_mut(self.offsets.magic()) = VMCOMPONENT_MAGIC;
         *self.vmctx_plus_offset_mut(self.offsets.libcalls()) = &libcalls::VMComponentLibcalls::INIT;
         *self.vmctx_plus_offset_mut(self.offsets.store()) = store;
@@ -658,7 +658,7 @@ impl OwnedComponentInstance {
     pub fn new(
         runtime_info: Arc<dyn ComponentRuntimeInfo>,
         resource_types: Arc<dyn Any + Send + Sync>,
-        store: *mut dyn Store,
+        store: *mut dyn VMStore,
     ) -> OwnedComponentInstance {
         let component = runtime_info.component();
         let offsets = VMComponentOffsets::new(HostPtr, component);

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -28,7 +28,7 @@ impl<'a, 'b> ConstEvalContext<'a, 'b> {
 
     fn global_get(&mut self, index: GlobalIndex) -> Result<ValRaw> {
         unsafe {
-            let gc_store = (*self.instance.store()).gc_store();
+            let gc_store = (*self.instance.store()).unwrap_gc_store_mut();
             let global = self
                 .instance
                 .defined_or_imported_global_ptr(index)

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -474,7 +474,7 @@ impl Instance {
             *self.vmctx_plus_offset_mut(self.offsets().ptr.vmctx_store()) = store;
             *self.runtime_limits() = (*store).vmruntime_limits();
             *self.epoch_ptr() = (*store).engine().epoch_counter();
-            self.set_gc_heap((*store).maybe_gc_store());
+            self.set_gc_heap((*store).gc_store_mut().ok());
         } else {
             assert_eq!(
                 mem::size_of::<*mut dyn VMStore>(),

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -473,7 +473,7 @@ impl Instance {
         if let Some(store) = store {
             *self.vmctx_plus_offset_mut(self.offsets().ptr.vmctx_store()) = store;
             *self.runtime_limits() = (*store).vmruntime_limits();
-            *self.epoch_ptr() = (*store).epoch_ptr();
+            *self.epoch_ptr() = (*store).engine().epoch_counter();
             self.set_gc_heap((*store).maybe_gc_store());
         } else {
             assert_eq!(

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1103,7 +1103,7 @@ impl Instance {
 
         if elt_ty == TableElementType::Func {
             for i in range {
-                let gc_store = unsafe { (*self.store()).gc_store() };
+                let gc_store = unsafe { (*self.store()).unwrap_gc_store_mut() };
                 let value = match self.tables[idx].1.get(gc_store, i) {
                     Some(value) => value,
                     None => {

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -14,7 +14,7 @@ use crate::runtime::vm::vmcontext::{
 };
 use crate::runtime::vm::{
     ExportFunction, ExportGlobal, ExportMemory, ExportTable, GcStore, Imports, ModuleRuntimeInfo,
-    SendSyncPtr, Store, VMFunctionBody, VMGcRef, WasmFault,
+    SendSyncPtr, VMFunctionBody, VMGcRef, VMStore, WasmFault,
 };
 use alloc::sync::Arc;
 use core::alloc::Layout;
@@ -461,14 +461,15 @@ impl Instance {
     /// functions are shared amongst threads and don't all share the same
     /// store).
     #[inline]
-    pub fn store(&self) -> *mut dyn Store {
-        let ptr =
-            unsafe { *self.vmctx_plus_offset::<*mut dyn Store>(self.offsets().ptr.vmctx_store()) };
+    pub fn store(&self) -> *mut dyn VMStore {
+        let ptr = unsafe {
+            *self.vmctx_plus_offset::<*mut dyn VMStore>(self.offsets().ptr.vmctx_store())
+        };
         debug_assert!(!ptr.is_null());
         ptr
     }
 
-    pub(crate) unsafe fn set_store(&mut self, store: Option<*mut dyn Store>) {
+    pub(crate) unsafe fn set_store(&mut self, store: Option<*mut dyn VMStore>) {
         if let Some(store) = store {
             *self.vmctx_plus_offset_mut(self.offsets().ptr.vmctx_store()) = store;
             *self.runtime_limits() = (*store).vmruntime_limits();
@@ -476,7 +477,7 @@ impl Instance {
             self.set_gc_heap((*store).maybe_gc_store());
         } else {
             assert_eq!(
-                mem::size_of::<*mut dyn Store>(),
+                mem::size_of::<*mut dyn VMStore>(),
                 mem::size_of::<[*mut (); 2]>()
             );
             *self.vmctx_plus_offset_mut::<[*mut (); 2]>(self.offsets().ptr.vmctx_store()) =
@@ -1480,7 +1481,7 @@ impl InstanceHandle {
 
     /// Returns the `Store` pointer that was stored on creation
     #[inline]
-    pub fn store(&self) -> *mut dyn Store {
+    pub fn store(&self) -> *mut dyn VMStore {
         self.instance().store()
     }
 
@@ -1488,7 +1489,7 @@ impl InstanceHandle {
     ///
     /// This is provided for the original `Store` itself to configure the first
     /// self-pointer after the original `Box` has been initialized.
-    pub unsafe fn set_store(&mut self, store: *mut dyn Store) {
+    pub unsafe fn set_store(&mut self, store: *mut dyn VMStore) {
         self.instance_mut().set_store(Some(store));
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -575,7 +575,7 @@ fn initialize_tables(instance: &mut Instance, module: &Module) -> Result<()> {
                 match module.table_plans[idx].table.ref_type.heap_type.top() {
                     WasmHeapTopType::Extern => {
                         let gc_ref = VMGcRef::from_raw_u32(raw.get_externref());
-                        let gc_store = unsafe { (*instance.store()).gc_store() };
+                        let gc_store = unsafe { (*instance.store()).unwrap_gc_store_mut() };
                         let items = (0..table.size())
                             .map(|_| gc_ref.as_ref().map(|r| gc_store.clone_gc_ref(r)));
                         table.init_gc_refs(0, items).err2anyhow()?;
@@ -583,7 +583,7 @@ fn initialize_tables(instance: &mut Instance, module: &Module) -> Result<()> {
 
                     WasmHeapTopType::Any => {
                         let gc_ref = VMGcRef::from_raw_u32(raw.get_anyref());
-                        let gc_store = unsafe { (*instance.store()).gc_store() };
+                        let gc_store = unsafe { (*instance.store()).unwrap_gc_store_mut() };
                         let items = (0..table.size())
                             .map(|_| gc_ref.as_ref().map(|r| gc_store.clone_gc_ref(r)));
                         table.init_gc_refs(0, items).err2anyhow()?;

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -5,7 +5,7 @@ use crate::runtime::vm::instance::{Instance, InstanceHandle};
 use crate::runtime::vm::memory::Memory;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::table::Table;
-use crate::runtime::vm::{CompiledModuleId, ModuleRuntimeInfo, Store, VMFuncRef, VMGcRef};
+use crate::runtime::vm::{CompiledModuleId, ModuleRuntimeInfo, VMFuncRef, VMGcRef, VMStore};
 use core::{any::Any, mem, ptr};
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, HostPtr, InitMemory, MemoryInitialization,
@@ -79,7 +79,7 @@ pub struct InstanceAllocationRequest<'a> {
 /// InstanceAllocationRequest, rather than on a &mut InstanceAllocationRequest
 /// itself, because several use-sites require a split mut borrow on the
 /// InstanceAllocationRequest.
-pub struct StorePtr(Option<*mut dyn Store>);
+pub struct StorePtr(Option<*mut dyn VMStore>);
 
 impl StorePtr {
     /// A pointer to no Store.
@@ -88,19 +88,19 @@ impl StorePtr {
     }
 
     /// A pointer to a Store.
-    pub fn new(ptr: *mut dyn Store) -> Self {
+    pub fn new(ptr: *mut dyn VMStore) -> Self {
         Self(Some(ptr))
     }
 
     /// The raw contents of this struct
-    pub fn as_raw(&self) -> Option<*mut dyn Store> {
+    pub fn as_raw(&self) -> Option<*mut dyn VMStore> {
         self.0
     }
 
     /// Use the StorePtr as a mut ref to the Store.
     ///
     /// Safety: must not be used outside the original lifetime of the borrow.
-    pub(crate) unsafe fn get(&mut self) -> Option<&mut dyn Store> {
+    pub(crate) unsafe fn get(&mut self) -> Option<&mut dyn VMStore> {
         match self.0 {
             Some(ptr) => Some(&mut *ptr),
             None => None,

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -238,7 +238,7 @@ unsafe fn table_grow_gc_ref(
     let element = match instance.table_element_type(table_index) {
         TableElementType::Func => unreachable!(),
         TableElementType::GcRef => VMGcRef::from_raw_u32(init_value)
-            .map(|r| (*instance.store()).gc_store().clone_gc_ref(&r))
+            .map(|r| (*instance.store()).unwrap_gc_store_mut().clone_gc_ref(&r))
             .into(),
     };
 
@@ -262,7 +262,7 @@ unsafe fn table_fill_func_ref(
     match table.element_type() {
         TableElementType::Func => {
             let val = val.cast::<VMFuncRef>();
-            table.fill((*instance.store()).gc_store(), dst, val.into(), len)
+            table.fill((*instance.store()).unwrap_gc_store_mut(), dst, val.into(), len)
         }
         TableElementType::GcRef => unreachable!(),
     }
@@ -281,7 +281,7 @@ unsafe fn table_fill_gc_ref(
     match table.element_type() {
         TableElementType::Func => unreachable!(),
         TableElementType::GcRef => {
-            let gc_store = (*instance.store()).gc_store();
+            let gc_store = (*instance.store()).unwrap_gc_store_mut();
             let gc_ref = VMGcRef::from_raw_u32(val);
             let gc_ref = gc_ref.map(|r| gc_store.clone_gc_ref(&r));
             table.fill(gc_store, dst, gc_ref.into(), len)
@@ -304,7 +304,7 @@ unsafe fn table_copy(
     // Lazy-initialize the whole range in the source table first.
     let src_range = src..(src.checked_add(len).unwrap_or(u64::MAX));
     let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);
-    let gc_store = (*instance.store()).gc_store();
+    let gc_store = (*instance.store()).unwrap_gc_store_mut();
     Table::copy(gc_store, dst_table, src_table, dst, src, len)
 }
 
@@ -391,7 +391,7 @@ unsafe fn table_get_lazy_init_func_ref(
 ) -> *mut u8 {
     let table_index = TableIndex::from_u32(table_index);
     let table = instance.get_table_with_lazy_init(table_index, core::iter::once(index));
-    let gc_store = (*instance.store()).gc_store();
+    let gc_store = (*instance.store()).unwrap_gc_store_mut();
     let elem = (*table)
         .get(gc_store, index)
         .expect("table access already bounds-checked");
@@ -404,7 +404,7 @@ unsafe fn table_get_lazy_init_func_ref(
 unsafe fn drop_gc_ref(instance: &mut Instance, gc_ref: u32) {
     log::trace!("libcalls::drop_gc_ref({gc_ref:#x})");
     let gc_ref = VMGcRef::from_raw_u32(gc_ref).expect("non-null VMGcRef");
-    (*instance.store()).gc_store().drop_gc_ref(gc_ref);
+    (*instance.store()).unwrap_gc_store_mut().drop_gc_ref(gc_ref);
 }
 
 /// Do a GC, keeping `gc_ref` rooted and returning the updated `gc_ref`
@@ -412,7 +412,7 @@ unsafe fn drop_gc_ref(instance: &mut Instance, gc_ref: u32) {
 #[cfg(feature = "gc")]
 unsafe fn gc(instance: &mut Instance, gc_ref: u32) -> Result<u32> {
     let gc_ref = VMGcRef::from_raw_u32(gc_ref);
-    let gc_ref = gc_ref.map(|r| (*instance.store()).gc_store().clone_gc_ref(&r));
+    let gc_ref = gc_ref.map(|r| (*instance.store()).unwrap_gc_store_mut().clone_gc_ref(&r));
 
     if let Some(gc_ref) = &gc_ref {
         // It is possible that we are GC'ing because the DRC's activation
@@ -422,7 +422,7 @@ unsafe fn gc(instance: &mut Instance, gc_ref: u32) -> Result<u32> {
         // time of a GC. So make sure to "expose" this GC reference to Wasm (aka
         // insert it into the DRC's activation table) before we do the actual
         // GC.
-        let gc_store = (*instance.store()).gc_store();
+        let gc_store = (*instance.store()).unwrap_gc_store_mut();
         let gc_ref = gc_store.clone_gc_ref(gc_ref);
         gc_store.expose_gc_ref_to_wasm(gc_ref);
     }
@@ -431,7 +431,7 @@ unsafe fn gc(instance: &mut Instance, gc_ref: u32) -> Result<u32> {
         None => Ok(0),
         Some(r) => {
             let raw = r.as_raw_u32();
-            (*instance.store()).gc_store().expose_gc_ref_to_wasm(r);
+            (*instance.store()).unwrap_gc_store_mut().expose_gc_ref_to_wasm(r);
             Ok(raw)
         }
     }
@@ -471,7 +471,7 @@ unsafe fn gc_alloc_raw(
     let align = usize::try_from(align).unwrap();
     let layout = Layout::from_size_align(size, align).unwrap();
 
-    let gc_ref = match (*instance.store()).gc_store().alloc_raw(header, layout)? {
+    let gc_ref = match (*instance.store()).unwrap_gc_store_mut().alloc_raw(header, layout)? {
         Some(r) => r,
         None => {
             // If the allocation failed, do a GC to hopefully clean up space.
@@ -479,7 +479,7 @@ unsafe fn gc_alloc_raw(
 
             // And then try again.
             (*instance.store())
-                .gc_store()
+                .unwrap_gc_store_mut()
                 .alloc_raw(header, layout)?
                 .ok_or_else(|| GcHeapOutOfMemory::new(()))
                 .err2anyhow()?

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -262,7 +262,12 @@ unsafe fn table_fill_func_ref(
     match table.element_type() {
         TableElementType::Func => {
             let val = val.cast::<VMFuncRef>();
-            table.fill((*instance.store()).unwrap_gc_store_mut(), dst, val.into(), len)
+            table.fill(
+                (*instance.store()).unwrap_gc_store_mut(),
+                dst,
+                val.into(),
+                len,
+            )
         }
         TableElementType::GcRef => unreachable!(),
     }
@@ -404,7 +409,9 @@ unsafe fn table_get_lazy_init_func_ref(
 unsafe fn drop_gc_ref(instance: &mut Instance, gc_ref: u32) {
     log::trace!("libcalls::drop_gc_ref({gc_ref:#x})");
     let gc_ref = VMGcRef::from_raw_u32(gc_ref).expect("non-null VMGcRef");
-    (*instance.store()).unwrap_gc_store_mut().drop_gc_ref(gc_ref);
+    (*instance.store())
+        .unwrap_gc_store_mut()
+        .drop_gc_ref(gc_ref);
 }
 
 /// Do a GC, keeping `gc_ref` rooted and returning the updated `gc_ref`
@@ -431,7 +438,9 @@ unsafe fn gc(instance: &mut Instance, gc_ref: u32) -> Result<u32> {
         None => Ok(0),
         Some(r) => {
             let raw = r.as_raw_u32();
-            (*instance.store()).unwrap_gc_store_mut().expose_gc_ref_to_wasm(r);
+            (*instance.store())
+                .unwrap_gc_store_mut()
+                .expose_gc_ref_to_wasm(r);
             Ok(raw)
         }
     }
@@ -471,7 +480,10 @@ unsafe fn gc_alloc_raw(
     let align = usize::try_from(align).unwrap();
     let layout = Layout::from_size_align(size, align).unwrap();
 
-    let gc_ref = match (*instance.store()).unwrap_gc_store_mut().alloc_raw(header, layout)? {
+    let gc_ref = match (*instance.store())
+        .unwrap_gc_store_mut()
+        .alloc_raw(header, layout)?
+    {
         Some(r) => r,
         None => {
             // If the allocation failed, do a GC to hopefully clean up space.

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -618,9 +618,8 @@ impl Table {
             }
         }
 
-        // casting to u64 is ok to unwrap
         self.fill(
-            store.unwrap_gc_store_mut(),
+            store.store_opaque_mut().unwrap_gc_store_mut(),
             u64::try_from(old_size).unwrap(),
             init_value,
             u64::try_from(delta).unwrap(),

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -620,7 +620,7 @@ impl Table {
 
         // casting to u64 is ok to unwrap
         self.fill(
-            store.gc_store(),
+            store.unwrap_gc_store_mut(),
             u64::try_from(old_size).unwrap(),
             init_value,
             u64::try_from(delta).unwrap(),

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -6,7 +6,7 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::vmcontext::{VMFuncRef, VMTableDefinition};
-use crate::runtime::vm::{GcStore, SendSyncPtr, Store, VMGcRef};
+use crate::runtime::vm::{GcStore, SendSyncPtr, VMGcRef, VMStore};
 use core::ops::Range;
 use core::ptr::{self, NonNull};
 use core::slice;
@@ -268,7 +268,7 @@ fn wasm_to_table_type(ty: WasmRefType) -> TableElementType {
 
 impl Table {
     /// Create a new dynamic (movable) table instance for the specified table plan.
-    pub fn new_dynamic(plan: &TablePlan, store: &mut dyn Store) -> Result<Self> {
+    pub fn new_dynamic(plan: &TablePlan, store: &mut dyn VMStore) -> Result<Self> {
         let (minimum, maximum) = Self::limit_new(plan, store)?;
         match wasm_to_table_type(plan.table.ref_type) {
             TableElementType::Func => {
@@ -290,7 +290,7 @@ impl Table {
     pub unsafe fn new_static(
         plan: &TablePlan,
         data: SendSyncPtr<[u8]>,
-        store: &mut dyn Store,
+        store: &mut dyn VMStore,
     ) -> Result<Self> {
         let (minimum, maximum) = Self::limit_new(plan, store)?;
         let size = minimum;
@@ -348,7 +348,7 @@ impl Table {
     // Calls the `store`'s limiter to optionally prevent the table from being created.
     //
     // Returns the minimum and maximum size of the table if the table can be created.
-    fn limit_new(plan: &TablePlan, store: &mut dyn Store) -> Result<(usize, Option<usize>)> {
+    fn limit_new(plan: &TablePlan, store: &mut dyn VMStore) -> Result<(usize, Option<usize>)> {
         // No matter how the table limits are specified
         // The table size is limited by the host's pointer size
         let absolute_max = usize::MAX;
@@ -551,7 +551,7 @@ impl Table {
         &mut self,
         delta: u64,
         init_value: TableElement,
-        store: &mut dyn Store,
+        store: &mut dyn VMStore,
     ) -> Result<Option<usize>, Error> {
         let old_size = self.size();
 

--- a/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
+++ b/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::runtime::vm::memory::{validate_atomic_addr, MmapMemory};
 use crate::runtime::vm::threads::parking_spot::{ParkingSpot, Waiter};
 use crate::runtime::vm::vmcontext::VMMemoryDefinition;
-use crate::runtime::vm::{Memory, RuntimeLinearMemory, Store, WaitResult};
+use crate::runtime::vm::{Memory, RuntimeLinearMemory, VMStore, WaitResult};
 use std::cell::RefCell;
 use std::ops::Range;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -79,7 +79,7 @@ impl SharedMemory {
     pub fn grow(
         &self,
         delta_pages: u64,
-        store: Option<&mut dyn Store>,
+        store: Option<&mut dyn VMStore>,
     ) -> Result<Option<(usize, usize)>, Error> {
         let mut memory = self.0.memory.write().unwrap();
         let result = memory.grow(delta_pages, store)?;
@@ -204,7 +204,7 @@ impl RuntimeLinearMemory for SharedMemory {
     fn grow(
         &mut self,
         delta_pages: u64,
-        store: Option<&mut dyn Store>,
+        store: Option<&mut dyn VMStore>,
     ) -> Result<Option<(usize, usize)>, Error> {
         SharedMemory::grow(self, delta_pages, store)
     }

--- a/crates/wasmtime/src/runtime/vm/threads/shared_memory_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/threads/shared_memory_disabled.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use crate::prelude::*;
-use crate::runtime::vm::{RuntimeLinearMemory, Store, VMMemoryDefinition, WaitResult};
+use crate::runtime::vm::{RuntimeLinearMemory, VMMemoryDefinition, VMStore, WaitResult};
 use core::ops::Range;
 use core::time::Duration;
 use wasmtime_environ::{MemoryPlan, Trap};
@@ -33,7 +33,7 @@ impl SharedMemory {
     pub fn grow(
         &self,
         _delta_pages: u64,
-        _store: Option<&mut dyn Store>,
+        _store: Option<&mut dyn VMStore>,
     ) -> Result<Option<(usize, usize)>> {
         match *self {}
     }
@@ -77,7 +77,7 @@ impl RuntimeLinearMemory for SharedMemory {
     fn grow(
         &mut self,
         _delta_pages: u64,
-        _store: Option<&mut dyn Store>,
+        _store: Option<&mut dyn VMStore>,
     ) -> Result<Option<(usize, usize)>> {
         match *self {}
     }


### PR DESCRIPTION
This dates back from the `wasmtime` vs `wasmtime-runtime` crate split. Now that those crates merged, we can simplify some bits and remove unnecessary abstractions and indirections.