### PR TITLE
Deprecate Context::compile_and_emit

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -109,21 +109,7 @@ impl Context {
     }
 
     /// Compile the function, and emit machine code into a `Vec<u8>`.
-    ///
-    /// Run the function through all the passes necessary to generate
-    /// code for the target ISA represented by `isa`, as well as the
-    /// final step of emitting machine code into a `Vec<u8>`. The
-    /// machine code is not relocated. Instead, any relocations can be
-    /// obtained from `compiled_code()`.
-    ///
-    /// Performs any optimizations that are enabled, unless
-    /// `optimize()` was already invoked.
-    ///
-    /// This function calls `compile`, taking care to resize `mem` as
-    /// needed.
-    ///
-    /// Returns information about the function's code and read-only
-    /// data.
+    #[deprecated = "use Context::compile"]
     pub fn compile_and_emit(
         &mut self,
         isa: &dyn TargetIsa,
@@ -198,13 +184,18 @@ impl Context {
         Ok(())
     }
 
-    /// Compile the function.
+    /// Compile the function,
     ///
-    /// Run the function through all the passes necessary to generate code for the target ISA
-    /// represented by `isa`. This does not include the final step of emitting machine code into a
-    /// code sink.
+    /// Run the function through all the passes necessary to generate
+    /// code for the target ISA represented by `isa`. The generated
+    /// machine code is not relocated. Instead, any relocations can be
+    /// obtained from `compiled_code.buffer.relocs()`.
     ///
-    /// Returns information about the function's code and read-only data.
+    /// Performs any optimizations that are enabled, unless
+    /// `optimize()` was already invoked.
+    ///
+    /// Returns the generated machine code as well as information about
+    /// the function's code and read-only data.
     pub fn compile(
         &mut self,
         isa: &dyn TargetIsa,

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -331,16 +331,15 @@ impl Module for ObjectModule {
         ctrl_plane: &mut ControlPlane,
     ) -> ModuleResult<()> {
         info!("defining function {}: {}", func_id, ctx.func.display());
-        let mut code: Vec<u8> = Vec::new();
 
-        let res = ctx.compile_and_emit(self.isa(), &mut code, ctrl_plane)?;
+        let res = ctx.compile(self.isa(), ctrl_plane)?;
         let alignment = res.buffer.alignment as u64;
 
         self.define_function_bytes(
             func_id,
             &ctx.func,
             alignment,
-            &code,
+            ctx.compiled_code().unwrap().code_buffer(),
             ctx.compiled_code().unwrap().buffer.relocs(),
         )
     }

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -954,9 +954,6 @@ struct CrashCheckContext<'a> {
     /// Cached `Context`, to prevent repeated allocation.
     context: Context,
 
-    /// Cached code memory, to prevent repeated allocation.
-    code_memory: Vec<u8>,
-
     /// The target isa to compile for.
     isa: &'a dyn TargetIsa,
 }
@@ -986,7 +983,6 @@ impl<'a> CrashCheckContext<'a> {
     fn new(isa: &'a dyn TargetIsa) -> Self {
         CrashCheckContext {
             context: Context::new(),
-            code_memory: Vec::new(),
             isa,
         }
     }
@@ -994,7 +990,6 @@ impl<'a> CrashCheckContext<'a> {
     #[cfg_attr(test, allow(unreachable_code))]
     fn check_for_crash(&mut self, func: &Function) -> CheckResult {
         self.context.clear();
-        self.code_memory.clear();
 
         self.context.func = func.clone();
 
@@ -1035,11 +1030,7 @@ impl<'a> CrashCheckContext<'a> {
         std::panic::set_hook(Box::new(|_| {})); // silence panics
 
         let res = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = self.context.compile_and_emit(
-                self.isa,
-                &mut self.code_memory,
-                &mut Default::default(),
-            );
+            let _ = self.context.compile(self.isa, &mut Default::default());
         })) {
             Ok(()) => CheckResult::Succeed,
             Err(err) => CheckResult::Crash(get_panic_string(err)),

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -98,11 +98,10 @@ fn handle_module(
     for (func, _) in test_file.functions {
         let mut context = Context::new();
         context.func = func;
-        let mut mem = vec![];
 
         // Compile and encode the result to machine code.
         let compiled_code = context
-            .compile_and_emit(isa, &mut mem, &mut Default::default())
+            .compile(isa, &mut Default::default())
             .map_err(|err| anyhow::anyhow!("{}", pretty_error(&err.func, err.inner)))?;
         let code_info = compiled_code.code_info();
 
@@ -129,7 +128,7 @@ fn handle_module(
             print_all(
                 isa,
                 &context.func,
-                &mem,
+                context.compiled_code().unwrap().code_buffer(),
                 code_info.total_size,
                 options.print,
                 result.buffer.relocs(),


### PR DESCRIPTION
The only thing it does over Context::compile is writing the machine code to a Vec specified by the user. Every user of Context::compile_and_emit in Cranelift didn't actually need ownership over the machine code bytes and thus would have been able to use Context::compile instead to avoid an unnecessary allocation. This commit moves all in-tree users of compile_and_emit to compile and additionally to avoid other users adding an unnecessary allocation as they though it to be necessary, this commit additionally deprecates compile_and_emit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
