### PR TITLE
Add release artifacts for ARM64 Windows

### DIFF
--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -64,6 +64,11 @@ const array = [
     "os": "ubuntu-latest",
     "target": "x86_64-unknown-linux-musl",
   },
+  {
+    "build": "aarch64-windows",
+    "os": "windows-latest",
+    "target": "aarch64-pc-windows-msvc",
+  },
 ];
 
 const builds = [];

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -68,7 +68,8 @@ case $build in
     fi
     ;;
 
-  x86_64-mingw*)
+  # Skip the MSI for non-x86_64 builds of Windows
+  x86_64-mingw* | *-windows*)
     cp target/$target/release/wasmtime.exe tmp/$bin_pkgname/wasmtime$min.exe
     fmt=zip
     ;;


### PR DESCRIPTION
With #9266 Wasmtime should have full support for this platform. While not tested in CI it can still be useful to build artifacts nonetheless in case users are interested.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
