### PR TITLE
Introduce the `wasmtime::EqRef` type

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -601,18 +601,23 @@ impl Func {
     /// | `Func`                            | `(ref func)`                              |
     /// | `Option<Nofunc>`                  | `nullfuncref` aka `(ref null nofunc)`     |
     /// | `NoFunc`                          | `(ref nofunc)`                            |
-    /// | `Option<ExternRef>`               | `externref` aka `(ref null extern)`       |
-    /// | `ExternRef`                       | `(ref extern)`                            |
+    /// | `Option<Rooted<ExternRef>>`       | `externref` aka `(ref null extern)`       |
+    /// | `Rooted<ExternRef>`               | `(ref extern)`                            |
     /// | `Option<NoExtern>`                | `nullexternref` aka `(ref null noextern)` |
     /// | `NoExtern`                        | `(ref noextern)`                          |
-    /// | `Option<AnyRef>`                  | `anyref` aka `(ref null any)`             |
-    /// | `AnyRef`                          | `(ref any)`                               |
+    /// | `Option<Rooted<AnyRef>>`          | `anyref` aka `(ref null any)`             |
+    /// | `Rooted<AnyRef>`                  | `(ref any)`                               |
+    /// | `Option<Rooted<EqRef>>`           | `eqref` aka `(ref null eq)`               |
+    /// | `Rooted<EqRef>`                   | `(ref eq)`                                |
     /// | `Option<I31>`                     | `i31ref` aka `(ref null i31)`             |
     /// | `I31`                             | `(ref i31)`                               |
-    /// | `Option<StructRef>`               | `(ref null struct)`                       |
-    /// | `StructRef`                       | `(ref struct)`                            |
-    /// | `Option<ArrayRef>`                | `(ref null array)`                        |
-    /// | `ArrayRef`                        | `(ref array)`                             |
+    /// | `Option<Rooted<StructRef>>`       | `(ref null struct)`                       |
+    /// | `Rooted<StructRef>`               | `(ref struct)`                            |
+    /// | `Option<Rooted<ArrayRef>>`        | `(ref null array)`                        |
+    /// | `Rooted<ArrayRef>`                | `(ref array)`                             |
+    ///
+    /// Note that anywhere a `Rooted<T>` appears, a `ManuallyRooted<T>` may also
+    /// be used.
     ///
     /// Any of the Rust types can be returned from the closure as well, in
     /// addition to some extra types
@@ -1425,18 +1430,20 @@ impl Func {
     /// | `i64`                                     | `i64` or `u64`                        |
     /// | `f32`                                     | `f32`                                 |
     /// | `f64`                                     | `f64`                                 |
-    /// | `externref` aka `(ref null extern)`       | `Option<ExternRef>`                   |
-    /// | `(ref extern)`                            | `ExternRef`                           |
-    /// | `(ref noextern)`                          | `NoExtern`                            |
+    /// | `externref` aka `(ref null extern)`       | `Option<Rooted<ExternRef>>`           |
+    /// | `(ref extern)`                            | `Rooted<ExternRef>`                   |
     /// | `nullexternref` aka `(ref null noextern)` | `Option<NoExtern>`                    |
-    /// | `anyref` aka `(ref null any)`             | `Option<AnyRef>`                      |
-    /// | `(ref any)`                               | `AnyRef`                              |
+    /// | `(ref noextern)`                          | `NoExtern`                            |
+    /// | `anyref` aka `(ref null any)`             | `Option<Rooted<AnyRef>>`              |
+    /// | `(ref any)`                               | `Rooted<AnyRef>`                      |
+    /// | `eqref` aka `(ref null eq)`               | `Option<Rooted<EqRef>>`               |
+    /// | `(ref eq)`                                | `Rooted<EqRef>`                       |
     /// | `i31ref` aka `(ref null i31)`             | `Option<I31>`                         |
     /// | `(ref i31)`                               | `I31`                                 |
-    /// | `structref` aka `(ref null struct)`       | `Option<Struct>`                      |
-    /// | `(ref struct)`                            | `Struct`                              |
-    /// | `arrayref` aka `(ref null array)`         | `Option<Array>`                       |
-    /// | `(ref array)`                             | `Array`                               |
+    /// | `structref` aka `(ref null struct)`       | `Option<Rooted<StructRef>>`           |
+    /// | `(ref struct)`                            | `Rooted<StructRef>`                   |
+    /// | `arrayref` aka `(ref null array)`         | `Option<Rooted<ArrayRef>>`            |
+    /// | `(ref array)`                             | `Rooted<ArrayRef>`                    |
     /// | `funcref` aka `(ref null func)`           | `Option<Func>`                        |
     /// | `(ref func)`                              | `Func`                                |
     /// | `(ref null <func type index>)`            | `Option<Func>`                        |
@@ -1445,7 +1452,8 @@ impl Func {
     /// | `(ref nofunc)`                            | `NoFunc`                              |
     /// | `v128`                                    | `V128` on `x86-64` and `aarch64` only |
     ///
-    /// (Note that this mapping is the same as that of [`Func::wrap`]).
+    /// (Note that this mapping is the same as that of [`Func::wrap`], and that
+    /// anywhere a `Rooted<T>` appears, a `ManuallyRooted<T>` may also appear).
     ///
     /// Note that once the [`TypedFunc`] return value is acquired you'll use either
     /// [`TypedFunc::call`] or [`TypedFunc::call_async`] as necessary to actually invoke

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1450,7 +1450,7 @@ impl Func {
     /// | `(ref <func type index>)`                 | `Func`                                |
     /// | `nullfuncref` aka `(ref null nofunc)`     | `Option<NoFunc>`                      |
     /// | `(ref nofunc)`                            | `NoFunc`                              |
-    /// | `v128`                                    | `V128` on `x86-64` and `aarch64` only |
+    /// | `v128`                                    | `V128`                                |
     ///
     /// (Note that this mapping is the same as that of [`Func::wrap`], and that
     /// anywhere a `Rooted<T>` appears, a `ManuallyRooted<T>` may also appear).

--- a/crates/wasmtime/src/runtime/gc/disabled.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled.rs
@@ -10,6 +10,7 @@
 
 mod anyref;
 mod arrayref;
+mod eqref;
 mod externref;
 mod i31;
 mod rooting;
@@ -17,6 +18,7 @@ mod structref;
 
 pub use anyref::*;
 pub use arrayref::*;
+pub use eqref::*;
 pub use externref::*;
 pub use i31::*;
 pub use rooting::*;

--- a/crates/wasmtime/src/runtime/gc/disabled/eqref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/eqref.rs
@@ -1,78 +1,50 @@
 use crate::runtime::vm::VMGcRef;
 use crate::{
     store::{AutoAssertNoGc, StoreOpaque},
-    ArrayRef, AsContext, AsContextMut, EqRef, GcRefImpl, HeapType, ManuallyRooted, Result, Rooted,
+    ArrayRef, AsContext, AsContextMut, GcRefImpl, HeapType, ManuallyRooted, Result, Rooted,
     StructRef, I31,
 };
 
-/// Support for `anyref` disabled at compile time because the `gc` cargo feature
+/// Support for `eqref` disabled at compile time because the `gc` cargo feature
 /// was not enabled.
-pub enum AnyRef {}
+pub enum EqRef {}
 
-impl From<Rooted<EqRef>> for Rooted<AnyRef> {
-    #[inline]
-    fn from(s: Rooted<EqRef>) -> Self {
-        match s.inner {}
-    }
-}
-
-impl From<ManuallyRooted<EqRef>> for ManuallyRooted<AnyRef> {
-    #[inline]
-    fn from(s: ManuallyRooted<EqRef>) -> Self {
-        match s.inner {}
-    }
-}
-
-impl From<Rooted<StructRef>> for Rooted<AnyRef> {
+impl From<Rooted<StructRef>> for Rooted<EqRef> {
     #[inline]
     fn from(s: Rooted<StructRef>) -> Self {
         match s.inner {}
     }
 }
 
-impl From<ManuallyRooted<StructRef>> for ManuallyRooted<AnyRef> {
+impl From<ManuallyRooted<StructRef>> for ManuallyRooted<EqRef> {
     #[inline]
     fn from(s: ManuallyRooted<StructRef>) -> Self {
         match s.inner {}
     }
 }
 
-impl From<Rooted<ArrayRef>> for Rooted<AnyRef> {
+impl From<Rooted<ArrayRef>> for Rooted<EqRef> {
     #[inline]
     fn from(s: Rooted<ArrayRef>) -> Self {
         match s.inner {}
     }
 }
 
-impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<AnyRef> {
+impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<EqRef> {
     #[inline]
     fn from(s: ManuallyRooted<ArrayRef>) -> Self {
         match s.inner {}
     }
 }
 
-impl GcRefImpl for AnyRef {}
+impl GcRefImpl for EqRef {}
 
-impl AnyRef {
+impl EqRef {
     pub(crate) fn from_cloned_gc_ref(
         _store: &mut AutoAssertNoGc<'_>,
         _gc_ref: VMGcRef,
     ) -> Rooted<Self> {
         unreachable!()
-    }
-
-    pub unsafe fn from_raw(_store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
-        assert_eq!(raw, 0);
-        None
-    }
-
-    pub unsafe fn _from_raw(_store: &mut AutoAssertNoGc<'_>, raw: u32) -> Option<Rooted<Self>> {
-        assert_eq!(raw, 0);
-        None
-    }
-
-    pub unsafe fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
-        match *self {}
     }
 
     pub fn ty(&self, _store: impl AsContext) -> Result<HeapType> {
@@ -84,22 +56,6 @@ impl AnyRef {
     }
 
     pub fn matches_ty(&self, _store: impl AsContext, _ty: &HeapType) -> Result<bool> {
-        match *self {}
-    }
-
-    pub fn is_eqref(&self, _store: impl AsContext) -> Result<bool> {
-        match *self {}
-    }
-
-    pub(crate) fn _is_eqref(&self, _store: &StoreOpaque) -> Result<bool> {
-        match *self {}
-    }
-
-    pub fn as_eqref(&self, _store: impl AsContext) -> Result<Option<EqRef>> {
-        match *self {}
-    }
-
-    pub fn unwrap_eqref(&self, _store: impl AsContext) -> Result<EqRef> {
         match *self {}
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled.rs
@@ -3,6 +3,7 @@
 
 mod anyref;
 mod arrayref;
+mod eqref;
 mod externref;
 mod i31;
 mod rooting;
@@ -10,6 +11,7 @@ mod structref;
 
 pub use anyref::*;
 pub use arrayref::*;
+pub use eqref::*;
 pub use externref::*;
 pub use i31::*;
 pub use rooting::*;

--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -95,6 +95,20 @@ pub struct AnyRef {
     pub(super) inner: GcRootIndex,
 }
 
+impl From<Rooted<EqRef>> for Rooted<AnyRef> {
+    #[inline]
+    fn from(e: Rooted<EqRef>) -> Self {
+        e.to_anyref()
+    }
+}
+
+impl From<ManuallyRooted<EqRef>> for ManuallyRooted<AnyRef> {
+    #[inline]
+    fn from(e: ManuallyRooted<EqRef>) -> Self {
+        e.to_anyref()
+    }
+}
+
 impl From<Rooted<StructRef>> for Rooted<AnyRef> {
     #[inline]
     fn from(s: Rooted<StructRef>) -> Self {

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -6,7 +6,7 @@ use crate::vm::{VMArrayRef, VMGcHeader};
 use crate::{
     prelude::*,
     store::{AutoAssertNoGc, StoreContextMut, StoreOpaque},
-    ArrayType, AsContext, AsContextMut, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType,
+    ArrayType, AsContext, AsContextMut, EqRef, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType,
     ManuallyRooted, RefType, Rooted, Val, ValRaw, ValType, WasmTy,
 };
 use crate::{AnyRef, FieldType};
@@ -206,12 +206,24 @@ impl Rooted<ArrayRef> {
     pub fn to_anyref(self) -> Rooted<AnyRef> {
         self.unchecked_cast()
     }
+
+    /// Upcast this `arrayref` into an `eqref`.
+    #[inline]
+    pub fn to_eqref(self) -> Rooted<EqRef> {
+        self.unchecked_cast()
+    }
 }
 
 impl ManuallyRooted<ArrayRef> {
     /// Upcast this `arrayref` into an `anyref`.
     #[inline]
     pub fn to_anyref(self) -> ManuallyRooted<AnyRef> {
+        self.unchecked_cast()
+    }
+
+    /// Upcast this `arrayref` into an `eqref`.
+    #[inline]
+    pub fn to_eqref(self) -> ManuallyRooted<EqRef> {
         self.unchecked_cast()
     }
 }

--- a/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
@@ -92,6 +92,34 @@ pub struct EqRef {
     pub(super) inner: GcRootIndex,
 }
 
+impl From<Rooted<StructRef>> for Rooted<EqRef> {
+    #[inline]
+    fn from(s: Rooted<StructRef>) -> Self {
+        s.to_eqref()
+    }
+}
+
+impl From<ManuallyRooted<StructRef>> for ManuallyRooted<EqRef> {
+    #[inline]
+    fn from(s: ManuallyRooted<StructRef>) -> Self {
+        s.to_eqref()
+    }
+}
+
+impl From<Rooted<ArrayRef>> for Rooted<EqRef> {
+    #[inline]
+    fn from(s: Rooted<ArrayRef>) -> Self {
+        s.to_eqref()
+    }
+}
+
+impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<EqRef> {
+    #[inline]
+    fn from(s: ManuallyRooted<ArrayRef>) -> Self {
+        s.to_eqref()
+    }
+}
+
 unsafe impl GcRefImpl for EqRef {
     #[allow(private_interfaces)]
     fn transmute_ref(index: &GcRootIndex) -> &Self {

--- a/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
@@ -1,132 +1,101 @@
-//! Implementation of `anyref` in Wasmtime.
+//! Working with GC `eqref`s.
 
-use crate::prelude::*;
-use crate::runtime::vm::VMGcRef;
 use crate::{
+    prelude::*,
+    runtime::vm::VMGcRef,
     store::{AutoAssertNoGc, StoreOpaque},
-    ArrayRef, ArrayType, AsContext, AsContextMut, EqRef, GcRefImpl, GcRootIndex, HeapType,
-    ManuallyRooted, RefType, Result, Rooted, StructRef, StructType, ValRaw, ValType, WasmTy, I31,
+    AnyRef, ArrayRef, ArrayType, AsContext, GcRefImpl, GcRootIndex, HeapType, ManuallyRooted,
+    RefType, Rooted, StructRef, StructType, ValRaw, ValType, WasmTy, I31,
 };
-use core::mem;
-use core::mem::MaybeUninit;
+use core::mem::{self, MaybeUninit};
 use wasmtime_environ::VMGcKind;
 
-/// An `anyref` GC reference.
+/// A reference to a GC-managed object that can be tested for equality.
 ///
-/// The `AnyRef` type represents WebAssembly `anyref` values. These can be
-/// references to `struct`s and `array`s or inline/unboxed 31-bit
-/// integers. Unlike `externref`, Wasm guests can directly allocate `anyref`s.
+/// The WebAssembly reference types that can be tested for equality, and
+/// therefore are `eqref`s, include `structref`s, `arrayref`s, and
+/// `i31ref`s. `funcref`s, `exnref`s, and `externref`s cannot be tested for
+/// equality by Wasm, and are not `eqref`s.
 ///
-/// Like all WebAssembly references, these are opaque and unforgable to Wasm:
-/// they cannot be faked and Wasm cannot, for example, cast the integer
-/// `0x12345678` into a reference, pretend it is a valid `anyref`, and trick the
+/// Use the [`Rooted::ref_eq`][Rooted::ref_eq] method to actually test two
+/// references for equality.
+///
+/// Like all WebAssembly references, these are opaque to and unforgeable by
+/// Wasm: they cannot be faked and Wasm cannot, for example, cast the integer
+/// `0x12345678` into a reference, pretend it is a valid `eqref`, and trick the
 /// host into dereferencing it and segfaulting or worse.
 ///
-/// Note that you can also use `Rooted<AnyRef>` and `ManuallyRooted<AnyRef>` as
-/// a type parameter with [`Func::typed`][crate::Func::typed]- and
+/// Note that you can also use `Rooted<EqRef>` and `ManuallyRooted<EqRef>` as a
+/// type parameter with [`Func::typed`][crate::Func::typed]- and
 /// [`Func::wrap`][crate::Func::wrap]-style APIs.
 ///
 /// # Example
 ///
 /// ```
-/// # use wasmtime::*;
-/// # fn _foo() -> Result<()> {
+/// use wasmtime::*;
+///
+/// # fn foo() -> Result<()> {
 /// let mut config = Config::new();
+/// config.wasm_function_references(true);
 /// config.wasm_gc(true);
 ///
 /// let engine = Engine::new(&config)?;
+/// let mut store = Store::new(&engine, ());
 ///
-/// // Define a module which does stuff with `anyref`s.
+/// // Define a module that exports a function that returns a new `eqref` each
+/// // time it is invoked.
 /// let module = Module::new(&engine, r#"
 ///     (module
-///         (func (export "increment-if-i31") (param (ref null any)) (result (ref null any))
-///             block
-///                 ;; Try to cast the arg to an `i31`, otherwise branch out
-///                 ;; of this `block`.
-///                 local.get 0
-///                 br_on_cast_fail (ref null any) (ref i31) 0
-///                 ;; Get the `i31`'s inner value and add one to it.
-///                 i31.get_u
-///                 i32.const 1
-///                 i32.add
-///                 ;; Wrap the incremented value back into an `i31` reference and
-///                 ;; return it.
-///                 ref.i31
-///                 return
-///             end
+///         (global $g (mut i32) (i32.const 0))
+///         (func (export "new-eqref") (result (ref eq))
+///             ;; Increment $g.
+///             global.get $g
+///             i32.const 1
+///             i32.add
+///             global.set $g
 ///
-///             ;; If the `anyref` we were given is not an `i31`, just return it
-///             ;; as-is.
-///             local.get 0
+///             ;; Create an `i31ref`, which is a kind of `eqref`, from $g.
+///             global.get $g
+///             ref.i31
 ///         )
 ///     )
 /// "#)?;
 ///
 /// // Instantiate the module.
-/// let mut store = Store::new(&engine, ());
 /// let instance = Instance::new(&mut store, &module, &[])?;
 ///
-/// // Extract the function.
-/// let increment_if_i31 = instance
-///     .get_typed_func::<Option<Rooted<AnyRef>>, Option<Rooted<AnyRef>>>(
-///         &mut store,
-///         "increment-if-i31",
-///     )?;
+/// // Get the exported function.
+/// let new_eqref = instance.get_typed_func::<(), Rooted<EqRef>>(&mut store, "new-eqref")?;
 ///
 /// {
-///     // Create a new scope for the `Rooted` arguments and returns.
 ///     let mut scope = RootScope::new(&mut store);
 ///
-///     // Call the function with an `i31`.
-///     let arg = AnyRef::from_i31(&mut scope, I31::wrapping_u32(419));
-///     let result = increment_if_i31.call(&mut scope, Some(arg))?;
-///     assert_eq!(result.unwrap().as_i31(&scope)?, Some(I31::wrapping_u32(420)));
+///     // Call the function to get an `eqref`.
+///     let x = new_eqref.call(&mut scope, ())?;
 ///
-///     // Call the function with something that isn't an `i31`.
-///     let result = increment_if_i31.call(&mut scope, None)?;
-///     assert!(result.is_none());
+///     // `x` is equal to itself!
+///     assert!(Rooted::ref_eq(&scope, &x, &x)?);
+///
+///     // Call the function again to get a new, different `eqref`.
+///     let y = new_eqref.call(&mut scope, ())?;
+///
+///     // `x` is not equal to `y`!
+///     assert!(!Rooted::ref_eq(&scope, &x, &y)?);
 /// }
 /// # Ok(())
 /// # }
+/// # foo().unwrap();
 /// ```
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct AnyRef {
+pub struct EqRef {
     pub(super) inner: GcRootIndex,
 }
 
-impl From<Rooted<StructRef>> for Rooted<AnyRef> {
-    #[inline]
-    fn from(s: Rooted<StructRef>) -> Self {
-        s.to_anyref()
-    }
-}
-
-impl From<ManuallyRooted<StructRef>> for ManuallyRooted<AnyRef> {
-    #[inline]
-    fn from(s: ManuallyRooted<StructRef>) -> Self {
-        s.to_anyref()
-    }
-}
-
-impl From<Rooted<ArrayRef>> for Rooted<AnyRef> {
-    #[inline]
-    fn from(s: Rooted<ArrayRef>) -> Self {
-        s.to_anyref()
-    }
-}
-
-impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<AnyRef> {
-    #[inline]
-    fn from(s: ManuallyRooted<ArrayRef>) -> Self {
-        s.to_anyref()
-    }
-}
-
-unsafe impl GcRefImpl for AnyRef {
+unsafe impl GcRefImpl for EqRef {
     #[allow(private_interfaces)]
     fn transmute_ref(index: &GcRootIndex) -> &Self {
-        // Safety: `AnyRef` is a newtype of a `GcRootIndex`.
+        // Safety: `EqRef` is a newtype of a `GcRootIndex`.
         let me: &Self = unsafe { mem::transmute(index) };
 
         // Assert we really are just a newtype of a `GcRootIndex`.
@@ -141,73 +110,23 @@ unsafe impl GcRefImpl for AnyRef {
     }
 }
 
-impl AnyRef {
-    /// Construct an `anyref` from an `i31`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use wasmtime::*;
-    /// # fn _foo() -> Result<()> {
-    /// let mut store = Store::<()>::default();
-    ///
-    /// // Create an `i31`.
-    /// let i31 = I31::wrapping_u32(999);
-    ///
-    /// // Convert it into an `anyref`.
-    /// let anyref = AnyRef::from_i31(&mut store, i31);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn from_i31(mut store: impl AsContextMut, value: I31) -> Rooted<Self> {
-        let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
-        Self::_from_i31(&mut store, value)
+impl Rooted<EqRef> {
+    /// Upcast this `eqref` into an `anyref`.
+    #[inline]
+    pub fn to_anyref(self) -> Rooted<AnyRef> {
+        self.unchecked_cast()
     }
+}
 
-    pub(crate) fn _from_i31(store: &mut AutoAssertNoGc<'_>, value: I31) -> Rooted<Self> {
-        let gc_ref = VMGcRef::from_i31(value.runtime_i31());
-        Rooted::new(store, gc_ref)
+impl ManuallyRooted<EqRef> {
+    /// Upcast this `eqref` into an `anyref`.
+    #[inline]
+    pub fn to_anyref(self) -> ManuallyRooted<AnyRef> {
+        self.unchecked_cast()
     }
+}
 
-    /// Creates a new strongly-owned [`AnyRef`] from the raw value provided.
-    ///
-    /// This is intended to be used in conjunction with [`Func::new_unchecked`],
-    /// [`Func::call_unchecked`], and [`ValRaw`] with its `anyref` field.
-    ///
-    /// This function assumes that `raw` is an `anyref` value which is currently
-    /// rooted within the [`Store`].
-    ///
-    /// # Unsafety
-    ///
-    /// This function is particularly `unsafe` because `raw` not only must be a
-    /// valid `anyref` value produced prior by [`AnyRef::to_raw`] but it must
-    /// also be correctly rooted within the store. When arguments are provided
-    /// to a callback with [`Func::new_unchecked`], for example, or returned via
-    /// [`Func::call_unchecked`], if a GC is performed within the store then
-    /// floating `anyref` values are not rooted and will be GC'd, meaning that
-    /// this function will no longer be safe to call with the values cleaned up.
-    /// This function must be invoked *before* possible GC operations can happen
-    /// (such as calling Wasm).
-    ///
-    /// When in doubt try to not use this. Instead use the safe Rust APIs of
-    /// [`TypedFunc`] and friends.
-    ///
-    /// [`Func::call_unchecked`]: crate::Func::call_unchecked
-    /// [`Func::new_unchecked`]: crate::Func::new_unchecked
-    /// [`Store`]: crate::Store
-    /// [`TypedFunc`]: crate::TypedFunc
-    /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn from_raw(mut store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
-        let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
-        Self::_from_raw(&mut store, raw)
-    }
-
-    // (Not actually memory unsafe since we have indexed GC heaps.)
-    pub(crate) fn _from_raw(store: &mut AutoAssertNoGc, raw: u32) -> Option<Rooted<Self>> {
-        let gc_ref = VMGcRef::from_raw_u32(raw)?;
-        Some(Self::from_cloned_gc_ref(store, gc_ref))
-    }
-
+impl EqRef {
     /// Create a new `Rooted<AnyRef>` from the given GC reference.
     ///
     /// `gc_ref` should point to a valid `anyref` and should belong to the
@@ -223,7 +142,7 @@ impl AnyRef {
                     .unwrap_gc_store()
                     .header(&gc_ref)
                     .kind()
-                    .matches(VMGcKind::AnyRef)
+                    .matches(VMGcKind::EqRef)
         );
         Rooted::new(store, gc_ref)
     }
@@ -231,30 +150,6 @@ impl AnyRef {
     #[inline]
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
         self.inner.comes_from_same_store(store)
-    }
-
-    /// Converts this [`AnyRef`] to a raw value suitable to store within a
-    /// [`ValRaw`].
-    ///
-    /// Returns an error if this `anyref` has been unrooted.
-    ///
-    /// # Unsafety
-    ///
-    /// Produces a raw value which is only safe to pass into a store if a GC
-    /// doesn't happen between when the value is produce and when it's passed
-    /// into the store.
-    ///
-    /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn to_raw(&self, mut store: impl AsContextMut) -> Result<u32> {
-        let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
-        self._to_raw(&mut store)
-    }
-
-    pub(crate) unsafe fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
-        let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = gc_ref.as_raw_u32();
-        store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
-        Ok(raw)
     }
 
     /// Get the type of this reference.
@@ -291,10 +186,10 @@ impl AnyRef {
             )));
         }
 
-        unreachable!("no other kinds of `anyref`s")
+        unreachable!("no other kinds of `eqref`s")
     }
 
-    /// Does this `anyref` match the given type?
+    /// Does this `eqref` match the given type?
     ///
     /// That is, is this object's type a subtype of the given type?
     ///
@@ -326,72 +221,7 @@ impl AnyRef {
         }
     }
 
-    /// Is this `anyref` an `eqref`?
-    ///
-    /// # Errors
-    ///
-    /// Return an error if this reference has been unrooted.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this reference is associated with a different store.
-    pub fn is_eqref(&self, store: impl AsContext) -> Result<bool> {
-        self._is_eqref(store.as_context().0)
-    }
-
-    pub(crate) fn _is_eqref(&self, store: &StoreOpaque) -> Result<bool> {
-        assert!(self.comes_from_same_store(store));
-        let gc_ref = self.inner.try_gc_ref(store)?;
-        Ok(gc_ref.is_i31() || store.gc_store()?.kind(gc_ref).matches(VMGcKind::EqRef))
-    }
-
-    /// Downcast this `anyref` to an `eqref`.
-    ///
-    /// If this `anyref` is an `eqref`, then `Some(_)` is returned.
-    ///
-    /// If this `anyref` is not an `eqref`, then `None` is returned.
-    ///
-    /// # Errors
-    ///
-    /// Return an error if this reference has been unrooted.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this reference is associated with a different store.
-    pub fn as_eqref(&self, store: impl AsContext) -> Result<Option<Rooted<EqRef>>> {
-        self._as_eqref(store.as_context().0)
-    }
-
-    pub(crate) fn _as_eqref(&self, store: &StoreOpaque) -> Result<Option<Rooted<EqRef>>> {
-        if self._is_eqref(store)? {
-            Ok(Some(Rooted::from_gc_root_index(self.inner)))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Downcast this `anyref` to an `eqref`, panicking if this `anyref` is not
-    /// an `eqref`.
-    ///
-    /// # Errors
-    ///
-    /// Return an error if this reference has been unrooted.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this reference is associated with a different store, or if
-    /// this `anyref` is not an `eqref`.
-    pub fn unwrap_eqref(&self, store: impl AsContext) -> Result<Rooted<EqRef>> {
-        self._unwrap_eqref(store.as_context().0)
-    }
-
-    pub(crate) fn _unwrap_eqref(&self, store: &StoreOpaque) -> Result<Rooted<EqRef>> {
-        Ok(self
-            ._as_eqref(store)?
-            .expect("AnyRef::unwrap_eqref on non-eqref"))
-    }
-
-    /// Is this `anyref` an `i31`?
+    /// Is this `eqref` an `i31`?
     ///
     /// # Errors
     ///
@@ -410,11 +240,11 @@ impl AnyRef {
         Ok(gc_ref.is_i31())
     }
 
-    /// Downcast this `anyref` to an `i31`.
+    /// Downcast this `eqref` to an `i31`.
     ///
-    /// If this `anyref` is an `i31`, then `Some(_)` is returned.
+    /// If this `eqref` is an `i31`, then `Some(_)` is returned.
     ///
-    /// If this `anyref` is not an `i31`, then `None` is returned.
+    /// If this `eqref` is not an `i31`, then `None` is returned.
     ///
     /// # Errors
     ///
@@ -433,7 +263,7 @@ impl AnyRef {
         Ok(gc_ref.as_i31().map(Into::into))
     }
 
-    /// Downcast this `anyref` to an `i31`, panicking if this `anyref` is not an
+    /// Downcast this `eqref` to an `i31`, panicking if this `eqref` is not an
     /// `i31`.
     ///
     /// # Errors
@@ -443,12 +273,12 @@ impl AnyRef {
     /// # Panics
     ///
     /// Panics if this reference is associated with a different store, or if
-    /// this `anyref` is not an `i31`.
+    /// this `eqref` is not an `i31`.
     pub fn unwrap_i31(&self, store: impl AsContext) -> Result<I31> {
-        Ok(self.as_i31(store)?.expect("AnyRef::unwrap_i31 on non-i31"))
+        Ok(self.as_i31(store)?.expect("EqRef::unwrap_i31 on non-i31"))
     }
 
-    /// Is this `anyref` a `structref`?
+    /// Is this `eqref` a `structref`?
     ///
     /// # Errors
     ///
@@ -466,11 +296,11 @@ impl AnyRef {
         Ok(!gc_ref.is_i31() && store.gc_store()?.kind(gc_ref).matches(VMGcKind::StructRef))
     }
 
-    /// Downcast this `anyref` to a `structref`.
+    /// Downcast this `eqref` to a `structref`.
     ///
-    /// If this `anyref` is a `structref`, then `Some(_)` is returned.
+    /// If this `eqref` is a `structref`, then `Some(_)` is returned.
     ///
-    /// If this `anyref` is not a `structref`, then `None` is returned.
+    /// If this `eqref` is not a `structref`, then `None` is returned.
     ///
     /// # Errors
     ///
@@ -491,7 +321,7 @@ impl AnyRef {
         }
     }
 
-    /// Downcast this `anyref` to a `structref`, panicking if this `anyref` is
+    /// Downcast this `eqref` to a `structref`, panicking if this `eqref` is
     /// not a `structref`.
     ///
     /// # Errors
@@ -501,7 +331,7 @@ impl AnyRef {
     /// # Panics
     ///
     /// Panics if this reference is associated with a different store, or if
-    /// this `anyref` is not a `struct`.
+    /// this `eqref` is not a `struct`.
     pub fn unwrap_struct(&self, store: impl AsContext) -> Result<Rooted<StructRef>> {
         self._unwrap_struct(store.as_context().0)
     }
@@ -509,10 +339,10 @@ impl AnyRef {
     pub(crate) fn _unwrap_struct(&self, store: &StoreOpaque) -> Result<Rooted<StructRef>> {
         Ok(self
             ._as_struct(store)?
-            .expect("AnyRef::unwrap_struct on non-structref"))
+            .expect("EqRef::unwrap_struct on non-structref"))
     }
 
-    /// Is this `anyref` an `arrayref`?
+    /// Is this `eqref` an `arrayref`?
     ///
     /// # Errors
     ///
@@ -530,11 +360,11 @@ impl AnyRef {
         Ok(!gc_ref.is_i31() && store.gc_store()?.kind(gc_ref).matches(VMGcKind::ArrayRef))
     }
 
-    /// Downcast this `anyref` to an `arrayref`.
+    /// Downcast this `eqref` to an `arrayref`.
     ///
-    /// If this `anyref` is an `arrayref`, then `Some(_)` is returned.
+    /// If this `eqref` is an `arrayref`, then `Some(_)` is returned.
     ///
-    /// If this `anyref` is not an `arrayref`, then `None` is returned.
+    /// If this `eqref` is not an `arrayref`, then `None` is returned.
     ///
     /// # Errors
     ///
@@ -555,7 +385,7 @@ impl AnyRef {
         }
     }
 
-    /// Downcast this `anyref` to an `arrayref`, panicking if this `anyref` is
+    /// Downcast this `eqref` to an `arrayref`, panicking if this `eqref` is
     /// not an `arrayref`.
     ///
     /// # Errors
@@ -565,7 +395,7 @@ impl AnyRef {
     /// # Panics
     ///
     /// Panics if this reference is associated with a different store, or if
-    /// this `anyref` is not an `array`.
+    /// this `eqref` is not an `array`.
     pub fn unwrap_array(&self, store: impl AsContext) -> Result<Rooted<ArrayRef>> {
         self._unwrap_array(store.as_context().0)
     }
@@ -573,14 +403,14 @@ impl AnyRef {
     pub(crate) fn _unwrap_array(&self, store: &StoreOpaque) -> Result<Rooted<ArrayRef>> {
         Ok(self
             ._as_array(store)?
-            .expect("AnyRef::unwrap_array on non-arrayref"))
+            .expect("EqRef::unwrap_array on non-arrayref"))
     }
 }
 
-unsafe impl WasmTy for Rooted<AnyRef> {
+unsafe impl WasmTy for Rooted<EqRef> {
     #[inline]
     fn valtype() -> ValType {
-        ValType::Ref(RefType::new(false, HeapType::Any))
+        ValType::Ref(RefType::new(false, HeapType::Eq))
     }
 
     #[inline]
@@ -603,14 +433,14 @@ unsafe impl WasmTy for Rooted<AnyRef> {
     }
 
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        Self::wasm_ty_load(store, ptr.get_anyref(), AnyRef::from_cloned_gc_ref)
+        Self::wasm_ty_load(store, ptr.get_anyref(), EqRef::from_cloned_gc_ref)
     }
 }
 
-unsafe impl WasmTy for Option<Rooted<AnyRef>> {
+unsafe impl WasmTy for Option<Rooted<EqRef>> {
     #[inline]
     fn valtype() -> ValType {
-        ValType::ANYREF
+        ValType::EQREF
     }
 
     #[inline]
@@ -626,7 +456,7 @@ unsafe impl WasmTy for Option<Rooted<AnyRef>> {
         ty: &HeapType,
     ) -> Result<()> {
         match self {
-            Some(a) => a.ensure_matches_ty(store, ty),
+            Some(s) => Rooted::<EqRef>::dynamic_concrete_type_check(s, store, nullable, ty),
             None => {
                 ensure!(
                     nullable,
@@ -643,18 +473,18 @@ unsafe impl WasmTy for Option<Rooted<AnyRef>> {
     }
 
     fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
-        <Rooted<AnyRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
+        <Rooted<EqRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
     }
 
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        <Rooted<AnyRef>>::wasm_ty_option_load(store, ptr.get_anyref(), AnyRef::from_cloned_gc_ref)
+        <Rooted<EqRef>>::wasm_ty_option_load(store, ptr.get_anyref(), EqRef::from_cloned_gc_ref)
     }
 }
 
-unsafe impl WasmTy for ManuallyRooted<AnyRef> {
+unsafe impl WasmTy for ManuallyRooted<EqRef> {
     #[inline]
     fn valtype() -> ValType {
-        ValType::Ref(RefType::new(false, HeapType::Any))
+        ValType::Ref(RefType::new(false, HeapType::Eq))
     }
 
     #[inline]
@@ -666,7 +496,7 @@ unsafe impl WasmTy for ManuallyRooted<AnyRef> {
     fn dynamic_concrete_type_check(
         &self,
         store: &StoreOpaque,
-        _nullable: bool,
+        _: bool,
         ty: &HeapType,
     ) -> Result<()> {
         self.ensure_matches_ty(store, ty)
@@ -677,14 +507,14 @@ unsafe impl WasmTy for ManuallyRooted<AnyRef> {
     }
 
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        Self::wasm_ty_load(store, ptr.get_anyref(), AnyRef::from_cloned_gc_ref)
+        Self::wasm_ty_load(store, ptr.get_anyref(), EqRef::from_cloned_gc_ref)
     }
 }
 
-unsafe impl WasmTy for Option<ManuallyRooted<AnyRef>> {
+unsafe impl WasmTy for Option<ManuallyRooted<EqRef>> {
     #[inline]
     fn valtype() -> ValType {
-        ValType::ANYREF
+        ValType::EQREF
     }
 
     #[inline]
@@ -701,7 +531,7 @@ unsafe impl WasmTy for Option<ManuallyRooted<AnyRef>> {
         ty: &HeapType,
     ) -> Result<()> {
         match self {
-            Some(a) => a.ensure_matches_ty(store, ty),
+            Some(s) => ManuallyRooted::<EqRef>::dynamic_concrete_type_check(s, store, nullable, ty),
             None => {
                 ensure!(
                     nullable,
@@ -718,14 +548,14 @@ unsafe impl WasmTy for Option<ManuallyRooted<AnyRef>> {
     }
 
     fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
-        <ManuallyRooted<AnyRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
+        <ManuallyRooted<EqRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
     }
 
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        <ManuallyRooted<AnyRef>>::wasm_ty_option_load(
+        <ManuallyRooted<EqRef>>::wasm_ty_option_load(
             store,
             ptr.get_anyref(),
-            AnyRef::from_cloned_gc_ref,
+            EqRef::from_cloned_gc_ref,
         )
     }
 }

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -6,8 +6,8 @@ use crate::vm::{VMGcHeader, VMStructRef};
 use crate::{
     prelude::*,
     store::{AutoAssertNoGc, StoreContextMut, StoreOpaque},
-    AsContext, AsContextMut, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType, ManuallyRooted,
-    RefType, Rooted, StructType, Val, ValRaw, ValType, WasmTy,
+    AsContext, AsContextMut, EqRef, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType,
+    ManuallyRooted, RefType, Rooted, StructType, Val, ValRaw, ValType, WasmTy,
 };
 use crate::{AnyRef, FieldType};
 use core::mem::{self, MaybeUninit};
@@ -189,12 +189,24 @@ impl Rooted<StructRef> {
     pub fn to_anyref(self) -> Rooted<AnyRef> {
         self.unchecked_cast()
     }
+
+    /// Upcast this `structref` into an `eqref`.
+    #[inline]
+    pub fn to_eqref(self) -> Rooted<EqRef> {
+        self.unchecked_cast()
+    }
 }
 
 impl ManuallyRooted<StructRef> {
     /// Upcast this `structref` into an `anyref`.
     #[inline]
     pub fn to_anyref(self) -> ManuallyRooted<AnyRef> {
+        self.unchecked_cast()
+    }
+
+    /// Upcast this `structref` into an `eqref`.
+    #[inline]
+    pub fn to_eqref(self) -> ManuallyRooted<EqRef> {
         self.unchecked_cast()
     }
 }

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -139,6 +139,9 @@ impl ValType {
     /// The `anyref` type, aka `(ref null any)`.
     pub const ANYREF: Self = ValType::Ref(RefType::ANYREF);
 
+    /// The `eqref` type, aka `(ref null eq)`.
+    pub const EQREF: Self = ValType::Ref(RefType::EQREF);
+
     /// The `i31ref` type, aka `(ref null i31)`.
     pub const I31REF: Self = ValType::Ref(RefType::I31REF);
 
@@ -415,6 +418,12 @@ impl RefType {
     pub const ANYREF: Self = RefType {
         is_nullable: true,
         heap_type: HeapType::Any,
+    };
+
+    /// The `eqref` type, aka `(ref null eq)`.
+    pub const EQREF: Self = RefType {
+        is_nullable: true,
+        heap_type: HeapType::Eq,
     };
 
     /// The `i31ref` type, aka `(ref null i31)`.

--- a/crates/wasmtime/src/runtime/vm/gc/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/disabled.rs
@@ -29,6 +29,8 @@ unsafe impl GcRuntime for DisabledCollector {
 
 pub enum VMExternRef {}
 
+pub enum VMEqRef {}
+
 pub enum VMStructRef {}
 
 pub enum VMArrayRef {}


### PR DESCRIPTION
This commit introduces the `wasmtime::EqRef` type, which corresponds to Wasm's `(ref eq)` type, and statically represents Wasm references that can be tested for equality. This is primarily for use with `Func::typed`-style APIs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
