### PR TITLE
Remove the `wasmtime::runtime::vm::ModuleInfo[Lookup]` traits

### DIFF
--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -898,10 +898,6 @@ impl Module {
         }
     }
 
-    pub(crate) fn module_info(&self) -> &dyn crate::runtime::vm::ModuleInfo {
-        &*self.inner
-    }
-
     /// Returns the range of bytes in memory where this module's compilation
     /// image resides.
     ///
@@ -1070,6 +1066,31 @@ impl Module {
             .as_ref();
         Ok(images)
     }
+
+    /// Lookup the stack map at a program counter value.
+    pub(crate) fn lookup_stack_map(&self, pc: usize) -> Option<&wasmtime_environ::StackMap> {
+        let text_offset = pc - self.inner.module.text().as_ptr() as usize;
+        let (index, func_offset) = self.inner.module.func_by_text_offset(text_offset)?;
+        let info = self.inner.module.wasm_func_info(index);
+
+        // Do a binary search to find the stack map for the given offset.
+        let index = match info
+            .stack_maps
+            .binary_search_by_key(&func_offset, |i| i.code_offset)
+        {
+            // Found it.
+            Ok(i) => i,
+
+            // No stack map associated with this PC.
+            //
+            // Because we know we are in Wasm code, and we must be at some kind
+            // of call/safepoint, then the Cranelift backend must have avoided
+            // emitting a stack map for this location because no refs were live.
+            Err(_) => return None,
+        };
+
+        Some(&info.stack_maps[index].stack_map)
+    }
 }
 
 /// Describes a function for a given module.
@@ -1106,32 +1127,6 @@ pub struct ModuleExport {
 fn _assert_send_sync() {
     fn _assert<T: Send + Sync>() {}
     _assert::<Module>();
-}
-
-impl crate::runtime::vm::ModuleInfo for ModuleInner {
-    fn lookup_stack_map(&self, pc: usize) -> Option<&wasmtime_environ::StackMap> {
-        let text_offset = pc - self.module.text().as_ptr() as usize;
-        let (index, func_offset) = self.module.func_by_text_offset(text_offset)?;
-        let info = self.module.wasm_func_info(index);
-
-        // Do a binary search to find the stack map for the given offset.
-        let index = match info
-            .stack_maps
-            .binary_search_by_key(&func_offset, |i| i.code_offset)
-        {
-            // Found it.
-            Ok(i) => i,
-
-            // No stack map associated with this PC.
-            //
-            // Because we know we are in Wasm code, and we must be at some kind
-            // of call/safepoint, then the Cranelift backend must have avoided
-            // emitting a stack map for this location because no refs were live.
-            Err(_) => return None,
-        };
-
-        Some(&info.stack_maps[index].stack_map)
-    }
 }
 
 /// Helper method to construct a `ModuleMemoryImages` for an associated

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -65,10 +65,10 @@ impl ModuleRegistry {
         }
     }
 
-    /// Fetches information about a registered module given a program counter value.
-    pub fn lookup_module_info(&self, pc: usize) -> Option<&dyn crate::runtime::vm::ModuleInfo> {
+    /// Fetches a registered module given a program counter value.
+    pub fn lookup_module_by_pc(&self, pc: usize) -> Option<&Module> {
         let (module, _) = self.module_and_offset(pc)?;
-        Some(module.module_info())
+        Some(module)
     }
 
     fn code(&self, pc: usize) -> Option<(&LoadedCode, usize)> {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1704,7 +1704,7 @@ impl StoreOpaque {
 
             let module_info = self
                 .modules()
-                .lookup(pc)
+                .lookup_module_by_pc(pc)
                 .expect("should have module info for Wasm frame");
 
             let stack_map = match module_info.lookup_stack_map(pc) {
@@ -2734,7 +2734,7 @@ impl Drop for StoreOpaque {
 }
 
 impl crate::runtime::vm::ModuleInfoLookup for ModuleRegistry {
-    fn lookup(&self, pc: usize) -> Option<&Module> {
+    fn lookup_module_by_pc(&self, pc: usize) -> Option<&Module> {
         self.lookup_module_by_pc(pc)
     }
 }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1687,8 +1687,7 @@ impl StoreOpaque {
     #[cfg(feature = "gc")]
     fn trace_wasm_stack_roots(&mut self, gc_roots_list: &mut GcRootsList) {
         use core::ptr::NonNull;
-
-        use crate::runtime::vm::{ModuleInfoLookup, SendSyncPtr};
+        use crate::runtime::vm::SendSyncPtr;
 
         log::trace!("Begin trace GC roots :: Wasm stack");
 
@@ -2730,12 +2729,6 @@ impl Drop for StoreOpaque {
             ManuallyDrop::drop(&mut self.store_data);
             ManuallyDrop::drop(&mut self.rooted_host_funcs);
         }
-    }
-}
-
-impl crate::runtime::vm::ModuleInfoLookup for ModuleRegistry {
-    fn lookup_module_by_pc(&self, pc: usize) -> Option<&Module> {
-        self.lookup_module_by_pc(pc)
     }
 }
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1686,8 +1686,8 @@ impl StoreOpaque {
 
     #[cfg(feature = "gc")]
     fn trace_wasm_stack_roots(&mut self, gc_roots_list: &mut GcRootsList) {
-        use core::ptr::NonNull;
         use crate::runtime::vm::SendSyncPtr;
+        use core::ptr::NonNull;
 
         log::trace!("Begin trace GC roots :: Wasm stack");
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2734,8 +2734,8 @@ impl Drop for StoreOpaque {
 }
 
 impl crate::runtime::vm::ModuleInfoLookup for ModuleRegistry {
-    fn lookup(&self, pc: usize) -> Option<&dyn crate::runtime::vm::ModuleInfo> {
-        self.lookup_module_info(pc)
+    fn lookup(&self, pc: usize) -> Option<&Module> {
+        self.lookup_module_by_pc(pc)
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -18,8 +18,8 @@ pub use gc_runtime::*;
 pub use host_data::*;
 pub use i31::*;
 
-use crate::prelude::*;
 use crate::runtime::vm::GcHeapAllocationIndex;
+use crate::{prelude::*, Module};
 use core::alloc::Layout;
 use core::ptr;
 use core::{any::Any, num::NonZeroUsize};
@@ -29,13 +29,7 @@ use wasmtime_environ::{GcArrayLayout, GcStructLayout, StackMap, VMGcKind, VMShar
 /// program counter value.
 pub trait ModuleInfoLookup {
     /// Lookup the module information from a program counter value.
-    fn lookup(&self, pc: usize) -> Option<&dyn ModuleInfo>;
-}
-
-/// Used by the runtime to query module information.
-pub trait ModuleInfo {
-    /// Lookup the stack map at a program counter value.
-    fn lookup_stack_map(&self, pc: usize) -> Option<&StackMap>;
+    fn lookup(&self, pc: usize) -> Option<&Module>;
 }
 
 /// GC-related data that is one-to-one with a `wasmtime::Store`.

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -29,7 +29,7 @@ use wasmtime_environ::{GcArrayLayout, GcStructLayout, StackMap, VMGcKind, VMShar
 /// program counter value.
 pub trait ModuleInfoLookup {
     /// Lookup the module information from a program counter value.
-    fn lookup(&self, pc: usize) -> Option<&Module>;
+    fn lookup_module_by_pc(&self, pc: usize) -> Option<&Module>;
 }
 
 /// GC-related data that is one-to-one with a `wasmtime::Store`.

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -18,19 +18,12 @@ pub use gc_runtime::*;
 pub use host_data::*;
 pub use i31::*;
 
+use crate::prelude::*;
 use crate::runtime::vm::GcHeapAllocationIndex;
-use crate::{prelude::*, Module};
 use core::alloc::Layout;
 use core::ptr;
 use core::{any::Any, num::NonZeroUsize};
-use wasmtime_environ::{GcArrayLayout, GcStructLayout, StackMap, VMGcKind, VMSharedTypeIndex};
-
-/// Used by the runtime to lookup information about a module given a
-/// program counter value.
-pub trait ModuleInfoLookup {
-    /// Lookup the module information from a program counter value.
-    fn lookup_module_by_pc(&self, pc: usize) -> Option<&Module>;
-}
+use wasmtime_environ::{GcArrayLayout, GcStructLayout, VMGcKind, VMSharedTypeIndex};
 
 /// GC-related data that is one-to-one with a `wasmtime::Store`.
 ///


### PR DESCRIPTION
Vestigial abstractions from when `wasmtime` and `wasmtime-runtime` were two different crates. Now unnecessary.