### PR TITLE
feat: component bindgen: add support for multiple wit paths

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -171,8 +171,7 @@ impl Parse for Config {
         let (resolve, pkgs, files) = parse_source(&paths, &inline, &features)
             .map_err(|err| Error::new(call_site, format!("{err:?}")))?;
 
-        let world = 
-            select_world(&resolve, &pkgs, world.as_deref())
+        let world = select_world(&resolve, &pkgs, world.as_deref())
             .map_err(|e| Error::new(call_site, format!("{e:?}")))?;
         Ok(Config {
             opts,
@@ -195,7 +194,11 @@ fn parse_source(
     let mut pkgs = Vec::new();
     let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
-    let parse = |resolve: &mut Resolve, files: &mut Vec<PathBuf>, pkgs: &mut Vec<PackageId>, paths: &[String]| -> anyhow::Result<_> {
+    let parse = |resolve: &mut Resolve,
+                 files: &mut Vec<PathBuf>,
+                 pkgs: &mut Vec<PackageId>,
+                 paths: &[String]|
+     -> anyhow::Result<_> {
         for path in paths {
             let p = root.join(path);
             // Try to normalize the path to make the error message more understandable when
@@ -315,7 +318,7 @@ impl Parse for Opt {
             input.parse::<Token![:]>()?;
 
             let mut paths: Vec<syn::LitStr> = vec![];
-            
+
             let l = input.lookahead1();
             if l.peek(syn::LitStr) {
                 paths.push(input.parse()?);

--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -80,7 +80,7 @@ impl Parse for Config {
         let mut opts = Opts::default();
         let mut world = None;
         let mut inline = None;
-        let mut path = None;
+        let mut paths = Vec::new();
         let mut async_configured = false;
         let mut features = Vec::new();
         let mut include_generated_code_from_file = false;
@@ -91,11 +91,8 @@ impl Parse for Config {
             let fields = Punctuated::<Opt, Token![,]>::parse_terminated(&content)?;
             for field in fields.into_pairs() {
                 match field.into_value() {
-                    Opt::Path(s) => {
-                        if path.is_some() {
-                            return Err(Error::new(s.span(), "cannot specify second path"));
-                        }
-                        path = Some(s.value());
+                    Opt::Path(p) => {
+                        paths.extend(p.into_iter().map(|p| p.value()));
                     }
                     Opt::World(s) => {
                         if world.is_some() {
@@ -168,14 +165,14 @@ impl Parse for Config {
         } else {
             world = input.parse::<Option<syn::LitStr>>()?.map(|s| s.value());
             if input.parse::<Option<syn::token::In>>()?.is_some() {
-                path = Some(input.parse::<syn::LitStr>()?.value());
+                paths.push(input.parse::<syn::LitStr>()?.value());
             }
         }
-        let (resolve, pkg, files) = parse_source(&path, &inline, &features)
+        let (resolve, pkgs, files) = parse_source(&paths, &inline, &features)
             .map_err(|err| Error::new(call_site, format!("{err:?}")))?;
 
-        let world = resolve
-            .select_world(pkg, world.as_deref())
+        let world = 
+            select_world(&resolve, &pkgs, world.as_deref())
             .map_err(|e| Error::new(call_site, format!("{e:?}")))?;
         Ok(Config {
             opts,
@@ -188,45 +185,83 @@ impl Parse for Config {
 }
 
 fn parse_source(
-    path: &Option<String>,
+    paths: &Vec<String>,
     inline: &Option<String>,
     features: &[String],
-) -> anyhow::Result<(Resolve, PackageId, Vec<PathBuf>)> {
+) -> anyhow::Result<(Resolve, Vec<PackageId>, Vec<PathBuf>)> {
     let mut resolve = Resolve::default();
     resolve.features.extend(features.iter().cloned());
     let mut files = Vec::new();
+    let mut pkgs = Vec::new();
     let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
-    let mut parse = |resolve: &mut Resolve, path: &Path| -> anyhow::Result<_> {
-        // Try to normalize the path to make the error message more understandable when
-        // the path is not correct. Fallback to the original path if normalization fails
-        // (probably return an error somewhere else).
-        let normalized_path = match std::fs::canonicalize(path) {
-            Ok(p) => p,
-            Err(_) => path.to_path_buf(),
-        };
-        let (pkg, sources) = resolve.push_path(normalized_path)?;
-        files.extend(sources);
-        Ok(pkg)
+    let parse = |resolve: &mut Resolve, files: &mut Vec<PathBuf>, pkgs: &mut Vec<PackageId>, paths: &[String]| -> anyhow::Result<_> {
+        for path in paths {
+            let p = root.join(path);
+            // Try to normalize the path to make the error message more understandable when
+            // the path is not correct. Fallback to the original path if normalization fails
+            // (probably return an error somewhere else).
+            let normalized_path = match std::fs::canonicalize(&p) {
+                Ok(p) => p,
+                Err(_) => p.to_path_buf(),
+            };
+            let (pkg, sources) = resolve.push_path(normalized_path)?;
+            pkgs.push(pkg);
+            files.extend(sources);
+        }
+        Ok(())
     };
 
-    let path_pkg = if let Some(path) = path {
-        Some(parse(&mut resolve, &root.join(path))?)
-    } else {
-        None
-    };
+    if !paths.is_empty() {
+        parse(&mut resolve, &mut files, &mut pkgs, &paths)?;
+    }
 
-    let inline_pkgs = if let Some(inline) = inline {
-        Some(resolve.push_group(UnresolvedPackageGroup::parse("macro-input", inline)?)?)
-    } else {
-        None
-    };
+    if let Some(inline) = inline {
+        pkgs.push(resolve.push_group(UnresolvedPackageGroup::parse("macro-input", inline)?)?);
+    }
 
-    let pkgs = inline_pkgs
-        .or(path_pkg)
-        .map_or_else(|| parse(&mut resolve, &root.join("wit")), Ok)?;
+    if pkgs.is_empty() {
+        parse(&mut resolve, &mut files, &mut pkgs, &["wit".into()])?;
+    }
 
     Ok((resolve, pkgs, files))
+}
+
+fn select_world(
+    resolve: &Resolve,
+    pkgs: &[PackageId],
+    world: Option<&str>,
+) -> anyhow::Result<WorldId> {
+    if pkgs.len() == 1 {
+        resolve.select_world(pkgs[0], world)
+    } else {
+        assert!(!pkgs.is_empty());
+        match world {
+            Some(name) => {
+                if !name.contains(":") {
+                    anyhow::bail!(
+                        "with multiple packages a fully qualified \
+                         world name must be specified"
+                    )
+                }
+
+                // This will ignore the package argument due to the fully
+                // qualified name being used.
+                resolve.select_world(pkgs[0], world)
+            }
+            None => {
+                let worlds = pkgs
+                    .iter()
+                    .filter_map(|p| resolve.select_world(*p, None).ok())
+                    .collect::<Vec<_>>();
+                match &worlds[..] {
+                    [] => anyhow::bail!("no packages have a world"),
+                    [world] => Ok(*world),
+                    _ => anyhow::bail!("multiple packages have a world, must specify which to use"),
+                }
+            }
+        }
+    }
 }
 
 mod kw {
@@ -253,7 +288,7 @@ mod kw {
 
 enum Opt {
     World(syn::LitStr),
-    Path(syn::LitStr),
+    Path(Vec<syn::LitStr>),
     Inline(syn::LitStr),
     Tracing(bool),
     VerboseTracing(bool),
@@ -278,7 +313,27 @@ impl Parse for Opt {
         if l.peek(kw::path) {
             input.parse::<kw::path>()?;
             input.parse::<Token![:]>()?;
-            Ok(Opt::Path(input.parse()?))
+
+            let mut paths: Vec<syn::LitStr> = vec![];
+            
+            let l = input.lookahead1();
+            if l.peek(syn::LitStr) {
+                paths.push(input.parse()?);
+            } else if l.peek(syn::token::Bracket) {
+                let contents;
+                syn::bracketed!(contents in input);
+                let list = Punctuated::<_, Token![,]>::parse_terminated(&contents)?;
+
+                paths.extend(list.into_iter());
+
+                if input.peek(Token![,]) {
+                    input.parse::<Token![,]>()?;
+                }
+            } else {
+                return Err(l.error());
+            };
+
+            Ok(Opt::Path(paths))
         } else if l.peek(kw::inline) {
             input.parse::<kw::inline>()?;
             input.parse::<Token![:]>()?;

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -112,6 +112,7 @@ mod with_key_and_resources {
 
 mod trappable_errors_with_versioned_and_unversioned_packages {
     wasmtime::component::bindgen!({
+        world: "foo:foo/nope",
         inline: "
             package foo:foo@0.1.0;
 
@@ -694,6 +695,22 @@ mod trappable_error_type_and_versions {
             trappable_error_type: {
                 "my:inline/i@1.0.0/e" => super::MyError,
             },
+        });
+    }
+}
+
+mod paths {
+    mod multiple_paths {
+        wasmtime::component::bindgen!({
+            world: "test:paths/test",
+            inline: r#"
+            package test:paths;
+            world test {
+                import paths:path1/test;
+                export paths:path2/test;
+            }
+            "#,
+            path: ["tests/codegen/path1", "tests/codegen/path2"],
         });
     }
 }

--- a/crates/component-macro/tests/codegen/path1/world.wit
+++ b/crates/component-macro/tests/codegen/path1/world.wit
@@ -1,0 +1,7 @@
+package paths:path1;
+
+interface test {}
+
+world path1 {
+    import test;
+}

--- a/crates/component-macro/tests/codegen/path2/world.wit
+++ b/crates/component-macro/tests/codegen/path2/world.wit
@@ -1,0 +1,7 @@
+package paths:path2;
+
+interface test {}
+
+world path2 {
+    import test;
+}

--- a/crates/component-macro/tests/expanded/path1.rs
+++ b/crates/component-macro/tests/expanded/path1.rs
@@ -1,0 +1,208 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path1`.
+///
+/// This structure is created through [`Path1Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path1`] as well.
+pub struct Path1Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path1Indices,
+}
+impl<T> Clone for Path1Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path1Pre<_T> {
+    /// Creates a new copy of `Path1Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path1Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path1`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path1> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path1`.
+///
+/// This is an implementation detail of [`Path1Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path1`] as well.
+#[derive(Clone)]
+pub struct Path1Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path1`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path1::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path1Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path1Pre::instantiate`] to
+///   create a [`Path1`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path1::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path1Indices::new_instance`] followed
+///   by [`Path1Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path1 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path1Indices {
+        /// Creates a new copy of `Path1Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path1Indices {})
+        }
+        /// Creates a new instance of [`Path1Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path1`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path1`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path1Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path1`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let _instance = instance;
+            Ok(Path1 {})
+        }
+    }
+    impl Path1 {
+        /// Convenience wrapper around [`Path1Pre::new`] and
+        /// [`Path1Pre::instantiate`].
+        pub fn instantiate<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path1> {
+            let pre = linker.instantiate_pre(component)?;
+            Path1Pre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`Path1Indices::new_instance`] and
+        /// [`Path1Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let indices = Path1Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: paths::path1::test::Host,
+        {
+            paths::path1::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path1 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host;
+            }
+            impl<F, T, O> GetHost<T> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<T>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: impl for<'a> GetHost<&'a mut T>,
+            ) -> wasmtime::Result<()> {
+                let mut inst = linker.instance("paths:path1/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/path1_async.rs
+++ b/crates/component-macro/tests/expanded/path1_async.rs
@@ -1,0 +1,221 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path1`.
+///
+/// This structure is created through [`Path1Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path1`] as well.
+pub struct Path1Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path1Indices,
+}
+impl<T> Clone for Path1Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path1Pre<_T> {
+    /// Creates a new copy of `Path1Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path1Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path1`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path1>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path1`.
+///
+/// This is an implementation detail of [`Path1Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path1`] as well.
+#[derive(Clone)]
+pub struct Path1Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path1`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path1::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path1Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path1Pre::instantiate_async`] to
+///   create a [`Path1`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path1::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path1Indices::new_instance`] followed
+///   by [`Path1Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path1 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path1Indices {
+        /// Creates a new copy of `Path1Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path1Indices {})
+        }
+        /// Creates a new instance of [`Path1Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path1`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path1`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path1Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path1`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let _instance = instance;
+            Ok(Path1 {})
+        }
+    }
+    impl Path1 {
+        /// Convenience wrapper around [`Path1Pre::new`] and
+        /// [`Path1Pre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path1>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            Path1Pre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`Path1Indices::new_instance`] and
+        /// [`Path1Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let indices = Path1Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send,
+            U: paths::path1::test::Host + Send,
+        {
+            paths::path1::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path1 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: Send {}
+            pub trait GetHost<
+                T,
+            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, O> GetHost<T> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<T>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: impl for<'a> GetHost<&'a mut T>,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+            {
+                let mut inst = linker.instance("paths:path1/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            #[wasmtime::component::__internal::async_trait]
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/path1_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path1_tracing_async.rs
@@ -1,0 +1,221 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path1`.
+///
+/// This structure is created through [`Path1Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path1`] as well.
+pub struct Path1Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path1Indices,
+}
+impl<T> Clone for Path1Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path1Pre<_T> {
+    /// Creates a new copy of `Path1Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path1Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path1`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path1>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path1`.
+///
+/// This is an implementation detail of [`Path1Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path1`] as well.
+#[derive(Clone)]
+pub struct Path1Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path1`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path1::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path1Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path1Pre::instantiate_async`] to
+///   create a [`Path1`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path1::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path1Indices::new_instance`] followed
+///   by [`Path1Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path1 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path1Indices {
+        /// Creates a new copy of `Path1Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path1Indices {})
+        }
+        /// Creates a new instance of [`Path1Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path1`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path1`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path1Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path1`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let _instance = instance;
+            Ok(Path1 {})
+        }
+    }
+    impl Path1 {
+        /// Convenience wrapper around [`Path1Pre::new`] and
+        /// [`Path1Pre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path1>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            Path1Pre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`Path1Indices::new_instance`] and
+        /// [`Path1Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let indices = Path1Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send,
+            U: paths::path1::test::Host + Send,
+        {
+            paths::path1::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path1 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: Send {}
+            pub trait GetHost<
+                T,
+            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, O> GetHost<T> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<T>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: impl for<'a> GetHost<&'a mut T>,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+            {
+                let mut inst = linker.instance("paths:path1/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            #[wasmtime::component::__internal::async_trait]
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/path2.rs
+++ b/crates/component-macro/tests/expanded/path2.rs
@@ -1,0 +1,208 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path2`.
+///
+/// This structure is created through [`Path2Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path2`] as well.
+pub struct Path2Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path2Indices,
+}
+impl<T> Clone for Path2Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path2Pre<_T> {
+    /// Creates a new copy of `Path2Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path2Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path2`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub fn instantiate(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path2> {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate(&mut store)?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path2`.
+///
+/// This is an implementation detail of [`Path2Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path2`] as well.
+#[derive(Clone)]
+pub struct Path2Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path2`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path2::instantiate`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path2Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path2Pre::instantiate`] to
+///   create a [`Path2`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path2::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path2Indices::new_instance`] followed
+///   by [`Path2Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path2 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path2Indices {
+        /// Creates a new copy of `Path2Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path2Indices {})
+        }
+        /// Creates a new instance of [`Path2Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path2`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path2`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path2Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path2`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let _instance = instance;
+            Ok(Path2 {})
+        }
+    }
+    impl Path2 {
+        /// Convenience wrapper around [`Path2Pre::new`] and
+        /// [`Path2Pre::instantiate`].
+        pub fn instantiate<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path2> {
+            let pre = linker.instantiate_pre(component)?;
+            Path2Pre::new(pre)?.instantiate(store)
+        }
+        /// Convenience wrapper around [`Path2Indices::new_instance`] and
+        /// [`Path2Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let indices = Path2Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            U: paths::path2::test::Host,
+        {
+            paths::path2::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path2 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host;
+            }
+            impl<F, T, O> GetHost<T> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<T>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: impl for<'a> GetHost<&'a mut T>,
+            ) -> wasmtime::Result<()> {
+                let mut inst = linker.instance("paths:path2/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/path2_async.rs
+++ b/crates/component-macro/tests/expanded/path2_async.rs
@@ -1,0 +1,221 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path2`.
+///
+/// This structure is created through [`Path2Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path2`] as well.
+pub struct Path2Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path2Indices,
+}
+impl<T> Clone for Path2Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path2Pre<_T> {
+    /// Creates a new copy of `Path2Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path2Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path2`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path2>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path2`.
+///
+/// This is an implementation detail of [`Path2Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path2`] as well.
+#[derive(Clone)]
+pub struct Path2Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path2`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path2::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path2Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path2Pre::instantiate_async`] to
+///   create a [`Path2`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path2::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path2Indices::new_instance`] followed
+///   by [`Path2Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path2 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path2Indices {
+        /// Creates a new copy of `Path2Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path2Indices {})
+        }
+        /// Creates a new instance of [`Path2Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path2`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path2`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path2Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path2`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let _instance = instance;
+            Ok(Path2 {})
+        }
+    }
+    impl Path2 {
+        /// Convenience wrapper around [`Path2Pre::new`] and
+        /// [`Path2Pre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path2>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            Path2Pre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`Path2Indices::new_instance`] and
+        /// [`Path2Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let indices = Path2Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send,
+            U: paths::path2::test::Host + Send,
+        {
+            paths::path2::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path2 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: Send {}
+            pub trait GetHost<
+                T,
+            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, O> GetHost<T> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<T>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: impl for<'a> GetHost<&'a mut T>,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+            {
+                let mut inst = linker.instance("paths:path2/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            #[wasmtime::component::__internal::async_trait]
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/path2_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path2_tracing_async.rs
@@ -1,0 +1,221 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path2`.
+///
+/// This structure is created through [`Path2Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path2`] as well.
+pub struct Path2Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path2Indices,
+}
+impl<T> Clone for Path2Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path2Pre<_T> {
+    /// Creates a new copy of `Path2Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path2Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path2`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path2>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path2`.
+///
+/// This is an implementation detail of [`Path2Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path2`] as well.
+#[derive(Clone)]
+pub struct Path2Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path2`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path2::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path2Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path2Pre::instantiate_async`] to
+///   create a [`Path2`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path2::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path2Indices::new_instance`] followed
+///   by [`Path2Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path2 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path2Indices {
+        /// Creates a new copy of `Path2Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path2Indices {})
+        }
+        /// Creates a new instance of [`Path2Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path2`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path2`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path2Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path2`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let _instance = instance;
+            Ok(Path2 {})
+        }
+    }
+    impl Path2 {
+        /// Convenience wrapper around [`Path2Pre::new`] and
+        /// [`Path2Pre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path2>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            Path2Pre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`Path2Indices::new_instance`] and
+        /// [`Path2Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let indices = Path2Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send,
+            U: paths::path2::test::Host + Send,
+        {
+            paths::path2::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path2 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            #[wasmtime::component::__internal::async_trait]
+            pub trait Host: Send {}
+            pub trait GetHost<
+                T,
+            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, O> GetHost<T> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<T>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: impl for<'a> GetHost<&'a mut T>,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send,
+            {
+                let mut inst = linker.instance("paths:path2/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            #[wasmtime::component::__internal::async_trait]
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+        }
+    }
+}


### PR DESCRIPTION
This change makes it possible to compile bindings from multiple wit source paths. It resolves https://github.com/bytecodealliance/wasmtime/issues/9249 and is heavily informed by the work done for wit-bindgen in https://github.com/bytecodealliance/wit-bindgen/pull/1003

I had to modify one existing test (`trappable_errors_with_versioned_and_unversioned_packages`) to support this behaviour as the existing test was created without the expectation that the world in `tests/codegen/unversioned-foo.wit` would be considered a candidate world for selection.