### PR TITLE
ci: use node20 for github release action

### DIFF
--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: ''
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'


### PR DESCRIPTION
Blog post: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
