### PR TITLE
Add the `ArrayOutOfBounds` trap code

### DIFF
--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -361,7 +361,7 @@ impl MemFlags {
             0b1001 => Some(TrapCode::UnreachableCodeReached),
             0b1010 => Some(TrapCode::Interrupt),
             0b1011 => Some(TrapCode::NullReference),
-            // 0b1100 => {} not allocated
+            0b1100 => Some(TrapCode::ArrayOutOfBounds),
             // 0b1101 => {} not allocated
             // 0b1110 => {} not allocated
             0b1111 => None,
@@ -390,6 +390,7 @@ impl MemFlags {
             Some(TrapCode::UnreachableCodeReached) => 0b1001,
             Some(TrapCode::Interrupt) => 0b1010,
             Some(TrapCode::NullReference) => 0b1011,
+            Some(TrapCode::ArrayOutOfBounds) => 0b1100,
             None => 0b1111,
 
             Some(TrapCode::User(_)) => panic!("cannot set user trap code in mem flags"),

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -27,6 +27,9 @@ pub enum TrapCode {
     /// A `table_addr` instruction detected an out-of-bounds error.
     TableOutOfBounds,
 
+    /// An array access attempted to index beyond its array's bounds.
+    ArrayOutOfBounds,
+
     /// Indirect call to a null table entry.
     IndirectCallToNull,
 
@@ -92,6 +95,7 @@ impl Display for TrapCode {
             Interrupt => "interrupt",
             User(x) => return write!(f, "user{x}"),
             NullReference => "null_reference",
+            ArrayOutOfBounds => "array_oob",
         };
         f.write_str(identifier)
     }
@@ -115,6 +119,7 @@ impl FromStr for TrapCode {
             "unreachable" => Ok(UnreachableCodeReached),
             "interrupt" => Ok(Interrupt),
             "null_reference" => Ok(NullReference),
+            "array_oob" => Ok(ArrayOutOfBounds),
             _ if s.starts_with("user") => s[4..].parse().map(User).map_err(|_| ()),
             _ => Err(()),
         }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -248,6 +248,7 @@ fn clif_trap_to_env_trap(trap: ir::TrapCode) -> Option<Trap> {
         ir::TrapCode::User(ALWAYS_TRAP_CODE) => Trap::AlwaysTrapAdapter,
         ir::TrapCode::User(CANNOT_ENTER_CODE) => Trap::CannotEnterComponent,
         ir::TrapCode::NullReference => Trap::NullReference,
+        ir::TrapCode::ArrayOutOfBounds => Trap::ArrayOutOfBounds,
 
         // These do not get converted to wasmtime traps, since they
         // shouldn't ever be hit in theory. Instead of catching and handling

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -74,6 +74,9 @@ pub enum Trap {
     /// Call to a null reference.
     NullReference,
 
+    /// Attempt to access beyond the bounds of an array.
+    ArrayOutOfBounds,
+
     /// When the `component-model` feature is enabled this trap represents a
     /// scenario where one component tried to call another component but it
     /// would have violated the reentrance rules of the component model,
@@ -111,6 +114,7 @@ impl Trap {
             OutOfFuel
             AtomicWaitNonSharedMemory
             NullReference
+            ArrayOutOfBounds
             CannotEnterComponent
         }
 
@@ -138,6 +142,7 @@ impl fmt::Display for Trap {
             OutOfFuel => "all fuel consumed by WebAssembly",
             AtomicWaitNonSharedMemory => "atomic wait on non-shared memory",
             NullReference => "null reference",
+            ArrayOutOfBounds => "out of bounds array access",
             CannotEnterComponent => "cannot enter component instance",
         };
         write!(f, "wasm trap: {desc}")


### PR DESCRIPTION
This is needed in the implementation of Wasm GC's array instructions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
