### PR TITLE
Print an error on async stack overflow

### DIFF
--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -389,6 +389,9 @@ unsafe impl StackMemory for CHostStackMemory {
         let base = unsafe { top.sub(len) as usize };
         base..base + len
     }
+    fn guard_range(&self) -> Range<*mut u8> {
+        std::ptr::null_mut()..std::ptr::null_mut()
+    }
 }
 
 pub type wasmtime_new_stack_memory_callback_t = extern "C" fn(

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -15,7 +15,11 @@ impl FiberStack {
         Ok(Self(size))
     }
 
-    pub unsafe fn from_raw_parts(_base: *mut u8, _len: usize) -> io::Result<Self> {
+    pub unsafe fn from_raw_parts(
+        _base: *mut u8,
+        _guard_size: usize,
+        _len: usize,
+    ) -> io::Result<Self> {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }
 
@@ -32,6 +36,10 @@ impl FiberStack {
     }
 
     pub fn range(&self) -> Option<Range<usize>> {
+        None
+    }
+
+    pub fn guard_range(&self) -> Option<Range<*mut u8>> {
         None
     }
 }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1610,6 +1610,7 @@ pub(crate) fn invoke_wasm_and_catch_traps<T>(
             store.0.signal_handler(),
             store.0.engine().config().wasm_backtrace,
             store.0.engine().config().coredump_on_trap,
+            store.0.async_guard_range(),
             store.0.default_caller(),
             closure,
         );

--- a/crates/wasmtime/src/runtime/stack.rs
+++ b/crates/wasmtime/src/runtime/stack.rs
@@ -57,6 +57,8 @@ pub unsafe trait StackMemory: Send + Sync {
     fn top(&self) -> *mut u8;
     /// The range of where this stack resides in memory, excluding guard pages.
     fn range(&self) -> Range<usize>;
+    /// The range of memory where the guard region of this stack resides.
+    fn guard_range(&self) -> Range<*mut u8>;
 }
 
 pub(crate) struct FiberStackProxy(pub Box<dyn StackMemory>);
@@ -68,5 +70,9 @@ unsafe impl RuntimeFiberStack for FiberStackProxy {
 
     fn range(&self) -> Range<usize> {
         self.0.range()
+    }
+
+    fn guard_range(&self) -> Range<*mut u8> {
+        self.0.guard_range()
     }
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -105,13 +105,16 @@ impl StackPool {
             let bottom_of_stack = self
                 .mapping
                 .as_ptr()
-                .add((index * self.stack_size) + self.page_size)
+                .add(index * self.stack_size)
                 .cast_mut();
 
             commit_pages(bottom_of_stack, size_without_guard)?;
 
-            let stack =
-                wasmtime_fiber::FiberStack::from_raw_parts(bottom_of_stack, size_without_guard)?;
+            let stack = wasmtime_fiber::FiberStack::from_raw_parts(
+                bottom_of_stack,
+                self.page_size,
+                size_without_guard,
+            )?;
             Ok(stack)
         }
     }

--- a/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
@@ -96,6 +96,10 @@ unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINT
             Some(info) => info,
             None => return ExceptionContinueSearch,
         };
+        // Suppress a warning about this field otherwise being unused on
+        // Windows. Right now it's mainly used on Unix.
+        let _ = info.async_guard_range;
+
         let context = &*(*exception_info).ContextRecord;
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "x86_64")] {

--- a/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
@@ -96,10 +96,6 @@ unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINT
             Some(info) => info,
             None => return ExceptionContinueSearch,
         };
-        // Suppress a warning about this field otherwise being unused on
-        // Windows. Right now it's mainly used on Unix.
-        let _ = info.async_guard_range;
-
         let context = &*(*exception_info).ContextRecord;
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "x86_64")] {

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -310,6 +310,7 @@ mod call_thread_state {
         pub(crate) limits: *const VMRuntimeLimits,
 
         pub(super) prev: Cell<tls::Ptr>,
+        #[cfg_attr(any(windows, miri), allow(dead_code))]
         pub(crate) async_guard_range: Range<*mut u8>,
 
         // The values of `VMRuntimeLimits::last_wasm_{exit_{pc,fp},entry_sp}`

--- a/tests/all/stack_creator.rs
+++ b/tests/all/stack_creator.rs
@@ -31,6 +31,9 @@ unsafe impl StackMemory for CustomStack {
         let base = self.base.as_ptr() as usize;
         base..base + self.len
     }
+    fn guard_range(&self) -> Range<*mut u8> {
+        std::ptr::null_mut()..std::ptr::null_mut()
+    }
 }
 
 // A creator that allocates stacks on the heap instead of mmap'ing.


### PR DESCRIPTION
This commit updates Wasmtime's handling of traps on Unix platforms to print an error message on stack overflow when the guard page is hit. This is distinct from stack overflow in WebAssembly which raises a normal trap and can be caught. This is instead to be used on misconfigured hosts where the async stack is too small or wasm was allowed to take up too much of the async stack. Currently no error message is printed and the program simply aborts with a core dump which can be difficult to debug.

This instead registers the range of the async guard page with the trap handling infrastructure to test the faulting address and if it lies within this range. If so then a small message is printed and then the program is aborted with `libc::abort()`.

This does not impact the safety of any prior embedding or fix any issues. It's instead intended purely as a diagnostic tool to help users more quickly understand that stack size configuration settings are the likely culprit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
