### PR TITLE
Add a `wasmtime completion` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b378c786d3bde9442d2c6dd7e6080b2a818db2b96e30d6e7f1b6d224eb617d3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,6 +3556,7 @@ dependencies = [
  "capstone",
  "cfg-if",
  "clap",
+ "clap_complete",
  "component-macro-test",
  "component-test-util",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ wasmtime-wasi-keyvalue = { workspace = true, optional = true }
 wasmtime-wasi-threads = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
 clap = { workspace = true }
+clap_complete = { workspace = true, optional = true }
 anyhow = { workspace = true, features = ['std'] }
 target-lexicon = { workspace = true }
 once_cell = { workspace = true }
@@ -288,6 +289,7 @@ windows-sys = "0.59.0"
 env_logger = "0.11.5"
 log = { version = "0.4.8", default-features = false }
 clap = { version = "4.5.17", default-features = false, features = ["std", "derive"] }
+clap_complete = "4.4.7"
 hashbrown = { version = "0.14", default-features = false }
 capstone = "0.12.0"
 once_cell = { version = "1.12.0", default-features = false }
@@ -360,6 +362,7 @@ default = [
   "serve",
   "wast",
   "config",
+  "completion",
 
   # On-by-default WASI features
   "wasi-nn",
@@ -456,6 +459,7 @@ run = [
   "dep:tokio",
   "wasmtime-cli-flags/async",
 ]
+completion = ["dep:clap_complete"]
 
 [[test]]
 name = "host_segfault"

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -4,7 +4,7 @@
 //! See `wasmtime --help` for usage.
 
 use anyhow::Result;
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 
 /// Wasmtime WebAssembly Runtime
 #[derive(Parser)]
@@ -144,6 +144,8 @@ pub struct CompletionCommand {
 #[cfg(feature = "completion")]
 impl CompletionCommand {
     pub fn execute(&self) -> Result<()> {
+        use clap::CommandFactory;
+
         let mut cmd = Wasmtime::command();
         let cli_name = cmd.get_name().to_owned();
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3814,6 +3814,12 @@ user-id = 6743 # Ed Page (epage)
 start = "2023-03-28"
 end = "2025-09-20"
 
+[[trusted.clap_complete]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-12-31"
+end = "2025-09-25"
+
 [[trusted.clap_derive]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -815,6 +815,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.clap_complete]]
+version = "4.5.28"
+when = "2024-09-17"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.clap_derive]]
 version = "4.3.12"
 when = "2023-07-14"


### PR DESCRIPTION
This commit adds a new subcommand to the `wasmtime` CLI which can be used to generate shell completions for the `wasmtime` version that is installed. This is relatively easy to do with the `clap_complete` crate which is also used with various other clap-based CLIs in Rust to generate completions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
