### PR TITLE
Remove module field from wasmtime::runtime::vm::const_expr::ConstEval…

### DIFF
--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -20,7 +20,7 @@ pub struct ConstExprEvaluator {
 
 /// The context within which a particular const expression is evaluated.
 pub struct ConstEvalContext<'a> {
-    instance: &'a mut Instance
+    instance: &'a mut Instance,
 }
 
 impl<'a> ConstEvalContext<'a> {
@@ -37,7 +37,10 @@ impl<'a> ConstEvalContext<'a> {
                 .as_ref()
                 .unwrap();
             let mut gc_store = store.unwrap_gc_store_mut();
-            Ok(global.to_val_raw(&mut gc_store, self.instance.env_module().globals[index].wasm_ty))
+            Ok(global.to_val_raw(
+                &mut gc_store,
+                self.instance.env_module().globals[index].wasm_ty,
+            ))
         }
     }
 
@@ -239,7 +242,8 @@ impl ConstExprEvaluator {
 
                 #[cfg(feature = "gc")]
                 ConstOp::StructNew { struct_type_index } => {
-                    let interned_type_index = context.instance.env_module().types[*struct_type_index];
+                    let interned_type_index =
+                        context.instance.env_module().types[*struct_type_index];
                     let len = context.struct_fields_len(interned_type_index);
 
                     if self.stack.len() < len {
@@ -261,7 +265,8 @@ impl ConstExprEvaluator {
 
                 #[cfg(feature = "gc")]
                 ConstOp::StructNewDefault { struct_type_index } => {
-                    let interned_type_index = context.instance.env_module().types[*struct_type_index];
+                    let interned_type_index =
+                        context.instance.env_module().types[*struct_type_index];
                     self.stack
                         .push(context.struct_new_default(&mut store, interned_type_index)?);
                 }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -874,7 +874,7 @@ impl Instance {
                     .get(src..)
                     .and_then(|s| s.get(..len))
                     .ok_or(Trap::TableOutOfBounds)?;
-                let mut context = ConstEvalContext::new(self, &module);
+                let mut context = ConstEvalContext::new(self);
                 match module.table_plans[table_index]
                     .table
                     .ref_type
@@ -1277,7 +1277,7 @@ impl Instance {
         module: &Module,
     ) {
         for (index, init) in module.global_initializers.iter() {
-            let mut context = ConstEvalContext::new(self, module);
+            let mut context = ConstEvalContext::new(self);
             let raw = const_evaluator
                 .eval(&mut context, init)
                 .expect("should be a valid const expr");

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -628,10 +628,7 @@ fn initialize_tables(instance: &mut Instance, module: &Module) -> Result<()> {
     Ok(())
 }
 
-fn get_memory_init_start(
-    init: &MemoryInitializer,
-    instance: &mut Instance
-) -> Result<u64> {
+fn get_memory_init_start(init: &MemoryInitializer, instance: &mut Instance) -> Result<u64> {
     let mut context = ConstEvalContext::new(instance);
     let mut const_evaluator = ConstExprEvaluator::default();
     unsafe { const_evaluator.eval(&mut context, &init.offset) }.map(|v| {


### PR DESCRIPTION
Remove module field from wasmtime::runtime::vm::const_expr::ConstEvalContext
issue #9311 
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
