### PR TITLE
ci: add `clippy` results to GitHub code scans

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,54 @@
+# Scan the code in this repository; publish results to
+# https://github.com/bytecodealliance/wasmtime/security/code-scanning.
+
+name: Code Scan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "4 3 * * 2"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Rust)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    env:
+        CARGO_NDK_VERSION: 2.12.2
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+            submodules: true
+
+      - uses: ./.github/actions/install-rust
+
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@3a99ae3c155195e5518c9ff954bee1b90f98b82c # v1.10.6
+
+      - name: Install dependencies
+        run: cargo binstall --no-confirm clippy-sarif sarif-fmt
+
+      - name: Run clippy
+        run: |
+          cargo clippy --workspace --all-targets --message-format=json > clippy.json
+          clippy-sarif --input clippy.json --output clippy.sarif
+          sarif-fmt --input clippy.sarif
+        continue-on-error: true
+
+      - name: Upload analysis
+        uses: github/codeql-action/upload-sarif@5618c9fc1e675841ca52c1c6b1304f5255a905a0 # v2.19.0
+        with:
+          sarif_file: clippy.sarif
+          wait-for-processing: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ manual_strip = 'warn'
 unnecessary_mut_passed = 'warn'
 unnecessary_fallible_conversions = 'warn'
 unnecessary_cast = 'warn'
+question_mark = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }


### PR DESCRIPTION
In the past, we've overlooked clippy warnings that get lost in the CI build logs. This change would collect all of those warnings, put them in [SARIF] form, and list them in GitHub's code scanning view. I recently added this to `ittapi` and it looks like this: [Code Scanning]. This means warnings and errors will show up on the security tab as a notification; the UI allows one to dismiss the warnings. There might be some integration with PRs but I haven't experimented with that.

I configured this to also run periodically (every Tuesday night); we can remove that if we only want commits to `main`, e.g. If we do adopt this, we should think about what to do with the `clippy` job in `main.yml`--does it stay or go?

[SARIF]: https://sarifweb.azurewebsites.net
[Code Scanning]: https://github.com/intel/ittapi/security/code-scanning?query=branch%3Amaster+

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
