### PR TITLE
bug: bindgen erraneously parses extra comma

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -328,10 +328,6 @@ impl Parse for Opt {
                 let list = Punctuated::<_, Token![,]>::parse_terminated(&contents)?;
 
                 paths.extend(list.into_iter());
-
-                if input.peek(Token![,]) {
-                    input.parse::<Token![,]>()?;
-                }
             } else {
                 return Err(l.error());
             };


### PR DESCRIPTION
Fixes an issue introduced in #9288 where an additional comma token is erroneously consumed. This meant if path was not the last property in the bindgen options, you would see an error "expected ,"

The provided tests were simple enough that path happened to be the last property. I haven't included a new test here because I think testing for such an issue is outside the scope of the tests.