### PR TITLE
Fix clippy lints on aarch64-apple-darwin

### DIFF
--- a/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
@@ -31,7 +31,14 @@
 //! function declarations. Many bits and pieces are copied or translated from
 //! the SpiderMonkey implementation and it should pass all the tests!
 
-#![allow(non_snake_case, clippy::cast_sign_loss)]
+#![allow(
+    // FFI bindings here for C/etc don't follow Rust's naming conventions.
+    non_snake_case,
+    // Platform-specific code has a lot of false positives with these lints so
+    // like Unix disable the lints for this module.
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
 
 use crate::runtime::module::lookup_code;
 use crate::runtime::vm::sys::traphandlers::wasmtime_longjmp;


### PR DESCRIPTION
This isn't caught in CI because it's in platform-specific code, but allow a few extra lints in platform-specific code since the "noisier than default" stance is not as useful for platform-specific code where we have far less control over integral types.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
