### PR TITLE
Enable a few miscellaneous Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ unnecessary_to_owned = 'warn'
 manual_strip = 'warn'
 unnecessary_mut_passed = 'warn'
 unnecessary_fallible_conversions = 'warn'
+unnecessary_cast = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ map_clone = 'warn'
 uninlined_format_args = 'warn'
 unnecessary_to_owned = 'warn'
 manual_strip = 'warn'
+unnecessary_mut_passed = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ uninlined_format_args = 'warn'
 unnecessary_to_owned = 'warn'
 manual_strip = 'warn'
 unnecessary_mut_passed = 'warn'
+unnecessary_fallible_conversions = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -745,7 +745,7 @@ impl<'a> EgraphPass<'a> {
             self.func,
             &self.domtree,
             self.loop_analysis,
-            &mut self.remat_values,
+            &self.remat_values,
             &mut self.stats,
             self.ctrl_plane,
         );

--- a/cranelift/codegen/src/flowgraph.rs
+++ b/cranelift/codegen/src/flowgraph.rs
@@ -303,8 +303,8 @@ mod tests {
         func.dfg
             .replace(br_block0_block2_block1)
             .brif(cond, block1, &[], ret_block, &[]);
-        cfg.recompute_block(&mut func, block0);
-        cfg.recompute_block(&mut func, ret_block);
+        cfg.recompute_block(&func, block0);
+        cfg.recompute_block(&func, ret_block);
         let br_block0_block1_ret_block = br_block0_block2_block1;
 
         {

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -95,16 +95,16 @@ pub fn mem_finalize(
 
 pub(crate) fn machreg_to_gpr(m: Reg) -> u32 {
     assert_eq!(m.class(), RegClass::Int);
-    u32::try_from(m.to_real_reg().unwrap().hw_enc() & 31).unwrap()
+    u32::from(m.to_real_reg().unwrap().hw_enc() & 31)
 }
 
 pub(crate) fn machreg_to_vec(m: Reg) -> u32 {
     assert_eq!(m.class(), RegClass::Float);
-    u32::try_from(m.to_real_reg().unwrap().hw_enc()).unwrap()
+    u32::from(m.to_real_reg().unwrap().hw_enc())
 }
 
 fn machreg_to_gpr_or_vec(m: Reg) -> u32 {
-    u32::try_from(m.to_real_reg().unwrap().hw_enc() & 31).unwrap()
+    u32::from(m.to_real_reg().unwrap().hw_enc() & 31)
 }
 
 pub(crate) fn enc_arith_rrr(

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -25,14 +25,14 @@ impl EmitInfo {
 }
 
 pub(crate) fn reg_to_gpr_num(m: Reg) -> u32 {
-    u32::try_from(m.to_real_reg().unwrap().hw_enc() & 31).unwrap()
+    u32::from(m.to_real_reg().unwrap().hw_enc() & 31)
 }
 
 pub(crate) fn reg_to_compressed_gpr_num(m: Reg) -> u32 {
     let real_reg = m.to_real_reg().unwrap().hw_enc();
     debug_assert!(real_reg >= 8 && real_reg < 16);
     let compressed_reg = real_reg - 8;
-    u32::try_from(compressed_reg).unwrap()
+    u32::from(compressed_reg)
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -200,9 +200,7 @@ impl wasmtime_environ::Compiler for Compiler {
         });
         let stack_limit = context.func.create_global_value(ir::GlobalValueData::Load {
             base: interrupts_ptr,
-            offset: i32::try_from(func_env.offsets.ptr.vmruntime_limits_stack_limit())
-                .unwrap()
-                .into(),
+            offset: i32::from(func_env.offsets.ptr.vmruntime_limits_stack_limit()).into(),
             global_type: isa.pointer_type(),
             flags: MemFlags::trusted(),
         });
@@ -341,7 +339,7 @@ impl wasmtime_environ::Compiler for Compiler {
             pointer_type,
             MemFlags::trusted(),
             caller_vmctx,
-            i32::try_from(ptr.vmcontext_runtime_limits()).unwrap(),
+            i32::from(ptr.vmcontext_runtime_limits()),
         );
         save_last_wasm_exit_fp_and_pc(&mut builder, pointer_type, &ptr, limits);
 
@@ -546,7 +544,7 @@ impl wasmtime_environ::Compiler for Compiler {
             pointer_type,
             mem_flags,
             vmctx,
-            i32::try_from(ptr_size.vmcontext_builtin_functions()).unwrap(),
+            i32::from(ptr_size.vmcontext_builtin_functions()),
         );
         let body_offset = i32::try_from(index.index() * pointer_type.bytes()).unwrap();
         let func_addr = builder
@@ -671,7 +669,7 @@ impl Compiler {
         {
             let values_vec_len = builder
                 .ins()
-                .iconst(ir::types::I32, i64::try_from(values_vec_len).unwrap());
+                .iconst(ir::types::I32, i64::from(values_vec_len));
             self.store_values_to_array(builder, ty.params(), args, values_vec_ptr, values_vec_len);
         }
 

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -35,12 +35,12 @@ impl ExpressionWriter {
     }
 
     fn write_op(&mut self, op: gimli::DwOp) -> write::Result<()> {
-        self.write_u8(op.0 as u8)
+        self.write_u8(op.0)
     }
 
     fn write_op_reg(&mut self, reg: u16) -> write::Result<()> {
         if reg < 32 {
-            self.write_u8(gimli::constants::DW_OP_reg0.0 as u8 + reg as u8)
+            self.write_u8(gimli::constants::DW_OP_reg0.0 + reg as u8)
         } else {
             self.write_op(gimli::constants::DW_OP_regx)?;
             self.write_uleb128(reg.into())
@@ -49,7 +49,7 @@ impl ExpressionWriter {
 
     fn write_op_breg(&mut self, reg: u16) -> write::Result<()> {
         if reg < 32 {
-            self.write_u8(gimli::constants::DW_OP_breg0.0 as u8 + reg as u8)
+            self.write_u8(gimli::constants::DW_OP_breg0.0 + reg as u8)
         } else {
             self.write_op(gimli::constants::DW_OP_bregx)?;
             self.write_uleb128(reg.into())
@@ -363,7 +363,7 @@ impl CompiledExpression {
                                             true => gimli::constants::DW_OP_bra,
                                             false => gimli::constants::DW_OP_skip,
                                         }
-                                        .0 as u8,
+                                        .0,
                                     );
                                     code_buf.push(!0);
                                     code_buf.push(!0); // these will be relocated below
@@ -404,11 +404,11 @@ impl CompiledExpression {
 fn is_old_expression_format(buf: &[u8]) -> bool {
     // Heuristic to detect old variable expression format without DW_OP_fbreg:
     // DW_OP_plus_uconst op must be present, but not DW_OP_fbreg.
-    if buf.contains(&(gimli::constants::DW_OP_fbreg.0 as u8)) {
+    if buf.contains(&(gimli::constants::DW_OP_fbreg.0)) {
         // Stop check if DW_OP_fbreg exist.
         return false;
     }
-    buf.contains(&(gimli::constants::DW_OP_plus_uconst.0 as u8))
+    buf.contains(&(gimli::constants::DW_OP_plus_uconst.0))
 }
 
 pub fn compile_expression<R>(
@@ -589,7 +589,7 @@ where
             }
             Operation::WasmLocal { index } => {
                 flush_code_chunk!();
-                let label = ValueLabel::from_u32(index as u32);
+                let label = ValueLabel::from_u32(index);
                 push!(CompiledExpressionPart::Local {
                     label,
                     trailing: false,
@@ -1079,7 +1079,7 @@ mod tests {
             DW_OP_plus_uconst,
             1,
             DW_OP_skip,
-            (-11 as i8),
+            (-11_i8),
             (!0), // --> loop
             /* done */ DW_OP_stack_value
         );

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -606,7 +606,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         let vmctx = self.vmctx(builder.func);
         let pointer_type = self.pointer_type();
         let base = builder.ins().global_value(pointer_type, vmctx);
-        let offset = i32::try_from(self.offsets.ptr.vmctx_epoch_ptr()).unwrap();
+        let offset = i32::from(self.offsets.ptr.vmctx_epoch_ptr());
         let epoch_ptr = builder
             .ins()
             .load(pointer_type, ir::MemFlags::trusted(), base, offset);

--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -955,9 +955,7 @@ impl FuncEnvironment<'_> {
 
         let offset = match offset {
             Offset::Dynamic(offset) => uextend_i32_to_pointer_type(builder, pointer_type, offset),
-            Offset::Static(offset) => builder
-                .ins()
-                .iconst(pointer_type, i64::try_from(offset).unwrap()),
+            Offset::Static(offset) => builder.ins().iconst(pointer_type, i64::from(offset)),
         };
 
         let index_and_offset = builder.ins().uadd_overflow_trap(
@@ -980,9 +978,7 @@ impl FuncEnvironment<'_> {
             }
             BoundsCheck::Access(access_size) => {
                 // Check that `index + offset + access_size` is in bounds.
-                let access_size = builder
-                    .ins()
-                    .iconst(pointer_type, i64::try_from(access_size).unwrap());
+                let access_size = builder.ins().iconst(pointer_type, i64::from(access_size));
                 builder.ins().uadd_overflow_trap(
                     index_and_offset,
                     access_size,

--- a/crates/test-programs/src/bin/preview1_file_pread_pwrite.rs
+++ b/crates/test-programs/src/bin/preview1_file_pread_pwrite.rs
@@ -23,8 +23,7 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    let mut nwritten =
-        wasi::fd_pwrite(file_fd, &mut [ciovec], 0).expect("writing bytes at offset 0");
+    let mut nwritten = wasi::fd_pwrite(file_fd, &[ciovec], 0).expect("writing bytes at offset 0");
     assert_eq!(nwritten, 4, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
@@ -111,7 +110,7 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    nwritten = wasi::fd_pwrite(file_fd, &mut [ciovec], 2).expect("writing bytes at offset 2");
+    nwritten = wasi::fd_pwrite(file_fd, &[ciovec], 2).expect("writing bytes at offset 2");
     assert_eq!(nwritten, 2, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
@@ -152,7 +151,7 @@ unsafe fn test_file_pwrite_and_file_pos(dir_fd: wasi::Fd) {
         buf: [].as_ptr(),
         buf_len: 0,
     };
-    let n = wasi::fd_pwrite(file_fd, &mut [ciovec], 50).expect("writing bytes at offset 2");
+    let n = wasi::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 2");
     assert_eq!(n, 0);
 
     assert_eq!(wasi::fd_tell(file_fd).unwrap(), 0);
@@ -165,7 +164,7 @@ unsafe fn test_file_pwrite_and_file_pos(dir_fd: wasi::Fd) {
         buf: buf.as_ptr(),
         buf_len: buf.len(),
     };
-    let n = wasi::fd_pwrite(file_fd, &mut [ciovec], 50).expect("writing bytes at offset 50");
+    let n = wasi::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 50");
     assert_eq!(n, 1);
 
     assert_eq!(wasi::fd_tell(file_fd).unwrap(), 0);

--- a/crates/test-programs/src/bin/preview1_file_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_read_write.rs
@@ -23,7 +23,7 @@ unsafe fn test_file_read_write(dir_fd: wasi::Fd) {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    let mut nwritten = wasi::fd_write(file_fd, &mut [ciovec]).expect("writing bytes at offset 0");
+    let mut nwritten = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 0");
     assert_eq!(nwritten, 4, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
@@ -114,7 +114,7 @@ unsafe fn test_file_read_write(dir_fd: wasi::Fd) {
         buf_len: contents.len(),
     };
     wasi::fd_seek(file_fd, 2, wasi::WHENCE_SET).expect("seeking to offset 2");
-    nwritten = wasi::fd_write(file_fd, &mut [ciovec]).expect("writing bytes at offset 2");
+    nwritten = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 2");
     assert_eq!(nwritten, 2, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
@@ -157,7 +157,7 @@ unsafe fn test_file_write_and_file_pos(dir_fd: wasi::Fd) {
         buf_len: 0,
     };
     wasi::fd_seek(file_fd, 2, wasi::WHENCE_SET).expect("seeking to offset 2");
-    let n = wasi::fd_write(file_fd, &mut [ciovec]).expect("writing bytes at offset 2");
+    let n = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 2");
     assert_eq!(n, 0);
 
     assert_eq!(wasi::fd_tell(file_fd).unwrap(), 2);
@@ -171,7 +171,7 @@ unsafe fn test_file_write_and_file_pos(dir_fd: wasi::Fd) {
         buf_len: buf.len(),
     };
     wasi::fd_seek(file_fd, 50, wasi::WHENCE_SET).expect("seeking to offset 50");
-    let n = wasi::fd_write(file_fd, &mut [ciovec]).expect("writing bytes at offset 50");
+    let n = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 50");
     assert_eq!(n, 1);
 
     assert_eq!(wasi::fd_tell(file_fd).unwrap(), 51);

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -266,7 +266,7 @@ impl Descriptors {
     fn push(&self, desc: Descriptor) -> Result<Fd, Errno> {
         unsafe {
             let table = (*self.table.get()).as_mut_ptr();
-            let len = usize::try_from(self.table_len.get()).trapping_unwrap();
+            let len = usize::from(self.table_len.get());
             if len >= (*table).len() {
                 return Err(wasi::ERRNO_NOMEM);
             }
@@ -280,7 +280,7 @@ impl Descriptors {
         unsafe {
             std::slice::from_raw_parts(
                 (*self.table.get()).as_ptr().cast(),
-                usize::try_from(self.table_len.get()).trapping_unwrap(),
+                usize::from(self.table_len.get()),
             )
         }
     }
@@ -289,7 +289,7 @@ impl Descriptors {
         unsafe {
             std::slice::from_raw_parts_mut(
                 (*self.table.get()).as_mut_ptr().cast(),
-                usize::try_from(self.table_len.get()).trapping_unwrap(),
+                usize::from(self.table_len.get()),
             )
         }
     }

--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -192,12 +192,8 @@ impl WasmCoreDump {
                 let init = match g.get(&mut store) {
                     Val::I32(x) => wasm_encoder::ConstExpr::i32_const(x),
                     Val::I64(x) => wasm_encoder::ConstExpr::i64_const(x),
-                    Val::F32(x) => {
-                        wasm_encoder::ConstExpr::f32_const(unsafe { std::mem::transmute(x) })
-                    }
-                    Val::F64(x) => {
-                        wasm_encoder::ConstExpr::f64_const(unsafe { std::mem::transmute(x) })
-                    }
+                    Val::F32(x) => wasm_encoder::ConstExpr::f32_const(f32::from_bits(x)),
+                    Val::F64(x) => wasm_encoder::ConstExpr::f64_const(f64::from_bits(x)),
                     Val::V128(x) => wasm_encoder::ConstExpr::v128_const(x.as_u128() as i128),
                     Val::FuncRef(_) => {
                         wasm_encoder::ConstExpr::ref_null(wasm_encoder::HeapType::FUNC)

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -197,7 +197,7 @@ impl Global {
                     let new = match e {
                         None => None,
                         #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
-                        Some(e) => Some(e.try_gc_ref(&mut store)?.unchecked_copy()),
+                        Some(e) => Some(e.try_gc_ref(&store)?.unchecked_copy()),
                     };
                     let new = new.as_ref();
                     definition.write_gc_ref(store.unwrap_gc_store_mut(), new);
@@ -206,7 +206,7 @@ impl Global {
                     let new = match a {
                         None => None,
                         #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
-                        Some(a) => Some(a.try_gc_ref(&mut store)?.unchecked_copy()),
+                        Some(a) => Some(a.try_gc_ref(&store)?.unchecked_copy()),
                     };
                     let new = new.as_ref();
                     definition.write_gc_ref(store.unwrap_gc_store_mut(), new);

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1342,7 +1342,7 @@ impl StoreOpaque {
     }
 
     pub(crate) fn fill_func_refs(&mut self) {
-        self.func_refs.fill(&mut self.modules);
+        self.func_refs.fill(&self.modules);
     }
 
     pub(crate) fn push_instance_pre_func_refs(&mut self, func_refs: Arc<[VMFuncRef]>) {

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -43,7 +43,7 @@ pub fn generate_global_export(
                 let new = match x {
                     None => None,
                     #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
-                    Some(x) => Some(x.try_gc_ref(&mut store)?.unchecked_copy()),
+                    Some(x) => Some(x.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
                 global.write_gc_ref(store.gc_store_mut()?, new);
@@ -52,7 +52,7 @@ pub fn generate_global_export(
                 let new = match a {
                     None => None,
                     #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
-                    Some(a) => Some(a.try_gc_ref(&mut store)?.unchecked_copy()),
+                    Some(a) => Some(a.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
                 global.write_gc_ref(store.gc_store_mut()?, new);

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -130,10 +130,7 @@ impl TablePool {
             let base = self.get(allocation_index);
 
             unsafe {
-                commit_pages(
-                    base as *mut u8,
-                    self.table_elements * mem::size_of::<*mut u8>(),
-                )?;
+                commit_pages(base, self.table_elements * mem::size_of::<*mut u8>())?;
             }
 
             let ptr = NonNull::new(std::ptr::slice_from_raw_parts_mut(

--- a/tests/all/externals.rs
+++ b/tests/all/externals.rs
@@ -408,7 +408,7 @@ fn read_write_memory_via_api() {
     assert!(res.is_err());
 
     // Write offset overflow.
-    let res = mem.write(&mut store, usize::MAX, &mut buffer);
+    let res = mem.write(&mut store, usize::MAX, &buffer);
     assert!(res.is_err());
 }
 

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -444,7 +444,7 @@ impl<'a> CodeGenContext<'a> {
     /// This function exists for cases in which triggering an unconditional
     /// spill is needed, like before entering control flow.
     pub fn spill<M: MacroAssembler>(&mut self, masm: &mut M) {
-        Self::spill_impl(&mut self.stack, &mut self.regalloc, &mut self.frame, masm);
+        Self::spill_impl(&mut self.stack, &mut self.regalloc, &self.frame, masm);
     }
 
     /// Prepares the compiler to emit an uncoditional jump to the given

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -112,7 +112,7 @@ impl Assembler {
             let jmp = Inst::Jump {
                 dest: BranchTarget::Label(label),
             };
-            jmp.emit(&mut self.buffer, &mut self.emit_info, &mut self.emit_state);
+            jmp.emit(&mut self.buffer, &self.emit_info, &mut self.emit_state);
             self.buffer
                 .emit_island(needed_space, self.emit_state.ctrl_plane_mut());
             self.buffer

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -69,7 +69,7 @@ impl Masm for MacroAssembler {
 
         if self.shared_flags.unwind_info() {
             self.asm.emit_unwind_inst(UnwindInst::PushFrameRegs {
-                offset_upward_to_caller_sp: Self::ABI::arg_base_offset().try_into().unwrap(),
+                offset_upward_to_caller_sp: Self::ABI::arg_base_offset().into(),
             })
         }
 
@@ -99,7 +99,7 @@ impl Masm for MacroAssembler {
         // Emit unwind info.
         if self.shared_flags.unwind_info() {
             self.asm.emit_unwind_inst(UnwindInst::DefineNewFrame {
-                offset_upward_to_caller_sp: Self::ABI::arg_base_offset().try_into().unwrap(),
+                offset_upward_to_caller_sp: Self::ABI::arg_base_offset().into(),
 
                 // The Winch calling convention has no callee-save registers, so nothing will be
                 // clobbered.


### PR DESCRIPTION
I was browsing the [list of lints](https://rust-lang.github.io/rust-clippy/master/index.html) and enabled a few that seemed useful for cleaning up code after a refactoring.