### PR TITLE
Reexport `wasmtime::hash_{map,set}` from `hashbrown` internally

### DIFF
--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -22,12 +22,14 @@
 //!   functions. It is up to the caller to serialize the relevant parts of the
 //!   `Artifacts` into the ELF file.
 
+use crate::hash_map::HashMap;
+use crate::hash_set::HashSet;
 use crate::prelude::*;
 use crate::Engine;
 use std::{
     any::Any,
     borrow::Cow,
-    collections::{btree_map, BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{btree_map, BTreeMap, BTreeSet},
     mem,
 };
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1,9 +1,10 @@
+use crate::hash_map::HashMap;
+use crate::hash_set::HashSet;
 use crate::prelude::*;
 use alloc::sync::Arc;
 use bitflags::Flags;
 use core::fmt;
 use core::str::FromStr;
-use hashbrown::{HashMap, HashSet};
 use serde_derive::{Deserialize, Serialize};
 #[cfg(any(feature = "cache", feature = "cranelift", feature = "winch"))]
 use std::path::Path;

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -294,6 +294,8 @@ pub(crate) mod prelude {
     pub use wasmtime_environ::prelude::*;
 }
 
+pub(crate) use hashbrown::{hash_map, hash_set};
+
 /// A helper macro to safely map `MaybeUninit<T>` to `MaybeUninit<U>` where `U`
 /// is a field projection within `T`.
 ///

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -5,13 +5,13 @@ use crate::component::types;
 use crate::component::{
     Component, ComponentNamedList, Instance, InstancePre, Lift, Lower, ResourceType, Val,
 };
+use crate::hash_map::HashMap;
 use crate::prelude::*;
 use crate::{AsContextMut, Engine, Module, StoreContextMut};
 use alloc::sync::Arc;
 use core::future::Future;
 use core::marker;
 use core::pin::Pin;
-use hashbrown::hash_map::HashMap;
 use wasmtime_environ::component::{NameMap, NameMapIntern};
 use wasmtime_environ::PrimaryMap;
 

--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -1,9 +1,10 @@
+use crate::hash_map::HashMap;
 use crate::prelude::*;
 use crate::{
     store::StoreOpaque, AsContextMut, FrameInfo, Global, HeapType, Instance, Memory, Module,
     StoreContextMut, Val, ValType, WasmBacktrace,
 };
-use std::{collections::HashMap, fmt};
+use std::fmt;
 
 /// Representation of a core dump of a WebAssembly module
 ///

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -1,4 +1,5 @@
 use crate::func::HostFunc;
+use crate::hash_map::{Entry, HashMap};
 use crate::instance::InstancePre;
 use crate::store::StoreOpaque;
 use crate::{prelude::*, IntoFunc};
@@ -13,7 +14,6 @@ use core::future::Future;
 use core::marker;
 #[cfg(feature = "async")]
 use core::pin::Pin;
-use hashbrown::hash_map::{Entry, HashMap};
 use log::warn;
 
 /// Structure used to link wasm modules/instances together.

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -76,6 +76,7 @@
 //! contents of `StoreOpaque`. This is an invariant that we, as the authors of
 //! `wasmtime`, must uphold for the public interface to be safe.
 
+use crate::hash_set::HashSet;
 use crate::instance::InstanceData;
 use crate::linker::Definition;
 use crate::module::RegisteredModuleId;
@@ -324,7 +325,7 @@ pub struct StoreOpaque {
     gc_roots: RootSet,
     gc_roots_list: GcRootsList,
     // Types for which the embedder has created an allocator for.
-    gc_host_alloc_types: hashbrown::HashSet<RegisteredType>,
+    gc_host_alloc_types: HashSet<RegisteredType>,
 
     // Numbers of resources instantiated in this store, and their limits
     instance_count: usize,
@@ -542,7 +543,7 @@ impl<T> Store<T> {
                 gc_store: None,
                 gc_roots: RootSet::default(),
                 gc_roots_list: GcRootsList::default(),
-                gc_host_alloc_types: hashbrown::HashSet::default(),
+                gc_host_alloc_types: HashSet::default(),
                 modules: ModuleRegistry::default(),
                 func_refs: FuncRefs::default(),
                 host_globals: Vec::new(),

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -3,6 +3,7 @@
 //! Helps implement fast indirect call signature checking, reference type
 //! downcasting, and etc...
 
+use crate::hash_set::HashSet;
 use crate::prelude::*;
 use crate::sync::RwLock;
 use crate::vm::GcRuntime;
@@ -20,7 +21,6 @@ use core::{
         Ordering::{AcqRel, Acquire},
     },
 };
-use hashbrown::HashSet;
 use wasmtime_environ::{
     iter_entity_range, packed_option::PackedOption, EngineOrModuleTypeIndex, GcLayout,
     ModuleInternedTypeIndex, ModuleTypes, PrimaryMap, SecondaryMap, TypeTrace, VMSharedTypeIndex,

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -43,6 +43,7 @@
 
 use super::free_list::FreeList;
 use super::{VMArrayRef, VMGcObjectDataMut, VMStructRef};
+use crate::hash_set::HashSet;
 use crate::prelude::*;
 use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
@@ -57,7 +58,6 @@ use core::{
     num::NonZeroUsize,
     ptr::{self, NonNull},
 };
-use hashbrown::HashSet;
 use wasmtime_environ::drc::DrcTypeLayouts;
 use wasmtime_environ::{GcArrayLayout, GcStructLayout, GcTypeLayouts, VMGcKind, VMSharedTypeIndex};
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
@@ -313,8 +313,9 @@ fn round_usize_down_to_pow2(value: usize, divisor: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hash_map::HashMap;
     use proptest::prelude::*;
-    use std::{collections::HashMap, num::NonZeroUsize};
+    use std::num::NonZeroUsize;
 
     fn free_list_block_len_and_size(free_list: &FreeList) -> (usize, Option<usize>) {
         let len = free_list.free_block_index_to_len.len();

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -1,8 +1,8 @@
 //! Index/slot allocator policies for the pooling allocator.
 
+use crate::hash_map::{Entry, HashMap};
 use crate::prelude::*;
 use crate::runtime::vm::CompiledModuleId;
-use std::collections::hash_map::{Entry, HashMap};
 use std::mem;
 use std::sync::Mutex;
 use wasmtime_environ::DefinedMemoryIndex;


### PR DESCRIPTION
Some modules were using `std::collections::{HashMap, HashSet}` when they knew that they were only compiled when the `std` feature was enabled. But we need to use `hashbrown` in certain other places (Cranelift's e-graphs, pooling allocator's index allocator, etc.), so we should simply use `hashbrown` everywhere. This should reduce binary size some small amount, but also means that we never have to ask ourselves "which hash map should I import?" when adding a new hash map import: always `use crate::hash_map::HashMap` et al.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
