### PR TITLE
Update region to 3.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,15 +1805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,14 +2339,14 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "region"
-version = "2.2.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "mach",
- "winapi",
+ "mach2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-codegen = { workspace = true, features = ["std"] }
 cranelift-entity = { workspace = true }
 cranelift-control = { workspace = true }
 anyhow = { workspace = true }
-region = "2.2.0"
+region = "3.0.2"
 libc = { workspace = true }
 target-lexicon = { workspace = true }
 memmap2 = { version = "0.2.1", optional = true }

--- a/cranelift/jit/src/memory.rs
+++ b/cranelift/jit/src/memory.rs
@@ -36,7 +36,7 @@ impl PtrLen {
     /// suitably sized and aligned for memory protection.
     #[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
     fn with_size(size: usize) -> io::Result<Self> {
-        let alloc_size = region::page::ceil(size);
+        let alloc_size = region::page::ceil(size as *const ()) as usize;
         MmapMut::map_anon(alloc_size).map(|mut mmap| {
             // The order here is important; we assign the pointer first to get
             // around compile time borrow errors.
@@ -52,7 +52,7 @@ impl PtrLen {
     fn with_size(size: usize) -> io::Result<Self> {
         assert_ne!(size, 0);
         let page_size = region::page::size();
-        let alloc_size = region::page::ceil(size);
+        let alloc_size = region::page::ceil(size as *const ()) as usize;
         let layout = alloc::Layout::from_size_align(alloc_size, page_size).unwrap();
         // Safety: We assert that the size is non-zero above.
         let ptr = unsafe { alloc::alloc(layout) };
@@ -85,7 +85,7 @@ impl PtrLen {
         if !ptr.is_null() {
             Ok(Self {
                 ptr: ptr as *mut u8,
-                len: region::page::ceil(size),
+                len: region::page::ceil(size as *const ()) as usize,
             })
         } else {
             Err(io::Error::last_os_error())

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2475,6 +2475,18 @@ criteria = "safe-to-deploy"
 delta = "0.6.1 -> 0.7.0"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[audits.region]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.0 -> 3.0.2"
+notes = """
+This release brings a number of refactorings and new platforms to be supported
+in the crate. Lots of `unsafe` code because that's what the crate is
+fundamentally doing, managing virtual memory. That being said it's all largely
+the same as before where it's all as expected and the `unsafe` has to do with
+managing OS APIs.
+"""
+
 [[audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Hi there -- I've been working on some code changes to wasmtime (primarily around illumos support) and I noticed that the region dependency was out of date. Here's a PR to update the dependency to version 3, which supports illumos.

The main API difference is that `region::page::ceil` now works on addresses rather than usizes, so there's a small adaptation for that in this PR. Thanks!