### PR TITLE
Handle another DWARF attribute when rewriting DWARF

### DIFF
--- a/crates/cranelift/src/debug/transform/attr.rs
+++ b/crates/cranelift/src/debug/transform/attr.rs
@@ -100,6 +100,7 @@ where
             AttributeValue::Data1(d) => write::AttributeValue::Data1(d),
             AttributeValue::Data2(d) => write::AttributeValue::Data2(d),
             AttributeValue::Data4(d) => write::AttributeValue::Data4(d),
+            AttributeValue::Data8(d) => write::AttributeValue::Data8(d),
             AttributeValue::Sdata(d) => write::AttributeValue::Sdata(d),
             AttributeValue::Flag(f) => write::AttributeValue::Flag(f),
             AttributeValue::DebugLineRef(line_program_offset) => {


### PR DESCRIPTION
I don't know what `Data8` is, but it looks a lot like `Data4`, so process it in the same way as `Data4`.

Closes #9333

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
