### PR TITLE
Fix asan build of wasmtime-fiber

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -560,9 +560,9 @@ jobs:
     - run: sudo apt-get update && sudo apt install -y ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev
     - run: cargo fetch
       working-directory: ./fuzz
-    - run: cargo fuzz build --dev -s none
-    - run: cargo fuzz build --dev -s none --fuzz-dir ./cranelift/isle/fuzz
-    - run: cargo fuzz build --dev -s none --fuzz-dir ./crates/environ/fuzz --features component-model
+    - run: cargo fuzz build --dev
+    - run: cargo fuzz build --dev --fuzz-dir ./cranelift/isle/fuzz
+    - run: cargo fuzz build --dev --fuzz-dir ./crates/environ/fuzz --features component-model
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -458,6 +458,10 @@ mod asan {
             let end = base + self.0.mapping_len;
             base + page_size()..end
         }
+
+        fn guard_range(&self) -> Range<*mut u8> {
+            self.0.mapping_base..self.0.mapping_base.wrapping_add(page_size())
+        }
     }
 
     impl Drop for AsanFiberStack {


### PR DESCRIPTION
This commit fixes an issue with #9304 where the asan build of `wasmtime-fiber` has broken which was preventing oss-fuzz from updating and making progress.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
