### PR TITLE
Relax `rust-version` for `wasi-preview1-component-adapter-provider`

### DIFF
--- a/crates/wasi-preview1-component-adapter/provider/Cargo.toml.in
+++ b/crates/wasi-preview1-component-adapter/provider/Cargo.toml.in
@@ -9,7 +9,11 @@ documentation = "https://docs.rs/wasi-preview1-component-adapter-provider/"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
-rust-version.workspace = true
+
+# NB: this is intentionally smaller than the workspace as this crate is just a
+# few `include_bytes!` so can have a more conservative version than the rest of
+# the workspace.
+rust-version = "1.60.0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
This crate is distributed on crates.io to allow access to the adapter via a Rust API and doesn't need to have the same requirement as the rest of the workspace.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
