### PR TITLE
Fix some fuzz issues from updating wasm-tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,6 +3734,7 @@ dependencies = [
  "cranelift-reader",
  "env_logger 0.11.5",
  "libfuzzer-sys",
+ "log",
  "once_cell",
  "proc-macro2",
  "pulley-interpreter-fuzz",

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -168,6 +168,8 @@ impl Config {
             .wasm_tail_call(self.module_config.config.tail_call_enabled)
             .wasm_custom_page_sizes(self.module_config.config.custom_page_sizes_enabled)
             .wasm_threads(self.module_config.config.threads_enabled)
+            .wasm_function_references(self.module_config.config.gc_enabled)
+            .wasm_gc(self.module_config.config.gc_enabled)
             .native_unwind_info(cfg!(target_os = "windows") || self.wasmtime.native_unwind_info)
             .cranelift_nan_canonicalization(self.wasmtime.canonicalize_nans)
             .cranelift_opt_level(self.wasmtime.opt_level.to_wasmtime())
@@ -466,6 +468,12 @@ impl WasmtimeConfig {
         config: &mut wasm_smith::Config,
         u: &mut Unstructured<'_>,
     ) -> arbitrary::Result<()> {
+        // Not implemented in Wasmtime
+        config.exceptions_enabled = false;
+
+        // Not fully implemented in Wasmtime and fuzzing.
+        config.gc_enabled = false;
+
         // Winch doesn't support the same set of wasm proposal as Cranelift at
         // this time, so if winch is selected be sure to disable wasm proposals
         // in `Config` to ensure that Winch can compile the module that
@@ -476,7 +484,6 @@ impl WasmtimeConfig {
             config.gc_enabled = false;
             config.threads_enabled = false;
             config.tail_call_enabled = false;
-            config.exceptions_enabled = false;
             config.reference_types_enabled = false;
 
             // Winch requires host trap handlers to be enabled at this time.

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -19,6 +19,7 @@ impl WasmiEngine {
         config.memory64_enabled = false;
         config.threads_enabled = false;
         config.exceptions_enabled = false;
+        config.gc_enabled = false;
         config.max_memories = config.max_memories.min(1);
         config.min_memories = config.min_memories.min(1);
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,6 +31,7 @@ wasmtime = { workspace = true, features = ["winch"] }
 wasmtime-fuzzing = { workspace = true }
 component-test-util = { workspace = true }
 component-fuzz-util = { workspace = true }
+log = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
This commit fixes some fuzz-related issues from the update of the `wasm-tools` family of crates in #9336:

* Fuzzing with wasmi disables the GC proposal
* The exceptions proposal is always disabled for Wasmtime
* Wasmtime conditionally enables the GC/reference-types proposal
* Fully disable the GC proposal for now in Wasmtime as its implementation is not complete and fuzzing needs more support.
* Log wasm module config before generating to help debug issues like bytecodealliance/wasm-tools#1834

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
