### PR TITLE
Enable Rust's `unused-macro-rules` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ trivial_numeric_casts = 'warn'
 unstable_features = 'warn'
 unused_import_braces = 'warn'
 unused-lifetimes = 'warn'
+unused-macro-rules = 'warn'
 
 [workspace.lints.clippy]
 # The default set of lints in Clippy is viewed as "too noisy" right now so

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -176,12 +176,6 @@ macro_rules! unary_match {
             _ => unimplemented!()
         }
     };
-    ( $op:tt($arg1:expr); [ $( $data_value_ty:ident ),* ] ) => {
-        match $arg1 {
-            $( DataValue::$data_value_ty(a) => { Ok(DataValue::$data_value_ty($op a)) } )*
-            _ => unimplemented!()
-        }
-    };
 }
 macro_rules! binary_match {
     ( $op:ident($arg1:expr, $arg2:expr); [ $( $data_value_ty:ident ),* ] ) => {
@@ -227,16 +221,6 @@ macro_rules! binary_match {
         match ($arg1, $arg2) {
             $( (DataValue::$data_value_ty(a), DataValue::$rhs(b)) => { Ok(DataValue::$data_value_ty((*a as $a_type).$op(*b as $rhs_type) as _)) } )*
             _ => unimplemented!()
-        }
-    };
-    ( $op:ident($arg1:expr, $arg2:expr); unsigned integers ) => {
-        match ($arg1, $arg2) {
-            (DataValue::I8(a), DataValue::I8(b)) => { Ok(DataValue::I8((u8::try_from(*a)?.$op(u8::try_from(*b)?) as i8))) }
-            (DataValue::I16(a), DataValue::I16(b)) => { Ok(DataValue::I16((u16::try_from(*a)?.$op(u16::try_from(*b)?) as i16))) }
-            (DataValue::I32(a), DataValue::I32(b)) => { Ok(DataValue::I32((u32::try_from(*a)?.$op(u32::try_from(*b)?) as i32))) }
-            (DataValue::I64(a), DataValue::I64(b)) => { Ok(DataValue::I64((u64::try_from(*a)?.$op(u64::try_from(*b)?) as i64))) }
-            (DataValue::I128(a), DataValue::I128(b)) => { Ok(DataValue::I128((u128::try_from(*a)?.$op(u128::try_from(*b)?) as i64))) }
-            _ => { Err(ValueError::InvalidType(ValueTypeClass::Integer, if !($arg1).ty().is_int() { ($arg1).ty() } else { ($arg2).ty() })) }
         }
     };
 }

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -23,7 +23,6 @@ impl VMComponentLibcalls {
 
 macro_rules! signature {
     (@ty size) => (usize);
-    (@ty size_pair) => (usize);
     (@ty ptr_u8) => (*mut u8);
     (@ty ptr_u16) => (*mut u16);
     (@ty ptr_size) => (*mut usize);
@@ -31,9 +30,6 @@ macro_rules! signature {
     (@ty u32) => (u32);
     (@ty u64) => (u64);
     (@ty vmctx) => (*mut VMComponentContext);
-
-    (@retptr size_pair) => (*mut usize);
-    (@retptr $other:ident) => (());
 }
 
 /// Defines a `VMComponentBuiltins` structure which contains any builtins such

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -144,7 +144,6 @@ pub mod raw {
         (@ty u8) => (u8);
         (@ty reference) => (u32);
         (@ty pointer) => (*mut u8);
-        (@ty vmctx) => (*mut VMContext);
     }
 
     wasmtime_environ::foreach_builtin_function!(libcall);

--- a/pulley/src/opcode.rs
+++ b/pulley/src/opcode.rs
@@ -80,9 +80,6 @@ macro_rules! define_extended_opcode {
             pub const MAX: u16 = define_opcode!( @max $( $name )* );
         }
     };
-
-    ( @max $x:ident ) => { 0 };
-    ( @max $x:ident $( $xs:ident )* ) => { 1 + define_opcode!(@max $( $xs )* ) };
 }
 for_each_extended_op!(define_extended_opcode);
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -223,7 +223,6 @@ macro_rules! def_unsupported {
     (emit I64Load32U $($rest:tt)*) => {};
     (emit I64Load $($rest:tt)*) => {};
     (emit I32Store $($rest:tt)*) => {};
-    (emit I32Store $($rest:tt)*) => {};
     (emit I32Store8 $($rest:tt)*) => {};
     (emit I32Store16 $($rest:tt)*) => {};
     (emit I64Store $($rest:tt)*) => {};


### PR DESCRIPTION
This is allow-by-default in the compiler but looks like it's got a high fidelity for us where we don't use macros super heavily, so let's try having it enabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
