### PR TITLE
winch: Properly define destination registers

### DIFF
--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -10,6 +10,7 @@ use super::{CodeGenContext, OperandSize, Reg, TypedReg};
 use crate::{
     abi::{ABIOperand, ABIResults, ABISig, RetArea, ABI},
     masm::{IntCmpKind, MacroAssembler, MemMoveDirection, RegImm, SPOffset},
+    reg::writable,
     stack::Val,
     CallingConvention,
 };
@@ -918,7 +919,7 @@ impl ControlStackFrame {
                     let base = context
                         .without::<_, M, _>(results.regs(), masm, |cx, masm| cx.any_gpr(masm));
                     let local_addr = masm.local_address(&slot);
-                    masm.load_ptr(local_addr, base);
+                    masm.load_ptr(local_addr, writable!(base));
                     Some(base)
                 }
                 _ => None,

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     abi::{scratch, vmctx, ABIOperand, ABISig, RetArea},
     codegen::BlockSig,
-    isa::reg::Reg,
+    isa::reg::{writable, Reg},
     masm::{
         ExtendKind, IntCmpKind, MacroAssembler, OperandSize, RegImm, SPOffset, ShiftKind, TrapCode,
     },
@@ -134,8 +134,11 @@ where
         // We need to use the vmctx parameter before pinning it for stack checking.
         self.masm.prologue(vmctx);
         // Pin the `VMContext` pointer.
-        self.masm
-            .mov(vmctx.into(), vmctx!(M), self.env.ptr_type().into());
+        self.masm.mov(
+            writable!(vmctx!(M)),
+            vmctx.into(),
+            self.env.ptr_type().into(),
+        );
 
         self.masm.reserve_stack(self.context.frame.locals_size);
 
@@ -344,7 +347,7 @@ where
         // Load the signatures address into the scratch register.
         self.masm.load(
             self.masm.address_at_vmctx(signatures_base_offset.into()),
-            scratch,
+            writable!(scratch),
             ptr_size,
         );
 
@@ -352,7 +355,7 @@ where
         let caller_id = self.context.any_gpr(self.masm);
         self.masm.load(
             self.masm.address_at_reg(scratch, sig_offset),
-            caller_id,
+            writable!(caller_id),
             sig_size,
         );
 
@@ -360,7 +363,7 @@ where
         self.masm.load(
             self.masm
                 .address_at_reg(funcref_ptr, funcref_sig_offset.into()),
-            callee_id,
+            writable!(callee_id),
             sig_size,
         );
 
@@ -454,7 +457,7 @@ where
         let addr = if data.imported {
             let global_base = self.masm.address_at_reg(vmctx!(M), data.offset);
             let scratch = scratch!(M);
-            self.masm.load_ptr(global_base, scratch);
+            self.masm.load_ptr(global_base, writable!(scratch));
             self.masm.address_at_reg(scratch, 0)
         } else {
             self.masm.address_at_reg(vmctx!(M), data.offset)
@@ -488,7 +491,7 @@ where
         let base = self.context.any_gpr(self.masm);
 
         let elem_addr = self.emit_compute_table_elem_addr(index.into(), base, &table_data);
-        self.masm.load_ptr(elem_addr, elem_value);
+        self.masm.load_ptr(elem_addr, writable!(elem_value));
         // Free the register used as base, once we have loaded the element
         // address into the element value register.
         self.context.free_reg(base);
@@ -531,7 +534,7 @@ where
         self.masm.bind(defined);
         let imm = RegImm::i64(FUNCREF_MASK as i64);
         let dst = top.into();
-        self.masm.and(dst, dst, imm, top.ty.into());
+        self.masm.and(writable!(dst), dst, imm, top.ty.into());
 
         self.masm.bind(cont);
     }
@@ -604,8 +607,8 @@ where
                 // * The memory64 proposal specifies that the index is bound to
                 // the heap type instead of hardcoding it to 32-bits (i32).
                 self.masm.mov(
+                    writable!(index_offset_and_access_size),
                     index_reg.into(),
-                    index_offset_and_access_size,
                     heap.ty.into(),
                 );
                 // Perform
@@ -619,7 +622,7 @@ where
                 // result could be clamped, resulting in an erroneus overflow
                 // check.
                 self.masm.checked_uadd(
-                    index_offset_and_access_size,
+                    writable!(index_offset_and_access_size),
                     index_offset_and_access_size,
                     RegImm::i64(offset_with_access_size as i64),
                     ptr_size,
@@ -762,7 +765,7 @@ where
             };
 
             let src = self.masm.address_at_reg(addr, 0);
-            self.masm.wasm_load(src, dst, size, sextend);
+            self.masm.wasm_load(src, writable!(dst), size, sextend);
             self.context.stack.push(TypedReg::new(ty, dst).into());
             self.context.free_reg(addr);
         }
@@ -797,11 +800,12 @@ where
             // If the table data declares a particular offset base,
             // load the address into a register to further use it as
             // the table address.
-            self.masm.load_ptr(self.masm.address_at_vmctx(offset), base);
+            self.masm
+                .load_ptr(self.masm.address_at_vmctx(offset), writable!(base));
         } else {
             // Else, simply move the vmctx register into the addr register as
             // the base to calculate the table address.
-            self.masm.mov(vmctx!(M).into(), base, ptr_size);
+            self.masm.mov(writable!(base), vmctx!(M).into(), ptr_size);
         };
 
         // OOB check.
@@ -809,7 +813,8 @@ where
             .masm
             .address_at_reg(base, table_data.current_elems_offset);
         let bound_size = table_data.current_elements_size;
-        self.masm.load(bound_addr, bound, bound_size.into());
+        self.masm
+            .load(bound_addr, writable!(bound), bound_size.into());
         self.masm.cmp(index, bound.into(), bound_size);
         self.masm
             .trapif(IntCmpKind::GeU, TrapCode::TableOutOfBounds);
@@ -818,25 +823,29 @@ where
         // element address.
         // Moving the value of the index register to the scratch register
         // also avoids overwriting the context of the index register.
-        self.masm.mov(index.into(), scratch, bound_size);
+        self.masm.mov(writable!(scratch), index.into(), bound_size);
         self.masm.mul(
-            scratch,
+            writable!(scratch),
             scratch,
             RegImm::i32(table_data.element_size.bytes() as i32),
             table_data.element_size,
         );
-        self.masm
-            .load_ptr(self.masm.address_at_reg(base, table_data.offset), base);
+        self.masm.load_ptr(
+            self.masm.address_at_reg(base, table_data.offset),
+            writable!(base),
+        );
         // Copy the value of the table base into a temporary register
         // so that we can use it later in case of a misspeculation.
-        self.masm.mov(base.into(), tmp, ptr_size);
+        self.masm.mov(writable!(tmp), base.into(), ptr_size);
         // Calculate the address of the table element.
-        self.masm.add(base, base, scratch.into(), ptr_size);
+        self.masm
+            .add(writable!(base), base, scratch.into(), ptr_size);
         if self.env.table_access_spectre_mitigation() {
             // Perform a bounds check and override the value of the
             // table element address in case the index is out of bounds.
             self.masm.cmp(index, bound.into(), OperandSize::S32);
-            self.masm.cmov(tmp, base, IntCmpKind::GeU, ptr_size);
+            self.masm
+                .cmov(writable!(base), tmp, IntCmpKind::GeU, ptr_size);
         }
         self.context.free_reg(bound);
         self.context.free_reg(tmp);
@@ -851,16 +860,20 @@ where
 
         if let Some(offset) = table_data.import_from {
             self.masm
-                .load_ptr(self.masm.address_at_vmctx(offset), scratch);
+                .load_ptr(self.masm.address_at_vmctx(offset), writable!(scratch));
         } else {
-            self.masm.mov(vmctx!(M).into(), scratch, ptr_size);
+            self.masm
+                .mov(writable!(scratch), vmctx!(M).into(), ptr_size);
         };
 
         let size_addr = self
             .masm
             .address_at_reg(scratch, table_data.current_elems_offset);
-        self.masm
-            .load(size_addr, size, table_data.current_elements_size.into());
+        self.masm.load(
+            size_addr,
+            writable!(size),
+            table_data.current_elements_size.into(),
+        );
 
         self.context.stack.push(TypedReg::i32(size).into());
     }
@@ -872,7 +885,7 @@ where
 
         let base = if let Some(offset) = heap_data.import_from {
             self.masm
-                .load_ptr(self.masm.address_at_vmctx(offset), scratch);
+                .load_ptr(self.masm.address_at_vmctx(offset), writable!(scratch));
             scratch
         } else {
             vmctx!(M)
@@ -881,12 +894,12 @@ where
         let size_addr = self
             .masm
             .address_at_reg(base, heap_data.current_length_offset);
-        self.masm.load_ptr(size_addr, size_reg);
+        self.masm.load_ptr(size_addr, writable!(size_reg));
         // Emit a shift to get the size in pages rather than in bytes.
         let dst = TypedReg::new(heap_data.ty, size_reg);
         let pow = heap_data.page_size_log2;
         self.masm.shift_ir(
-            dst.reg,
+            writable!(dst.reg),
             pow as u64,
             dst.into(),
             ShiftKind::ShrU,

--- a/winch/codegen/src/isa/reg.rs
+++ b/winch/codegen/src/isa/reg.rs
@@ -11,6 +11,18 @@ pub use regalloc2::RegClass;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Reg(PReg);
 
+pub(crate) type WritableReg = cranelift_codegen::Writable<Reg>;
+
+/// Mark a given register as writable. This macro constructs
+/// a [`cranelift_codegen::Writable`].
+macro_rules! writable {
+    ($e:expr) => {
+        cranelift_codegen::Writable::from_reg($e)
+    };
+}
+
+pub(crate) use writable;
+
 impl Reg {
     /// Create a register from its encoding and class.
     pub fn from(class: RegClass, enc: usize) -> Self {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1,6 +1,6 @@
 use crate::abi::{self, align_to, scratch, LocalSlot};
 use crate::codegen::{CodeGenContext, FuncEnv};
-use crate::isa::reg::Reg;
+use crate::isa::reg::{writable, Reg, WritableReg};
 use cranelift_codegen::{
     binemit::CodeOffset,
     ir::{Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef},
@@ -605,7 +605,7 @@ pub(crate) trait MacroAssembler {
     fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize);
 
     /// Perform a zero-extended stack load.
-    fn load(&mut self, src: Self::Address, dst: Reg, size: OperandSize);
+    fn load(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize);
 
     /// Perform a WebAssembly load.
     /// A WebAssembly load introduces several additional invariants compared to
@@ -618,26 +618,26 @@ pub(crate) trait MacroAssembler {
     fn wasm_load(
         &mut self,
         src: Self::Address,
-        dst: Reg,
+        dst: WritableReg,
         size: OperandSize,
         kind: Option<ExtendKind>,
     );
 
     /// Alias for `MacroAssembler::load` with the operand size corresponding
     /// to the pointer size of the target.
-    fn load_ptr(&mut self, src: Self::Address, dst: Reg);
+    fn load_ptr(&mut self, src: Self::Address, dst: WritableReg);
 
     /// Loads the effective address into destination.
-    fn load_addr(&mut self, _src: Self::Address, _dst: Reg, _size: OperandSize);
+    fn load_addr(&mut self, _src: Self::Address, _dst: WritableReg, _size: OperandSize);
 
     /// Pop a value from the machine stack into the given register.
-    fn pop(&mut self, dst: Reg, size: OperandSize);
+    fn pop(&mut self, dst: WritableReg, size: OperandSize);
 
     /// Perform a move.
-    fn mov(&mut self, src: RegImm, dst: Reg, size: OperandSize);
+    fn mov(&mut self, dst: WritableReg, src: RegImm, size: OperandSize);
 
     /// Perform a conditional move.
-    fn cmov(&mut self, src: Reg, dst: Reg, cc: IntCmpKind, size: OperandSize);
+    fn cmov(&mut self, dst: WritableReg, src: Reg, cc: IntCmpKind, size: OperandSize);
 
     /// Performs a memory move of bytes from src to dest.
     /// Bytes are moved in blocks of 8 bytes, where possible.
@@ -661,7 +661,10 @@ pub(crate) trait MacroAssembler {
             dst_offs += word_bytes;
             src_offs += word_bytes;
 
-            self.load_ptr(self.address_from_sp(SPOffset::from_u32(src_offs)), scratch);
+            self.load_ptr(
+                self.address_from_sp(SPOffset::from_u32(src_offs)),
+                writable!(scratch),
+            );
             self.store_ptr(
                 scratch.into(),
                 self.address_from_sp(SPOffset::from_u32(dst_offs)),
@@ -677,7 +680,7 @@ pub(crate) trait MacroAssembler {
 
             self.load(
                 self.address_from_sp(SPOffset::from_u32(src_offs)),
-                scratch,
+                writable!(scratch),
                 ptr_size,
             );
             self.store(
@@ -689,47 +692,54 @@ pub(crate) trait MacroAssembler {
     }
 
     /// Perform add operation.
-    fn add(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn add(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform a checked unsigned integer addition, emitting the provided trap
     /// if the addition overflows.
-    fn checked_uadd(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize, trap: TrapCode);
+    fn checked_uadd(
+        &mut self,
+        dst: WritableReg,
+        lhs: Reg,
+        rhs: RegImm,
+        size: OperandSize,
+        trap: TrapCode,
+    );
 
     /// Perform subtraction operation.
-    fn sub(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn sub(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform multiplication operation.
-    fn mul(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn mul(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform a floating point add operation.
-    fn float_add(&mut self, dst: Reg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_add(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
 
     /// Perform a floating point subtraction operation.
-    fn float_sub(&mut self, dst: Reg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_sub(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
 
     /// Perform a floating point multiply operation.
-    fn float_mul(&mut self, dst: Reg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_mul(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
 
     /// Perform a floating point divide operation.
-    fn float_div(&mut self, dst: Reg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_div(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
 
     /// Perform a floating point minimum operation. In x86, this will emit
     /// multiple instructions.
-    fn float_min(&mut self, dst: Reg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_min(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
 
     /// Perform a floating point maximum operation. In x86, this will emit
     /// multiple instructions.
-    fn float_max(&mut self, dst: Reg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_max(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
 
     /// Perform a floating point copysign operation. In x86, this will emit
     /// multiple instructions.
-    fn float_copysign(&mut self, dst: Reg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_copysign(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
 
     /// Perform a floating point abs operation.
-    fn float_abs(&mut self, dst: Reg, size: OperandSize);
+    fn float_abs(&mut self, dst: WritableReg, size: OperandSize);
 
     /// Perform a floating point negation operation.
-    fn float_neg(&mut self, dst: Reg, size: OperandSize);
+    fn float_neg(&mut self, dst: WritableReg, size: OperandSize);
 
     /// Perform a floating point floor operation.
     fn float_round<F: FnMut(&mut FuncEnv<Self::Ptr>, &mut CodeGenContext, &mut Self)>(
@@ -742,19 +752,26 @@ pub(crate) trait MacroAssembler {
     );
 
     /// Perform a floating point square root operation.
-    fn float_sqrt(&mut self, dst: Reg, src: Reg, size: OperandSize);
+    fn float_sqrt(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
 
     /// Perform logical and operation.
-    fn and(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn and(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform logical or operation.
-    fn or(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn or(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform logical exclusive or operation.
-    fn xor(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn xor(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform a shift operation between a register and an immediate.
-    fn shift_ir(&mut self, dst: Reg, imm: u64, lhs: Reg, kind: ShiftKind, size: OperandSize);
+    fn shift_ir(
+        &mut self,
+        dst: WritableReg,
+        imm: u64,
+        lhs: Reg,
+        kind: ShiftKind,
+        size: OperandSize,
+    );
 
     /// Perform a shift operation between two registers.
     /// This case is special in that some architectures have specific expectations
@@ -794,15 +811,15 @@ pub(crate) trait MacroAssembler {
     /// The initial value in `dst` is the left-hand-side of the comparison and
     /// the initial value in `src` is the right-hand-side of the comparison.
     /// That means for `a < b` then `dst == a` and `src == b`.
-    fn cmp_with_set(&mut self, src: RegImm, dst: Reg, kind: IntCmpKind, size: OperandSize);
+    fn cmp_with_set(&mut self, dst: WritableReg, src: RegImm, kind: IntCmpKind, size: OperandSize);
 
     /// Compare floats in src1 and src2 and put the result in dst.
     /// In x86, this will emit multiple instructions.
     fn float_cmp_with_set(
         &mut self,
+        dst: WritableReg,
         src1: Reg,
         src2: Reg,
-        dst: Reg,
         kind: FloatCmpKind,
         size: OperandSize,
     );
@@ -810,12 +827,12 @@ pub(crate) trait MacroAssembler {
     /// Count the number of leading zeroes in src and put the result in dst.
     /// In x64, this will emit multiple instructions if the `has_lzcnt` flag is
     /// false.
-    fn clz(&mut self, src: Reg, dst: Reg, size: OperandSize);
+    fn clz(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
 
     /// Count the number of trailing zeroes in src and put the result in dst.masm
     /// In x64, this will emit multiple instructions if the `has_tzcnt` flag is
     /// false.
-    fn ctz(&mut self, src: Reg, dst: Reg, size: OperandSize);
+    fn ctz(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
 
     /// Push the register to the stack, returning the stack slot metadata.
     // NB
@@ -829,24 +846,24 @@ pub(crate) trait MacroAssembler {
     fn finalize(self, base: Option<SourceLoc>) -> MachBufferFinalized<Final>;
 
     /// Zero a particular register.
-    fn zero(&mut self, reg: Reg);
+    fn zero(&mut self, reg: WritableReg);
 
     /// Count the number of 1 bits in src and put the result in dst. In x64,
     /// this will emit multiple instructions if the `has_popcnt` flag is false.
     fn popcnt(&mut self, context: &mut CodeGenContext, size: OperandSize);
 
     /// Converts an i64 to an i32 by discarding the high 32 bits.
-    fn wrap(&mut self, src: Reg, dst: Reg);
+    fn wrap(&mut self, dst: WritableReg, src: Reg);
 
     /// Extends an integer of a given size to a larger size.
-    fn extend(&mut self, src: Reg, dst: Reg, kind: ExtendKind);
+    fn extend(&mut self, dst: WritableReg, src: Reg, kind: ExtendKind);
 
     /// Emits one or more instructions to perform a signed truncation of a
     /// float into an integer.
     fn signed_truncate(
         &mut self,
+        dst: WritableReg,
         src: Reg,
-        dst: Reg,
         src_size: OperandSize,
         dst_size: OperandSize,
         kind: TruncKind,
@@ -856,8 +873,8 @@ pub(crate) trait MacroAssembler {
     /// float into an integer.
     fn unsigned_truncate(
         &mut self,
+        dst: WritableReg,
         src: Reg,
-        dst: Reg,
         tmp_fpr: Reg,
         src_size: OperandSize,
         dst_size: OperandSize,
@@ -866,30 +883,36 @@ pub(crate) trait MacroAssembler {
 
     /// Emits one or more instructions to perform a signed convert of an
     /// integer into a float.
-    fn signed_convert(&mut self, src: Reg, dst: Reg, src_size: OperandSize, dst_size: OperandSize);
+    fn signed_convert(
+        &mut self,
+        dst: WritableReg,
+        src: Reg,
+        src_size: OperandSize,
+        dst_size: OperandSize,
+    );
 
     /// Emits one or more instructions to perform an unsigned convert of an
     /// integer into a float.
     fn unsigned_convert(
         &mut self,
+        dst: WritableReg,
         src: Reg,
-        dst: Reg,
         tmp_gpr: Reg,
         src_size: OperandSize,
         dst_size: OperandSize,
     );
 
     /// Reinterpret a float as an integer.
-    fn reinterpret_float_as_int(&mut self, src: Reg, dst: Reg, size: OperandSize);
+    fn reinterpret_float_as_int(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
 
     /// Reinterpret an integer as a float.
-    fn reinterpret_int_as_float(&mut self, src: Reg, dst: Reg, size: OperandSize);
+    fn reinterpret_int_as_float(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
 
     /// Demote an f64 to an f32.
-    fn demote(&mut self, src: Reg, dst: Reg);
+    fn demote(&mut self, dst: WritableReg, src: Reg);
 
     /// Promote an f32 to an f64.
-    fn promote(&mut self, src: Reg, dst: Reg);
+    fn promote(&mut self, dst: WritableReg, src: Reg);
 
     /// Zero a given memory range.
     ///
@@ -928,7 +951,7 @@ pub(crate) trait MacroAssembler {
             // given a considerably large amount of slots
             // this will be inefficient.
             let zero = scratch!(Self);
-            self.zero(zero);
+            self.zero(writable!(zero));
             let zero = RegImm::reg(zero);
 
             for step in (start..end).into_iter().step_by(word_size as usize) {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -10,7 +10,7 @@ use crate::masm::{
     DivKind, ExtendKind, FloatCmpKind, IntCmpKind, MacroAssembler, MemMoveDirection, OperandSize,
     RegImm, RemKind, RoundingMode, SPOffset, ShiftKind, TruncKind,
 };
-use crate::reg::Reg;
+use crate::reg::{writable, Reg};
 use crate::stack::{TypedReg, Val};
 use cranelift_codegen::ir::TrapCode;
 use regalloc2::RegClass;
@@ -279,7 +279,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_add(dst, dst, src, size);
+                masm.float_add(writable!(dst), dst, src, size);
                 TypedReg::f32(dst)
             },
         );
@@ -290,7 +290,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_add(dst, dst, src, size);
+                masm.float_add(writable!(dst), dst, src, size);
                 TypedReg::f64(dst)
             },
         );
@@ -301,7 +301,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_sub(dst, dst, src, size);
+                masm.float_sub(writable!(dst), dst, src, size);
                 TypedReg::f32(dst)
             },
         );
@@ -312,7 +312,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_sub(dst, dst, src, size);
+                masm.float_sub(writable!(dst), dst, src, size);
                 TypedReg::f64(dst)
             },
         );
@@ -323,7 +323,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_mul(dst, dst, src, size);
+                masm.float_mul(writable!(dst), dst, src, size);
                 TypedReg::f32(dst)
             },
         );
@@ -334,7 +334,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_mul(dst, dst, src, size);
+                masm.float_mul(writable!(dst), dst, src, size);
                 TypedReg::f64(dst)
             },
         );
@@ -345,7 +345,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_div(dst, dst, src, size);
+                masm.float_div(writable!(dst), dst, src, size);
                 TypedReg::f32(dst)
             },
         );
@@ -356,7 +356,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_div(dst, dst, src, size);
+                masm.float_div(writable!(dst), dst, src, size);
                 TypedReg::f64(dst)
             },
         );
@@ -367,7 +367,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_min(dst, dst, src, size);
+                masm.float_min(writable!(dst), dst, src, size);
                 TypedReg::f32(dst)
             },
         );
@@ -378,7 +378,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_min(dst, dst, src, size);
+                masm.float_min(writable!(dst), dst, src, size);
                 TypedReg::f64(dst)
             },
         );
@@ -389,7 +389,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_max(dst, dst, src, size);
+                masm.float_max(writable!(dst), dst, src, size);
                 TypedReg::f32(dst)
             },
         );
@@ -400,7 +400,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_max(dst, dst, src, size);
+                masm.float_max(writable!(dst), dst, src, size);
                 TypedReg::f64(dst)
             },
         );
@@ -411,7 +411,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_copysign(dst, dst, src, size);
+                masm.float_copysign(writable!(dst), dst, src, size);
                 TypedReg::f32(dst)
             },
         );
@@ -422,7 +422,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_copysign(dst, dst, src, size);
+                masm.float_copysign(writable!(dst), dst, src, size);
                 TypedReg::f64(dst)
             },
         );
@@ -431,7 +431,7 @@ where
     fn visit_f32_abs(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_abs(reg, size);
+                masm.float_abs(writable!(reg), size);
                 TypedReg::f32(reg)
             });
     }
@@ -439,7 +439,7 @@ where
     fn visit_f64_abs(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_abs(reg, size);
+                masm.float_abs(writable!(reg), size);
                 TypedReg::f64(reg)
             });
     }
@@ -447,7 +447,7 @@ where
     fn visit_f32_neg(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_neg(reg, size);
+                masm.float_neg(writable!(reg), size);
                 TypedReg::f32(reg)
             });
     }
@@ -455,7 +455,7 @@ where
     fn visit_f64_neg(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_neg(reg, size);
+                masm.float_neg(writable!(reg), size);
                 TypedReg::f64(reg)
             });
     }
@@ -567,7 +567,7 @@ where
     fn visit_f32_sqrt(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_sqrt(reg, reg, size);
+                masm.float_sqrt(writable!(reg), reg, size);
                 TypedReg::f32(reg)
             });
     }
@@ -575,7 +575,7 @@ where
     fn visit_f64_sqrt(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_sqrt(reg, reg, size);
+                masm.float_sqrt(writable!(reg), reg, size);
                 TypedReg::f64(reg)
             });
     }
@@ -585,7 +585,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Eq, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Eq, size);
             },
         );
     }
@@ -595,7 +595,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Eq, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Eq, size);
             },
         );
     }
@@ -605,7 +605,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Ne, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ne, size);
             },
         );
     }
@@ -615,7 +615,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Ne, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ne, size);
             },
         );
     }
@@ -625,7 +625,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Lt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Lt, size);
             },
         );
     }
@@ -635,7 +635,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Lt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Lt, size);
             },
         );
     }
@@ -645,7 +645,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Gt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Gt, size);
             },
         );
     }
@@ -655,7 +655,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Gt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Gt, size);
             },
         );
     }
@@ -665,7 +665,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Le, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Le, size);
             },
         );
     }
@@ -675,7 +675,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Le, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Le, size);
             },
         );
     }
@@ -685,7 +685,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Ge, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ge, size);
             },
         );
     }
@@ -695,7 +695,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(src1, src2, dst, FloatCmpKind::Ge, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ge, size);
             },
         );
     }
@@ -703,7 +703,7 @@ where
     fn visit_f32_convert_i32_s(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::F32, |masm, dst, src, dst_size| {
-                masm.signed_convert(src, dst, OperandSize::S32, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S32, dst_size);
             });
     }
 
@@ -713,7 +713,7 @@ where
             WasmValType::F32,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S32, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S32, dst_size);
             },
         );
     }
@@ -721,7 +721,7 @@ where
     fn visit_f32_convert_i64_s(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::F32, |masm, dst, src, dst_size| {
-                masm.signed_convert(src, dst, OperandSize::S64, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S64, dst_size);
             });
     }
 
@@ -731,7 +731,7 @@ where
             WasmValType::F32,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S64, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S64, dst_size);
             },
         );
     }
@@ -739,7 +739,7 @@ where
     fn visit_f64_convert_i32_s(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::F64, |masm, dst, src, dst_size| {
-                masm.signed_convert(src, dst, OperandSize::S32, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S32, dst_size);
             });
     }
 
@@ -749,7 +749,7 @@ where
             WasmValType::F64,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S32, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S32, dst_size);
             },
         );
     }
@@ -757,7 +757,7 @@ where
     fn visit_f64_convert_i64_s(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::F64, |masm, dst, src, dst_size| {
-                masm.signed_convert(src, dst, OperandSize::S64, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S64, dst_size);
             });
     }
 
@@ -767,7 +767,7 @@ where
             WasmValType::F64,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S64, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S64, dst_size);
             },
         );
     }
@@ -775,21 +775,21 @@ where
     fn visit_f32_reinterpret_i32(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::F32, |masm, dst, src, size| {
-                masm.reinterpret_int_as_float(src.into(), dst, size);
+                masm.reinterpret_int_as_float(writable!(dst), src.into(), size);
             });
     }
 
     fn visit_f64_reinterpret_i64(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::F64, |masm, dst, src, size| {
-                masm.reinterpret_int_as_float(src.into(), dst, size);
+                masm.reinterpret_int_as_float(writable!(dst), src.into(), size);
             });
     }
 
     fn visit_f32_demote_f64(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, _size| {
-                masm.demote(reg, reg);
+                masm.demote(writable!(reg), reg);
                 TypedReg::f32(reg)
             });
     }
@@ -797,49 +797,49 @@ where
     fn visit_f64_promote_f32(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, _size| {
-                masm.promote(reg, reg);
+                masm.promote(writable!(reg), reg);
                 TypedReg::f64(reg)
             });
     }
 
     fn visit_i32_add(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.add(dst, dst, src, size);
+            masm.add(writable!(dst), dst, src, size);
             TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_add(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.add(dst, dst, src, size);
+            masm.add(writable!(dst), dst, src, size);
             TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_sub(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.sub(dst, dst, src, size);
+            masm.sub(writable!(dst), dst, src, size);
             TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_sub(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.sub(dst, dst, src, size);
+            masm.sub(writable!(dst), dst, src, size);
             TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_mul(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.mul(dst, dst, src, size);
+            masm.mul(writable!(dst), dst, src, size);
             TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_mul(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.mul(dst, dst, src, size);
+            masm.mul(writable!(dst), dst, src, size);
             TypedReg::i64(dst)
         });
     }
@@ -984,7 +984,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.cmp_with_set(RegImm::i32(0), reg.into(), IntCmpKind::Eq, size);
+            masm.cmp_with_set(writable!(reg.into()), RegImm::i32(0), IntCmpKind::Eq, size);
             TypedReg::i32(reg)
         });
     }
@@ -993,7 +993,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.cmp_with_set(RegImm::i64(0), reg.into(), IntCmpKind::Eq, size);
+            masm.cmp_with_set(writable!(reg.into()), RegImm::i64(0), IntCmpKind::Eq, size);
             TypedReg::i32(reg) // Return value for `i64.eqz` is an `i32`.
         });
     }
@@ -1002,7 +1002,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.clz(reg, reg, size);
+            masm.clz(writable!(reg), reg, size);
             TypedReg::i32(reg)
         });
     }
@@ -1011,7 +1011,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.clz(reg, reg, size);
+            masm.clz(writable!(reg), reg, size);
             TypedReg::i64(reg)
         });
     }
@@ -1020,7 +1020,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.ctz(reg, reg, size);
+            masm.ctz(writable!(reg), reg, size);
             TypedReg::i32(reg)
         });
     }
@@ -1029,49 +1029,49 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.ctz(reg, reg, size);
+            masm.ctz(writable!(reg), reg, size);
             TypedReg::i64(reg)
         });
     }
 
     fn visit_i32_and(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.and(dst, dst, src, size);
+            masm.and(writable!(dst), dst, src, size);
             TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_and(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.and(dst, dst, src, size);
+            masm.and(writable!(dst), dst, src, size);
             TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_or(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.or(dst, dst, src, size);
+            masm.or(writable!(dst), dst, src, size);
             TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_or(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.or(dst, dst, src, size);
+            masm.or(writable!(dst), dst, src, size);
             TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_xor(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.xor(dst, dst, src, size);
+            masm.xor(writable!(dst), dst, src, size);
             TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_xor(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.xor(dst, dst, src, size);
+            masm.xor(writable!(dst), dst, src, size);
             TypedReg::i64(dst)
         });
     }
@@ -1160,7 +1160,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.wrap(reg, reg);
+            masm.wrap(writable!(reg), reg);
             TypedReg::i32(reg)
         });
     }
@@ -1169,7 +1169,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(reg, reg, ExtendKind::I64ExtendI32S);
+            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32S);
             TypedReg::i64(reg)
         });
     }
@@ -1178,7 +1178,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(reg, reg, ExtendKind::I64ExtendI32U);
+            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32U);
             TypedReg::i64(reg)
         });
     }
@@ -1187,7 +1187,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(reg, reg, ExtendKind::I32Extend8S);
+            masm.extend(writable!(reg), reg, ExtendKind::I32Extend8S);
             TypedReg::i32(reg)
         });
     }
@@ -1196,7 +1196,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(reg, reg, ExtendKind::I32Extend16S);
+            masm.extend(writable!(reg), reg, ExtendKind::I32Extend16S);
             TypedReg::i32(reg)
         });
     }
@@ -1205,7 +1205,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.extend(reg, reg, ExtendKind::I64Extend8S);
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend8S);
             TypedReg::i64(reg)
         });
     }
@@ -1214,7 +1214,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.extend(reg, reg, ExtendKind::I64Extend16S);
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend16S);
             TypedReg::i64(reg)
         });
     }
@@ -1223,7 +1223,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.extend(reg, reg, ExtendKind::I64Extend32S);
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32S);
             TypedReg::i64(reg)
         });
     }
@@ -1233,7 +1233,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S32, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Unchecked);
             });
     }
 
@@ -1245,7 +1245,14 @@ where
             WasmValType::I32,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S32, dst_size, TruncKind::Unchecked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S32,
+                    dst_size,
+                    TruncKind::Unchecked,
+                );
             },
         );
     }
@@ -1255,7 +1262,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S64, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Unchecked);
             });
     }
 
@@ -1267,7 +1274,14 @@ where
             WasmValType::I32,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S64, dst_size, TruncKind::Unchecked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S64,
+                    dst_size,
+                    TruncKind::Unchecked,
+                );
             },
         );
     }
@@ -1277,7 +1291,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S32, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Unchecked);
             });
     }
 
@@ -1289,7 +1303,14 @@ where
             WasmValType::I64,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S32, dst_size, TruncKind::Unchecked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S32,
+                    dst_size,
+                    TruncKind::Unchecked,
+                );
             },
         );
     }
@@ -1299,7 +1320,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S64, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Unchecked);
             });
     }
 
@@ -1311,7 +1332,14 @@ where
             WasmValType::I64,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S64, dst_size, TruncKind::Unchecked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S64,
+                    dst_size,
+                    TruncKind::Unchecked,
+                );
             },
         );
     }
@@ -1319,14 +1347,14 @@ where
     fn visit_i32_reinterpret_f32(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, size| {
-                masm.reinterpret_float_as_int(src.into(), dst, size);
+                masm.reinterpret_float_as_int(writable!(dst), src.into(), size);
             });
     }
 
     fn visit_i64_reinterpret_f64(&mut self) {
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, size| {
-                masm.reinterpret_float_as_int(src.into(), dst, size);
+                masm.reinterpret_float_as_int(writable!(dst), src.into(), size);
             });
     }
 
@@ -1519,7 +1547,7 @@ where
                         self.emit_compute_table_elem_addr(index.into(), base, &table_data);
                     // Set the initialized bit.
                     self.masm.or(
-                        value.into(),
+                        writable!(value.into()),
                         value.into(),
                         RegImm::i64(FUNCREF_INIT_BIT as i64),
                         ptr_type.into(),
@@ -1639,7 +1667,7 @@ where
             // the result of the memory32_grow builtin.
             (WasmValType::I64, WasmValType::I32) => {
                 let top: Reg = self.context.pop_to_reg(self.masm, None).into();
-                self.masm.wrap(top.into(), top.into());
+                self.masm.wrap(writable!(top.into()), top.into());
                 self.context.stack.push(TypedReg::i32(top).into());
             }
             _ => unimplemented!("Support for 32-bit platforms"),
@@ -1875,7 +1903,7 @@ where
         let index = GlobalIndex::from_u32(global_index);
         let (ty, addr) = self.emit_get_global_addr(index);
         let dst = self.context.reg_for_type(ty, self.masm);
-        self.masm.load(addr, dst, ty.into());
+        self.masm.load(addr, writable!(dst), ty.into());
         self.context.stack.push(Val::reg(dst, ty));
     }
 
@@ -1904,8 +1932,12 @@ where
             .cmp(cond.reg.into(), RegImm::i32(0), OperandSize::S32);
         // Conditionally move val1 to val2 if the comparison is
         // not zero.
-        self.masm
-            .cmov(val1.into(), val2.into(), IntCmpKind::Ne, val1.ty.into());
+        self.masm.cmov(
+            writable!(val2.into()),
+            val1.into(),
+            IntCmpKind::Ne,
+            val1.ty.into(),
+        );
         self.context.stack.push(val2.into());
         self.context.free_reg(val1.reg);
         self.context.free_reg(cond);
@@ -2041,7 +2073,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S32, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Checked);
             });
     }
 
@@ -2053,7 +2085,14 @@ where
             WasmValType::I32,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S32, dst_size, TruncKind::Checked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S32,
+                    dst_size,
+                    TruncKind::Checked,
+                );
             },
         );
     }
@@ -2063,7 +2102,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S64, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Checked);
             });
     }
 
@@ -2075,7 +2114,14 @@ where
             WasmValType::I32,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S64, dst_size, TruncKind::Checked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S64,
+                    dst_size,
+                    TruncKind::Checked,
+                );
             },
         );
     }
@@ -2085,7 +2131,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S32, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Checked);
             });
     }
 
@@ -2097,7 +2143,14 @@ where
             WasmValType::I64,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S32, dst_size, TruncKind::Checked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S32,
+                    dst_size,
+                    TruncKind::Checked,
+                );
             },
         );
     }
@@ -2107,7 +2160,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(src, dst, S64, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Checked);
             });
     }
 
@@ -2119,7 +2172,14 @@ where
             WasmValType::I64,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
-                masm.unsigned_truncate(src, dst, tmp_fpr, S64, dst_size, TruncKind::Checked);
+                masm.unsigned_truncate(
+                    writable!(dst),
+                    src,
+                    tmp_fpr,
+                    S64,
+                    dst_size,
+                    TruncKind::Checked,
+                );
             },
         );
     }
@@ -2133,7 +2193,7 @@ where
 {
     fn cmp_i32s(&mut self, kind: IntCmpKind) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.cmp_with_set(src, dst, kind, size);
+            masm.cmp_with_set(writable!(dst), src, kind, size);
             TypedReg::i32(dst)
         });
     }
@@ -2141,7 +2201,7 @@ where
     fn cmp_i64s(&mut self, kind: IntCmpKind) {
         self.context
             .i64_binop(self.masm, move |masm, dst, src, size| {
-                masm.cmp_with_set(src, dst, kind, size);
+                masm.cmp_with_set(writable!(dst), src, kind, size);
                 TypedReg::i32(dst) // Return value for comparisons is an `i32`.
             });
     }


### PR DESCRIPTION
No functional changes are introduced as part of this change.

This commit introduces a formal mechanism for identifying destination registers in Winch's MacroAssembler and Assembler layers.

Before this change, there was no standardized way to identify writable registers, which made it challenging to:

* Audit register clobbering effectively.
* Establish a consistent approach for defining new MacroAssembler methods, as the identification of writable registers was done ad-hoc and varied from method to method.

This enhancement aims to improve code maintainability and reduce potential errors related to register management.

This commit makes use of Cranelift's `Writable<T>` type to identify writable registers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
