### PR TITLE
Update CI nightly to the latest nightly

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -36,7 +36,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2024-09-05" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2024-10-01" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/crates/component-util/src/lib.rs
+++ b/crates/component-util/src/lib.rs
@@ -75,18 +75,13 @@ impl FlagsSize {
         } else if count <= 16 {
             FlagsSize::Size2
         } else {
-            let amt = ceiling_divide(count, 32);
+            let amt = count.div_ceil(32);
             if amt > (u8::MAX as usize) {
                 panic!("too many flags");
             }
             FlagsSize::Size4Plus(amt as u8)
         }
     }
-}
-
-/// Divide `n` by `d`, rounding up in the case of a non-zero remainder.
-const fn ceiling_divide(n: usize, d: usize) -> usize {
-    (n + d - 1) / d
 }
 
 /// A simple bump allocator which can be used with modules

--- a/crates/test-programs/src/bin/api_reactor.rs
+++ b/crates/test-programs/src/bin/api_reactor.rs
@@ -1,3 +1,5 @@
+use std::sync::{Mutex, MutexGuard};
+
 wit_bindgen::generate!({
     world: "test-reactor",
     path: "../wasi/wit",
@@ -8,57 +10,59 @@ struct T;
 
 export!(T);
 
-static mut STATE: Vec<String> = Vec::new();
+fn state() -> MutexGuard<'static, Vec<String>> {
+    static STATE: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    STATE.lock().unwrap()
+}
 
 impl Guest for T {
     fn add_strings(ss: Vec<String>) -> u32 {
+        let mut state = state();
         for s in ss {
             match s.split_once("$") {
                 Some((prefix, var)) if prefix.is_empty() => match std::env::var(var) {
-                    Ok(val) => unsafe { STATE.push(val) },
-                    Err(_) => unsafe { STATE.push("undefined".to_owned()) },
+                    Ok(val) => state.push(val),
+                    Err(_) => state.push("undefined".to_owned()),
                 },
-                _ => unsafe { STATE.push(s) },
+                _ => state.push(s),
             }
         }
-        unsafe { STATE.len() as u32 }
+        state.len() as u32
     }
     fn get_strings() -> Vec<String> {
-        unsafe { STATE.clone() }
+        state().clone()
     }
 
     fn write_strings_to(o: OutputStream) -> Result<(), ()> {
         let pollable = o.subscribe();
-        unsafe {
-            for s in STATE.iter() {
-                let mut out = s.as_bytes();
-                while !out.is_empty() {
-                    pollable.block();
-                    let n = match o.check_write() {
-                        Ok(n) => n,
-                        Err(_) => return Err(()),
-                    };
+        for s in state().iter() {
+            let mut out = s.as_bytes();
+            while !out.is_empty() {
+                pollable.block();
+                let n = match o.check_write() {
+                    Ok(n) => n,
+                    Err(_) => return Err(()),
+                };
 
-                    let len = (n as usize).min(out.len());
-                    match o.write(&out[..len]) {
-                        Ok(_) => out = &out[len..],
-                        Err(_) => return Err(()),
-                    }
+                let len = (n as usize).min(out.len());
+                match o.write(&out[..len]) {
+                    Ok(_) => out = &out[len..],
+                    Err(_) => return Err(()),
                 }
             }
-
-            match o.flush() {
-                Ok(_) => {}
-                Err(_) => return Err(()),
-            }
-            pollable.block();
-            match o.check_write() {
-                Ok(_) => {}
-                Err(_) => return Err(()),
-            }
-
-            Ok(())
         }
+
+        match o.flush() {
+            Ok(_) => {}
+            Err(_) => return Err(()),
+        }
+        pollable.block();
+        match o.check_write() {
+            Ok(_) => {}
+            Err(_) => return Err(()),
+        }
+
+        Ok(())
     }
     fn pass_an_imported_record(stat: wasi::filesystem::types::DescriptorStat) -> String {
         format!("{stat:?}")

--- a/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
@@ -55,7 +55,7 @@ use mach2::thread_act::*;
 use mach2::thread_status::*;
 use mach2::traps::*;
 use std::io;
-use std::mem::{self, MaybeUninit};
+use std::mem;
 use std::ptr::addr_of_mut;
 use std::thread;
 use wasmtime_environ::Trap;

--- a/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
@@ -69,7 +69,7 @@ pub struct TrapHandler {
     thread: Option<thread::JoinHandle<()>>,
 }
 
-static mut PREV_SIGBUS: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
+static mut PREV_SIGBUS: libc::sigaction = unsafe { mem::zeroed() };
 
 impl TrapHandler {
     pub unsafe fn new() -> TrapHandler {
@@ -103,7 +103,7 @@ impl TrapHandler {
             handler.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK;
             handler.sa_sigaction = sigbus_handler as usize;
             libc::sigemptyset(&mut handler.sa_mask);
-            if libc::sigaction(libc::SIGBUS, &handler, PREV_SIGBUS.as_mut_ptr()) != 0 {
+            if libc::sigaction(libc::SIGBUS, &handler, addr_of_mut!(PREV_SIGBUS)) != 0 {
                 panic!(
                     "unable to install signal handler: {}",
                     io::Error::last_os_error(),
@@ -149,7 +149,7 @@ unsafe extern "C" fn sigbus_handler(
     });
 
     super::signals::delegate_signal_to_previous_handler(
-        PREV_SIGBUS.as_ptr(),
+        addr_of_mut!(PREV_SIGBUS),
         signum,
         siginfo,
         context,


### PR DESCRIPTION
Brings in a new warning which fires on generating a safe (either `&` or `&mut`) reference to a `static mut`. This then additionally refactors code to use `addr_of_mut!` appropriately and/or switch to other alternatives.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
