### PR TITLE
Allow alignments that eat the remaining allocation

### DIFF
--- a/crates/test-programs/src/bin/cli_stdin_empty.rs
+++ b/crates/test-programs/src/bin/cli_stdin_empty.rs
@@ -1,0 +1,16 @@
+use test_programs::preview1::STDIN_FD;
+
+fn main() {
+    let mut buffer = [0_u8; 0];
+
+    unsafe {
+        wasi::fd_read(
+            STDIN_FD,
+            &[wasi::Iovec {
+                buf: buffer.as_mut_ptr(),
+                buf_len: 0,
+            }],
+        )
+        .expect("empty read should succeed");
+    }
+}

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -448,7 +448,7 @@ impl BumpAlloc {
             unreachable!("invalid alignment");
         }
         let align_offset = self.base.align_offset(align);
-        if align_offset >= self.len {
+        if align_offset > self.len {
             unreachable!("failed to allocate")
         }
         self.len -= align_offset;

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1161,6 +1161,27 @@ mod test_programs {
     }
 
     #[test]
+    fn cli_stdin_empty() -> Result<()> {
+        let mut child = get_wasmtime_command()?
+            .args(&["run", "-Wcomponent-model", CLI_STDIN_EMPTY_COMPONENT])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::piped())
+            .spawn()?;
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"not to be read")
+            .unwrap();
+        let output = child.wait_with_output()?;
+        println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    #[test]
     fn cli_stdin() -> Result<()> {
         let mut child = get_wasmtime_command()?
             .args(&["run", "-Wcomponent-model", CLI_STDIN_COMPONENT])


### PR DESCRIPTION
The preview1 adapter has an implementation of cabi_realloc that facilitates calling component imports that return dynamically allocated results, like lists and strings. However, when returning a zero-length value to a buffer that's been allocated with zero bytes available, a trap will occur. This is because the alignment check requires that there is space left over after alignment has been added to the base pointer, which in the case of an empty buffer, will not be possible.

This PR fixes the issue by relaxing the alignment check to require that the amount required to align the base does not exceed the length of the buffer, but may consume the entire allocation.
