### PR TITLE
Disable tail-call/relaxed-simd when fuzzing the spec interpreter

### DIFF
--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -23,6 +23,7 @@ impl SpecInterpreter {
         config.threads_enabled = false;
         config.bulk_memory_enabled = false;
         config.reference_types_enabled = false;
+        config.tail_call_enabled = false;
 
         Self
     }

--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -24,6 +24,7 @@ impl SpecInterpreter {
         config.bulk_memory_enabled = false;
         config.reference_types_enabled = false;
         config.tail_call_enabled = false;
+        config.relaxed_simd_enabled = false;
 
         Self
     }


### PR DESCRIPTION
Our copy of the reference interpreter does not implement the tail-call proposal, so fix OSS-Fuzz by disabling it. This technically should have been done in #9336 when wasm-tools was updated to auto-try to enable this proposal by default, but alas I am not a human fuzzer so I waited until OSS-Fuzz found it.

cc @conrad-watt we haven't updated our submodule in quite some time, but I figured this was a good a time as any to ask - have there been any major updates on your spec interpreter fork in the past year or so? If not no worries, but if so we can try to update too!