### PR TITLE
s390x: Hard code the link register for ElfTlsGetOffset

### DIFF
--- a/cranelift/bforest/src/node.rs
+++ b/cranelift/bforest/src/node.rs
@@ -13,7 +13,6 @@ use core::fmt;
 ///
 /// An inner node contains at least M/2 node references unless it is the right-most node at its
 /// level. A leaf node contains at least N/2 keys unless it is the right-most leaf.
-#[allow(dead_code)] // workaround for https://github.com/rust-lang/rust/issues/64362
 pub(super) enum NodeData<F: Forest> {
     Inner {
         /// The number of keys in this node.

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -2,7 +2,6 @@
 
 // Some variants are never constructed, but we still want them as options in the future.
 use super::Inst;
-#[allow(dead_code)]
 use std::fmt::{Debug, Display, Formatter, Result};
 
 #[derive(Copy, Clone, Debug, Default)]

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1020,7 +1020,6 @@
       (tls_offset WritableReg)
       (got Reg)
       (got_offset Reg)
-      (link WritableReg)
       (symbol BoxSymbolReloc))
 ))
 

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -3250,9 +3250,7 @@ impl Inst {
                 put(sink, &enc_rr(opcode, gpr(15), rn));
                 sink.add_call_site();
             }
-            &Inst::ElfTlsGetOffset {
-                ref symbol, link, ..
-            } => {
+            &Inst::ElfTlsGetOffset { ref symbol, .. } => {
                 let opcode = 0xc05; // BRASL
 
                 // Add relocation for target function. This has to be done
@@ -3265,7 +3263,7 @@ impl Inst {
                     _ => unreachable!(),
                 }
 
-                put(sink, &enc_ril_b(opcode, link.to_reg(), 0));
+                put(sink, &enc_ril_b(opcode, gpr(14), 0));
                 sink.add_call_site();
             }
             &Inst::Args { .. } => {}

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -2279,7 +2279,7 @@
 (rule (lib_call_tls_get_offset got got_offset symbol)
       (let ((tls_offset WritableReg (temp_writable_reg $I64))
             (_ Unit (abi_for_elf_tls_get_offset))
-            (_ Unit (emit (MInst.ElfTlsGetOffset tls_offset got got_offset (writable_link_reg) symbol))))
+            (_ Unit (emit (MInst.ElfTlsGetOffset tls_offset got got_offset symbol))))
         tls_offset))
 
 (decl abi_for_elf_tls_get_offset () Unit)


### PR DESCRIPTION
The ElfTlsGetOffset pseudo-instruction already hard codes the rest of the abi anyway and if another abi is ever needed, adding another pseudo-instruction or an enum field to the existing one would likely be necessary anyway. Also remove a couple of dead_code allows.