### PR TITLE
Fix cranelift-fuzzgen fuzzer from TrapCode refactoring

### DIFF
--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -107,6 +107,9 @@ impl Default for Statistics {
         // Pre-Register all trap codes since we can't modify this hashmap atomically.
         let mut run_result_trap = HashMap::new();
         run_result_trap.insert(CraneliftTrap::Debug, AtomicU64::new(0));
+        run_result_trap.insert(CraneliftTrap::BadSignature, AtomicU64::new(0));
+        run_result_trap.insert(CraneliftTrap::UnreachableCodeReached, AtomicU64::new(0));
+        run_result_trap.insert(CraneliftTrap::HeapMisaligned, AtomicU64::new(0));
         for trapcode in TrapCode::non_user_traps() {
             run_result_trap.insert(CraneliftTrap::User(*trapcode), AtomicU64::new(0));
         }


### PR DESCRIPTION
This commit fixes an issue found on OSS-Fuzz for the cranelift-fuzzgen fuzzer which was caused by #9338 but that PR forgot to fix.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
