### PR TITLE
Release Wasmtime 22.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "22.0.0"
+version = "22.0.1"
 
 [[package]]
 name = "byteorder"
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -591,14 +591,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -628,25 +628,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.109.0"
+version = "0.109.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.3",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.109.0"
+version = "0.109.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1056,7 +1056,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3090,7 +3090,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3140,7 +3140,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3431,14 +3431,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3454,14 +3454,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3608,11 +3608,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "22.0.0"
+version = "22.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "object 0.36.0",
  "once_cell",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "22.0.0"
+version = "22.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "22.0.0"
+version = "22.0.1"
 
 [[package]]
 name = "wast"
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "22.0.0"
+version = "22.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4078,7 +4078,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "22.0.0"
+version = "22.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -176,56 +176,56 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=22.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "22.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=22.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=22.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=22.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=22.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=22.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=22.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=22.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=22.0.0" }
-wasmtime-types = { path = "crates/types", version = "22.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=22.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=22.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "22.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=22.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "22.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "22.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=22.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=22.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=22.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=22.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=22.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=22.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "22.0.1", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=22.0.1" }
+wasmtime-cache = { path = "crates/cache", version = "=22.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=22.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=22.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=22.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=22.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=22.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=22.0.1" }
+wasmtime-types = { path = "crates/types", version = "22.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=22.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=22.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "22.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=22.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "22.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "22.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=22.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=22.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=22.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=22.0.1" }
+wasmtime-slab = { path = "crates/slab", version = "=22.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=22.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=22.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=22.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=22.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=22.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=22.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=22.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=22.0.1", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=22.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=22.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=22.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=22.0.1" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.109.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.109.0", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.109.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.109.0" }
-cranelift-native = { path = "cranelift/native", version = "0.109.0" }
-cranelift-module = { path = "cranelift/module", version = "0.109.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.109.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.109.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.109.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.109.1", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.109.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.109.1" }
+cranelift-native = { path = "cranelift/native", version = "0.109.1" }
+cranelift-module = { path = "cranelift/module", version = "0.109.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.109.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.109.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.109.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.109.0" }
+cranelift-object = { path = "cranelift/object", version = "0.109.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.109.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.109.0" }
-cranelift-control = { path = "cranelift/control", version = "0.109.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.109.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.109.1" }
+cranelift-control = { path = "cranelift/control", version = "0.109.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.109.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.20.0" }
+winch-codegen = { path = "winch/codegen", version = "=0.20.1" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.109.0"
+version = "0.109.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.109.0"
+version = "0.109.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.109.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.109.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -46,8 +46,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.109.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.109.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.109.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.109.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.109.0"
+version = "0.109.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.109.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.109.1" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.109.0"
+version = "0.109.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.109.0"
+version = "0.109.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.109.0"
+version = "0.109.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.109.0"
+version = "0.109.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.109.0"
+version = "0.109.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.109.0"
+version = "0.109.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.109.0"
+version = "0.109.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.109.0"
+version = "0.109.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.109.0"
+version = "0.109.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.109.0"
+version = "0.109.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.109.0"
+version = "0.109.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.109.0"
+version = "0.109.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.109.0"
+version = "0.109.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.109.0"
+version = "0.109.1"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "22.0.0"
+#define WASMTIME_VERSION "22.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -24,6 +28,10 @@ audited_as = "0.106.1"
 [[unpublished.cranelift-bforest]]
 version = "0.109.0"
 audited_as = "0.107.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.109.1"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-codegen]]
 version = "0.107.0"
@@ -37,6 +45,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-codegen]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -48,6 +60,10 @@ audited_as = "0.106.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.109.0"
 audited_as = "0.107.1"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.109.1"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.107.0"
@@ -61,6 +77,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-control]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -72,6 +92,10 @@ audited_as = "0.106.1"
 [[unpublished.cranelift-control]]
 version = "0.109.0"
 audited_as = "0.107.1"
+
+[[unpublished.cranelift-control]]
+version = "0.109.1"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-entity]]
 version = "0.107.0"
@@ -85,6 +109,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-entity]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-frontend]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -96,6 +124,10 @@ audited_as = "0.106.1"
 [[unpublished.cranelift-frontend]]
 version = "0.109.0"
 audited_as = "0.107.1"
+
+[[unpublished.cranelift-frontend]]
+version = "0.109.1"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.107.0"
@@ -109,6 +141,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-isle]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -120,6 +156,10 @@ audited_as = "0.106.1"
 [[unpublished.cranelift-isle]]
 version = "0.109.0"
 audited_as = "0.107.1"
+
+[[unpublished.cranelift-isle]]
+version = "0.109.1"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-jit]]
 version = "0.107.0"
@@ -133,6 +173,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-jit]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-module]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -144,6 +188,10 @@ audited_as = "0.106.1"
 [[unpublished.cranelift-module]]
 version = "0.109.0"
 audited_as = "0.107.1"
+
+[[unpublished.cranelift-module]]
+version = "0.109.1"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-native]]
 version = "0.107.0"
@@ -157,6 +205,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-native]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-object]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -168,6 +220,10 @@ audited_as = "0.106.1"
 [[unpublished.cranelift-object]]
 version = "0.109.0"
 audited_as = "0.107.1"
+
+[[unpublished.cranelift-object]]
+version = "0.109.1"
+audited_as = "0.109.0"
 
 [[unpublished.cranelift-reader]]
 version = "0.107.0"
@@ -181,6 +237,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -193,6 +253,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.cranelift-wasm]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -205,6 +269,10 @@ audited_as = "0.106.1"
 version = "0.109.0"
 audited_as = "0.107.1"
 
+[[unpublished.cranelift-wasm]]
+version = "0.109.1"
+audited_as = "0.109.0"
+
 [[unpublished.wasi-common]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -216,6 +284,10 @@ audited_as = "19.0.1"
 [[unpublished.wasi-common]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasi-common]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime]]
 version = "20.0.0"
@@ -229,6 +301,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -240,6 +316,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cache]]
 version = "20.0.0"
@@ -253,6 +333,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-cache]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -264,6 +348,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-cli]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "20.0.0"
@@ -277,6 +365,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-component-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -288,6 +380,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-component-macro]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-component-util]]
 version = "20.0.0"
@@ -301,6 +397,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-cranelift]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -312,6 +412,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "20.0.0"
@@ -329,6 +433,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-explorer]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -340,6 +448,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-explorer]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-explorer]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-fiber]]
 version = "20.0.0"
@@ -353,6 +465,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-fiber]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -365,6 +481,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -376,6 +496,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-runtime]]
 version = "20.0.0"
@@ -397,6 +521,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-slab]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-types]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -408,6 +536,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-types]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-types]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wasi]]
 version = "20.0.0"
@@ -421,6 +553,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -432,6 +568,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "20.0.0"
@@ -445,6 +585,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -456,6 +600,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wast]]
 version = "20.0.0"
@@ -469,6 +617,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-winch]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -480,6 +632,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-winch]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-winch]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "20.0.0"
@@ -493,6 +649,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -504,6 +664,10 @@ audited_as = "19.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wiggle]]
 version = "20.0.0"
@@ -517,6 +681,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wiggle]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -529,6 +697,10 @@ audited_as = "19.0.1"
 version = "22.0.0"
 audited_as = "20.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "22.0.1"
+audited_as = "22.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -540,6 +712,10 @@ audited_as = "19.0.1"
 [[unpublished.wiggle-macro]]
 version = "22.0.0"
 audited_as = "20.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "22.0.1"
+audited_as = "22.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -556,6 +732,10 @@ audited_as = "0.17.1"
 [[unpublished.winch-codegen]]
 version = "0.20.0"
 audited_as = "0.18.1"
+
+[[unpublished.winch-codegen]]
+version = "0.20.1"
+audited_as = "0.20.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -750,6 +930,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -765,6 +951,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -786,6 +978,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -801,6 +999,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -822,6 +1026,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -837,6 +1047,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -858,6 +1074,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -873,6 +1095,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -894,6 +1122,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -909,6 +1143,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -930,6 +1170,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -945,6 +1191,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -966,6 +1218,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -981,6 +1239,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1002,6 +1266,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1020,6 +1290,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.109.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.105.2"
 when = "2024-02-28"
@@ -1035,6 +1311,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.107.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.109.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1454,6 +1736,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1795,6 +2083,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1810,6 +2104,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1831,6 +2131,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1846,6 +2152,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1867,6 +2179,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1882,6 +2200,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1903,6 +2227,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1918,6 +2248,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1939,6 +2275,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1954,6 +2296,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1975,6 +2323,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -1993,6 +2347,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-debug]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2008,6 +2368,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2029,6 +2395,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-slab]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-types]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2044,6 +2416,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-types]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-types]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2065,6 +2443,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2080,6 +2464,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2101,6 +2491,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2116,6 +2512,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2137,6 +2539,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2152,6 +2560,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-winch]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2173,6 +2587,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2188,6 +2608,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2317,6 +2743,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2335,6 +2767,12 @@ when = "2024-05-03"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "22.0.0"
+when = "2024-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "18.0.2"
 when = "2024-02-28"
@@ -2350,6 +2788,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "20.0.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "22.0.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2382,6 +2826,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.18.1"
 when = "2024-05-03"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.20.0"
+when = "2024-06-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 22.0.1, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-22.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
