### PR TITLE
Release Wasmtime 23.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "23.0.2"
+version = "23.0.3"
 
 [[package]]
 name = "byteorder"
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -569,14 +569,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "serde",
  "serde_derive",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -615,25 +615,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.110.2"
+version = "0.110.3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.3",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.110.2"
+version = "0.110.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1044,7 +1044,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3079,7 +3079,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3129,7 +3129,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3423,14 +3423,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3446,14 +3446,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3600,11 +3600,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "23.0.2"
+version = "23.0.3"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "object 0.36.0",
  "once_cell",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "23.0.2"
+version = "23.0.3"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "log",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "log",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "23.0.2"
+version = "23.0.3"
 
 [[package]]
 name = "wast"
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "23.0.2"
+version = "23.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4085,7 +4085,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "23.0.2"
+version = "23.0.3"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -176,57 +176,57 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=23.0.2" }
-wasmtime = { path = "crates/wasmtime", version = "23.0.2", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=23.0.2" }
-wasmtime-cache = { path = "crates/cache", version = "=23.0.2" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=23.0.2" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=23.0.2" }
-wasmtime-winch = { path = "crates/winch", version = "=23.0.2" }
-wasmtime-environ = { path = "crates/environ", version = "=23.0.2" }
-wasmtime-explorer = { path = "crates/explorer", version = "=23.0.2" }
-wasmtime-fiber = { path = "crates/fiber", version = "=23.0.2" }
-wasmtime-types = { path = "crates/types", version = "23.0.2" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=23.0.2" }
-wasmtime-wast = { path = "crates/wast", version = "=23.0.2" }
-wasmtime-wasi = { path = "crates/wasi", version = "23.0.2", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=23.0.2", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "23.0.2" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "23.0.2" }
-wasmtime-component-util = { path = "crates/component-util", version = "=23.0.2" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=23.0.2" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=23.0.2" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=23.0.2" }
-wasmtime-slab = { path = "crates/slab", version = "=23.0.2" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=23.0.3" }
+wasmtime = { path = "crates/wasmtime", version = "23.0.3", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=23.0.3" }
+wasmtime-cache = { path = "crates/cache", version = "=23.0.3" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=23.0.3" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=23.0.3" }
+wasmtime-winch = { path = "crates/winch", version = "=23.0.3" }
+wasmtime-environ = { path = "crates/environ", version = "=23.0.3" }
+wasmtime-explorer = { path = "crates/explorer", version = "=23.0.3" }
+wasmtime-fiber = { path = "crates/fiber", version = "=23.0.3" }
+wasmtime-types = { path = "crates/types", version = "23.0.3" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=23.0.3" }
+wasmtime-wast = { path = "crates/wast", version = "=23.0.3" }
+wasmtime-wasi = { path = "crates/wasi", version = "23.0.3", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=23.0.3", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "23.0.3" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "23.0.3" }
+wasmtime-component-util = { path = "crates/component-util", version = "=23.0.3" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=23.0.3" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=23.0.3" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=23.0.3" }
+wasmtime-slab = { path = "crates/slab", version = "=23.0.3" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=23.0.2", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=23.0.2" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=23.0.2" }
-wasi-common = { path = "crates/wasi-common", version = "=23.0.2", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=23.0.3", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=23.0.3" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=23.0.3" }
+wasi-common = { path = "crates/wasi-common", version = "=23.0.3", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=23.0.2" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=23.0.2" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=23.0.3" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=23.0.3" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.110.2" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.110.2", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.110.2" }
-cranelift-entity = { path = "cranelift/entity", version = "0.110.2" }
-cranelift-native = { path = "cranelift/native", version = "0.110.2" }
-cranelift-module = { path = "cranelift/module", version = "0.110.2" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.110.2" }
-cranelift-reader = { path = "cranelift/reader", version = "0.110.2" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.110.3" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.110.3", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.110.3" }
+cranelift-entity = { path = "cranelift/entity", version = "0.110.3" }
+cranelift-native = { path = "cranelift/native", version = "0.110.3" }
+cranelift-module = { path = "cranelift/module", version = "0.110.3" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.110.3" }
+cranelift-reader = { path = "cranelift/reader", version = "0.110.3" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.110.2" }
-cranelift-jit = { path = "cranelift/jit", version = "0.110.2" }
+cranelift-object = { path = "cranelift/object", version = "0.110.3" }
+cranelift-jit = { path = "cranelift/jit", version = "0.110.3" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.110.2" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.110.2" }
-cranelift-control = { path = "cranelift/control", version = "0.110.2" }
-cranelift = { path = "cranelift/umbrella", version = "0.110.2" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.110.3" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.110.3" }
+cranelift-control = { path = "cranelift/control", version = "0.110.3" }
+cranelift = { path = "cranelift/umbrella", version = "0.110.3" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.21.2" }
+winch-codegen = { path = "winch/codegen", version = "=0.21.3" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.110.2"
+version = "0.110.3"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.110.2"
+version = "0.110.3"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.110.2"
+version = "0.110.3"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.110.2" }
+cranelift-codegen-shared = { path = "./shared", version = "0.110.3" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.110.2" }
-cranelift-isle = { path = "../isle/isle", version = "=0.110.2" }
+cranelift-codegen-meta = { path = "meta", version = "0.110.3" }
+cranelift-isle = { path = "../isle/isle", version = "=0.110.3" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.110.2"
+version = "0.110.3"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.110.2" }
+cranelift-codegen-shared = { path = "../shared", version = "0.110.3" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.110.2"
+version = "0.110.3"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.110.2"
+version = "0.110.3"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.110.2"
+version = "0.110.3"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.110.2"
+version = "0.110.3"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.110.2"
+version = "0.110.3"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.110.2"
+version = "0.110.3"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.110.2"
+version = "0.110.3"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.110.2"
+version = "0.110.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.110.2"
+version = "0.110.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.110.2"
+version = "0.110.3"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.110.2"
+version = "0.110.3"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.110.2"
+version = "0.110.3"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.110.2"
+version = "0.110.3"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.110.2"
+version = "0.110.3"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "23.0.2"
+#define WASMTIME_VERSION "23.0.3"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 2
+#define WASMTIME_VERSION_PATCH 3
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -25,6 +25,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-bforest]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -48,11 +52,19 @@ audited_as = "0.110.0"
 [[unpublished.cranelift-bforest]]
 version = "0.110.2"
 audited_as = "0.110.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.110.3"
+audited_as = "0.110.2"
 
 [[unpublished.cranelift-bitset]]
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-codegen]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -77,6 +89,10 @@ audited_as = "0.109.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-codegen]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -101,6 +117,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -125,6 +145,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-control]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -148,6 +172,10 @@ audited_as = "0.110.0"
 [[unpublished.cranelift-control]]
 version = "0.110.2"
 audited_as = "0.110.1"
+
+[[unpublished.cranelift-control]]
+version = "0.110.3"
+audited_as = "0.110.2"
 
 [[unpublished.cranelift-entity]]
 version = "0.107.0"
@@ -173,6 +201,10 @@ audited_as = "0.109.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-entity]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-frontend]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -197,6 +229,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -221,6 +257,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-isle]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -244,6 +284,10 @@ audited_as = "0.110.0"
 [[unpublished.cranelift-isle]]
 version = "0.110.2"
 audited_as = "0.110.1"
+
+[[unpublished.cranelift-isle]]
+version = "0.110.3"
+audited_as = "0.110.2"
 
 [[unpublished.cranelift-jit]]
 version = "0.107.0"
@@ -269,6 +313,10 @@ audited_as = "0.109.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-jit]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-module]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -293,6 +341,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-module]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-native]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -317,6 +369,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-native]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-object]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -341,6 +397,10 @@ audited_as = "0.110.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-object]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-reader]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -364,6 +424,10 @@ audited_as = "0.110.0"
 [[unpublished.cranelift-reader]]
 version = "0.110.2"
 audited_as = "0.110.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.110.3"
+audited_as = "0.110.2"
 
 [[unpublished.cranelift-serde]]
 version = "0.107.0"
@@ -389,6 +453,10 @@ audited_as = "0.109.0"
 version = "0.110.2"
 audited_as = "0.110.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.110.3"
+audited_as = "0.110.2"
+
 [[unpublished.cranelift-wasm]]
 version = "0.107.0"
 audited_as = "0.105.2"
@@ -412,6 +480,10 @@ audited_as = "0.110.0"
 [[unpublished.cranelift-wasm]]
 version = "0.110.2"
 audited_as = "0.110.1"
+
+[[unpublished.cranelift-wasm]]
+version = "0.110.3"
+audited_as = "0.110.2"
 
 [[unpublished.wasi-common]]
 version = "20.0.0"
@@ -437,6 +509,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasi-common]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -461,6 +537,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -485,6 +565,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-cache]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -508,6 +592,10 @@ audited_as = "23.0.0"
 [[unpublished.wasmtime-cache]]
 version = "23.0.2"
 audited_as = "23.0.1"
+
+[[unpublished.wasmtime-cache]]
+version = "23.0.3"
+audited_as = "23.0.2"
 
 [[unpublished.wasmtime-cli]]
 version = "20.0.0"
@@ -533,6 +621,10 @@ audited_as = "22.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-cli]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -557,6 +649,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-component-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -581,6 +677,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-component-macro]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-component-util]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -605,6 +705,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-cranelift]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -628,6 +732,10 @@ audited_as = "23.0.0"
 [[unpublished.wasmtime-cranelift]]
 version = "23.0.2"
 audited_as = "23.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "23.0.3"
+audited_as = "23.0.2"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "20.0.0"
@@ -657,6 +765,10 @@ audited_as = "22.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-explorer]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -681,6 +793,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-explorer]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-fiber]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -705,6 +821,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-fiber]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -729,6 +849,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -752,6 +876,10 @@ audited_as = "23.0.0"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "23.0.2"
 audited_as = "23.0.1"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "23.0.3"
+audited_as = "23.0.2"
 
 [[unpublished.wasmtime-runtime]]
 version = "20.0.0"
@@ -785,6 +913,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-slab]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-types]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -809,6 +941,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-types]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-wasi]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -833,6 +969,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -857,6 +997,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -880,6 +1024,10 @@ audited_as = "23.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "23.0.2"
 audited_as = "23.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "23.0.3"
+audited_as = "23.0.2"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "20.0.0"
@@ -905,6 +1053,10 @@ audited_as = "22.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-wast]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -928,6 +1080,10 @@ audited_as = "23.0.0"
 [[unpublished.wasmtime-wast]]
 version = "23.0.2"
 audited_as = "23.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "23.0.3"
+audited_as = "23.0.2"
 
 [[unpublished.wasmtime-winch]]
 version = "20.0.0"
@@ -953,6 +1109,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-winch]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -977,6 +1137,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -1001,6 +1165,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wiggle]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -1025,6 +1193,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wiggle]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wiggle-generate]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -1049,6 +1221,10 @@ audited_as = "23.0.0"
 version = "23.0.2"
 audited_as = "23.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "23.0.3"
+audited_as = "23.0.2"
+
 [[unpublished.wiggle-macro]]
 version = "20.0.0"
 audited_as = "18.0.2"
@@ -1072,6 +1248,10 @@ audited_as = "23.0.0"
 [[unpublished.wiggle-macro]]
 version = "23.0.2"
 audited_as = "23.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "23.0.3"
+audited_as = "23.0.2"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -1100,6 +1280,10 @@ audited_as = "0.21.0"
 [[unpublished.winch-codegen]]
 version = "0.21.2"
 audited_as = "0.21.1"
+
+[[unpublished.winch-codegen]]
+version = "0.21.3"
+audited_as = "0.21.2"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1327,6 +1511,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bitset]]
 version = "0.110.1"
 when = "2024-07-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bitset]]
+version = "0.110.2"
+when = "2024-08-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2878,6 +3068,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-slab]]
 version = "23.0.1"
 when = "2024-07-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-slab]]
+version = "23.0.2"
+when = "2024-08-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.21.2"
+version = "0.21.3"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 23.0.3, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-23.0.3/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
