### PR TITLE
Release Wasmtime 25.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "25.0.1"
+version = "25.0.2"
 
 [[package]]
 name = "byteorder"
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -576,14 +576,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "arbitrary",
  "serde",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -624,25 +624,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.112.1"
+version = "0.112.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-codegen",
  "env_logger",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.112.1"
+version = "0.112.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1055,7 +1055,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arbitrary",
  "cranelift-bitset",
@@ -3146,7 +3146,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "wasmparser 0.217.0",
@@ -3196,7 +3196,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3529,14 +3529,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3552,14 +3552,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3708,11 +3708,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "25.0.1"
+version = "25.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "object",
  "once_cell",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "25.0.1"
+version = "25.0.2"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "25.0.1"
+version = "25.0.2"
 
 [[package]]
 name = "wast"
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "25.0.1"
+version = "25.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4219,7 +4219,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "25.0.1"
+version = "25.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -184,62 +184,62 @@ manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=25.0.1" }
-wasmtime = { path = "crates/wasmtime", version = "25.0.1", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=25.0.1" }
-wasmtime-cache = { path = "crates/cache", version = "=25.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=25.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=25.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=25.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=25.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=25.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=25.0.1" }
-wasmtime-types = { path = "crates/types", version = "25.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=25.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=25.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "25.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=25.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "25.0.1" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "25.0.1" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "25.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "25.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=25.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=25.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=25.0.1" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=25.0.1" }
-wasmtime-slab = { path = "crates/slab", version = "=25.0.1" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=25.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "25.0.2", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=25.0.2" }
+wasmtime-cache = { path = "crates/cache", version = "=25.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=25.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=25.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=25.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=25.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=25.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=25.0.2" }
+wasmtime-types = { path = "crates/types", version = "25.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=25.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=25.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "25.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=25.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "25.0.2" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "25.0.2" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "25.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "25.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=25.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=25.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=25.0.2" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=25.0.2" }
+wasmtime-slab = { path = "crates/slab", version = "=25.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=25.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=25.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=25.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=25.0.1", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=25.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=25.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=25.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=25.0.2", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=25.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=25.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=25.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=25.0.2" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=0.1.1" }
+pulley-interpreter = { path = 'pulley', version = "=0.1.2" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.112.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.112.1", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.112.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.112.1" }
-cranelift-native = { path = "cranelift/native", version = "0.112.1" }
-cranelift-module = { path = "cranelift/module", version = "0.112.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.112.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.112.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.112.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.112.2", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.112.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.112.2" }
+cranelift-native = { path = "cranelift/native", version = "0.112.2" }
+cranelift-module = { path = "cranelift/module", version = "0.112.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.112.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.112.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.112.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.112.1" }
+cranelift-object = { path = "cranelift/object", version = "0.112.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.112.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.112.1" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.112.1" }
-cranelift-control = { path = "cranelift/control", version = "0.112.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.112.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.112.2" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.112.2" }
+cranelift-control = { path = "cranelift/control", version = "0.112.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.112.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.23.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.23.2" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.112.1"
+version = "0.112.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.112.1"
+version = "0.112.2"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.112.1"
+version = "0.112.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -20,7 +20,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.112.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.112.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -49,8 +49,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.112.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.112.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.112.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.112.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.112.1"
+version = "0.112.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,4 +16,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.112.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.112.2" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.112.1"
+version = "0.112.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.112.1"
+version = "0.112.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.112.1"
+version = "0.112.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.112.1"
+version = "0.112.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.112.1"
+version = "0.112.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.112.1"
+version = "0.112.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.112.1"
+version = "0.112.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.112.1"
+version = "0.112.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.112.1"
+version = "0.112.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.112.1"
+version = "0.112.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.112.1"
+version = "0.112.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.112.1"
+version = "0.112.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.112.1"
+version = "0.112.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.112.1"
+version = "0.112.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "25.0.1"
+#define WASMTIME_VERSION "25.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/pulley/Cargo.toml
+++ b/pulley/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "pulley-interpreter"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/pulley"
-version = "0.1.1"
+version = "0.1.2"
 
 [lints]
 workspace = true

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -24,6 +28,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-bforest]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -37,6 +45,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -48,6 +60,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-codegen]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -61,6 +77,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -72,6 +92,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -85,6 +109,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-control]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -96,6 +124,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-entity]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
@@ -109,6 +141,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -120,6 +156,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
@@ -133,6 +173,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -144,6 +188,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-jit]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
@@ -157,6 +205,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-module]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -168,6 +220,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-native]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-native]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
@@ -181,6 +237,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-object]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -192,6 +252,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-reader]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-reader]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
@@ -205,6 +269,10 @@ audited_as = "0.110.1"
 version = "0.112.1"
 audited_as = "0.112.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.112.2"
+audited_as = "0.112.1"
+
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -216,6 +284,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-wasm]]
 version = "0.112.1"
 audited_as = "0.112.0"
+
+[[unpublished.cranelift-wasm]]
+version = "0.112.2"
+audited_as = "0.112.1"
 
 [[unpublished.pulley-interpreter]]
 version = "0.1.0"
@@ -225,6 +297,10 @@ audited_as = "0.0.0"
 version = "0.1.1"
 audited_as = "0.1.0"
 
+[[unpublished.pulley-interpreter]]
+version = "0.1.2"
+audited_as = "0.1.1"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -236,6 +312,10 @@ audited_as = "23.0.1"
 [[unpublished.wasi-common]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasi-common]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -249,6 +329,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -260,6 +344,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -273,6 +361,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -284,6 +376,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-cli]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -297,6 +393,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -308,6 +408,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
@@ -321,6 +425,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -332,6 +440,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
@@ -345,6 +457,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-environ]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -356,6 +472,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-explorer]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-explorer]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
@@ -369,6 +489,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-fiber]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -380,6 +504,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
@@ -393,6 +521,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -404,6 +536,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-slab]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-slab]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
@@ -417,6 +553,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-types]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -429,6 +569,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -440,6 +584,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "25.0.0"
@@ -449,6 +597,10 @@ audited_as = "24.0.0"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -460,6 +612,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "25.0.0"
@@ -469,6 +625,10 @@ audited_as = "24.0.0"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-wasi-runtime-config]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -480,6 +640,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
@@ -493,6 +657,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -504,6 +672,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-winch]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
@@ -517,6 +689,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -528,6 +704,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wiggle]]
 version = "24.0.0"
@@ -541,6 +721,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wiggle]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -553,6 +737,10 @@ audited_as = "23.0.1"
 version = "25.0.1"
 audited_as = "25.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "25.0.2"
+audited_as = "25.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -564,6 +752,10 @@ audited_as = "23.0.1"
 [[unpublished.wiggle-macro]]
 version = "25.0.1"
 audited_as = "25.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "25.0.2"
+audited_as = "25.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -580,6 +772,10 @@ audited_as = "0.21.1"
 [[unpublished.winch-codegen]]
 version = "0.23.1"
 audited_as = "0.23.0"
+
+[[unpublished.winch-codegen]]
+version = "0.23.2"
+audited_as = "0.23.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -768,6 +964,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -777,6 +979,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -792,6 +1000,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-bitset]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -801,6 +1015,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -816,6 +1036,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-meta]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-shared]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -825,6 +1051,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-shared]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-shared]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -840,6 +1072,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-control]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-entity]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -849,6 +1087,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-entity]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-entity]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -864,6 +1108,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-frontend]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-interpreter]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -873,6 +1123,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-interpreter]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-interpreter]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -888,6 +1144,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-isle]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-jit]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -897,6 +1159,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-jit]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-jit]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -912,6 +1180,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-module]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-native]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -921,6 +1195,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-native]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-native]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -936,6 +1216,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-object]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-reader]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -945,6 +1231,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-reader]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-reader]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -960,6 +1252,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.112.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -969,6 +1267,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.112.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.112.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1403,6 +1707,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1546,6 +1856,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1555,6 +1871,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1570,6 +1892,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1579,6 +1907,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1594,6 +1928,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1603,6 +1943,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1618,6 +1964,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1627,6 +1979,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1642,6 +2000,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1651,6 +2015,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1666,6 +2036,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1675,6 +2051,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1690,6 +2072,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-slab]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1699,6 +2087,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-slab]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-slab]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1714,6 +2108,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1723,6 +2123,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1738,6 +2144,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-http]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-keyvalue]]
 version = "24.0.0"
 when = "2024-08-20"
@@ -1747,6 +2159,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-keyvalue]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-keyvalue]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1762,6 +2180,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-runtime-config]]
 version = "24.0.0"
 when = "2024-08-20"
@@ -1774,6 +2198,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-runtime-config]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1783,6 +2213,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1798,6 +2234,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1807,6 +2249,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-winch]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1822,6 +2270,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1831,6 +2285,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1894,6 +2354,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1906,6 +2372,12 @@ when = "2024-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "25.0.1"
+when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1915,6 +2387,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "25.0.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "25.0.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1941,6 +2419,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.23.0"
 when = "2024-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.23.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.23.1"
+version = "0.23.2"
 edition.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 25.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-25.0.2/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
