### PR TITLE
[24.0.0] Fix version bumps with cargo-vet

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -533,8 +533,24 @@ start = "2023-05-22"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-wasi-keyvalue]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2025-07-30"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasmtime-wasi-nn]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2025-07-30"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-runtime-config]]
+who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -160,7 +160,13 @@ audit-as-crates-io = true
 [policy.wasmtime-wasi-http]
 audit-as-crates-io = true
 
+[policy.wasmtime-wasi-keyvalue]
+audit-as-crates-io = true
+
 [policy.wasmtime-wasi-nn]
+audit-as-crates-io = true
+
+[policy.wasmtime-wasi-runtime-config]
 audit-as-crates-io = true
 
 [policy.wasmtime-wasi-threads]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1026,9 +1026,21 @@ when = "2024-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-keyvalue]]
+version = "24.0.0"
+when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "23.0.1"
 when = "2024-07-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-runtime-config]]
+version = "24.0.0"
+when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Fixup some cargo-vet configuration. Still unsure what's going on, but this should fix things for now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
