### PR TITLE
[21.0.0] Use AlmaLinux:8 for x86_64-linux binary-compatible-builds

### DIFF
--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos:7
+FROM almalinux:8
 
-RUN yum install -y git gcc
+RUN dnf install -y git gcc make cmake
 
 ENV PATH=$PATH:/rust/bin


### PR DESCRIPTION
Backport of #8892 and #8896