### PR TITLE
[22.0.0] Use AlmaLinux:8 for x86_64-linux binary-compatible-builds

### DIFF
--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,10 +1,5 @@
-FROM centos:7
+FROM almalinux:8
 
-RUN yum install -y git gcc make
-
-# The CMake in Centos 7 was a bit too old for us to use so download one from
-# CMake's own releases and use that instead.
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
-ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
+RUN dnf install -y git gcc make cmake
 
 ENV PATH=$PATH:/rust/bin


### PR DESCRIPTION
Backport of https://github.com/bytecodealliance/wasmtime/pull/8892 and https://github.com/bytecodealliance/wasmtime/pull/8896