### PR TITLE
Update pulley-interpreter and winch-codegen versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "0.2.0"
+version = "26.0.0"
 dependencies = [
  "arbitrary",
  "cranelift-bitset",
@@ -4228,7 +4228,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.24.0"
+version = "26.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version 
 wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=26.0.0" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=0.2.0" }
+pulley-interpreter = { path = 'pulley', version = "=26.0.0" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
 cranelift-codegen = { path = "cranelift/codegen", version = "0.113.0", default-features = false, features = ["std", "unwind"] }
@@ -243,7 +243,7 @@ cranelift-bitset = { path = "cranelift/bitset", version = "0.113.0" }
 cranelift-control = { path = "cranelift/control", version = "0.113.0" }
 cranelift = { path = "cranelift/umbrella", version = "0.113.0" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.24.0" }
+winch-codegen = { path = "winch/codegen", version = "=26.0.0" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/pulley/Cargo.toml
+++ b/pulley/Cargo.toml
@@ -7,14 +7,14 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "pulley-interpreter"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/pulley"
-version = "0.2.0"
+version.workspace = true
 
 [lints]
 workspace = true
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-cranelift-bitset = { workspace = true } 
+cranelift-bitset = { workspace = true }
 log = { workspace = true }
 sptr = { workspace = true }
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -221,6 +221,10 @@ audited_as = "0.111.0"
 version = "0.2.0"
 audited_as = "0.1.1"
 
+[[unpublished.pulley-interpreter]]
+version = "26.0.0"
+audited_as = "0.1.1"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -576,6 +580,10 @@ audited_as = "0.21.1"
 [[unpublished.winch-codegen]]
 version = "0.24.0"
 audited_as = "0.22.0"
+
+[[unpublished.winch-codegen]]
+version = "26.0.0"
+audited_as = "0.23.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -2083,6 +2091,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.22.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.23.1"
+when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.24.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
Update these two crates to match the Wasmtime crate version instead of having separate version tracks. Helps keep everything in-sync with fewer versions to worry about in general.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
