### PR TITLE
Fix testing the cranelift-reader test alone

### DIFF
--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -18,3 +18,7 @@ anyhow = { workspace = true, features = ['std'] }
 cranelift-codegen = { workspace = true }
 smallvec = { workspace = true }
 target-lexicon = { workspace = true, features = ['std'] }
+
+[dev-dependencies]
+# Some tests require that the x86_64 target parses for the target specification.
+cranelift-codegen = { workspace = true, features = ['x86'] }


### PR DESCRIPTION
This PR is intended to help unblock #9178. That PR uncovered the consequence that testing the `cranelift-reader` crate alone does not work on non-x86_64 platforms. One of its tests relies on parsing the `x86_64` target specification to work, and that only works if the `x86` feature of the cranelift-codegen crate is enabled. This PR unconditionally enables this feature when testing.

This was uncovered on #9178 because the set of crates tested in each shard of our sharded builders depends on the set of crates in the workspace. When a new crate is added it may shuffle around which crates are tested in which location. Previously `cranelift-reader` must have been always tested with a crate that unconditionally enables `cranelift-codegen/x86` as a feature, but #9178 got unlucky where it moved to a set that didn't include this, thus exposing the failure.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
