### PR TITLE
Fix Readme example

### DIFF
--- a/crates/wasi-preview1-component-adapter/provider/README.md
+++ b/crates/wasi-preview1-component-adapter/provider/README.md
@@ -36,10 +36,10 @@ use wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_REACTOR_ADA
 use wit_component::ComponentEncoder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let wasm_p1_bytes = std::fs::read("path/to/your/your-component.p1.wasm");
+    let wasm_p1_bytes = std::fs::read("path/to/your/your-component.p1.wasm")?;
 
     let wasm_p2_bytes = ComponentEncoder::default()
-        .module(&wasm_module_bytes)?
+        .module(&wasm_p1_bytes)?
         .adapter(
             "wasi_snapshot_preview1",
             WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER,


### PR DESCRIPTION
There were a few missing pieces for the readme example to compile when I attempted to copy/paste to get started.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
