### PR TITLE
Fix type interning during Wasm-to-CLIF translation

### DIFF
--- a/tests/misc_testsuite/gc/more-rec-groups-than-types.wast
+++ b/tests/misc_testsuite/gc/more-rec-groups-than-types.wast
@@ -1,0 +1,18 @@
+;; Test that we properly handle empty rec groups and when we have more rec
+;; groups defined in the type section than actual types (and therefore the
+;; length that the type section reports is greater than the length of the types
+;; index space).
+
+(module
+  (rec)
+  (rec)
+  (rec)
+  (rec)
+  (rec)
+  (rec)
+  (rec)
+  (rec)
+  (rec)
+  (rec)
+  (type (func (param i32) (result i32)))
+)


### PR DESCRIPTION
We were handling the case where we had fewer rec groups than types, in the case where a rec group defines multiple types, but were failing to handle the case when we have more rec groups than types due to empty rec groups.

The fix is to bound the loop by the number of types, not the number of rec groups.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
