### PR TITLE
winch: Finalize migration to proper destination registers

### DIFF
--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -314,9 +314,9 @@ impl Assembler {
         });
     }
 
-    pub fn mov_from_vec(&mut self, rn: Reg, rd: Reg, idx: u8, size: OperandSize) {
+    pub fn mov_from_vec(&mut self, rn: Reg, rd: WritableReg, idx: u8, size: OperandSize) {
         self.emit(Inst::MovFromVec {
-            rd: Writable::from_reg(rd.into()),
+            rd: rd.map(Into::into),
             rn: rn.into(),
             idx,
             size: size.into(),
@@ -341,10 +341,10 @@ impl Assembler {
     }
 
     /// Add across Vector.
-    pub fn addv(&mut self, rn: Reg, rd: Reg, size: VectorSize) {
+    pub fn addv(&mut self, rn: Reg, rd: WritableReg, size: VectorSize) {
         self.emit(Inst::VecLanes {
             op: VecLanesOp::Addv,
-            rd: Writable::from_reg(rd.into()),
+            rd: rd.map(Into::into),
             rn: rn.into(),
             size,
         });
@@ -539,7 +539,7 @@ impl Assembler {
     }
 
     /// Float round (ceil, trunc, floor) with two registers.
-    pub fn fround_rr(&mut self, rn: Reg, rd: Reg, mode: RoundingMode, size: OperandSize) {
+    pub fn fround_rr(&mut self, rn: Reg, rd: WritableReg, mode: RoundingMode, size: OperandSize) {
         let fpu_mode = match (mode, size) {
             (RoundingMode::Nearest, OperandSize::S32) => FpuRoundMode::Nearest32,
             (RoundingMode::Up, OperandSize::S32) => FpuRoundMode::Plus32,
@@ -675,11 +675,11 @@ impl Assembler {
     }
 
     // Population Count per byte.
-    pub fn cnt(&mut self, rd: Reg) {
+    pub fn cnt(&mut self, rd: WritableReg) {
         self.emit(Inst::VecMisc {
             op: VecMisc2::Cnt,
-            rd: Writable::from_reg(rd.into()),
-            rn: rd.into(),
+            rd: rd.map(Into::into),
+            rn: rd.to_reg().into(),
             size: VectorSize::Size8x8,
         });
     }
@@ -828,10 +828,10 @@ impl Assembler {
         });
     }
 
-    fn emit_fpu_round(&mut self, op: FpuRoundMode, rn: Reg, rd: Reg) {
+    fn emit_fpu_round(&mut self, op: FpuRoundMode, rn: Reg, rd: WritableReg) {
         self.emit(Inst::FpuRound {
             op: op,
-            rd: Writable::from_reg(rd.into()),
+            rd: rd.map(Into::into),
             rn: rn.into(),
         });
     }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -358,7 +358,8 @@ impl Masm for MacroAssembler {
         _fallback: F,
     ) {
         let src = context.pop_to_reg(self, None);
-        self.asm.fround_rr(src.into(), src.into(), mode, size);
+        self.asm
+            .fround_rr(src.into(), writable!(src.into()), mode, size);
         context.stack.push(src.into());
     }
 
@@ -458,9 +459,10 @@ impl Masm for MacroAssembler {
         let src = context.pop_to_reg(self, None);
         let tmp = regs::float_scratch();
         self.asm.mov_to_fpu(src.into(), writable!(tmp), size);
-        self.asm.cnt(tmp);
-        self.asm.addv(tmp, tmp, VectorSize::Size8x8);
-        self.asm.mov_from_vec(tmp, src.into(), 0, OperandSize::S8);
+        self.asm.cnt(writable!(tmp));
+        self.asm.addv(tmp, writable!(tmp), VectorSize::Size8x8);
+        self.asm
+            .mov_from_vec(tmp, writable!(src.into()), 0, OperandSize::S8);
         context.stack.push(src.into());
     }
 

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1224,7 +1224,13 @@ impl Assembler {
 
     /// Perform rounding operation on float register src and place results in
     /// float register dst.
-    pub fn xmm_rounds_rr(&mut self, src: Reg, dst: Reg, mode: RoundingMode, size: OperandSize) {
+    pub fn xmm_rounds_rr(
+        &mut self,
+        src: Reg,
+        dst: WritableReg,
+        mode: RoundingMode,
+        size: OperandSize,
+    ) {
         let op = match size {
             OperandSize::S32 => SseOpcode::Roundss,
             OperandSize::S64 => SseOpcode::Roundsd,
@@ -1242,7 +1248,7 @@ impl Assembler {
             op,
             src: XmmMemAligned::from(Xmm::from(src)),
             imm,
-            dst: dst.into(),
+            dst: dst.map(Into::into),
         })
     }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -483,7 +483,8 @@ impl Masm for MacroAssembler {
     ) {
         if self.flags.has_sse41() {
             let src = context.pop_to_reg(self, None);
-            self.asm.xmm_rounds_rr(src.into(), src.into(), mode, size);
+            self.asm
+                .xmm_rounds_rr(src.into(), writable!(src.into()), mode, size);
             context.stack.push(src.into());
         } else {
             fallback(env, context, self);


### PR DESCRIPTION
This commit is a follow-up to
https://github.com/bytecodealliance/wasmtime/pull/9354. It finalizes the migration to proper destination registers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
