### PR TITLE
Run the nightly CI job when `pulley` files are touched in a PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,7 +247,7 @@ jobs:
           if grep -q debug names.log; then
             echo run-dwarf=true >> $GITHUB_OUTPUT
           fi
-          if grep -q pulley commits.log; then
+          if grep -q pulley names.log; then
             echo test-nightly=true >> $GITHUB_OUTPUT
             echo test-miri=true >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,6 +246,9 @@ jobs:
           if grep -q debug names.log; then
             echo run-dwarf=true >> $GITHUB_OUTPUT
           fi
+          if grep -q pulley commits.log; then
+            echo test-nightly=true >> $GITHUB_OUTPUT
+          fi
         fi
         matrix="$(node ./ci/build-test-matrix.js ./commits.log ./names.log $run_full)"
         echo "test-matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,6 +199,7 @@ jobs:
       build-matrix: ${{ steps.calculate.outputs.build-matrix }}
       test-capi: ${{ steps.calculate.outputs.test-capi }}
       test-nightly: ${{ steps.calculate.outputs.test-nightly }}
+      test-miri: ${{ steps.calculate.outputs.test-miri }}
       audit: ${{ steps.calculate.outputs.audit }}
       preview1-adapter: ${{ steps.calculate.outputs.preview1-adapter }}
       run-dwarf: ${{ steps.calculate.outputs.run-dwarf }}
@@ -248,6 +249,7 @@ jobs:
           fi
           if grep -q pulley commits.log; then
             echo test-nightly=true >> $GITHUB_OUTPUT
+            echo test-miri=true >> $GITHUB_OUTPUT
           fi
         fi
         matrix="$(node ./ci/build-test-matrix.js ./commits.log ./names.log $run_full)"
@@ -261,6 +263,7 @@ jobs:
             echo run-full=true >> $GITHUB_OUTPUT
             echo test-capi=true >> $GITHUB_OUTPUT
             echo test-nightly=true >> $GITHUB_OUTPUT
+            echo test-miri=true >> $GITHUB_OUTPUT
             echo audit=true >> $GITHUB_OUTPUT
             echo preview1-adapter=true >> $GITHUB_OUTPUT
             echo run-dwarf=true >> $GITHUB_OUTPUT
@@ -1030,7 +1033,7 @@ jobs:
           - "wasmtime-environ"
           - "pulley-interpreter --all-features"
     needs: determine
-    if: needs.determine.outputs.run-full && github.repository == 'bytecodealliance/wasmtime'
+    if: (needs.determine.outputs.run-full || needs.determine.outputs.test-miri) && github.repository == 'bytecodealliance/wasmtime'
     name: Miri
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1033,7 +1033,7 @@ jobs:
           - "wasmtime-environ"
           - "pulley-interpreter --all-features"
     needs: determine
-    if: (needs.determine.outputs.run-full || needs.determine.outputs.test-miri) && github.repository == 'bytecodealliance/wasmtime'
+    if: needs.determine.outputs.test-miri && github.repository == 'bytecodealliance/wasmtime'
     name: Miri
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
After https://github.com/bytecodealliance/wasmtime/pull/9251, we will check that Pulley builds with rustc's experimental tail calls feature enabled in the nightly CI job. So if we touch any pulley source files in a PR, we should also run that job in the PR's CI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
