### PR TITLE
Increase alignment of empty mmap pointers

### DIFF
--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -15,7 +15,7 @@ pub struct Mmap {
 impl Mmap {
     pub fn new_empty() -> Mmap {
         Mmap {
-            memory: SendSyncPtr::from(&mut [][..]),
+            memory: crate::vm::sys::empty_mmap(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -21,7 +21,7 @@ pub struct Mmap {
 impl Mmap {
     pub fn new_empty() -> Mmap {
         Mmap {
-            memory: SendSyncPtr::from(&mut [][..]),
+            memory: crate::vm::sys::empty_mmap(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/sys/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/mod.rs
@@ -8,6 +8,9 @@
 
 #![allow(clippy::cast_sign_loss)] // platforms too fiddly to worry about this
 
+use crate::runtime::vm::SendSyncPtr;
+use core::ptr::{self, NonNull};
+
 /// What happens to a mapping after it is decommitted?
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum DecommitBehavior {
@@ -17,6 +20,30 @@ pub enum DecommitBehavior {
     /// if it was a CoW mapping, then the original CoW mapping is restored;
     /// etc...
     RestoreOriginalMapping,
+}
+
+fn empty_mmap() -> SendSyncPtr<[u8]> {
+    // Callers of this API assume that `.as_ptr()` below returns something
+    // page-aligned and non-null. This is because the pointer returned from
+    // that location is casted to other types which reside at a higher
+    // alignment than a byte for example. Despite the length being zero we
+    // still need to ensure that the pointer is suitably aligned.
+    //
+    // To handle that do a bit of trickery here to get the compiler to
+    // generate an empty array to a high-alignment type (here 4k which is
+    // the min page size we work with today). Then use this empty array as
+    // the source pointer for an empty byte slice. It's a bit wonky but this
+    // makes it such that the returned length is always zero (so this is
+    // safe) but the pointer is always 4096 or suitably aligned.
+    #[repr(C, align(4096))]
+    struct PageAligned;
+    let empty_page_alloc: &mut [PageAligned] = &mut [];
+    let empty = NonNull::new(ptr::slice_from_raw_parts_mut(
+        empty_page_alloc.as_mut_ptr().cast(),
+        0,
+    ))
+    .unwrap();
+    SendSyncPtr::from(empty)
 }
 
 cfg_if::cfg_if! {

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -14,7 +14,7 @@ pub struct Mmap {
 impl Mmap {
     pub fn new_empty() -> Mmap {
         Mmap {
-            memory: SendSyncPtr::from(&mut [][..]),
+            memory: crate::vm::sys::empty_mmap(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -19,7 +19,7 @@ pub struct Mmap {
 impl Mmap {
     pub fn new_empty() -> Mmap {
         Mmap {
-            memory: SendSyncPtr::from(&mut [][..]),
+            memory: crate::vm::sys::empty_mmap(),
             is_file: false,
         }
     }


### PR DESCRIPTION
This commit updates platform implementations of `Mmap::new_empty()` to use a shared helper to create a pointer with a higher alignment than one. This fixes a debug assert tripping in niche configurations of the pooling allocator where if no virtual memory is given and table lazy init is disabled then a module could trip a debug-only assert about a slice being created from a raw pointer that is not properly aligned. The fix here is to use a helper that starts with an over-aligned empty slice which is then casted down to a byte slice.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
