### PR TITLE
docs(readme): mention wasmtime_home

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ script:
 ```sh
 curl https://wasmtime.dev/install.sh -sSf | bash
 ```
+This script installs into `$WASMTIME_HOME` (defaults to `$HOME/.wasmtime`), and executable is placed in `$WASMTIME_HOME/bin`.
 
 Windows or otherwise interested users can download installers and
 binaries directly from the [GitHub


### PR DESCRIPTION
This PR is very minor update to README:

- Mention `wasmtime_home` environment variable.

Reference: https://github.com/bytecodealliance/wasmtime.dev/blob/481a3aee5b86617b499274452dda34fe928fd7b0/install.sh#L548

Future PRs can elaborate further if needed but this PR is narrow scope.