### PR TITLE
Update WASI WITs to 0.2.2

### DIFF
--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -37,22 +37,22 @@ make_vendor() {
 cache_dir=$(mktemp -d)
 
 make_vendor "wasi" "
-  cli@v0.2.1
-  clocks@v0.2.1
-  filesystem@v0.2.1
-  io@v0.2.1
-  random@v0.2.1
-  sockets@v0.2.1
+  cli@v0.2.2
+  clocks@v0.2.2
+  filesystem@v0.2.2
+  io@v0.2.2
+  random@v0.2.2
+  sockets@v0.2.2
 "
 
 make_vendor "wasi-http" "
-  cli@v0.2.1
-  clocks@v0.2.1
-  filesystem@v0.2.1
-  io@v0.2.1
-  random@v0.2.1
-  sockets@v0.2.1
-  http@v0.2.1
+  cli@v0.2.2
+  clocks@v0.2.2
+  filesystem@v0.2.2
+  io@v0.2.2
+  random@v0.2.2
+  sockets@v0.2.2
+  http@v0.2.2
 "
 
 make_vendor "wasi-runtime-config" "runtime-config@c667fe6"

--- a/crates/test-programs/src/lib.rs
+++ b/crates/test-programs/src/lib.rs
@@ -8,8 +8,8 @@ wit_bindgen::generate!({
         package wasmtime:test;
 
         world test {
-            include wasi:cli/imports@0.2.1;
-            include wasi:http/imports@0.2.1;
+            include wasi:cli/imports@0.2.2;
+            include wasi:http/imports@0.2.2;
             include wasi:config/imports@0.2.0-draft;
             include wasi:keyvalue/imports@0.2.0-draft;
         }
@@ -31,17 +31,17 @@ pub mod proxy {
         default_bindings_module: "test_programs::proxy",
         pub_export_macro: true,
         with: {
-            "wasi:http/types@0.2.1": crate::wasi::http::types,
-            "wasi:http/outgoing-handler@0.2.1": crate::wasi::http::outgoing_handler,
-            "wasi:random/random@0.2.1": crate::wasi::random::random,
-            "wasi:io/error@0.2.1": crate::wasi::io::error,
-            "wasi:io/poll@0.2.1": crate::wasi::io::poll,
-            "wasi:io/streams@0.2.1": crate::wasi::io::streams,
-            "wasi:cli/stdout@0.2.1": crate::wasi::cli::stdout,
-            "wasi:cli/stderr@0.2.1": crate::wasi::cli::stderr,
-            "wasi:cli/stdin@0.2.1": crate::wasi::cli::stdin,
-            "wasi:clocks/monotonic-clock@0.2.1": crate::wasi::clocks::monotonic_clock,
-            "wasi:clocks/wall-clock@0.2.1": crate::wasi::clocks::wall_clock,
+            "wasi:http/types@0.2.2": crate::wasi::http::types,
+            "wasi:http/outgoing-handler@0.2.2": crate::wasi::http::outgoing_handler,
+            "wasi:random/random@0.2.2": crate::wasi::random::random,
+            "wasi:io/error@0.2.2": crate::wasi::io::error,
+            "wasi:io/poll@0.2.2": crate::wasi::io::poll,
+            "wasi:io/streams@0.2.2": crate::wasi::io::streams,
+            "wasi:cli/stdout@0.2.2": crate::wasi::cli::stdout,
+            "wasi:cli/stderr@0.2.2": crate::wasi::cli::stderr,
+            "wasi:cli/stdin@0.2.2": crate::wasi::cli::stdin,
+            "wasi:clocks/monotonic-clock@0.2.2": crate::wasi::clocks::monotonic_clock,
+            "wasi:clocks/wall-clock@0.2.2": crate::wasi::clocks::wall_clock,
         },
     });
 }

--- a/crates/wasi-http/wit/deps/cli/command.wit
+++ b/crates/wasi-http/wit/deps/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.1;
+package wasi:cli@0.2.2;
 
 @since(version = 0.2.0)
 world command {

--- a/crates/wasi-http/wit/deps/cli/imports.wit
+++ b/crates/wasi-http/wit/deps/cli/imports.wit
@@ -1,17 +1,17 @@
-package wasi:cli@0.2.1;
+package wasi:cli@0.2.2;
 
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  include wasi:clocks/imports@0.2.1;
+  include wasi:clocks/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:filesystem/imports@0.2.1;
+  include wasi:filesystem/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:sockets/imports@0.2.1;
+  include wasi:sockets/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:random/imports@0.2.1;
+  include wasi:random/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:io/imports@0.2.1;
+  include wasi:io/imports@0.2.2;
 
   @since(version = 0.2.0)
   import environment;

--- a/crates/wasi-http/wit/deps/cli/stdio.wit
+++ b/crates/wasi-http/wit/deps/cli/stdio.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface stdin {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{input-stream};
+  use wasi:io/streams@0.2.2.{input-stream};
 
   @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
@@ -10,7 +10,7 @@ interface stdin {
 @since(version = 0.2.0)
 interface stdout {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{output-stream};
+  use wasi:io/streams@0.2.2.{output-stream};
 
   @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
@@ -19,7 +19,7 @@ interface stdout {
 @since(version = 0.2.0)
 interface stderr {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{output-stream};
+  use wasi:io/streams@0.2.2.{output-stream};
 
   @since(version = 0.2.0)
   get-stderr: func() -> output-stream;

--- a/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -10,7 +10,7 @@ package wasi:clocks@0.2.1;
 @since(version = 0.2.0)
 interface monotonic-clock {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from

--- a/crates/wasi-http/wit/deps/clocks/timezone.wit
+++ b/crates/wasi-http/wit/deps/clocks/timezone.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 
 @unstable(feature = clocks-timezone)
 interface timezone {

--- a/crates/wasi-http/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/crates/wasi-http/wit/deps/clocks/world.wit
+++ b/crates/wasi-http/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi-http/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi-http/wit/deps/filesystem/preopens.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.1;
+package wasi:filesystem@0.2.2;
 
 @since(version = 0.2.0)
 interface preopens {

--- a/crates/wasi-http/wit/deps/filesystem/types.wit
+++ b/crates/wasi-http/wit/deps/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.1;
+package wasi:filesystem@0.2.2;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -26,9 +26,9 @@ package wasi:filesystem@0.2.1;
 @since(version = 0.2.0)
 interface types {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.1.{input-stream, output-stream, error};
+    use wasi:io/streams@0.2.2.{input-stream, output-stream, error};
     @since(version = 0.2.0)
-    use wasi:clocks/wall-clock@0.2.1.{datetime};
+    use wasi:clocks/wall-clock@0.2.2.{datetime};
 
     /// File size or length of a region within a file.
     @since(version = 0.2.0)
@@ -522,12 +522,6 @@ interface types {
         ) -> result<_, error-code>;
 
         /// Open a file or directory.
-        ///
-        /// The returned descriptor is not guaranteed to be the lowest-numbered
-        /// descriptor not currently open/ it is randomized to prevent applications
-        /// from depending on making assumptions about indexes, since this is
-        /// error-prone in multi-threaded contexts. The returned descriptor is
-        /// guaranteed to be less than 2**31.
         ///
         /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
         /// descriptor doesn't have `descriptor-flags::mutate-directory` set,

--- a/crates/wasi-http/wit/deps/filesystem/world.wit
+++ b/crates/wasi-http/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.1;
+package wasi:filesystem@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi-http/wit/deps/http/proxy.wit
+++ b/crates/wasi-http/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.1;
+package wasi:http@0.2.2;
 
 /// The `wasi:http/imports` world imports all the APIs for HTTP proxies.
 /// It is intended to be `include`d in other worlds.
@@ -6,25 +6,25 @@ package wasi:http@0.2.1;
 world imports {
   /// HTTP proxies have access to time and randomness.
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.1;
+  import wasi:clocks/monotonic-clock@0.2.2;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.1;
+  import wasi:clocks/wall-clock@0.2.2;
   @since(version = 0.2.0)
-  import wasi:random/random@0.2.1;
+  import wasi:random/random@0.2.2;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
   @since(version = 0.2.0)
-  import wasi:cli/stdout@0.2.1;
+  import wasi:cli/stdout@0.2.2;
   @since(version = 0.2.0)
-  import wasi:cli/stderr@0.2.1;
+  import wasi:cli/stderr@0.2.2;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
   @since(version = 0.2.0)
-  import wasi:cli/stdin@0.2.1;
+  import wasi:cli/stdin@0.2.2;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -4,13 +4,13 @@
 @since(version = 0.2.0)
 interface types {
   @since(version = 0.2.0)
-  use wasi:clocks/monotonic-clock@0.2.1.{duration};
+  use wasi:clocks/monotonic-clock@0.2.2.{duration};
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{input-stream, output-stream};
+  use wasi:io/streams@0.2.2.{input-stream, output-stream};
   @since(version = 0.2.0)
-  use wasi:io/error@0.2.1.{error as io-error};
+  use wasi:io/error@0.2.2.{error as io-error};
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.1.{pollable};
+  use wasi:io/poll@0.2.2.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   @since(version = 0.2.0)
@@ -124,12 +124,12 @@ interface types {
   /// setting or appending to a `fields` resource.
   @since(version = 0.2.0)
   variant header-error {
-    /// This error indicates that a `field-key` or `field-value` was
+    /// This error indicates that a `field-name` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
     /// `fields`.
     invalid-syntax,
 
-    /// This error indicates that a forbidden `field-key` was used when trying
+    /// This error indicates that a forbidden `field-name` was used when trying
     /// to set a header in a `fields`.
     forbidden,
 
@@ -138,8 +138,23 @@ interface types {
     immutable,
   }
 
+  /// Field names are always strings.
+  ///
+  /// Field names should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  @since(version = 0.2.1)
+  type field-name = field-key;
+
   /// Field keys are always strings.
+  ///
+  /// Field keys should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  /// 
+  /// # Deprecation
+  /// 
+  /// This type has been deprecated in favor of the `field-name` type.
   @since(version = 0.2.0)
+  @deprecated(version = 0.2.2)
   type field-key = string;
 
   /// Field values should always be ASCII strings. However, in
@@ -171,70 +186,73 @@ interface types {
     ///
     /// The resulting `fields` is mutable.
     ///
-    /// The list represents each key-value pair in the Fields. Keys
+    /// The list represents each name-value pair in the Fields. Names
     /// which have multiple values are represented by multiple entries in this
-    /// list with the same key.
+    /// list with the same name.
     ///
-    /// The tuple is a pair of the field key, represented as a string, and
+    /// The tuple is a pair of the field name, represented as a string, and
     /// Value, represented as a list of bytes.
     ///
-    /// An error result will be returned if any `field-key` or `field-value` is
+    /// An error result will be returned if any `field-name` or `field-value` is
     /// syntactically invalid, or if a field is forbidden.
     @since(version = 0.2.0)
     from-list: static func(
-      entries: list<tuple<field-key,field-value>>
+      entries: list<tuple<field-name,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key. If the key is not present
+    /// Get all of the values corresponding to a name. If the name is not present
     /// in this `fields` or is syntactically invalid, an empty list is returned.
-    /// However, if the key is present but empty, this is represented by a list
+    /// However, if the name is present but empty, this is represented by a list
     /// with one or more empty field-values present.
     @since(version = 0.2.0)
-    get: func(name: field-key) -> list<field-value>;
+    get: func(name: field-name) -> list<field-value>;
 
-    /// Returns `true` when the key is present in this `fields`. If the key is
+    /// Returns `true` when the name is present in this `fields`. If the name is
     /// syntactically invalid, `false` is returned.
     @since(version = 0.2.0)
-    has: func(name: field-key) -> bool;
+    has: func(name: field-name) -> bool;
 
-    /// Set all of the values for a key. Clears any existing values for that
-    /// key, if they have been set.
+    /// Set all of the values for a name. Clears any existing values for that
+    /// name, if they have been set.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
     ///
-    /// Fails with `header-error.invalid-syntax` if the `field-key` or any of
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or any of
     /// the `field-value`s are syntactically invalid.
     @since(version = 0.2.0)
-    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
+    set: func(name: field-name, value: list<field-value>) -> result<_, header-error>;
 
-    /// Delete all values for a key. Does nothing if no values for the key
+    /// Delete all values for a name. Does nothing if no values for the name
     /// exist.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
     ///
-    /// Fails with `header-error.invalid-syntax` if the `field-key` is
+    /// Fails with `header-error.invalid-syntax` if the `field-name` is
     /// syntactically invalid.
     @since(version = 0.2.0)
-    delete: func(name: field-key) -> result<_, header-error>;
+    delete: func(name: field-name) -> result<_, header-error>;
 
-    /// Append a value for a key. Does not change or delete any existing
-    /// values for that key.
+    /// Append a value for a name. Does not change or delete any existing
+    /// values for that name.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
     ///
-    /// Fails with `header-error.invalid-syntax` if the `field-key` or
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or
     /// `field-value` are syntactically invalid.
     @since(version = 0.2.0)
-    append: func(name: field-key, value: field-value) -> result<_, header-error>;
+    append: func(name: field-name, value: field-value) -> result<_, header-error>;
 
-    /// Retrieve the full set of keys and values in the Fields. Like the
-    /// constructor, the list represents each key-value pair.
+    /// Retrieve the full set of names and values in the Fields. Like the
+    /// constructor, the list represents each name-value pair.
     ///
-    /// The outer list represents each key-value pair in the Fields. Keys
+    /// The outer list represents each name-value pair in the Fields. Names
     /// which have multiple values are represented by multiple entries in this
-    /// list with the same key.
+    /// list with the same name.
+    ///
+    /// The names and values are always returned in the original casing and in
+    /// the order in which they will be serialized for transport.
     @since(version = 0.2.0)
-    entries: func() -> list<tuple<field-key,field-value>>;
+    entries: func() -> list<tuple<field-name,field-value>>;
 
     /// Make a deep copy of the Fields. Equivalent in behavior to calling the
     /// `fields` constructor on the return value of `entries`. The resulting

--- a/crates/wasi-http/wit/deps/io/error.wit
+++ b/crates/wasi-http/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 @since(version = 0.2.0)
 interface error {

--- a/crates/wasi-http/wit/deps/io/poll.wit
+++ b/crates/wasi-http/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -18,6 +18,9 @@ interface streams {
         /// The last operation (a write or flush) failed before completion.
         ///
         /// More information is available in the `error` payload.
+        ///
+        /// After this, the stream will be closed. All future operations return
+        /// `stream-error::closed`.
         last-operation-failed(error),
         /// The stream is closed: no more input will be accepted by the
         /// stream. A closed output-stream will return this error on all
@@ -205,6 +208,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.

--- a/crates/wasi-http/wit/deps/io/world.wit
+++ b/crates/wasi-http/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi-http/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi-http/wit/deps/random/insecure-seed.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/insecure.wit
+++ b/crates/wasi-http/wit/deps/random/insecure.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/random.wit
+++ b/crates/wasi-http/wit/deps/random/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/world.wit
+++ b/crates/wasi-http/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface ip-name-lookup {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-address};
 
@@ -48,7 +48,7 @@ interface ip-name-lookup {
 
         /// Create a `pollable` which will resolve once the stream is ready for I/O.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;

--- a/crates/wasi-http/wit/deps/sockets/network.wit
+++ b/crates/wasi-http/wit/deps/sockets/network.wit
@@ -1,5 +1,8 @@
 @since(version = 0.2.0)
 interface network {
+    @unstable(feature = network-error-code)
+    use wasi:io/error@0.2.2.{error};
+
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.
     /// There is no need for this to map 1:1 to a physical network interface.
@@ -104,6 +107,19 @@ interface network {
         /// A permanent failure in name resolution occurred.
         permanent-resolver-failure,
     }
+
+    /// Attempts to extract a network-related `error-code` from the stream
+    /// `error` provided.
+    ///
+    /// Stream operations which return `stream-error::last-operation-failed`
+    /// have a payload with more information about the operation that failed.
+    /// This payload can be passed through to this function to see if there's
+    /// network-related information about the error to return.
+    ///
+    /// Note that this function is fallible because not all stream-related
+    /// errors are network-related errors.
+    @unstable(feature = network-error-code)
+    network-error-code: func(err: borrow<error>) -> option<error-code>;
 
     @since(version = 0.2.0)
     enum ip-address-family {

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -1,11 +1,11 @@
 @since(version = 0.2.0)
 interface tcp {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.1.{input-stream, output-stream};
+    use wasi:io/streams@0.2.2.{input-stream, output-stream};
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
     @since(version = 0.2.0)
-    use wasi:clocks/monotonic-clock@0.2.1.{duration};
+    use wasi:clocks/monotonic-clock@0.2.2.{duration};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -353,7 +353,7 @@ interface tcp {
         /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
         /// for more information.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;

--- a/crates/wasi-http/wit/deps/sockets/udp.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface udp {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -184,7 +184,7 @@ interface udp {
 
         /// Create a `pollable` which will resolve once the socket is ready for I/O.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;
@@ -220,7 +220,7 @@ interface udp {
 
         /// Create a `pollable` which will resolve once the stream is ready to receive again.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;
@@ -280,7 +280,7 @@ interface udp {
         
         /// Create a `pollable` which will resolve once the stream is ready to send again.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;

--- a/crates/wasi-http/wit/deps/sockets/world.wit
+++ b/crates/wasi-http/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.1;
+package wasi:sockets@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi-http/wit/world.wit
+++ b/crates/wasi-http/wit/world.wit
@@ -2,5 +2,5 @@
 package wasmtime:wasi-http;
 
 world bindings {
-  include wasi:http/proxy@0.2.1;
+  include wasi:http/proxy@0.2.2;
 }

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -149,7 +149,7 @@ pub struct Descriptors {
 }
 
 #[cfg(not(feature = "proxy"))]
-#[link(wasm_import_module = "wasi:filesystem/preopens@0.2.1")]
+#[link(wasm_import_module = "wasi:filesystem/preopens@0.2.2")]
 extern "C" {
     #[link_name = "get-directories"]
     fn wasi_filesystem_get_directories(rval: *mut PreopenList);

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -91,12 +91,12 @@ pub mod bindings {
             package wasmtime:adapter;
 
             world adapter {
-                import wasi:clocks/wall-clock@0.2.1;
-                import wasi:clocks/monotonic-clock@0.2.1;
-                import wasi:random/random@0.2.1;
-                import wasi:cli/stdout@0.2.1;
-                import wasi:cli/stderr@0.2.1;
-                import wasi:cli/stdin@0.2.1;
+                import wasi:clocks/wall-clock@0.2.2;
+                import wasi:clocks/monotonic-clock@0.2.2;
+                import wasi:random/random@0.2.2;
+                import wasi:cli/stdout@0.2.2;
+                import wasi:cli/stderr@0.2.2;
+                import wasi:cli/stdin@0.2.2;
             }
         "#,
         world: "wasmtime:adapter/adapter",
@@ -115,7 +115,7 @@ pub mod bindings {
     }
 }
 
-#[export_name = "wasi:cli/run@0.2.1#run"]
+#[export_name = "wasi:cli/run@0.2.2#run"]
 #[cfg(feature = "command")]
 pub unsafe extern "C" fn run() -> u32 {
     #[link(wasm_import_module = "__main_module__")]
@@ -457,7 +457,7 @@ impl BumpAlloc {
 }
 
 #[cfg(not(feature = "proxy"))]
-#[link(wasm_import_module = "wasi:cli/environment@0.2.1")]
+#[link(wasm_import_module = "wasi:cli/environment@0.2.2")]
 extern "C" {
     #[link_name = "get-arguments"]
     fn wasi_cli_get_arguments(rval: *mut WasmStrList);
@@ -2156,7 +2156,7 @@ pub unsafe extern "C" fn poll_oneoff(
             });
         }
 
-        #[link(wasm_import_module = "wasi:io/poll@0.2.1")]
+        #[link(wasm_import_module = "wasi:io/poll@0.2.2")]
         #[allow(improper_ctypes)] // FIXME(bytecodealliance/wit-bindgen#684)
         extern "C" {
             #[link_name = "poll"]

--- a/crates/wasi/src/host/network.rs
+++ b/crates/wasi/src/host/network.rs
@@ -4,6 +4,7 @@ use crate::bindings::sockets::network::{
 };
 use crate::network::{from_ipv4_addr, from_ipv6_addr, to_ipv4_addr, to_ipv6_addr};
 use crate::{SocketError, WasiImpl, WasiView};
+use anyhow::Error;
 use rustix::io::Errno;
 use std::io;
 use wasmtime::component::Resource;
@@ -14,6 +15,12 @@ where
 {
     fn convert_error_code(&mut self, error: SocketError) -> anyhow::Result<ErrorCode> {
         error.downcast()
+    }
+
+    fn network_error_code(&mut self, err: Resource<Error>) -> anyhow::Result<Option<ErrorCode>> {
+        let err = self.table().get(&err)?;
+        let _ = err; // TODO: should fill in this implementation
+        Ok(None)
     }
 }
 

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -323,7 +323,7 @@ pub fn add_to_linker_with_options_async<T: WasiView>(
     crate::bindings::sockets::udp::add_to_linker_get_host(l, closure)?;
     crate::bindings::sockets::udp_create_socket::add_to_linker_get_host(l, closure)?;
     crate::bindings::sockets::instance_network::add_to_linker_get_host(l, closure)?;
-    crate::bindings::sockets::network::add_to_linker_get_host(l, closure)?;
+    crate::bindings::sockets::network::add_to_linker_get_host(l, &options.into(), closure)?;
     crate::bindings::sockets::ip_name_lookup::add_to_linker_get_host(l, closure)?;
     Ok(())
 }
@@ -422,7 +422,7 @@ pub fn add_to_linker_with_options_sync<T: WasiView>(
     crate::bindings::sync::sockets::udp::add_to_linker_get_host(l, closure)?;
     crate::bindings::sockets::udp_create_socket::add_to_linker_get_host(l, closure)?;
     crate::bindings::sockets::instance_network::add_to_linker_get_host(l, closure)?;
-    crate::bindings::sockets::network::add_to_linker_get_host(l, closure)?;
+    crate::bindings::sockets::network::add_to_linker_get_host(l, &options.into(), closure)?;
     crate::bindings::sockets::ip_name_lookup::add_to_linker_get_host(l, closure)?;
     Ok(())
 }

--- a/crates/wasi/wit/deps/cli/command.wit
+++ b/crates/wasi/wit/deps/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.1;
+package wasi:cli@0.2.2;
 
 @since(version = 0.2.0)
 world command {

--- a/crates/wasi/wit/deps/cli/imports.wit
+++ b/crates/wasi/wit/deps/cli/imports.wit
@@ -1,17 +1,17 @@
-package wasi:cli@0.2.1;
+package wasi:cli@0.2.2;
 
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  include wasi:clocks/imports@0.2.1;
+  include wasi:clocks/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:filesystem/imports@0.2.1;
+  include wasi:filesystem/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:sockets/imports@0.2.1;
+  include wasi:sockets/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:random/imports@0.2.1;
+  include wasi:random/imports@0.2.2;
   @since(version = 0.2.0)
-  include wasi:io/imports@0.2.1;
+  include wasi:io/imports@0.2.2;
 
   @since(version = 0.2.0)
   import environment;

--- a/crates/wasi/wit/deps/cli/stdio.wit
+++ b/crates/wasi/wit/deps/cli/stdio.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface stdin {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{input-stream};
+  use wasi:io/streams@0.2.2.{input-stream};
 
   @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
@@ -10,7 +10,7 @@ interface stdin {
 @since(version = 0.2.0)
 interface stdout {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{output-stream};
+  use wasi:io/streams@0.2.2.{output-stream};
 
   @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
@@ -19,7 +19,7 @@ interface stdout {
 @since(version = 0.2.0)
 interface stderr {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.1.{output-stream};
+  use wasi:io/streams@0.2.2.{output-stream};
 
   @since(version = 0.2.0)
   get-stderr: func() -> output-stream;

--- a/crates/wasi/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi/wit/deps/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -10,7 +10,7 @@ package wasi:clocks@0.2.1;
 @since(version = 0.2.0)
 interface monotonic-clock {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from

--- a/crates/wasi/wit/deps/clocks/timezone.wit
+++ b/crates/wasi/wit/deps/clocks/timezone.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 
 @unstable(feature = clocks-timezone)
 interface timezone {

--- a/crates/wasi/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi/wit/deps/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/crates/wasi/wit/deps/clocks/world.wit
+++ b/crates/wasi/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.1;
+package wasi:clocks@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi/wit/deps/filesystem/preopens.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.1;
+package wasi:filesystem@0.2.2;
 
 @since(version = 0.2.0)
 interface preopens {

--- a/crates/wasi/wit/deps/filesystem/types.wit
+++ b/crates/wasi/wit/deps/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.1;
+package wasi:filesystem@0.2.2;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -26,9 +26,9 @@ package wasi:filesystem@0.2.1;
 @since(version = 0.2.0)
 interface types {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.1.{input-stream, output-stream, error};
+    use wasi:io/streams@0.2.2.{input-stream, output-stream, error};
     @since(version = 0.2.0)
-    use wasi:clocks/wall-clock@0.2.1.{datetime};
+    use wasi:clocks/wall-clock@0.2.2.{datetime};
 
     /// File size or length of a region within a file.
     @since(version = 0.2.0)
@@ -522,12 +522,6 @@ interface types {
         ) -> result<_, error-code>;
 
         /// Open a file or directory.
-        ///
-        /// The returned descriptor is not guaranteed to be the lowest-numbered
-        /// descriptor not currently open/ it is randomized to prevent applications
-        /// from depending on making assumptions about indexes, since this is
-        /// error-prone in multi-threaded contexts. The returned descriptor is
-        /// guaranteed to be less than 2**31.
         ///
         /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
         /// descriptor doesn't have `descriptor-flags::mutate-directory` set,

--- a/crates/wasi/wit/deps/filesystem/world.wit
+++ b/crates/wasi/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.1;
+package wasi:filesystem@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi/wit/deps/io/error.wit
+++ b/crates/wasi/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 @since(version = 0.2.0)
 interface error {

--- a/crates/wasi/wit/deps/io/poll.wit
+++ b/crates/wasi/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -18,6 +18,9 @@ interface streams {
         /// The last operation (a write or flush) failed before completion.
         ///
         /// More information is available in the `error` payload.
+        ///
+        /// After this, the stream will be closed. All future operations return
+        /// `stream-error::closed`.
         last-operation-failed(error),
         /// The stream is closed: no more input will be accepted by the
         /// stream. A closed output-stream will return this error on all
@@ -205,6 +208,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.

--- a/crates/wasi/wit/deps/io/world.wit
+++ b/crates/wasi/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi/wit/deps/random/insecure-seed.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/insecure.wit
+++ b/crates/wasi/wit/deps/random/insecure.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/random.wit
+++ b/crates/wasi/wit/deps/random/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/world.wit
+++ b/crates/wasi/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.1;
+package wasi:random@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface ip-name-lookup {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-address};
 
@@ -48,7 +48,7 @@ interface ip-name-lookup {
 
         /// Create a `pollable` which will resolve once the stream is ready for I/O.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;

--- a/crates/wasi/wit/deps/sockets/network.wit
+++ b/crates/wasi/wit/deps/sockets/network.wit
@@ -1,5 +1,8 @@
 @since(version = 0.2.0)
 interface network {
+    @unstable(feature = network-error-code)
+    use wasi:io/error@0.2.2.{error};
+
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.
     /// There is no need for this to map 1:1 to a physical network interface.
@@ -104,6 +107,19 @@ interface network {
         /// A permanent failure in name resolution occurred.
         permanent-resolver-failure,
     }
+
+    /// Attempts to extract a network-related `error-code` from the stream
+    /// `error` provided.
+    ///
+    /// Stream operations which return `stream-error::last-operation-failed`
+    /// have a payload with more information about the operation that failed.
+    /// This payload can be passed through to this function to see if there's
+    /// network-related information about the error to return.
+    ///
+    /// Note that this function is fallible because not all stream-related
+    /// errors are network-related errors.
+    @unstable(feature = network-error-code)
+    network-error-code: func(err: borrow<error>) -> option<error-code>;
 
     @since(version = 0.2.0)
     enum ip-address-family {

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -1,11 +1,11 @@
 @since(version = 0.2.0)
 interface tcp {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.1.{input-stream, output-stream};
+    use wasi:io/streams@0.2.2.{input-stream, output-stream};
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
     @since(version = 0.2.0)
-    use wasi:clocks/monotonic-clock@0.2.1.{duration};
+    use wasi:clocks/monotonic-clock@0.2.2.{duration};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -353,7 +353,7 @@ interface tcp {
         /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
         /// for more information.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;

--- a/crates/wasi/wit/deps/sockets/udp.wit
+++ b/crates/wasi/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface udp {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.1.{pollable};
+    use wasi:io/poll@0.2.2.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -184,7 +184,7 @@ interface udp {
 
         /// Create a `pollable` which will resolve once the socket is ready for I/O.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;
@@ -220,7 +220,7 @@ interface udp {
 
         /// Create a `pollable` which will resolve once the stream is ready to receive again.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;
@@ -280,7 +280,7 @@ interface udp {
         
         /// Create a `pollable` which will resolve once the stream is ready to send again.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
         @since(version = 0.2.0)
         subscribe: func() -> pollable;

--- a/crates/wasi/wit/deps/sockets/world.wit
+++ b/crates/wasi/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.1;
+package wasi:sockets@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/crates/wasi/wit/test.wit
+++ b/crates/wasi/wit/test.wit
@@ -1,13 +1,13 @@
 world test-reactor {
-  include wasi:cli/imports@0.2.1;
+  include wasi:cli/imports@0.2.2;
 
   export add-strings: func(s: list<string>) -> u32;
   export get-strings: func() -> list<string>;
 
-  use wasi:io/streams@0.2.1.{output-stream};
+  use wasi:io/streams@0.2.2.{output-stream};
 
   export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types@0.2.1.{descriptor-stat};
+  use wasi:filesystem/types@0.2.2.{descriptor-stat};
   export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }

--- a/crates/wasi/wit/world.wit
+++ b/crates/wasi/wit/world.wit
@@ -2,5 +2,5 @@
 package wasmtime:wasi;
 
 world bindings {
-  include wasi:cli/imports@0.2.1;
+  include wasi:cli/imports@0.2.2;
 }


### PR DESCRIPTION
This bumps a number of versions in a number of locations and will be slated for Wasmtime 27. This additionally requires implementing the `network-error-code` function which I've left as a stub for now to get filled out with tests at a later date.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
