### PR TITLE
s390x cleanup: Do not hard-code ABI registers in ISA code

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -589,9 +589,8 @@ fn s390x_get_operands(inst: &mut Inst, collector: &mut DenyReuseVisitor<impl Ope
             collector.reg_use(rm);
         }
         Inst::MovPReg { rd, rm } => {
-            debug_assert!([gpr_preg(0), gpr_preg(14), gpr_preg(15)].contains(rm));
-            debug_assert!(rd.to_reg().is_virtual());
             collector.reg_def(rd);
+            collector.reg_fixed_nonallocatable(*rm);
         }
         Inst::Mov32 { rd, rm } => {
             collector.reg_def(rd);
@@ -3148,7 +3147,6 @@ impl Inst {
                 } else {
                     "".to_string()
                 };
-                debug_assert_eq!(link, gpr(14));
                 format!(
                     "brasl {}, {}{}",
                     show_reg(link),
@@ -3164,7 +3162,6 @@ impl Inst {
                 } else {
                     "".to_string()
                 };
-                debug_assert_eq!(link, gpr(14));
                 format!("basr {}, {}{}", show_reg(link), rn, callee_pop_size)
             }
             &Inst::ReturnCall { ref info } => {
@@ -3196,7 +3193,6 @@ impl Inst {
                     }
                     _ => unreachable!(),
                 };
-                debug_assert_eq!(link, gpr(14));
                 format!("brasl {}, {}", show_reg(link), dest)
             }
             &Inst::Args { ref args } => {
@@ -3218,7 +3214,6 @@ impl Inst {
                 s
             }
             &Inst::Ret { link } => {
-                debug_assert_eq!(link, gpr(14));
                 let link = show_reg(link);
                 format!("br {link}")
             }


### PR DESCRIPTION
This cleanup removes some places in ISA code where particular register values were hard-coded that actually do not have any particular significance at the ISA level, only in the ABI.

Specifically, the link register for calls is fully determined by the ABI and can be any GPR.  In addition, the MovPReg pseudo instruction works correctly as long as the source is any non-allocatable register - this can be checked directly instead of hardcoding a list of registers.

No functional change intended.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
