### PR TITLE
x64: Improve `select(icmp(...), ..., ...)` with i128

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2161,7 +2161,7 @@
 ;; instruction plus a `CMOV`; recall that `cmove_from_values` here may emit more
 ;; than one instruction for certain types (e.g., XMM-held, I128).
 
-(rule (lower (has_type ty (select (maybe_uextend (icmp cc a @ (value_type (fits_in_64 a_ty)) b)) x y)))
+(rule (lower (has_type ty (select (maybe_uextend (icmp cc a b)) x y)))
       (lower_select_icmp ty (emit_cmp cc a b) x y))
 
 ;; Finally, we lower `select` from a condition value `c`. These rules are meant

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -2141,3 +2141,42 @@ block0(v0: i64, v1: i64):
 ;   popq %rbp
 ;   retq
 
+function %select128(i128, i128) -> i32 {
+block0(v0: i128, v1: i128):
+    v2 = icmp ult v0, v1
+    v3 = iconst.i32 100
+    v4 = iconst.i32 200
+    v5 = select v2, v3, v4
+    return v5
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movl    $200, %eax
+;   cmpq    %rdx, %rdi
+;   sbbq    %rsi, %rcx, %rsi
+;   cmovbl  const(0), %eax, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl $0xc8, %eax
+;   cmpq %rdx, %rdi
+;   sbbq %rcx, %rsi
+;   cmovbl 0xa(%rip), %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %ah, (%rax, %rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+


### PR DESCRIPTION
Relax a lowering rule where the restriction isn't needed any longer due to historical refactorings of how icmp is handled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
