### PR TITLE
[24.0.x] Unbreak CI on release branch

### DIFF
--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -304,6 +304,7 @@ fn cross_engine_module_exports() -> Result<()> {
 /// Smoke test for registering and unregistering modules (and their rec group
 /// entries) concurrently.
 #[wasmtime_test(wasm_features(gc, function_references))]
+#[cfg_attr(miri, ignore)]
 fn concurrent_type_registry_modifications(config: &mut Config) -> Result<()> {
     let _ = env_logger::try_init();
 
@@ -446,6 +447,7 @@ fn concurrent_type_registry_modifications(config: &mut Config) -> Result<()> {
 }
 
 #[wasmtime_test(wasm_features(function_references))]
+#[cfg_attr(miri, ignore)]
 fn concurrent_type_modifications_and_checks(config: &mut Config) -> Result<()> {
     const THREADS_CHECKING: usize = 4;
 


### PR DESCRIPTION
Ignore new tests on MIRI

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
