### PR TITLE
 [22.0.x] Fix backtraces through empty sequences of Wasm frames 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+## 22.0.1
+
+Released 2024-10-09.
+
+### Fixed
+
+* Fix a runtime crash when combining tail-calls with host imports that capture a
+  stack trace or trap.
+  [GHSA-q8hx-mm92-4wvg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg)
+
+--------------------------------------------------------------------------------
+
 ## 22.0.0
 
 Released 2024-06-20.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,10 @@ Released 2024-10-09.
   stack trace or trap.
   [GHSA-q8hx-mm92-4wvg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg)
 
+* Fix a race condition could lead to WebAssembly control-flow integrity and type
+  safety violations.
+  [GHSA-7qmx-3fpx-r45m](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-7qmx-3fpx-r45m)
+
 --------------------------------------------------------------------------------
 
 ## 22.0.0

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -492,7 +492,6 @@ fn concurrent_type_modifications_and_checks() -> Result<()> {
 
     let mut config = Config::new();
     config.wasm_function_references(true);
-
     let engine = Engine::new(&config)?;
 
     let mut threads = Vec::new();

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -5,7 +5,6 @@ use std::panic::{self, AssertUnwindSafe};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use wasmtime::*;
-use wasmtime_test_macros::wasmtime_test;
 
 #[test]
 fn test_trap_return() -> Result<()> {
@@ -1681,9 +1680,11 @@ fn async_stack_size_ignored_if_disabled() -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(tail_call))]
-fn tail_call_to_imported_function(config: &mut Config) -> Result<()> {
-    let engine = Engine::new(config)?;
+#[test]
+fn tail_call_to_imported_function() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_tail_call(true);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(
         &engine,
@@ -1709,9 +1710,11 @@ fn tail_call_to_imported_function(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(tail_call))]
-fn tail_call_to_imported_function_in_start_function(config: &mut Config) -> Result<()> {
-    let engine = Engine::new(config)?;
+#[test]
+fn tail_call_to_imported_function_in_start_function() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_tail_call(true);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(
         &engine,
@@ -1736,9 +1739,11 @@ fn tail_call_to_imported_function_in_start_function(config: &mut Config) -> Resu
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(tail_call, function_references))]
-fn return_call_ref_to_imported_function(config: &mut Config) -> Result<()> {
-    let engine = Engine::new(config)?;
+#[test]
+fn return_call_ref_to_imported_function() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_tail_call(true);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(
         &engine,
@@ -1763,9 +1768,11 @@ fn return_call_ref_to_imported_function(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(tail_call, function_references))]
-fn return_call_indirect_to_imported_function(config: &mut Config) -> Result<()> {
-    let engine = Engine::new(config)?;
+#[test]
+fn return_call_indirect_to_imported_function() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_tail_call(true);
+    let engine = Engine::new(&config)?;
 
     let module = Module::new(
         &engine,

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1681,6 +1681,7 @@ fn async_stack_size_ignored_if_disabled() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(target_arch = "s390x"))]
 fn tail_call_to_imported_function() -> Result<()> {
     let mut config = Config::new();
     config.wasm_tail_call(true);
@@ -1711,6 +1712,7 @@ fn tail_call_to_imported_function() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(target_arch = "s390x"))]
 fn tail_call_to_imported_function_in_start_function() -> Result<()> {
     let mut config = Config::new();
     config.wasm_tail_call(true);
@@ -1740,6 +1742,7 @@ fn tail_call_to_imported_function_in_start_function() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(target_arch = "s390x"))]
 fn return_call_ref_to_imported_function() -> Result<()> {
     let mut config = Config::new();
     config.wasm_tail_call(true);
@@ -1770,6 +1773,7 @@ fn return_call_ref_to_imported_function() -> Result<()> {
 }
 
 #[test]
+#[cfg(not(target_arch = "s390x"))]
 fn return_call_indirect_to_imported_function() -> Result<()> {
     let mut config = Config::new();
     config.wasm_tail_call(true);

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1743,6 +1743,7 @@ fn tail_call_to_imported_function_in_start_function() -> Result<()> {
 fn return_call_ref_to_imported_function() -> Result<()> {
     let mut config = Config::new();
     config.wasm_tail_call(true);
+    config.wasm_function_references(true);
     let engine = Engine::new(&config)?;
 
     let module = Module::new(
@@ -1772,6 +1773,7 @@ fn return_call_ref_to_imported_function() -> Result<()> {
 fn return_call_indirect_to_imported_function() -> Result<()> {
     let mut config = Config::new();
     config.wasm_tail_call(true);
+    config.wasm_function_references(true);
     let engine = Engine::new(&config)?;
 
     let module = Module::new(


### PR DESCRIPTION


Manually making PR as merging from the security advisory looks like it's not going to work. This also gets CI to run.
