### PR TITLE
 [23.0.x] Fix backtraces through empty sequences of Wasm frames 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,10 @@ Released 2024-10-09.
   stack trace or trap.
   [GHSA-q8hx-mm92-4wvg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg)
 
+* Fix a race condition could lead to WebAssembly control-flow integrity and type
+  safety violations.
+  [GHSA-7qmx-3fpx-r45m](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-7qmx-3fpx-r45m)
+
 --------------------------------------------------------------------------------
 
 ## 23.0.2

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+## 23.0.3
+
+Released 2024-10-09.
+
+### Fixed
+
+* Fix a runtime crash when combining tail-calls with host imports that capture a
+  stack trace or trap.
+  [GHSA-q8hx-mm92-4wvg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg)
+
+--------------------------------------------------------------------------------
+
 ## 23.0.2
 
 Released 2024-08-12.

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -5,6 +5,8 @@ use std::panic::{self, AssertUnwindSafe};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use wasmtime::*;
+
+#[cfg(not(target_arch = "s390x"))]
 use wasmtime_test_macros::wasmtime_test;
 
 #[test]

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1682,6 +1682,7 @@ fn async_stack_size_ignored_if_disabled() -> Result<()> {
 }
 
 #[wasmtime_test(wasm_features(tail_call))]
+#[cfg(not(target_arch = "s390x"))]
 fn tail_call_to_imported_function(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
 
@@ -1710,6 +1711,7 @@ fn tail_call_to_imported_function(config: &mut Config) -> Result<()> {
 }
 
 #[wasmtime_test(wasm_features(tail_call))]
+#[cfg(not(target_arch = "s390x"))]
 fn tail_call_to_imported_function_in_start_function(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
 
@@ -1737,6 +1739,7 @@ fn tail_call_to_imported_function_in_start_function(config: &mut Config) -> Resu
 }
 
 #[wasmtime_test(wasm_features(tail_call, function_references))]
+#[cfg(not(target_arch = "s390x"))]
 fn return_call_ref_to_imported_function(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
 
@@ -1764,6 +1767,7 @@ fn return_call_ref_to_imported_function(config: &mut Config) -> Result<()> {
 }
 
 #[wasmtime_test(wasm_features(tail_call, function_references))]
+#[cfg(not(target_arch = "s390x"))]
 fn return_call_indirect_to_imported_function(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
 


### PR DESCRIPTION


Manually making PR as merging from the security advisory looks like it's not going to work. This also gets CI to run.
