### PR TITLE
 [24.0.x] Fix backtraces through empty sequences of Wasm frames 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,10 @@ Released 2024-10-09.
   stack trace or trap.
   [GHSA-q8hx-mm92-4wvg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg)
 
+* Fix a race condition could lead to WebAssembly control-flow integrity and type
+  safety violations.
+  [GHSA-7qmx-3fpx-r45m](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-7qmx-3fpx-r45m)
+
 --------------------------------------------------------------------------------
 
 ## 24.0.0

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+## 24.0.1
+
+Released 2024-10-09.
+
+### Fixed
+
+* Fix a runtime crash when combining tail-calls with host imports that capture a
+  stack trace or trap.
+  [GHSA-q8hx-mm92-4wvg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg)
+
+--------------------------------------------------------------------------------
+
 ## 24.0.0
 
 Released 2024-08-20.


### PR DESCRIPTION


Manually making PR as merging from the security advisory looks like it's not going to work. This also gets CI to run.
