### PR TITLE
 Change stack walking to stop at a precise fp 

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -280,7 +280,7 @@ impl wasmtime_environ::Compiler for Compiler {
         debug_assert_vmctx_kind(isa, &mut builder, vmctx, wasmtime_environ::VMCONTEXT_MAGIC);
         let offsets = VMOffsets::new(isa.pointer_bytes(), &translation.module);
         let vm_runtime_limits_offset = offsets.ptr.vmctx_runtime_limits();
-        save_last_wasm_entry_sp(
+        save_last_wasm_entry_fp(
             &mut builder,
             pointer_type,
             &offsets.ptr,
@@ -969,7 +969,7 @@ fn debug_assert_vmctx_kind(
     }
 }
 
-fn save_last_wasm_entry_sp(
+fn save_last_wasm_entry_fp(
     builder: &mut FunctionBuilder,
     pointer_type: ir::Type,
     ptr_size: &impl PtrSize,
@@ -985,12 +985,12 @@ fn save_last_wasm_entry_sp(
     );
 
     // Then store our current stack pointer into the appropriate slot.
-    let sp = builder.ins().get_stack_pointer(pointer_type);
+    let fp = builder.ins().get_frame_pointer(pointer_type);
     builder.ins().store(
         MemFlags::trusted(),
-        sp,
+        fp,
         limits,
-        ptr_size.vmruntime_limits_last_wasm_entry_sp(),
+        ptr_size.vmruntime_limits_last_wasm_entry_fp(),
     );
 }
 

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -172,8 +172,8 @@ pub trait PtrSize {
         self.vmruntime_limits_last_wasm_exit_fp() + self.size()
     }
 
-    /// Return the offset of the `last_wasm_entry_sp` field of `VMRuntimeLimits`.
-    fn vmruntime_limits_last_wasm_entry_sp(&self) -> u8 {
+    /// Return the offset of the `last_wasm_entry_fp` field of `VMRuntimeLimits`.
+    fn vmruntime_limits_last_wasm_entry_fp(&self) -> u8 {
         self.vmruntime_limits_last_wasm_exit_pc() + self.size()
     }
 

--- a/crates/fuzzing/src/oracles/stacks.rs
+++ b/crates/fuzzing/src/oracles/stacks.rs
@@ -40,7 +40,10 @@ pub fn check_stacks(stacks: Stacks) -> usize {
             "call_func",
             |mut caller: Caller<'_, ()>, f: Option<Func>| {
                 let f = f.unwrap();
-                f.call(&mut caller, &[], &mut [])?;
+                let ty = f.ty(&caller);
+                let params = vec![Val::I32(0); ty.params().len()];
+                let mut results = vec![Val::I32(0); ty.results().len()];
+                f.call(&mut caller, &params, &mut results)?;
                 Ok(())
             },
         )

--- a/crates/wasmtime/src/runtime/vm/arch/aarch64.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/aarch64.rs
@@ -50,14 +50,6 @@ pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
 // And the current frame pointer points to the next older frame pointer.
 pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = 0;
 
-pub fn reached_entry_sp(fp: usize, entry_sp: usize) -> bool {
-    fp >= entry_sp
-}
-
-pub fn assert_entry_sp_is_aligned(sp: usize) {
-    assert_eq!(sp % 16, 0, "stack should always be aligned to 16");
-}
-
 pub fn assert_fp_is_aligned(_fp: usize) {
     // From AAPCS64, section 6.2.3 The Frame Pointer[0]:
     //

--- a/crates/wasmtime/src/runtime/vm/arch/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/mod.rs
@@ -40,14 +40,6 @@ pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
 
 pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = imp::NEXT_OLDER_FP_FROM_FP_OFFSET;
 
-pub fn reached_entry_sp(fp: usize, entry_sp: usize) -> bool {
-    imp::reached_entry_sp(fp, entry_sp)
-}
-
-pub fn assert_entry_sp_is_aligned(sp: usize) {
-    imp::assert_entry_sp_is_aligned(sp)
-}
-
 pub fn assert_fp_is_aligned(fp: usize) {
     imp::assert_fp_is_aligned(fp)
 }

--- a/crates/wasmtime/src/runtime/vm/arch/riscv64.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/riscv64.rs
@@ -21,14 +21,6 @@ pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
 // And the current frame pointer points to the next older frame pointer.
 pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = 0;
 
-pub fn reached_entry_sp(fp: usize, entry_sp: usize) -> bool {
-    fp >= entry_sp
-}
-
-pub fn assert_entry_sp_is_aligned(sp: usize) {
-    assert_eq!(sp % 16, 0, "stack should always be aligned to 16");
-}
-
 pub fn assert_fp_is_aligned(fp: usize) {
     assert_eq!(fp % 16, 0, "stack should always be aligned to 16");
 }

--- a/crates/wasmtime/src/runtime/vm/arch/s390x.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/s390x.rs
@@ -17,14 +17,6 @@ pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
 // by the current "FP".
 pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = 0;
 
-pub fn reached_entry_sp(fp: usize, entry_sp: usize) -> bool {
-    fp > entry_sp
-}
-
-pub fn assert_entry_sp_is_aligned(sp: usize) {
-    assert_eq!(sp % 8, 0, "stack should always be aligned to 8");
-}
-
 pub fn assert_fp_is_aligned(fp: usize) {
     assert_eq!(fp % 8, 0, "stack should always be aligned to 8");
 }

--- a/crates/wasmtime/src/runtime/vm/arch/unsupported.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/unsupported.rs
@@ -31,14 +31,6 @@ pub unsafe fn get_next_older_pc_from_fp(_fp: usize) -> usize {
 
 pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = 0;
 
-pub fn reached_entry_sp(_fp: usize, _entry_sp: usize) -> bool {
-    panic!()
-}
-
-pub fn assert_entry_sp_is_aligned(_sp: usize) {
-    panic!()
-}
-
 pub fn assert_fp_is_aligned(_fp: usize) {
     panic!()
 }

--- a/crates/wasmtime/src/runtime/vm/arch/x86_64.rs
+++ b/crates/wasmtime/src/runtime/vm/arch/x86_64.rs
@@ -23,14 +23,6 @@ pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
 // And the current frame pointer points to the next older frame pointer.
 pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = 0;
 
-pub fn reached_entry_sp(fp: usize, entry_sp: usize) -> bool {
-    fp >= entry_sp
-}
-
-pub fn assert_entry_sp_is_aligned(sp: usize) {
-    assert_eq!(sp % 16, 0, "stack should always be aligned to 16");
-}
-
 pub fn assert_fp_is_aligned(fp: usize) {
     assert_eq!(fp % 16, 0, "stack should always be aligned to 16");
 }

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -323,7 +323,7 @@ mod call_thread_state {
         // contiguous-Wasm-frames stack regions for backtracing purposes.
         old_last_wasm_exit_fp: Cell<usize>,
         old_last_wasm_exit_pc: Cell<usize>,
-        old_last_wasm_entry_sp: Cell<usize>,
+        old_last_wasm_entry_fp: Cell<usize>,
     }
 
     impl Drop for CallThreadState {
@@ -331,7 +331,7 @@ mod call_thread_state {
             unsafe {
                 *(*self.limits).last_wasm_exit_fp.get() = self.old_last_wasm_exit_fp.get();
                 *(*self.limits).last_wasm_exit_pc.get() = self.old_last_wasm_exit_pc.get();
-                *(*self.limits).last_wasm_entry_sp.get() = self.old_last_wasm_entry_sp.get();
+                *(*self.limits).last_wasm_entry_fp.get() = self.old_last_wasm_entry_fp.get();
             }
         }
     }
@@ -359,7 +359,7 @@ mod call_thread_state {
                 prev: Cell::new(ptr::null()),
                 old_last_wasm_exit_fp: Cell::new(unsafe { *(*limits).last_wasm_exit_fp.get() }),
                 old_last_wasm_exit_pc: Cell::new(unsafe { *(*limits).last_wasm_exit_pc.get() }),
-                old_last_wasm_entry_sp: Cell::new(unsafe { *(*limits).last_wasm_entry_sp.get() }),
+                old_last_wasm_entry_fp: Cell::new(unsafe { *(*limits).last_wasm_entry_fp.get() }),
             }
         }
 
@@ -373,9 +373,9 @@ mod call_thread_state {
             self.old_last_wasm_exit_pc.get()
         }
 
-        /// Get the saved SP upon entry into Wasm for the previous `CallThreadState`.
-        pub fn old_last_wasm_entry_sp(&self) -> usize {
-            self.old_last_wasm_entry_sp.get()
+        /// Get the saved FP upon entry into Wasm for the previous `CallThreadState`.
+        pub fn old_last_wasm_entry_fp(&self) -> usize {
+            self.old_last_wasm_entry_fp.get()
         }
 
         /// Get the previous `CallThreadState`.

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -834,7 +834,7 @@ pub struct VMRuntimeLimits {
     ///
     /// Used to find the end of a contiguous sequence of Wasm frames when
     /// walking the stack.
-    pub last_wasm_entry_sp: UnsafeCell<usize>,
+    pub last_wasm_entry_fp: UnsafeCell<usize>,
 }
 
 // The `VMRuntimeLimits` type is a pod-type with no destructor, and we don't
@@ -852,7 +852,7 @@ impl Default for VMRuntimeLimits {
             epoch_deadline: UnsafeCell::new(0),
             last_wasm_exit_fp: UnsafeCell::new(0),
             last_wasm_exit_pc: UnsafeCell::new(0),
-            last_wasm_entry_sp: UnsafeCell::new(0),
+            last_wasm_entry_fp: UnsafeCell::new(0),
         }
     }
 }
@@ -888,8 +888,8 @@ mod test_vmruntime_limits {
             usize::from(offsets.ptr.vmruntime_limits_last_wasm_exit_pc())
         );
         assert_eq!(
-            offset_of!(VMRuntimeLimits, last_wasm_entry_sp),
-            usize::from(offsets.ptr.vmruntime_limits_last_wasm_entry_sp())
+            offset_of!(VMRuntimeLimits, last_wasm_entry_fp),
+            usize::from(offsets.ptr.vmruntime_limits_last_wasm_entry_fp())
         );
     }
 }


### PR DESCRIPTION
Prior to this commit entry trampolines into wasm would record their
stack pointer at the time of the function call to wasm and then this
stack pointer was used to halt the stack walking process. The problem
with this though is that due to the `tail` ABI it's possible that the
callee will update the caller's stack pointer temporarily. This means
that the recorded stack pointer at the time the trampoline called wasm
may differ from the callee's idea of what the stack pointer is when a
backtrace happens.

To handle this condition when stack walking the frame pointer instead of
the stack pointer is now recorded when wasm is invoked. This frame
pointer is a trusted value as it's managed by Cranelift itself. This
additionally enables the stop condition for frame walking to be a
precise "it must be this value" condition.

Put together this commit fixes an issue where when `return_call` is used
it's possible for the initial few frames of the stack to get lost in
stack traces. After this the frame pointer chain should always be
precisely walked in its entirety, even in the face of different numbers
of arguments and parameters as `return_call` instructions are executed.