### PR TITLE
s390x: Add support for inline probestack

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -977,6 +977,11 @@
       (ridx Reg)
       (targets BoxVecMachLabel))
 
+    ;; Stack probe loop sequence, as one compound instruction.
+    (StackProbeLoop
+      (probe_count WritableReg)
+      (guard_size i16))
+
     ;; Load an inline symbol reference with relocation.
     (LoadSymbolReloc
       (rd WritableReg)

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -7033,6 +7033,15 @@ fn test_s390x_binemit() {
     ));
 
     insns.push((
+        Inst::StackProbeLoop {
+            probe_count: writable_gpr(1),
+            guard_size: 4096,
+        },
+        "A7FBF0009200F000A716FFFC",
+        "0: aghi %r15, -4096 ; mvi 0(%r15), 0 ; brct %r1, 0b",
+    ));
+
+    insns.push((
         Inst::FpuMove32 {
             rd: writable_vr(8),
             rn: vr(4),

--- a/cranelift/filetests/filetests/isa/s390x/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/s390x/inline-probestack.clif
@@ -1,0 +1,96 @@
+test compile precise-output
+set enable_probestack=true
+set probestack_strategy=inline
+; This is the default and is equivalent to a page size of 4096
+set probestack_size_log2=12
+target s390x
+
+
+; If the stack size is just one page, we can avoid the stack probe entirely
+function %single_page() -> i64 tail {
+ss0 = explicit_slot 2048
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   aghi %r15, -2048
+; block0:
+;   la %r2, 0(%r15)
+;   aghi %r15, 2048
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   aghi %r15, -0x800
+; block1: ; offset 0x4
+;   la %r2, 0(%r15)
+;   aghi %r15, 0x800
+;   br %r14
+
+function %unrolled() -> i64 tail {
+ss0 = explicit_slot 8192
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   aghi %r15, -4096
+;   mvi 0(%r15), 0
+;   aghi %r15, -4096
+;   mvi 0(%r15), 0
+;   aghi %r15, 8192
+;   aghi %r15, -8192
+; block0:
+;   la %r2, 0(%r15)
+;   aghi %r15, 8192
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   aghi %r15, -0x1000
+;   mvi 0(%r15), 0
+;   aghi %r15, -0x1000
+;   mvi 0(%r15), 0
+;   aghi %r15, 0x2000
+;   aghi %r15, -0x2000
+; block1: ; offset 0x18
+;   la %r2, 0(%r15)
+;   aghi %r15, 0x2000
+;   br %r14
+
+function %large() -> i64 tail {
+ss0 = explicit_slot 100000
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   lhi %r1, 25
+;   0: aghi %r15, -4096 ; mvi 0(%r15), 0 ; brct %r1, 0b
+;   agfi %r15, 102400
+;   agfi %r15, -100000
+; block0:
+;   la %r2, 0(%r15)
+;   agfi %r15, 100000
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r1, 0x19
+;   aghi %r15, -0x1000
+;   mvi 0(%r15), 0
+;   brct %r1, 4
+;   agfi %r15, 0x19000
+;   agfi %r15, -0x186a0
+; block1: ; offset 0x1c
+;   la %r2, 0(%r15)
+;   agfi %r15, 0x186a0
+;   br %r14
+

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -8,7 +8,6 @@ use core::str::FromStr;
 use serde_derive::{Deserialize, Serialize};
 #[cfg(any(feature = "cache", feature = "cranelift", feature = "winch"))]
 use std::path::Path;
-use target_lexicon::Architecture;
 use wasmparser::WasmFeatures;
 #[cfg(feature = "cache")]
 use wasmtime_cache::CacheConfig;
@@ -2068,16 +2067,14 @@ impl Config {
 
         let target = self.compiler_target();
 
-        // On supported targets, we enable stack probing by default.
+        // We enable stack probing by default on all targets.
         // This is required on Windows because of the way Windows
         // commits its stacks, but it's also a good idea on other
         // platforms to ensure guard pages are hit for large frame
         // sizes.
-        if probestack_supported(target.architecture) {
-            self.compiler_config
-                .flags
-                .insert("enable_probestack".into());
-        }
+        self.compiler_config
+            .flags
+            .insert("enable_probestack".into());
 
         if let Some(unwind_requested) = self.native_unwind_info {
             if !self
@@ -3019,13 +3016,6 @@ impl PoolingAllocationConfig {
         self.config.limits.total_gc_heaps = count;
         self
     }
-}
-
-pub(crate) fn probestack_supported(arch: Architecture) -> bool {
-    matches!(
-        arch,
-        Architecture::X86_64 | Architecture::Aarch64(_) | Architecture::Riscv64(_)
-    )
 }
 
 #[cfg(feature = "std")]

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -306,7 +306,7 @@ impl Engine {
             // runtime.
             "libcall_call_conv" => *value == FlagValue::Enum("isa_default".into()),
             "preserve_frame_pointers" => *value == FlagValue::Bool(true),
-            "enable_probestack" => *value == FlagValue::Bool(crate::config::probestack_supported(target.architecture)),
+            "enable_probestack" => *value == FlagValue::Bool(true),
             "probestack_strategy" => *value == FlagValue::Enum("inline".into()),
 
             // Features wasmtime doesn't use should all be disabled, since


### PR DESCRIPTION
This implements the gen_inline_probestack callback in line with the implementation on other platforms, which allows detection of stack overflows with misconfigured hosts.

Fixes: https://github.com/bytecodealliance/wasmtime/issues/9396

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
