### PR TITLE
[24.0.x] Update publish script skipping versions

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -426,15 +426,16 @@ fn publish(krate: &Crate) -> bool {
 
     // First make sure the crate isn't already published at this version. This
     // script may be re-run and there's no need to re-attempt previous work.
-    let output = cmd_output(
-        Command::new("curl").arg(&format!("https://crates.io/api/v1/crates/{}", krate.name)),
-    );
+    let output = cmd_output(Command::new("curl").arg(&format!(
+        "https://crates.io/api/v1/crates/{}/versions",
+        krate.name
+    )));
     if output.status.success()
         && String::from_utf8_lossy(&output.stdout)
-            .contains(&format!("\"newest_version\":\"{}\"", krate.version))
+            .contains(&format!("\"num\":\"{}\"", krate.version))
     {
         println!(
-            "skip publish {} because {} is latest version",
+            "skip publish {} because {} is already published",
             krate.name, krate.version,
         );
         return true;


### PR DESCRIPTION
Instead of only checking the latest version check the list of recently published versions to determine if a version is already published.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
