### PR TITLE
Update docs/stabilization of wasm proposals

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1823,10 +1823,16 @@ impl Config {
         // On-by-default features that wasmtime has. Note that these are all
         // subject to the criteria at
         // https://docs.wasmtime.dev/contributing-implementing-wasm-proposals.html
+        // and
+        // https://docs.wasmtime.dev/stability-wasm-proposals.html
         features |= WasmFeatures::MULTI_MEMORY;
         features |= WasmFeatures::RELAXED_SIMD;
         features |= WasmFeatures::TAIL_CALL;
         features |= WasmFeatures::EXTENDED_CONST;
+        // NB: if you add a feature above this line please double-check
+        // https://docs.wasmtime.dev/stability-wasm-proposals.html
+        // to ensure all requirements are met and/or update the documentation
+        // there too.
 
         // Set some features to their conditionally-enabled defaults depending
         // on crate compile-time features.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -45,6 +45,7 @@
   - [Release Process](./stability-release.md)
   - [Tiers of support](./stability-tiers.md)
   - [Platform Support](./stability-platform-support.md)
+  - [Wasm Proposals](./stability-wasm-proposals.md)
 - [Security](security.md)
   - [Disclosure Policy](./security-disclosure.md)
   - [What is considered a security bug?](./security-what-is-considered-a-security-vulnerability.md)

--- a/docs/contributing-implementing-wasm-proposals.md
+++ b/docs/contributing-implementing-wasm-proposals.md
@@ -6,52 +6,23 @@ The following checkboxes enumerate the steps required to add support for a new
 WebAssembly proposal to Wasmtime. They can be completed over the course of
 multiple pull requests.
 
-* <input type="checkbox"/> Add support to the
-  [`wasmparser`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser)
-  crate.
-
-* <input type="checkbox"/> Add support to the
-  [`wat`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wat)
-  and
-  [`wast`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast)
-  crates.
-
-* <input type="checkbox"/> Add support to the
-  [`wasmprinter`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter)
-  crate.
-
-* <input type="checkbox"/> Add support to the
-  [`wasm-encoder`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder)
-  crate.
-
-* <input type="checkbox"/> Add support to the
-  [`wasm-smith`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith)
-  crate.
-
-* <input type="checkbox"/> Add a `wasmtime::Config::enable_foo_bar` method to
-  the `wasmtime` crate.
-
-* <input type="checkbox"/> Add a `--enable-foo-bar` command line flag to the
-  `wasmtime` binary.
-
-* <input type="checkbox"/> Enable the spec tests in
-  [`build.rs`](https://github.com/bytecodealliance/wasmtime/blob/c7cd70fcec3eee66c9d7b5aa6fb4580d5a802218/build.rs#L41-L52)
-  but [mark them as
-  ignored](https://github.com/bytecodealliance/wasmtime/blob/c7cd70fcec3eee66c9d7b5aa6fb4580d5a802218/build.rs#L196)
-  for now.
-
-* <input type="checkbox"/> Stop ignoring individual spec tests and get them
-  passing one by one.
-
-* <input type="checkbox"/> Enable the proposal in [the fuzz
-  targets](./contributing-fuzzing.html).
-
-  * <input type="checkbox"/> Add examples from the spec tests to [the relevant
-    corpora](https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus).
-
-    > The `wast2json` tool from [WABT] is useful for this.
-
-  * <input type="checkbox"/> Write a custom fuzz target, oracle, and/or test
+* [ ] Implement support for the proposal in the [`wasm-tools` repository].
+  [(example)](https://github.com/bytecodealliance/wasm-tools/pull/1853)
+  * [ ] [`wast`] - text parsing
+  * [ ] [`wasmparser`] - binary decoding and validation
+  * [ ] [`wasmprinter`] - binary-to-text
+  * [ ] [`wasm-encoder`] - binary encoding
+  * [ ] [`wasm-smith`] - fuzz test case generation
+* [ ] Update Wasmtime to use these `wasm-tools` crates, but leave the new
+  proposal unimplemented for now (implementation comes in subsequent PRs).
+  [(example)](https://github.com/bytecodealliance/wasmtime/pull/9399)
+* [ ] Add `Config::wasm_your_proposal` to the `wasmtime` crate.
+* [ ] Implement the proposal in `wasmtime`, gated behind this flag.
+* [ ] Add `-Wyour-proposal` to the `wasmtime-cli-flags` crate.
+* [ ] Update `tests/wast.rs` to spec tests should pass for this proposal.
+* [ ] Write custom tests in `tests/misc_testsuite/*.wast` for this proposal.
+* [ ] Enable the proposal in [the fuzz targets](./contributing-fuzzing.html).
+  * [ ] Write a custom fuzz target, oracle, and/or test
     case generator for fuzzing this proposal in particular.
 
     > For example, we wrote a [custom
@@ -61,69 +32,30 @@ multiple pull requests.
     > target](https://github.com/bytecodealliance/wasmtime/blob/c7cd70fcec3eee66c9d7b5aa6fb4580d5a802218/fuzz/fuzz_targets/table_ops.rs)
     > for exercising `table.{get,set}` instructions and their interaction with
     > GC while implementing the reference types proposal.
-
-* <input type="checkbox"/> Expose the proposal's new functionality in the
-  `wasmtime` crate's API.
+* [ ] Expose the proposal's new functionality in the `wasmtime` crate's API.
 
   > For example, the bulk memory operations proposal introduced a `table.copy`
   > instruction, and we exposed its functionality as the `wasmtime::Table::copy`
   > method.
-
-* <input type="checkbox"/> Expose the proposal's new functionality in the C API.
+* [ ] Expose the proposal's new functionality in the C API.
 
   > This may require extensions to the standard C API, and if so, should be
   > defined in
   > [`wasmtime.h`](https://github.com/bytecodealliance/wasmtime/blob/c7cd70fcec3eee66c9d7b5aa6fb4580d5a802218/crates/c-api/include/wasmtime.h)
   > and prefixed with `wasmtime_`.
+* [ ] Update `docs/stability-tiers.md` with an implementation status of the
+  proposal.
 
-* <input type="checkbox"/> Use the C API to expose the proposal's new
-  functionality in the other language embedding APIs:
 
-  * <input type="checkbox"/> [Python](https://github.com/bytecodealliance/wasmtime-py/)
+[`wasm-tools` repository]: https://github.com/bytecodealliance/wasm-tools
+[`wasmparser`]: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
+[`wast`]: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast
+[`wasmprinter`]: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter
+[`wasm-encoder`]: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder
+[`wasm-smith`]: https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wams-smith
 
-  * <input type="checkbox"/> [Go](https://github.com/bytecodealliance/wasmtime-go/)
-
-  * <input type="checkbox"/> [.NET](https://github.com/bytecodealliance/wasmtime-dotnet/)
-
-* <input type="checkbox"/> Document support for the proposal in
-  `wasmtime/docs/stability-wasm-proposals-support.md`.
-
-## Enabling Support for a Proposal by Default
-
-These are the standards that must be met to enable support for a proposal by
-default in Wasmtime, and can be used as a review checklist.
-
-* <input type="checkbox"/> The proposal must be in phase 4, or greater, of [the
-  WebAssembly standardization process][phases].
-
-* <input type="checkbox"/> All spec tests must be passing in Wasmtime.
-
-* <input type="checkbox"/> No open questions, design concerns, or serious known
-  bugs.
-
-* <input type="checkbox"/> Has been fuzzed for at least a week minimum.
-
-* <input type="checkbox"/> We are confident that the fuzzers are fully
-  exercising the proposal's functionality.
-
-  > For example, it would *not* have been enough to simply enable reference
-  > types in the `compile` fuzz target to enable that proposal by
-  > default. Compiling a module that uses reference types but not instantiating
-  > it nor running any of its functions doesn't exercise any of the GC
-  > implementation and does not run the inline fast paths for `table` operations
-  > emitted by the JIT. Exercising these things was the motivation for writing
-  > the custom fuzz target for `table.{get,set}` instructions.
-
-* <input type="checkbox"/> The proposal's functionality is exposed in the
-  `wasmtime` crate's API.
-
-* <input type="checkbox"/> The proposal's functionality is exposed in the C API.
-
-* <input type="checkbox"/> The proposal's functionality is exposed in at least
-  one of the other languages' APIs.
-
-[phases]: https://github.com/WebAssembly/meetings/blob/master/process/phases.md
-[WABT]: https://github.com/WebAssembly/wabt/
+For information about the status of implementation of various proposals in
+Wasmtime see the [associated documentation](./stability-wasm-proposals.md).
 
 ## Adding component functionality to WASI
 The [cap-std](https://github.com/bytecodealliance/cap-std) repository contains

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -149,12 +149,7 @@ features to figure out how best to implement them and at least move them to Tier
 * Target: SPARC
 * Target: PowerPC
 * Target: RISC-V 32-bit
-* [WebAssembly proposal: `branch-hinting`](https://github.com/WebAssembly/branch-hinting)
-* [WebAssembly proposal: `exception-handling`](https://github.com/WebAssembly/exception-handling)
-* [WebAssembly proposal: `extended-const`](https://github.com/WebAssembly/extended-const)
-* [WebAssembly proposal: `flexible-vectors`](https://github.com/WebAssembly/flexible-vectors)
-* [WebAssembly proposal: `memory-control`](https://github.com/WebAssembly/memory-control)
-* [WebAssembly proposal: `stack-switching`](https://github.com/WebAssembly/stack-switching)
+* WebAssembly Proposals: see [documentation here](./stability-wasm-proposals.md)
 * [WASI proposal: `proxy-wasm`](https://github.com/proxy-wasm/spec)
 * [WASI proposal: `wasi-blob-store`](https://github.com/WebAssembly/wasi-blob-store)
 * [WASI proposal: `wasi-crypto`](https://github.com/WebAssembly/wasi-crypto)
@@ -305,6 +300,9 @@ Tier 1 features include:
 
 * Major changes affecting Tier 1 features require an RFC and prior agreement on
   the change before an implementation is committed.
+
+* WebAssembly proposals meet [all stabilization
+  requirements](./stability-wasm-proposals.md).
 
 A major inclusion point for this tier is intended to be the continuous fuzzing
 of Wasmtime. This implies a significant commitment of resources for fixing

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -144,7 +144,6 @@ features to figure out how best to implement them and at least move them to Tier
 * Target: [FreeBSD](https://github.com/bytecodealliance/wasmtime/issues/5499)
 * Target: [NetBSD/OpenBSD](https://github.com/bytecodealliance/wasmtime/issues/6962)
 * Target: [i686 (32-bit Intel targets)](https://github.com/bytecodealliance/wasmtime/issues/1980)
-* Target: Android
 * Target: MIPS
 * Target: SPARC
 * Target: PowerPC

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -1,0 +1,115 @@
+# Wasm Proposals
+
+This document is intended to describe the current status of WebAssembly
+proposals in Wasmtime. For information about implementing a proposal in Wasmtime
+see the [associated
+documentation](./contributing-implementing-wasm-proposals.md).
+
+WebAssembly proposals that want to be [tier 2 or above](./stability-tiers.md)
+are required to check all boxes in this matrix. An explanation of each matrix
+column is below.
+
+## On-by-default proposals
+
+|  Proposal                | Phase 4 | Tests | Finished | Fuzzed | API | C API |
+|--------------------------|---------|-------|----------|--------|-----|-------|
+| [`mutable-globals`]      | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`sign-extension-ops`]   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`nontrapping-fptoint`]  | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`multi-value`]          | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`bulk-memory`]          | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`reference-types`]      | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`simd`]                 | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`component-model`]      | ❌[^1]  | ✅    | ✅       | ⚠️[^2]  | ✅  | ❌[^5]|
+| [`relaxed-simd`]         | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`multi-memory`]         | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`threads`]              | ✅      | ✅    | ✅       | ❌[^3] | ✅  | ✅    |
+| [`tail-call`]            | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`extended-const`]       | ✅      | ✅    | ✅       | ❌[^4] | ✅  | ✅    |
+
+[^1]: The `component-model` proposal is not at phase 4 in the standardization
+    process but it is still enabled-by-default in Wasmtime.
+[^2]: Various shapes of components are fuzzed but full-on fuzzing along the
+    lines of `wasm-smith` are not implemented for components.
+[^3]: Fuzzing with threads is an open implementation question that is expected
+    to get fleshed out as the [`shared-everything-threads`] proposal advances.
+[^4]: This was a mistake in Wasmtime's stabilization process. Support for
+    [`extended-const`] is not yet implemented in `wasm-smith`.
+[^5]: Support for the C API for components is desired by many embedders but
+    does not currently have anyone lined up to implement it.
+
+## Off-by-default proposals
+
+|  Proposal                | Phase 4 | Tests | Finished | Fuzzed | API | C API |
+|--------------------------|---------|-------|----------|--------|-----|-------|
+| [`memory64`]             | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`function-references`]  | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
+| [`gc`]                   | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
+| [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
+
+Unsupported WebAssembly proposals that Wasmtime does not have support for:
+
+* [`branch-hinting`]
+* [`exception-handling`]
+* [`flexible-vectors`]
+* [`memory-control`]
+* [`stack-switching`]
+* [`shared-everything-threads`]
+
+[`mutable-globals`]: https://github.com/WebAssembly/mutable-global/blob/master/proposals/mutable-global/Overview.md
+[`sign-extension-ops`]: https://github.com/WebAssembly/spec/blob/master/proposals/sign-extension-ops/Overview.md
+[`nontrapping-fptoint`]: https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md
+[`multi-value`]: https://github.com/WebAssembly/spec/blob/master/proposals/multi-value/Overview.md
+[`bulk-memory`]: https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md
+[`reference-types`]: https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md
+[`simd`]: https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md
+[`tail-call`]: https://github.com/WebAssembly/tail-call/blob/main/proposals/tail-call/Overview.md
+[`branch-hinting`]: https://github.com/WebAssembly/branch-hinting
+[`exception-handling`]: https://github.com/WebAssembly/exception-handling
+[`extended-const`]: https://github.com/WebAssembly/extended-const
+[`flexible-vectors`]: https://github.com/WebAssembly/flexible-vectors
+[`memory-control`]: https://github.com/WebAssembly/memory-control
+[`stack-switching`]: https://github.com/WebAssembly/stack-switching
+[`shared-everything-threads`]: https://github.com/WebAssembly/shared-everything-threads
+[`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
+[`multi-memory`]: https://github.com/WebAssembly/multi-memory/blob/master/proposals/multi-memory/Overview.md
+[`threads`]: https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md
+[`component-model`]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
+[`relaxed-simd`]: https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md
+[`function-references`]: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md
+[`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic/blob/main/proposals/wide-arithmetic/Overview.md
+[`gc`]: https://github.com/WebAssembly/gc
+
+For each column in the above table, this is a further explanation of its meaning:
+
+* **Phase 4** - The proposal must be in phase 4, or greater, of [the
+  WebAssembly standardization process][phases].
+
+* **Tests** - All spec tests must be passing in Wasmtime and where appropriate
+  Wasmtime-specific tests, for example for the API, should be passing. Tests
+  must pass at least for Cranelift on all [tier 1](./stability-tiers.md)
+  platforms, but missing other platforms is otherwise acceptable.
+
+* **Finished** - No open questions, design concerns, or serious known bugs. The
+  implementation should be complete to the extent that is possible. Support
+  must be implemented for all [tier 1](./stability-tiers.md) targets and
+  compiler backends.
+
+* **Fuzzed** - Has been fuzzed for at least a week minimum. We are also
+  confident that the fuzzers are fully exercising the proposal's functionality.
+
+  > For example, it would *not* have been enough to simply enable reference
+  > types in the `compile` fuzz target to enable that proposal by
+  > default. Compiling a module that uses reference types but not instantiating
+  > it nor running any of its functions doesn't exercise any of the GC
+  > implementation and does not run the inline fast paths for `table` operations
+  > emitted by the JIT. Exercising these things was the motivation for writing
+  > the custom fuzz target for `table.{get,set}` instructions.
+
+* **API** - The proposal's functionality is exposed in the `wasmtime` crate's
+  API. At minimum this is `Config::wasm_the_proposal` but proposals such as
+  [`gc`] also add new types to the API.
+
+* **C API** - The proposal's functionality is exposed in the C API.
+
+[phases]: https://github.com/WebAssembly/meetings/blob/master/process/phases.md

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -44,10 +44,14 @@ column is below.
 |--------------------------|---------|-------|----------|--------|-----|-------|
 | [`memory64`]             | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`function-references`]  | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
-| [`gc`]                   | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
+| [`gc`] [^6]              | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
 
-Unsupported WebAssembly proposals that Wasmtime does not have support for:
+[^6]: There is also a [tracking
+    issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for the
+    GC proposal.
+
+## Unsupported proposals
 
 * [`branch-hinting`]
 * [`exception-handling`]
@@ -80,7 +84,9 @@ Unsupported WebAssembly proposals that Wasmtime does not have support for:
 [`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic/blob/main/proposals/wide-arithmetic/Overview.md
 [`gc`]: https://github.com/WebAssembly/gc
 
-For each column in the above table, this is a further explanation of its meaning:
+## Feature requirements
+
+For each column in the above tables, this is a further explanation of its meaning:
 
 * **Phase 4** - The proposal must be in phase 4, or greater, of [the
   WebAssembly standardization process][phases].


### PR DESCRIPTION
This commit updates our documentation and documented status of various WebAssembly proposals. The goal of this commit it to explicitly list all requirements for each WebAssembly proposal in a way such that enabling a feature requires actively checking this table and performing effort to fill in. This is intended to mitigate GHSA-q8hx-mm92-4wvg where it was found that we were accidentally not fuzzing tail calls but had enabled it by default.

This shuffles around some documentation, modernizes a bit, and notably tries to list out a green checkbox or red X for the status of various proposals. Notes for "holes" in the "on by default matrix" are also added.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
