### PR TITLE
Remove the now-unused `VMGcRef::as_externref_unchecked` method

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/externref.rs
@@ -71,19 +71,6 @@ impl VMGcRef {
             None
         }
     }
-
-    /// Get this GC reference as an `externref` reference without checking if it
-    /// actually is an `externref` reference.
-    ///
-    /// Calling this method on a non-`externref` reference is memory safe, but
-    /// will lead to general incorrectness like panics and wrong results.
-    pub fn as_externref_unchecked(&self) -> &VMExternRef {
-        debug_assert!(!self.is_i31());
-        let ptr = self as *const VMGcRef;
-        let ret = unsafe { &*ptr.cast() };
-        assert!(matches!(ret, VMExternRef(VMGcRef { .. })));
-        ret
-    }
 }
 
 impl VMExternRef {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
