### PR TITLE
Implement the `ref.cast` Wasm GC instruction

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -55,6 +55,8 @@ pub const TRAP_HEAP_MISALIGNED: TrapCode =
     TrapCode::unwrap_user(Trap::HeapMisaligned as u8 + TRAP_OFFSET);
 pub const TRAP_TABLE_OUT_OF_BOUNDS: TrapCode =
     TrapCode::unwrap_user(Trap::TableOutOfBounds as u8 + TRAP_OFFSET);
+pub const TRAP_CAST_FAILURE: TrapCode =
+    TrapCode::unwrap_user(Trap::CastFailure as u8 + TRAP_OFFSET);
 
 /// Creates a new cranelift `Signature` with no wasm params/results for the
 /// given calling convention.

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -80,6 +80,9 @@ pub enum Trap {
     /// Attempted an allocation that was too large to succeed.
     AllocationTooLarge,
 
+    /// Attempted to cast a reference to a type that it is not an instance of.
+    CastFailure,
+
     /// When the `component-model` feature is enabled this trap represents a
     /// scenario where one component tried to call another component but it
     /// would have violated the reentrance rules of the component model,
@@ -119,6 +122,7 @@ impl Trap {
             NullReference
             ArrayOutOfBounds
             AllocationTooLarge
+            CastFailure
             CannotEnterComponent
         }
 
@@ -148,6 +152,7 @@ impl fmt::Display for Trap {
             NullReference => "null reference",
             ArrayOutOfBounds => "out of bounds array access",
             AllocationTooLarge => "allocation size too large",
+            CastFailure => "cast failure",
             CannotEnterComponent => "cannot enter component instance",
         };
         write!(f, "wasm trap: {desc}")

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -207,14 +207,12 @@ fn should_fail(test: &Path, strategy: Strategy) -> bool {
         "binary_gc.wast",
         "br_on_cast_fail.wast",
         "br_on_cast.wast",
-        "ref_cast.wast",
         "table_sub.wast",
         "type_canon.wast",
         "type_equivalence.wast",
         "type-rec.wast",
         "type-subtyping.wast",
         "unreached_valid.wast",
-        "i31.wast",
     ];
 
     for part in test.iter() {


### PR DESCRIPTION
Just building on top of our existing `ref.test` support and trapping if the test fails.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
