### PR TITLE
Implement the `br_on_cast[_fail]` Wasm GC instructions

### DIFF
--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -205,8 +205,6 @@ fn should_fail(test: &Path, strategy: Strategy) -> bool {
     }
     let unsupported_gc_tests = [
         "binary_gc.wast",
-        "br_on_cast_fail.wast",
-        "br_on_cast.wast",
         "table_sub.wast",
         "type_canon.wast",
         "type_equivalence.wast",


### PR DESCRIPTION
Just gluing our existing `ref.test` and conditional branching support together.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
