### PR TITLE
Implement subtype checking for `[return_]call_indirect` instructions

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1495,8 +1495,15 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         // Check that they match: in the case of Wasm GC, this means doing a
         // full subtype check. Otherwise, we do a simple equality check.
         let matches = if features.gc() {
-            self.env
-                .is_subtype(self.builder, callee_sig_id, caller_sig_id)
+            #[cfg(feature = "gc")]
+            {
+                self.env
+                    .is_subtype(self.builder, callee_sig_id, caller_sig_id)
+            }
+            #[cfg(not(feature = "gc"))]
+            {
+                unreachable!()
+            }
         } else {
             self.builder
                 .ins()

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -650,6 +650,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
 
             let call = environ.translate_call_indirect(
                 builder,
+                validator.features(),
                 TableIndex::from_u32(*table_index),
                 TypeIndex::from_u32(*type_index),
                 sigref,
@@ -717,6 +718,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
 
             environ.translate_return_call_indirect(
                 builder,
+                validator.features(),
                 TableIndex::from_u32(*table_index),
                 TypeIndex::from_u32(*type_index),
                 sigref,

--- a/crates/cranelift/src/translate/environ/spec.rs
+++ b/crates/cranelift/src/translate/environ/spec.rs
@@ -15,7 +15,7 @@ use cranelift_codegen::isa::{TargetFrontendConfig, TargetIsa};
 use cranelift_entity::PrimaryMap;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;
-use wasmparser::Operator;
+use wasmparser::{Operator, WasmFeatures};
 use wasmtime_environ::{
     DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeConvert, TypeIndex,
     WasmHeapType, WasmRefType, WasmResult,
@@ -196,6 +196,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn translate_call_indirect(
         &mut self,
         builder: &mut FunctionBuilder,
+        features: &WasmFeatures,
         table_index: TableIndex,
         sig_index: TypeIndex,
         sig_ref: ir::SigRef,
@@ -235,6 +236,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn translate_return_call_indirect(
         &mut self,
         builder: &mut FunctionBuilder,
+        features: &WasmFeatures,
         table_index: TableIndex,
         sig_index: TypeIndex,
         sig_ref: ir::SigRef,

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1012,11 +1012,14 @@ unsafe fn is_subtype(
     let actual = VMSharedTypeIndex::from_u32(actual_engine_type);
     let expected = VMSharedTypeIndex::from_u32(expected_engine_type);
 
-    (*instance.store())
+    let is_subtype: bool = (*instance.store())
         .engine()
         .signatures()
         .is_subtype(actual, expected)
-        .into()
+        .into();
+
+    log::trace!("is_subtype(actual={actual:?}, expected={expected:?}) -> {is_subtype}",);
+    is_subtype
 }
 
 // Implementation of `memory.atomic.notify` for locally defined memories.

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -204,8 +204,6 @@ fn should_fail(test: &Path, strategy: Strategy) -> bool {
         }
     }
 
-    let unsupported_gc_tests = ["type-subtyping.wast"];
-
     for part in test.iter() {
         // Not implemented in Wasmtime yet
         if part == "exception-handling" {
@@ -228,15 +226,6 @@ fn should_fail(test: &Path, strategy: Strategy) -> bool {
             {
                 return true;
             }
-            if unsupported_gc_tests.iter().any(|i| test.ends_with(i)) {
-                return true;
-            }
-        }
-
-        // Implementation of the GC proposal is a work-in-progress, this is
-        // a list of all currently known-to-fail tests.
-        if part == "gc" {
-            return unsupported_gc_tests.iter().any(|i| test.ends_with(i));
         }
     }
 


### PR DESCRIPTION
When Wasm GC is enabled, the `[return_]call_indirect` instructions must do full subtyping checks, rather than simple strict equality type checks.

This adds an additional branch and slow path to indirect calls, so we only emit code for this check when Wasm GC is enabled, even though it would otherwise be correct to always emit it (because the `is_subtype` check would always fail for non-equal types, since there is no subtyping before Wasm GC).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
