### PR TITLE
Centralize wasm-features-in-fuzzing a bit more

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -469,16 +469,6 @@ impl WasmtimeConfig {
         config: &mut wasm_smith::Config,
         u: &mut Unstructured<'_>,
     ) -> arbitrary::Result<()> {
-        // Not implemented in Wasmtime
-        config.exceptions_enabled = false;
-
-        // Not fully implemented in Wasmtime and fuzzing.
-        config.gc_enabled = false;
-
-        // Off-by-default in wasm-smith but implemented in wasmtime, so give the
-        // fuzzers a chance to run it.
-        config.wide_arithmetic_enabled = u.arbitrary()?;
-
         // Winch doesn't support the same set of wasm proposal as Cranelift at
         // this time, so if winch is selected be sure to disable wasm proposals
         // in `Config` to ensure that Winch can compile the module that

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -16,27 +16,42 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<ModuleConfig> {
         let mut config = wasm_smith::Config::arbitrary(u)?;
 
+        // This list is intended to be the definintive source of truth for
+        // what's at least possible to fuzz within Wasmtime. This is a
+        // combination of features in `wasm-smith` where some proposals are
+        // on-by-default (as determined by fuzz input) and others are
+        // off-by-default (as they aren't stage4+). Wasmtime will default-fuzz
+        // proposals that a pre-stage-4 to test our own implementation. Wasmtime
+        // might also unconditionally disable proposals that it doesn't
+        // implement yet which are stage4+. This is intended to be an exhaustive
+        // list of all the wasm proposals that `wasm-smith` supports and the
+        // fuzzing status within Wasmtime too.
+        let _ = config.multi_value_enabled;
+        let _ = config.saturating_float_to_int_enabled;
+        let _ = config.sign_extension_ops_enabled;
+        let _ = config.bulk_memory_enabled;
+        let _ = config.reference_types_enabled;
+        let _ = config.simd_enabled;
+        let _ = config.relaxed_simd_enabled;
+        let _ = config.tail_call_enabled;
+        config.exceptions_enabled = false;
+        config.gc_enabled = false;
+        config.wide_arithmetic_enabled = u.arbitrary()?;
+        config.memory64_enabled = u.ratio(1, 20)?;
+        // Allow the threads proposal if memory64 is not already enabled. FIXME:
+        // to allow threads and memory64 to coexist, see
+        // https://github.com/bytecodealliance/wasmtime/issues/4267.
+        config.threads_enabled = !config.memory64_enabled && u.ratio(1, 20)?;
+        // FIXME: this may be safe to enable
+        config.custom_page_sizes_enabled = false;
         // Allow multi-memory but make it unlikely
         if u.ratio(1, 20)? {
             config.max_memories = config.max_memories.max(2);
         } else {
             config.max_memories = 1;
         }
-
-        // Allow multi-table by default.
-        if config.reference_types_enabled {
-            config.max_tables = config.max_tables.max(4);
-        }
-
-        // Allow enabling some various wasm proposals by default. Note that
-        // these are all unconditionally turned off even with
-        // `SwarmConfig::arbitrary`.
-        config.memory64_enabled = u.ratio(1, 20)?;
-
-        // Allow the threads proposal if memory64 is not already enabled. FIXME:
-        // to allow threads and memory64 to coexist, see
-        // https://github.com/bytecodealliance/wasmtime/issues/4267.
-        config.threads_enabled = !config.memory64_enabled && u.ratio(1, 20)?;
+        // ... NB: if you add something above this line please be sure to update
+        // `docs/stability-wasm-proposals.md`
 
         // We get better differential execution when we disallow traps, so we'll
         // do that most of the time.

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -46,10 +46,13 @@ column is below.
 | [`function-references`]  | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
 | [`gc`] [^6]              | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`custom-page-sizes`]    | ❌      | ✅    | ❌       | ⚠️[^7]  | ✅  | ❌    |
 
 [^6]: There is also a [tracking
     issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for the
     GC proposal.
+[^7]: A custom fuzzer exists but this isn't enabled yet for general-purpose
+    fuzzing.
 
 ## Unsupported proposals
 
@@ -83,6 +86,7 @@ column is below.
 [`function-references`]: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md
 [`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic/blob/main/proposals/wide-arithmetic/Overview.md
 [`gc`]: https://github.com/WebAssembly/gc
+[`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
 
 ## Feature requirements
 
@@ -111,6 +115,10 @@ For each column in the above tables, this is a further explanation of its meanin
   > implementation and does not run the inline fast paths for `table` operations
   > emitted by the JIT. Exercising these things was the motivation for writing
   > the custom fuzz target for `table.{get,set}` instructions.
+
+  One indication of the status of fuzzing is [this
+  file](https://github.com/bytecodealliance/wasmtime/blob/main/crates/fuzzing/src/generators/module.rs#L16)
+  which controls module configuration during fuzzing.
 
 * **API** - The proposal's functionality is exposed in the `wasmtime` crate's
   API. At minimum this is `Config::wasm_the_proposal` but proposals such as


### PR DESCRIPTION
Move everything into the same location about what features are enabled, which are disabled, and such. Also statically enumerate all the features that wasm-smith enables for us and acknowledge that here too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
