### PR TITLE
Add a test that fuzzers generate wasm proposals

### DIFF
--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -103,6 +103,8 @@ For each column in the above tables, this is a further explanation of its meanin
 
 * **Fuzzed** - Has been fuzzed for at least a week minimum. We are also
   confident that the fuzzers are fully exercising the proposal's functionality.
+  The `module_generation_uses_expected_proposals` test in the `wasmtime-fuzzing`
+  crate must be updated to include this proposal.
 
   > For example, it would *not* have been enough to simply enable reference
   > types in the `compile` fuzz target to enable that proposal by


### PR DESCRIPTION
This commit adds a test to the `wasmtime-fuzzing` crate as a sanity-check that eventually a module is generated requiring all of the features that wasmtime supports. This is intended to be another double-check in the process of enabling a proposal in Wasmtime by ensuring that the feature is added to this list which then transitively requires that fuzzing eventually generates a module needing that feature.

cc #9449

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
