### PR TITLE
Add support for initializing/getting/setting `funcref`s in GC structs from host APIs

### DIFF
--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1275,6 +1275,13 @@ impl From<ValType> for StorageType {
     }
 }
 
+impl From<RefType> for StorageType {
+    #[inline]
+    fn from(r: RefType) -> Self {
+        StorageType::ValType(r.into())
+    }
+}
+
 impl StorageType {
     /// Is this an `i8`?
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -520,7 +520,7 @@ unsafe fn intern_func_ref_for_gc_heap(instance: &mut Instance, func_ref: *mut u8
     let func_ref = func_ref.cast::<VMFuncRef>();
     let func_ref = NonNull::new(func_ref).map(SendSyncPtr::new);
 
-    let func_ref_id = store.unwrap_gc_store_mut().func_ref_table.intern(func_ref);
+    let func_ref_id = store.gc_store_mut()?.func_ref_table.intern(func_ref);
     Ok(func_ref_id.into_raw())
 }
 

--- a/tests/all/structs.rs
+++ b/tests/all/structs.rs
@@ -721,14 +721,14 @@ fn can_put_funcrefs_in_structs() -> Result<()> {
     let f1 = Func::wrap(&mut store, |_caller: Caller<()>| -> u32 { 0x5678 });
 
     let pre = StructRefPre::new(&mut store, struct_ty.clone());
-    let s = StructRef::new(&mut store, &pre, &[f0.clone().into()])?;
+    let s = StructRef::new(&mut store, &pre, &[f0.into()])?;
 
     let f = s.field(&mut store, 0)?;
     let f = f.unwrap_funcref().unwrap();
     let f = f.typed::<(), u32>(&store)?;
     assert_eq!(f.call(&mut store, ())?, 0x1234);
 
-    s.set_field(&mut store, 0, f1.clone().into())?;
+    s.set_field(&mut store, 0, f1.into())?;
 
     let f = s.field(&mut store, 0)?;
     let f = f.unwrap_funcref().unwrap();


### PR DESCRIPTION
We implemented support for `funcref`s in arrays in both compiled Wasm and host APIs, but somehow only implemented support for `funcref`s in structs for compiled Wasm code, and mistakenly forgot about them in host APIs (and things that use host APIs, such as const expressions).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
