### PR TITLE
Change how env vars work in `differential` fuzzer

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -76,7 +76,7 @@ fn execute_one(data: &[u8]) -> Result<()> {
     let lhs = match *u.choose(&allowed_engines)? {
         Some(engine) => engine,
         None => {
-            log::debug!("test case uses a runtime-disabled engien");
+            log::debug!("test case uses a runtime-disabled engine");
             return Ok(());
         }
     };

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -22,8 +22,8 @@ static SETUP: Once = Once::new();
 // - ALLOWED_ENGINES=wasmi,spec cargo +nightly fuzz run ...
 // - ALLOWED_ENGINES=-v8 cargo +nightly fuzz run ...
 // - ALLOWED_MODULES=single-inst cargo +nightly fuzz run ...
-static ALLOWED_ENGINES: Mutex<Vec<&str>> = Mutex::new(vec![]);
-static ALLOWED_MODULES: Mutex<Vec<&str>> = Mutex::new(vec![]);
+static ALLOWED_ENGINES: Mutex<Vec<Option<&str>>> = Mutex::new(vec![]);
+static ALLOWED_MODULES: Mutex<Vec<Option<&str>>> = Mutex::new(vec![]);
 
 // Statistics about what's actually getting executed during fuzzing
 static STATS: RuntimeStats = RuntimeStats::new();
@@ -73,7 +73,13 @@ fn execute_one(data: &[u8]) -> Result<()> {
     // Choose an engine that Wasmtime will be differentially executed against.
     // The chosen engine is then created, which might update `config`, and
     // returned as a trait object.
-    let lhs = u.choose(&allowed_engines)?;
+    let lhs = match *u.choose(&allowed_engines)? {
+        Some(engine) => engine,
+        None => {
+            log::debug!("test case uses a runtime-disabled engien");
+            return Ok(());
+        }
+    };
     let mut lhs = match engine::build(&mut u, lhs, &mut config)? {
         Some(engine) => engine,
         // The chosen engine does not have support compiled into the fuzzer,
@@ -100,8 +106,12 @@ fn execute_one(data: &[u8]) -> Result<()> {
         panic!("unable to generate a module to fuzz against; check `ALLOWED_MODULES`")
     }
     let wasm = match *u.choose(&allowed_modules)? {
-        "wasm-smith" => build_wasm_smith_module(&mut u, &config)?,
-        "single-inst" => build_single_inst_module(&mut u, &config)?,
+        Some("wasm-smith") => build_wasm_smith_module(&mut u, &config)?,
+        Some("single-inst") => build_single_inst_module(&mut u, &config)?,
+        None => {
+            log::debug!("test case uses a runtime-disabled module strategy");
+            return Ok(());
+        }
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
This commit updates the processing of the `ALLOWED_*` environment variables to work differently than before. Previously the list of engines and module-generation-strategies were filtered based on `ALLOWED_*` environment variables but this meant that the meaning of a fuzz input changed depending on environment variables. This commit instead replaces the handling of these environment variables to ensure that the meaning of the fuzz input doesn't change depending on their values. Instead fuzz test cases are early-thrown-out if they request an engine that's disabled or a module-generation-strategy that's disabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
