### PR TITLE
Add I128 atomic support to the `x64` backend

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86.rs
+++ b/cranelift/codegen/meta/src/isa/x86.rs
@@ -17,6 +17,12 @@ pub(crate) fn define() -> TargetIsa {
         "SSSE3: CPUID.01H:ECX.SSSE3[bit 9]",
         false,
     );
+    let has_cmpxchg16b = settings.add_bool(
+        "has_cmpxchg16b",
+        "Has support for CMPXCHG16b.",
+        "CMPXCHG16b: CPUID.01H:ECX.CMPXCHG16B[bit 13]",
+        false,
+    );
     let has_sse41 = settings.add_bool(
         "has_sse41",
         "Has support for SSE4.1.",
@@ -106,6 +112,7 @@ pub(crate) fn define() -> TargetIsa {
         false,
     );
 
+    settings.add_predicate("use_cmpxchg16b", predicate!(has_cmpxchg16b));
     settings.add_predicate("use_ssse3", predicate!(has_ssse3));
     settings.add_predicate("use_sse41", predicate!(has_sse41));
     settings.add_predicate("use_sse42", predicate!(has_sse41 && has_sse42));
@@ -141,14 +148,30 @@ pub(crate) fn define() -> TargetIsa {
     // Intel CPUs
 
     // Netburst
-    settings.add_preset("nocona", "Nocona microarchitecture.", preset!(sse3));
+    settings.add_preset(
+        "nocona",
+        "Nocona microarchitecture.",
+        preset!(sse3 && has_cmpxchg16b),
+    );
 
     // Intel Core 2 Solo/Duo
-    settings.add_preset("core2", "Core 2 microarchitecture.", preset!(sse3));
-    settings.add_preset("penryn", "Penryn microarchitecture.", preset!(sse41));
+    settings.add_preset(
+        "core2",
+        "Core 2 microarchitecture.",
+        preset!(sse3 && has_cmpxchg16b),
+    );
+    settings.add_preset(
+        "penryn",
+        "Penryn microarchitecture.",
+        preset!(sse41 && has_cmpxchg16b),
+    );
 
     // Intel Atom CPUs
-    let atom = settings.add_preset("atom", "Atom microarchitecture.", preset!(ssse3));
+    let atom = settings.add_preset(
+        "atom",
+        "Atom microarchitecture.",
+        preset!(ssse3 && has_cmpxchg16b),
+    );
     settings.add_preset("bonnell", "Bonnell microarchitecture.", preset!(atom));
     let silvermont = settings.add_preset(
         "silvermont",
@@ -186,7 +209,7 @@ pub(crate) fn define() -> TargetIsa {
     let nehalem = settings.add_preset(
         "nehalem",
         "Nehalem microarchitecture.",
-        preset!(sse42 && has_popcnt),
+        preset!(sse42 && has_popcnt && has_cmpxchg16b),
     );
     settings.add_preset("corei7", "Core i7 microarchitecture.", preset!(nehalem));
     let westmere = settings.add_preset("westmere", "Westmere microarchitecture.", preset!(nehalem));
@@ -229,7 +252,15 @@ pub(crate) fn define() -> TargetIsa {
     let knights_landing = settings.add_preset(
         "knl",
         "Knights Landing microarchitecture.",
-        preset!(has_popcnt && has_avx512f && has_fma && has_bmi1 && has_bmi2 && has_lzcnt),
+        preset!(
+            has_popcnt
+                && has_avx512f
+                && has_fma
+                && has_bmi1
+                && has_bmi2
+                && has_lzcnt
+                && has_cmpxchg16b
+        ),
     );
     settings.add_preset(
         "knm",
@@ -312,22 +343,22 @@ pub(crate) fn define() -> TargetIsa {
     settings.add_preset(
         "opteron-sse3",
         "Opteron microarchitecture with support for SSE3 instructions.",
-        preset!(sse3),
+        preset!(sse3 && has_cmpxchg16b),
     );
     settings.add_preset(
         "k8-sse3",
         "K8 Hammer microarchitecture with support for SSE3 instructions.",
-        preset!(sse3),
+        preset!(sse3 && has_cmpxchg16b),
     );
     settings.add_preset(
         "athlon64-sse3",
         "Athlon 64 microarchitecture with support for SSE3 instructions.",
-        preset!(sse3),
+        preset!(sse3 && has_cmpxchg16b),
     );
     let barcelona = settings.add_preset(
         "barcelona",
         "Barcelona microarchitecture.",
-        preset!(has_popcnt && has_lzcnt),
+        preset!(has_popcnt && has_lzcnt && has_cmpxchg16b),
     );
     settings.add_preset(
         "amdfam10",
@@ -338,7 +369,7 @@ pub(crate) fn define() -> TargetIsa {
     let btver1 = settings.add_preset(
         "btver1",
         "Bobcat microarchitecture.",
-        preset!(ssse3 && has_lzcnt && has_popcnt),
+        preset!(ssse3 && has_lzcnt && has_popcnt && has_cmpxchg16b),
     );
     settings.add_preset(
         "btver2",
@@ -349,7 +380,7 @@ pub(crate) fn define() -> TargetIsa {
     let bdver1 = settings.add_preset(
         "bdver1",
         "Bulldozer microarchitecture",
-        preset!(has_lzcnt && has_popcnt && ssse3),
+        preset!(has_lzcnt && has_popcnt && ssse3 && has_cmpxchg16b),
     );
     let bdver2 = settings.add_preset(
         "bdver2",
@@ -366,7 +397,9 @@ pub(crate) fn define() -> TargetIsa {
     let znver1 = settings.add_preset(
         "znver1",
         "Zen (first generation) microarchitecture.",
-        preset!(sse42 && has_popcnt && has_bmi1 && has_bmi2 && has_lzcnt && has_fma),
+        preset!(
+            sse42 && has_popcnt && has_bmi1 && has_bmi2 && has_lzcnt && has_fma && has_cmpxchg16b
+        ),
     );
     let znver2 = settings.add_preset(
         "znver2",
@@ -397,7 +430,7 @@ pub(crate) fn define() -> TargetIsa {
     let x86_64_v2 = settings.add_preset(
         "x86-64-v2",
         "Generic x86-64 (V2) microarchitecture.",
-        preset!(sse42 && has_popcnt),
+        preset!(sse42 && has_popcnt && has_cmpxchg16b),
     );
     let x86_64_v3 = settings.add_preset(
         "x84_64_v3",

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3637,7 +3637,7 @@ pub(crate) fn define(
     let AtomicMem = &TypeVar::new(
         "AtomicMem",
         "Any type that can be stored in memory, which can be used in an atomic operation",
-        TypeSetBuilder::new().ints(8..64).build(),
+        TypeSetBuilder::new().ints(8..128).build(),
     );
 
     ig.push(
@@ -3645,10 +3645,11 @@ pub(crate) fn define(
             "atomic_rmw",
             r#"
         Atomically read-modify-write memory at `p`, with second operand `x`.  The old value is
-        returned.  `p` has the type of the target word size, and `x` may be an integer type of
-        8, 16, 32 or 64 bits, even on a 32-bit target.  The type of the returned value is the
-        same as the type of `x`.  This operation is sequentially consistent and creates
-        happens-before edges that order normal (non-atomic) loads and stores.
+        returned.  `p` has the type of the target word size, and `x` may be any integer type; note
+        that some targets require specific target features to be enabled in order to support 128-bit
+        integer atomics.  The type of the returned value is the same as the type of `x`.  This
+        operation is sequentially consistent and creates happens-before edges that order normal
+        (non-atomic) loads and stores.
         "#,
             &formats.atomic_rmw,
         )
@@ -3673,11 +3674,11 @@ pub(crate) fn define(
         Perform an atomic compare-and-swap operation on memory at `p`, with expected value `e`,
         storing `x` if the value at `p` equals `e`.  The old value at `p` is returned,
         regardless of whether the operation succeeds or fails.  `p` has the type of the target
-        word size, and `x` and `e` must have the same type and the same size, which may be an
-        integer type of 8, 16, 32 or 64 bits, even on a 32-bit target.  The type of the returned
-        value is the same as the type of `x` and `e`.  This operation is sequentially
-        consistent and creates happens-before edges that order normal (non-atomic) loads and
-        stores.
+        word size, and `x` and `e` must have the same type and the same size, which may be any
+        integer type; note that some targets require specific target features to be enabled in order
+        to support 128-bit integer atomics.  The type of the returned value is the same as the type
+        of `x` and `e`.  This operation is sequentially consistent and creates happens-before edges
+        that order normal (non-atomic) loads and stores.
         "#,
             &formats.atomic_cas,
         )
@@ -3702,9 +3703,10 @@ pub(crate) fn define(
         Atomically load from memory at `p`.
 
         This is a polymorphic instruction that can load any value type which has a memory
-        representation.  It should only be used for integer types with 8, 16, 32 or 64 bits.
-        This operation is sequentially consistent and creates happens-before edges that order
-        normal (non-atomic) loads and stores.
+        representation.  It can only be used for integer types; note that some targets require
+        specific target features to be enabled in order to support 128-bit integer atomics. This
+        operation is sequentially consistent and creates happens-before edges that order normal
+        (non-atomic) loads and stores.
         "#,
             &formats.load_no_offset,
         )
@@ -3726,9 +3728,10 @@ pub(crate) fn define(
         Atomically store `x` to memory at `p`.
 
         This is a polymorphic instruction that can store any value type with a memory
-        representation.  It should only be used for integer types with 8, 16, 32 or 64 bits.
-        This operation is sequentially consistent and creates happens-before edges that order
-        normal (non-atomic) loads and stores.
+        representation.  It can only be used for integer types; note that some targets require
+        specific target features to be enabled in order to support 128-bit integer atomics This
+        operation is sequentially consistent and creates happens-before edges that order normal
+        (non-atomic) loads and stores.
         "#,
             &formats.store_no_offset,
         )

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -664,6 +664,24 @@
                     (mem SyntheticAmode)
                     (dst_old WritableReg))
 
+       ;; A standard (native) `lock cmpxchg16b (amode)`, with register
+       ;; conventions:
+       ;;
+       ;; `mem`                    (read) address
+       ;; %rbx (low), %rcx (high)  (read) replacement value
+       ;; %rax (low), %rdx (high)  (modified) in: expected value, out: value that was actually at `dst`
+       ;; %rflags is written.  Do not assume anything about it after the instruction.
+       ;;
+       ;; The instruction "succeeded" iff the bits of %rax and %rdx
+       ;; afterwards are the same as they were before.
+       (LockCmpxchg16b (replacement_low Reg)
+                       (replacement_high Reg)
+                       (expected_low Reg)
+                       (expected_high Reg)
+                       (mem BoxSyntheticAmode)
+                       (dst_old_low WritableReg)
+                       (dst_old_high WritableReg))
+
        ;; A synthetic instruction, based on a loop around a native `lock
        ;; cmpxchg` instruction.
        ;;
@@ -695,6 +713,46 @@
                      (operand Reg)
                      (temp WritableReg)
                      (dst_old WritableReg))
+
+       ;; A synthetic instruction, based on a loop around a native `lock
+       ;; cmpxchg16b` instruction.
+       ;;
+       ;; This is the same as `AtomicRmwSeq`, but for 128-bit integers.
+       ;;
+       ;; For `MachAtomicRmwOp::Xchg`, use `Atomic128XchgSeq` instead.
+       ;;
+       ;; This instruction sequence has fixed register uses as follows:
+       ;; - %rax (low), %rdx (high)  (written) the old value at `mem`
+       ;; - %rbx (low), %rcx (high)  (written) used as temp registers to hold
+       ;;   the replacement value
+       ;; - %rflags is written.  Do not assume anything about it after the
+       ;;   instruction.
+       (Atomic128RmwSeq (op MachAtomicRmwOp)
+                        (mem BoxSyntheticAmode)
+                        (operand_low Reg)
+                        (operand_high Reg)
+                        (temp_low WritableReg)
+                        (temp_high WritableReg)
+                        (dst_old_low WritableReg)
+                        (dst_old_high WritableReg))
+
+       ;; A synthetic instruction, based on a loop around a native `lock
+       ;; cmpxchg16b` instruction.
+       ;;
+       ;; This is `Atomic128XchgSeq` but only for `MachAtomicRmwOp::Xchg`. As
+       ;; the replacement value is the same every time, this instruction doesn't
+       ;; require any temporary registers.
+       ;;
+       ;; This instruction sequence has fixed register uses as follows:
+       ;; - %rax (low), %rdx (high)  (written) the old value at `mem`
+       ;; - %rbx (low), %rcx (high)  (read) the replacement value
+       ;; - %rflags is written.  Do not assume anything about it after the
+       ;;   instruction.
+       (Atomic128XchgSeq (mem SyntheticAmode)
+                         (operand_low Reg)
+                         (operand_high Reg)
+                         (dst_old_low WritableReg)
+                         (dst_old_high WritableReg))
 
        ;; A memory fence (mfence, lfence or sfence).
        (Fence (kind FenceKind))
@@ -762,6 +820,11 @@
 (type BoxCallIndInfo extern (enum))
 (type BoxReturnCallInfo extern (enum))
 (type BoxReturnCallIndInfo extern (enum))
+(type BoxSyntheticAmode extern (enum))
+
+(decl pure box_synthetic_amode (SyntheticAmode) BoxSyntheticAmode)
+(extern constructor box_synthetic_amode box_synthetic_amode)
+(convert SyntheticAmode BoxSyntheticAmode box_synthetic_amode)
 
 ;; Get the `OperandSize` for a given `Type`, rounding smaller types up to 32 bits.
 (decl operand_size_of_type_32_64 (Type) OperandSize)
@@ -1861,6 +1924,9 @@
 
 (decl pure use_avx2 () bool)
 (extern constructor use_avx2 use_avx2)
+
+(decl pure use_cmpxchg16b () bool)
+(extern constructor use_cmpxchg16b use_cmpxchg16b)
 
 ;;;; Helpers for Merging and Sinking Immediates/Loads  ;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -5214,12 +5280,53 @@
             (_ Unit (emit (MInst.LockCmpxchg ty replacement expected addr dst))))
         dst))
 
+(decl x64_cmpxchg16b (ValueRegs ValueRegs SyntheticAmode) ValueRegs)
+(rule (x64_cmpxchg16b expected replacement addr)
+      (let ((expected_low Gpr (value_regs_get_gpr expected 0))
+            (expected_high Gpr (value_regs_get_gpr expected 1))
+            (replacement_low Gpr (value_regs_get_gpr replacement 0))
+            (replacement_high Gpr (value_regs_get_gpr replacement 1))
+            (dst_low WritableGpr (temp_writable_gpr))
+            (dst_high WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.LockCmpxchg16b replacement_low replacement_high expected_low expected_high addr dst_low dst_high))))
+        (value_regs dst_low dst_high)))
+
 (decl x64_atomic_rmw_seq (Type MachAtomicRmwOp SyntheticAmode Gpr) Gpr)
 (rule (x64_atomic_rmw_seq ty op mem input)
       (let ((dst WritableGpr (temp_writable_gpr))
             (tmp WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.AtomicRmwSeq ty op mem input tmp dst))))
         dst))
+
+(decl x64_atomic_128_rmw_seq (MachAtomicRmwOp SyntheticAmode ValueRegs) ValueRegs)
+(rule (x64_atomic_128_rmw_seq op mem input)
+      (let ((dst_low WritableGpr (temp_writable_gpr))
+            (dst_high WritableGpr (temp_writable_gpr))
+            (tmp_low WritableGpr (temp_writable_gpr))
+            (tmp_high WritableGpr (temp_writable_gpr))
+            (input_low Gpr (value_regs_get_gpr input 0))
+            (input_high Gpr (value_regs_get_gpr input 1))
+            (_ Unit (emit (MInst.Atomic128RmwSeq op mem input_low input_high tmp_low tmp_high dst_low dst_high))))
+        (value_regs dst_low dst_high)))
+
+(rule 1 (x64_atomic_128_rmw_seq (mach_atomic_rmw_op_xchg) mem input)
+        (let ((dst_low WritableGpr (temp_writable_gpr))
+              (dst_high WritableGpr (temp_writable_gpr))
+              (input_low Gpr (value_regs_get_gpr input 0))
+              (input_high Gpr (value_regs_get_gpr input 1))
+              (_ Unit (emit (MInst.Atomic128XchgSeq mem input_low input_high dst_low dst_high))))
+          (value_regs dst_low dst_high)))
+
+(decl x64_atomic_128_store_seq (SyntheticAmode ValueRegs) SideEffectNoResult)
+(rule (x64_atomic_128_store_seq mem input)
+        (let ((dst_low WritableGpr (temp_writable_gpr))
+              (dst_high WritableGpr (temp_writable_gpr))
+              (input_low Gpr (value_regs_get_gpr input 0))
+              (input_high Gpr (value_regs_get_gpr input 1)))
+          (SideEffectNoResult.Inst (MInst.Atomic128XchgSeq mem input_low input_high dst_low dst_high))))
+
+(decl mach_atomic_rmw_op_xchg () MachAtomicRmwOp)
+(extern extractor mach_atomic_rmw_op_xchg mach_atomic_rmw_op_is_xchg)
 
 ;; CLIF IR has one enumeration for atomic operations (`AtomicRmwOp`) while the
 ;; mach backend has another (`MachAtomicRmwOp`)--this converts one to the other.

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -959,6 +959,7 @@ pub enum CmpOpcode {
 pub(crate) enum InstructionSet {
     SSE,
     SSE2,
+    CMPXCHG16b,
     SSSE3,
     SSE41,
     SSE42,

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -4261,7 +4261,7 @@ pub(crate) fn emit(
                     // `cmp_rmi_r` and `alu_rmi_r` have opposite argument orders.
                     Inst::cmp_rmi_r(OperandSize::Size64, temp_low.to_reg(), operand_low_rmi)
                         .emit(sink, info, state);
-                    // Thie will clobber `temp_high`
+                    // This will clobber `temp_high`
                     Inst::alu_rmi_r(
                         OperandSize::Size64,
                         AluRmiROpcode::Sbb,

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3348,31 +3348,40 @@
 ;; sequencing to satisfy the CLIF synchronisation requirements for `AtomicLoad`
 ;; without the need for any fence instructions.
 ;;
-;; As described in the `atomic_load` documentation, this lowering is only valid
-;; for I8, I16, I32, and I64. The sub-64-bit types are zero extended, as with a
-;; normal load.
+;; This lowering is only valid for I8, I16, I32, and I64. The sub-64-bit types
+;; are zero extended, as with a normal load.
 (rule 1 (lower (has_type $I64 (atomic_load flags address)))
       (x64_mov (to_amode flags address (zero_offset))))
 (rule (lower (has_type (and (fits_in_32 ty) (ty_int _)) (atomic_load flags address)))
       (x64_movzx (ext_mode (ty_bits_u16 ty) 64) (to_amode flags address (zero_offset))))
+;; Lower 128-bit `atomic_load` using `cmpxchg16b`.
+(rule 1 (lower (has_type $I128 (atomic_load flags address)))
+      (if-let $true (use_cmpxchg16b))
+      (x64_cmpxchg16b (value_regs (imm $I64 0) (imm $I64 0)) (value_regs (imm $I64 0) (imm $I64 0)) (to_amode flags address (zero_offset))))
 
 ;; Rules for `atomic_store` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; This is a normal store followed by an `mfence` instruction. As described in
-;; the `atomic_load` documentation, this lowering is only valid for I8, I16,
-;; I32, and I64.
+;; This is a normal store followed by an `mfence` instruction. This lowering is
+;; only valid for I8, I16, I32, and I64.
 (rule (lower (atomic_store flags
                            value @ (value_type (and (fits_in_64 ty) (ty_int _)))
                            address))
       (side_effect (side_effect_concat
        (x64_movrm ty (to_amode flags address (zero_offset)) value)
        (x64_mfence))))
+;; Lower 128-bit `atomic_store` using `cmpxchg16b`.
+(rule 1 (lower (atomic_store flags value @ (value_type $I128) address))
+      (if-let $true (use_cmpxchg16b))
+      (side_effect (x64_atomic_128_store_seq (to_amode flags address (zero_offset)) value)))
 
 ;; Rules for `atomic_cas` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_cas flags address expected replacement)))
       (x64_cmpxchg ty expected replacement (to_amode flags address (zero_offset))))
+(rule 1 (lower (has_type $I128 (atomic_cas flags address expected replacement)))
+        (if-let $true (use_cmpxchg16b))
+        (x64_cmpxchg16b expected replacement (to_amode flags address (zero_offset))))
 
 ;; Rules for `atomic_rmw` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3389,6 +3398,9 @@
 (rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_rmw flags op address input)))
       (x64_atomic_rmw_seq ty op (to_amode flags address (zero_offset)) input))
+(rule 1 (lower (has_type $I128 (atomic_rmw flags op address input)))
+        (if-let $true (use_cmpxchg16b))
+        (x64_atomic_128_rmw_seq op (to_amode flags address (zero_offset)) input))
 
 ;; Rules for `call` and `call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -39,6 +39,7 @@ type BoxCallIndInfo = Box<CallInfo<RegMem>>;
 type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
 type BoxReturnCallIndInfo = Box<ReturnCallInfo<Reg>>;
 type VecArgPair = Vec<ArgPair>;
+type BoxSyntheticAmode = Box<SyntheticAmode>;
 
 pub struct SinkableLoad {
     inst: Inst,
@@ -238,6 +239,11 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     #[inline]
     fn use_sse42(&mut self) -> bool {
         self.backend.x64_flags.use_sse42()
+    }
+
+    #[inline]
+    fn use_cmpxchg16b(&mut self) -> bool {
+        self.backend.x64_flags.use_cmpxchg16b()
     }
 
     #[inline]
@@ -615,6 +621,15 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
+    fn mach_atomic_rmw_op_is_xchg(&mut self, op: &MachAtomicRmwOp) -> Option<()> {
+        if *op == MachAtomicRmwOp::Xchg {
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     fn preg_rbp(&mut self) -> PReg {
         regs::rbp().to_real_reg().unwrap().into()
     }
@@ -938,6 +953,10 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     fn writable_invalid_gpr(&mut self) -> WritableGpr {
         let reg = Gpr::new(self.invalid_reg()).unwrap();
         WritableGpr::from_reg(reg)
+    }
+
+    fn box_synthetic_amode(&mut self, amode: &SyntheticAmode) -> BoxSyntheticAmode {
+        Box::new(amode.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -886,6 +886,18 @@ pub(crate) fn check(
             Ok(())
         }
 
+        Inst::LockCmpxchg16b {
+            ref mem,
+            dst_old_low,
+            dst_old_high,
+            ..
+        } => {
+            ensure_no_fact(vcode, dst_old_low.to_reg())?;
+            ensure_no_fact(vcode, dst_old_high.to_reg())?;
+            check_store(ctx, None, mem, vcode, I128)?;
+            Ok(())
+        }
+
         Inst::AtomicRmwSeq {
             ref mem,
             temp,
@@ -895,6 +907,34 @@ pub(crate) fn check(
             ensure_no_fact(vcode, dst_old.to_reg())?;
             ensure_no_fact(vcode, temp.to_reg())?;
             check_store(ctx, None, mem, vcode, I64)?;
+            Ok(())
+        }
+
+        Inst::Atomic128RmwSeq {
+            ref mem,
+            temp_low,
+            temp_high,
+            dst_old_low,
+            dst_old_high,
+            ..
+        } => {
+            ensure_no_fact(vcode, dst_old_low.to_reg())?;
+            ensure_no_fact(vcode, dst_old_high.to_reg())?;
+            ensure_no_fact(vcode, temp_low.to_reg())?;
+            ensure_no_fact(vcode, temp_high.to_reg())?;
+            check_store(ctx, None, mem, vcode, I128)?;
+            Ok(())
+        }
+
+        Inst::Atomic128XchgSeq {
+            ref mem,
+            dst_old_low,
+            dst_old_high,
+            ..
+        } => {
+            ensure_no_fact(vcode, dst_old_low.to_reg())?;
+            ensure_no_fact(vcode, dst_old_high.to_reg())?;
+            check_store(ctx, None, mem, vcode, I128)?;
             Ok(())
         }
 

--- a/cranelift/filetests/filetests/isa/x64/atomic-128.clif
+++ b/cranelift/filetests/filetests/isa/x64/atomic-128.clif
@@ -1,0 +1,600 @@
+test compile precise-output
+set enable_llvm_abi_extensions
+target x86_64 has_cmpxchg16b
+
+function %load(i64) -> i128 {
+block0(v0: i64):
+    v1 = atomic_load.i128 v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   xorq    %rax, %rax, %rax
+;   xorq    %rdx, %rdx, %rdx
+;   xorq    %rbx, %rbx, %rbx
+;   xorq    %rcx, %rcx, %rcx
+;   lock cmpxchg16b 0(%rdi), replacement=%rcx:%rbx, expected=%rdx:%rax, dst_old=%rdx:%rax
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   xorq %rax, %rax
+;   xorq %rdx, %rdx
+;   xorq %rbx, %rbx
+;   xorq %rcx, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %store(i128, i64) {
+block0(v0: i128, v1: i64):
+    atomic_store.i128 v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rsi, %rcx
+;   movq    %rdi, %rbx
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%r11); 0(%r11) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rsi, %rcx
+;   movq %rdi, %rbx
+;   movq %rdx, %r11
+;   movq (%r11), %rax ; trap: heap_oob
+;   movq 8(%r11), %rdx ; trap: heap_oob
+;   lock cmpxchg16b (%r11) ; trap: heap_oob
+;   jne 0x1c
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %cas(i64, i128, i128) -> i128 {
+block0(v0: i64, v1: i128, v2: i128):
+    v3 = atomic_cas.i128 v0, v1, v2
+    return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rcx, %rbx
+;   movq    %r8, %rcx
+;   movq    %rsi, %rax
+;   lock cmpxchg16b 0(%rdi), replacement=%rcx:%rbx, expected=%rdx:%rax, dst_old=%rdx:%rax
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rcx, %rbx
+;   movq %r8, %rcx
+;   movq %rsi, %rax
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 add v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Add %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   addq %rsi, %rbx
+;   adcq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 sub v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Sub %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   subq %rsi, %rbx
+;   sbbq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 and v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax And %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   andq %rsi, %rbx
+;   andq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %nand(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 nand v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Nand %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   andq %rsi, %rbx
+;   andq %r11, %rcx
+;   notq %rbx
+;   notq %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 or v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Or %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   orq %rsi, %rbx
+;   orq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 xor v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Xor %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   xorq %rsi, %rbx
+;   xorq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xchg(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 xchg v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %rcx
+;   movq    %rsi, %rbx
+;   atomically { %rdx:%rax = 0(%rdi); 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %rcx
+;   movq %rsi, %rbx
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x19
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umin(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 umin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Umin %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   cmpq %rsi, %rbx
+;   sbbq %r11, %rcx
+;   movq %rdx, %rcx
+;   cmovaeq %rsi, %rbx
+;   cmovaeq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umax(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 umax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Umax %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   cmpq %rsi, %rbx
+;   sbbq %r11, %rcx
+;   movq %rdx, %rcx
+;   cmovbq %rsi, %rbx
+;   cmovbq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smin(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 smin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Smin %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   cmpq %rsi, %rbx
+;   sbbq %r11, %rcx
+;   movq %rdx, %rcx
+;   cmovgeq %rsi, %rbx
+;   cmovgeq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umax(i64, i128) -> i128 {
+block0(v0: i64, v1: i128):
+    v2 = atomic_rmw.i128 smax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+; block0:
+;   movq    %rdx, %r11
+;   atomically { %rdx:%rax = 0(%rdi); %rcx:%rbx = %rdx:%rax Smax %r11:%rsi; 0(%rdi) = %rcx:%rbx }
+;   movq    0(%rsp), %rbx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block1: ; offset 0xc
+;   movq %rdx, %r11
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rax, %rbx
+;   movq %rdx, %rcx
+;   cmpq %rsi, %rbx
+;   sbbq %r11, %rcx
+;   movq %rdx, %rcx
+;   cmovlq %rsi, %rbx
+;   cmovlq %r11, %rcx
+;   lock cmpxchg16b (%rdi) ; trap: heap_oob
+;   jne 0x16
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/runtests/atomic-128.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-128.clif
@@ -1,0 +1,274 @@
+test interpret
+test run
+set enable_llvm_abi_extensions
+target x86_64 has_cmpxchg16b
+
+function %atomic_load(i128) -> i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128):
+    stack_store.i128 v0, ss0
+    v1 = stack_addr.i64 ss0
+    v2 = atomic_load.i128 v1
+    return v2
+}
+; run: %atomic_load(0) == 0
+; run: %atomic_load(-1) == -1
+; run: %atomic_load(0x00000000_00000000_FFFFFFFF_FFFFFFFF) == 0x00000000_00000000_FFFFFFFF_FFFFFFFF
+; run: %atomic_load(0xFFFFFFFF_FFFFFFFF_00000000_00000000) == 0xFFFFFFFF_FFFFFFFF_00000000_00000000
+; run: %atomic_load(0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == 0xFEDCBA98_76543210_F7E6D5C4_B3A29180
+; run: %atomic_load(0xA00A00A0_0A00A00A_00A00A00_A00A00A0) == 0xA00A00A0_0A00A00A_00A00A00_A00A00A0
+; run: %atomic_load(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678) == 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678
+
+
+function %atomic_store(i128) -> i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128):
+    v1 = stack_addr.i64 ss0
+    atomic_store.i128 v0, v1
+    v2 = stack_load.i128 ss0
+    return v2
+}
+; run: %atomic_store(0) == 0
+; run: %atomic_store(-1) == -1
+; run: %atomic_store(0x00000000_00000000_FFFFFFFF_FFFFFFFF) == 0x00000000_00000000_FFFFFFFF_FFFFFFFF
+; run: %atomic_store(0xFFFFFFFF_FFFFFFFF_00000000_00000000) == 0xFFFFFFFF_FFFFFFFF_00000000_00000000
+; run: %atomic_store(0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == 0xFEDCBA98_76543210_F7E6D5C4_B3A29180
+; run: %atomic_store(0xA00A00A0_0A00A00A_00A00A00_A00A00A0) == 0xA00A00A0_0A00A00A_00A00A00_A00A00A0
+; run: %atomic_store(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678) == 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678
+
+
+function %atomic_cas(i128, i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128, v2: i128):
+    stack_store.i128 v0, ss0
+    v3 = stack_addr.i64 ss0
+    v4 = atomic_cas.i128 v3, v1, v2
+    v5 = stack_load.i128 ss0
+    return v5, v4
+}
+
+; run: %atomic_cas(0, 0, 2) == [2, 0]
+; run: %atomic_cas(1, 0, 2) == [1, 1]
+; run: %atomic_cas(0, 1, 2) == [0, 0]
+; run: %atomic_cas(0, 0xC0FFEEEE_ABCDEF01_00000000_00000000, 0xDECAFFFF_12345678) == [0, 0]
+; run: %atomic_cas(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xFEDCBA98_76543210_F7E6D5C4_B3A29180, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_add(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 add v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_add(0, 0) == [0, 0]
+; run: %atomic_add(1, 0) == [1, 1]
+; run: %atomic_add(0, 1) == [1, 0]
+; run: %atomic_add(1, 1) == [2, 1]
+; run: %atomic_add(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xDECAFFFF_12345678]
+; run: %atomic_add(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xBFDCA987_22222112_D6B1D5C3_C5D6E7F8, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_sub(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 sub v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_sub(0, 0) == [0, 0]
+; run: %atomic_sub(1, 0) == [1, 1]
+; run: %atomic_sub(0, 1) == [-1, 0]
+; run: %atomic_sub(1, 1) == [0, 1]
+; run: %atomic_sub(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0x3F001111_543210FF_DECAFFFF_12345678, 0xDECAFFFF_12345678]
+; run: %atomic_sub(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xC2233456_3579BCF0_E6E42A3A_5E91C4F8, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_and(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 and v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_and(0, 0) == [0, 0]
+; run: %atomic_and(1, 0) == [0, 1]
+; run: %atomic_and(0, 1) == [0, 0]
+; run: %atomic_and(1, 1) == [1, 1]
+; run: %atomic_and(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0, 0xDECAFFFF_12345678]
+; run: %atomic_and(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xC0DCAA88_22442200_D6C2D5C4_12201000, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_nand(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 nand v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_nand(0, 0) == [-1, 0]
+; run: %atomic_nand(1, 0) == [-1, 1]
+; run: %atomic_nand(0, 1) == [-1, 0]
+; run: %atomic_nand(1, 1) == [-2, 1]
+; run: %atomic_nand(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [-1, 0xDECAFFFF_12345678]
+; run: %atomic_nand(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0x3F235577_DDBBDDFF_293D2A3B_EDDFEFFF, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_or(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 or v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_or(0, 0) == [0, 0]
+; run: %atomic_or(1, 0) == [1, 1]
+; run: %atomic_or(0, 1) == [1, 0]
+; run: %atomic_or(1, 1) == [1, 1]
+; run: %atomic_or(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xDECAFFFF_12345678]
+; run: %atomic_or(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xFEFFFEFE_FFDDFF11_FFEEFFFF_B3B6D7F8, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_xor(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 xor v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_xor(0, 0) == [0, 0]
+; run: %atomic_xor(1, 0) == [1, 1]
+; run: %atomic_xor(0, 1) == [1, 0]
+; run: %atomic_xor(1, 1) == [0, 1]
+; run: %atomic_xor(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xDECAFFFF_12345678]
+; run: %atomic_xor(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0x3E235476_DD99DD11_292C2A3B_A196C7F8, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_xchg(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 xchg v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_xchg(0, 0) == [0, 0]
+; run: %atomic_xchg(1, 0) == [0, 1]
+; run: %atomic_xchg(0, 1) == [1, 0]
+; run: %atomic_xchg(1, 1) == [1, 1]
+; run: %atomic_xchg(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xC0FFEEEE_ABCDEF01_00000000_00000000, 0xDECAFFFF_12345678]
+; run: %atomic_xchg(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xFEDCBA98_76543210_F7E6D5C4_B3A29180, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_umin(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 umin v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_umin(0, 0) == [0, 0]
+; run: %atomic_umin(1, 0) == [0, 1]
+; run: %atomic_umin(0, 1) == [0, 0]
+; run: %atomic_umin(1, 1) == [1, 1]
+; run: %atomic_umin(-1, 1) == [1, -1]
+; run: %atomic_umin(1, -1) == [1, 1]
+; run: %atomic_umin(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xDECAFFFF_12345678, 0xDECAFFFF_12345678]
+; run: %atomic_umin(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_umax(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 umax v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_umax(0, 0) == [0, 0]
+; run: %atomic_umax(1, 0) == [1, 1]
+; run: %atomic_umax(0, 1) == [1, 0]
+; run: %atomic_umax(1, 1) == [1, 1]
+; run: %atomic_umax(-1, 1) == [-1, -1]
+; run: %atomic_umax(1, -1) == [-1, 1]
+; run: %atomic_umax(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xC0FFEEEE_ABCDEF01_00000000_00000000, 0xDECAFFFF_12345678]
+; run: %atomic_umax(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xFEDCBA98_76543210_F7E6D5C4_B3A29180, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_smin(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 smin v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_smin(0, 0) == [0, 0]
+; run: %atomic_smin(1, 0) == [0, 1]
+; run: %atomic_smin(0, 1) == [0, 0]
+; run: %atomic_smin(1, 1) == [1, 1]
+; run: %atomic_smin(-1, 1) == [-1, -1]
+; run: %atomic_smin(1, -1) == [-1, 1]
+; run: %atomic_smin(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xC0FFEEEE_ABCDEF01_00000000_00000000, 0xDECAFFFF_12345678]
+; run: %atomic_smin(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]
+
+
+function %atomic_smax(i128, i128) -> i128, i128 {
+    ss0 = explicit_slot 16
+
+block0(v0: i128, v1: i128):
+    stack_store.i128 v0, ss0
+    v2 = stack_addr.i64 ss0
+    v3 = atomic_rmw.i128 smax v2, v1
+    v4 = stack_load.i128 ss0
+    return v4, v3
+}
+
+; run: %atomic_smax(0, 0) == [0, 0]
+; run: %atomic_smax(1, 0) == [1, 1]
+; run: %atomic_smax(0, 1) == [1, 0]
+; run: %atomic_smax(1, 1) == [1, 1]
+; run: %atomic_smax(-1, 1) == [1, -1]
+; run: %atomic_smax(1, -1) == [1, 1]
+; run: %atomic_smax(0xDECAFFFF_12345678, 0xC0FFEEEE_ABCDEF01_00000000_00000000) == [0xDECAFFFF_12345678, 0xDECAFFFF_12345678]
+; run: %atomic_smax(0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678, 0xFEDCBA98_76543210_F7E6D5C4_B3A29180) == [0xFEDCBA98_76543210_F7E6D5C4_B3A29180, 0xC0FFEEEE_ABCDEF01_DECAFFFF_12345678]

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -49,6 +49,9 @@ pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'st
             return Err("x86 support requires SSE2");
         }
 
+        if std::is_x86_feature_detected!("cmpxchg16b") {
+            isa_builder.enable("has_cmpxchg16b").unwrap();
+        }
         if std::is_x86_feature_detected!("sse3") {
             isa_builder.enable("has_sse3").unwrap();
         }

--- a/crates/fuzzing/src/generators/codegen_settings.rs
+++ b/crates/fuzzing/src/generators/codegen_settings.rs
@@ -98,6 +98,7 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                 "x86_64" => {
                     test: is_x86_feature_detected,
 
+                    std:"cmpxchg16b" => clif:"has_cmpxchg16b",
                     std:"sse3" => clif:"has_sse3",
                     std:"ssse3" => clif:"has_ssse3",
                     std:"sse4.1" => clif:"has_sse41",

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -3066,6 +3066,7 @@ fn detect_host_feature(feature: &str) -> Option<bool> {
     #[cfg(target_arch = "x86_64")]
     {
         return match feature {
+            "cmpxchg16b" => Some(std::is_x86_feature_detected!("cmpxchg16b")),
             "sse3" => Some(std::is_x86_feature_detected!("sse3")),
             "ssse3" => Some(std::is_x86_feature_detected!("ssse3")),
             "sse4.1" => Some(std::is_x86_feature_detected!("sse4.1")),

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -426,6 +426,7 @@ impl Engine {
             "has_mie2" => "mie2",
 
             // x64 features to detect
+            "has_cmpxchg16b" => "cmpxchg16b",
             "has_sse3" => "sse3",
             "has_ssse3" => "ssse3",
             "has_sse41" => "sse4.1",


### PR DESCRIPTION
Rust is currently in the process of stabilising 128-bit atomics (https://github.com/rust-lang/rust/issues/99069#issuecomment-2142718778), but Cranelift (and therefore `rustc_codegen_cranelift`) doesn't currently support 128-bit atomics.

This PR adds IR support for 128-bit atomics and implements lowering them for the x64 backend using `cmpxchg16b`.