### PR TITLE
test-macros: Fix default return type

### DIFF
--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -218,7 +218,7 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
         };
         let func_name = &func.sig.ident;
         let ret = match &func.sig.output {
-            ReturnType::Default => quote! { () },
+            ReturnType::Default => quote! {},
             ReturnType::Type(_, ty) => quote! { -> #ty },
         };
         let test_name = Ident::new(


### PR DESCRIPTION
This commit fixes the handling of default return types in `wasmtime-test-macros`. Prior to this commit, functions returning `()` inserted a `()` as the return output, which resulted in a syntax error.

This commit fixes this issue by quoting empty tokens when the return type is the default one.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
