### PR TITLE
Move JIT debug image registration to CodeMemory

### DIFF
--- a/crates/environ/src/compile/module_artifacts.rs
+++ b/crates/environ/src/compile/module_artifacts.rs
@@ -237,7 +237,6 @@ impl<'a> ObjectBuilder<'a> {
             wasm_to_array_trampolines,
             func_names,
             meta: Metadata {
-                native_debug_info_present: self.tunables.generate_native_debuginfo,
                 has_unparsed_debuginfo,
                 code_section_offset: debuginfo.wasm_file.code_section_offset,
                 has_wasm_debuginfo: self.tunables.parse_wasm_debuginfo,

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -93,9 +93,6 @@ pub struct FunctionName {
 /// Metadata associated with a compiled ELF artifact.
 #[derive(Serialize, Deserialize)]
 pub struct Metadata {
-    /// Whether or not native debug information is available in `obj`
-    pub native_debug_info_present: bool,
-
     /// Whether or not the original wasm module contained debug information that
     /// we skipped and did not parse.
     pub has_unparsed_debuginfo: bool,

--- a/crates/wasmtime/src/runtime/code_memory.rs
+++ b/crates/wasmtime/src/runtime/code_memory.rs
@@ -44,6 +44,7 @@ impl Drop for CodeMemory {
         // Drop `unwind_registration` before `self.mmap`
         unsafe {
             ManuallyDrop::drop(&mut self.unwind_registration);
+            #[cfg(feature = "debug-builtins")]
             ManuallyDrop::drop(&mut self.debug_registration);
             ManuallyDrop::drop(&mut self.mmap);
         }

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -63,10 +63,6 @@ fn check_lldb_output(output: &str, directives: &str) -> Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 pub fn test_debug_dwarf_lldb() -> Result<()> {
     let output = lldb_with_script(
         &[
@@ -104,10 +100,6 @@ check: exited with status
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 pub fn test_debug_dwarf5_lldb() -> Result<()> {
     let output = lldb_with_script(
         &[
@@ -145,10 +137,6 @@ check: exited with status
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 pub fn test_debug_split_dwarf4_lldb() -> Result<()> {
     let output = lldb_with_script(
         &[
@@ -186,10 +174,6 @@ check: exited with status
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 pub fn test_debug_dwarf_ref() -> Result<()> {
     let output = lldb_with_script(
         &[
@@ -220,10 +204,6 @@ check: resuming
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 pub fn test_debug_inst_offsets_are_correct_when_branches_are_removed() -> Result<()> {
     let output = lldb_with_script(
         &[
@@ -247,10 +227,6 @@ check: exited with status
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 pub fn test_spilled_frame_base_is_accessible() -> Result<()> {
     let output = lldb_with_script(
         &[
@@ -305,10 +281,6 @@ int main()
  */
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 pub fn test_debug_dwarf5_fission_lldb() -> Result<()> {
     let output = lldb_with_script(
         &[
@@ -341,10 +313,6 @@ check: exited with status = 0
     Ok(())
 }
 
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 mod test_programs {
     use super::{check_lldb_output, lldb_with_script};
     use anyhow::Result;


### PR DESCRIPTION
JIT images correspond to ELF images, which may represent multiple modules within a single component.

Fixes #9461.

Tested manually on a moderately large component as well as with the existing LLDB tests.