### PR TITLE
winch: Implement Fuel-Based Interruption

### DIFF
--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -109,6 +109,7 @@ impl wasmtime_environ::Compiler for Compiler {
                 types,
                 &mut context.builtins,
                 &mut validator,
+                &self.tunables,
             )
             .map_err(|e| CompileError::Codegen(format!("{e:?}")));
         self.save_context(context, validator.into_allocations());

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1,4 +1,5 @@
 use wasmtime::*;
+use wasmtime_test_macros::wasmtime_test;
 use wast::parser::{self, Parse, ParseBuffer, Parser};
 use wast::token::Span;
 
@@ -23,14 +24,15 @@ impl<'a> Parse<'a> for FuelWast<'a> {
     }
 }
 
-#[test]
+#[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn run() -> Result<()> {
+fn run(config: &mut Config) -> Result<()> {
+    config.consume_fuel(true);
     let test = std::fs::read_to_string("tests/all/fuel.wast")?;
     let buf = ParseBuffer::new(&test)?;
     let mut wast = parser::parse::<FuelWast<'_>>(&buf)?;
     for (span, fuel, module) in wast.assertions.iter_mut() {
-        let consumed = fuel_consumed(&module.encode()?);
+        let consumed = fuel_consumed(&config, &module.encode()?);
         if consumed == *fuel {
             continue;
         }
@@ -46,9 +48,7 @@ fn run() -> Result<()> {
     Ok(())
 }
 
-fn fuel_consumed(wasm: &[u8]) -> u64 {
-    let mut config = Config::new();
-    config.consume_fuel(true);
+fn fuel_consumed(config: &Config, wasm: &[u8]) -> u64 {
     let engine = Engine::new(&config).unwrap();
     let module = Module::new(&engine, wasm).unwrap();
     let mut store = Store::new(&engine, ());
@@ -57,10 +57,12 @@ fn fuel_consumed(wasm: &[u8]) -> u64 {
     u64::MAX - store.get_fuel().unwrap()
 }
 
-#[test]
+#[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn iloop() {
+fn iloop(config: &mut Config) -> Result<()> {
+    config.consume_fuel(true);
     iloop_aborts(
+        &config,
         r#"
             (module
                 (start 0)
@@ -69,6 +71,7 @@ fn iloop() {
         "#,
     );
     iloop_aborts(
+        &config,
         r#"
             (module
                 (start 0)
@@ -77,6 +80,7 @@ fn iloop() {
         "#,
     );
     iloop_aborts(
+        &config,
         r#"
             (module
                 (start 0)
@@ -85,6 +89,7 @@ fn iloop() {
         "#,
     );
     iloop_aborts(
+        &config,
         r#"
             (module
                 (start 0)
@@ -109,9 +114,7 @@ fn iloop() {
         "#,
     );
 
-    fn iloop_aborts(wat: &str) {
-        let mut config = Config::new();
-        config.consume_fuel(true);
+    fn iloop_aborts(config: &Config, wat: &str) {
         let engine = Engine::new(&config).unwrap();
         let module = Module::new(&engine, wat).unwrap();
         let mut store = Store::new(&engine, ());
@@ -119,11 +122,12 @@ fn iloop() {
         let error = Instance::new(&mut store, &module, &[]).err().unwrap();
         assert_eq!(error.downcast::<Trap>().unwrap(), Trap::OutOfFuel);
     }
+
+    Ok(())
 }
 
-#[test]
-fn manual_fuel() {
-    let mut config = Config::new();
+#[wasmtime_test]
+fn manual_fuel(config: &mut Config) {
     config.consume_fuel(true);
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::new(&engine, ());
@@ -133,11 +137,10 @@ fn manual_fuel() {
     assert_eq!(store.get_fuel().ok(), Some(1));
 }
 
-#[test]
+#[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn host_function_consumes_all() {
+fn host_function_consumes_all(config: &mut Config) {
     const FUEL: u64 = 10_000;
-    let mut config = Config::new();
     config.consume_fuel(true);
     let engine = Engine::new(&config).unwrap();
     let module = Module::new(
@@ -166,9 +169,8 @@ fn host_function_consumes_all() {
     assert_eq!(trap.downcast::<Trap>().unwrap(), Trap::OutOfFuel);
 }
 
-#[test]
-fn manual_edge_cases() {
-    let mut config = Config::new();
+#[wasmtime_test]
+fn manual_edge_cases(config: &mut Config) {
     config.consume_fuel(true);
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::new(&engine, ());
@@ -176,10 +178,9 @@ fn manual_edge_cases() {
     assert_eq!(store.get_fuel().unwrap(), u64::MAX);
 }
 
-#[test]
+#[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping() {
-    let mut config = Config::new();
+fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping(config: &mut Config) {
     config.consume_fuel(true);
     config.static_memory_maximum_size(0x1_0000);
 
@@ -220,10 +221,11 @@ fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping() {
     assert!(consumed_fuel > 0);
 }
 
-#[test]
+#[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn get_fuel_clamps_at_zero() -> Result<()> {
-    let engine = Engine::new(Config::new().consume_fuel(true))?;
+fn get_fuel_clamps_at_zero(config: &mut Config) -> Result<()> {
+    config.consume_fuel(true);
+    let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
     let module = Module::new(
         &engine,

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -19,7 +19,7 @@ use masm::MacroAssembler as Aarch64Masm;
 use target_lexicon::Triple;
 use wasmparser::{FuncValidator, FunctionBody, ValidatorResources};
 use wasmtime_cranelift::CompiledFunction;
-use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, VMOffsets, WasmFuncType};
+use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, Tunables, VMOffsets, WasmFuncType};
 
 mod abi;
 mod address;
@@ -92,6 +92,7 @@ impl TargetIsa for Aarch64 {
         types: &ModuleTypesBuilder,
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
+        tunables: &Tunables,
     ) -> Result<CompiledFunction> {
         let pointer_bytes = self.pointer_bytes();
         let vmoffsets = VMOffsets::new(pointer_bytes, &translation.module);
@@ -124,7 +125,7 @@ impl TargetIsa for Aarch64 {
         );
         let regalloc = RegAlloc::from(gpr, fpr);
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
-        let mut codegen = CodeGen::new(&mut masm, codegen_context, env, abi_sig);
+        let mut codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
 
         codegen.emit(&mut body, validator)?;
         let names = codegen.env.take_name_map();

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -12,7 +12,7 @@ use std::{
 use target_lexicon::{Architecture, Triple};
 use wasmparser::{FuncValidator, FunctionBody, ValidatorResources};
 use wasmtime_cranelift::CompiledFunction;
-use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, WasmFuncType};
+use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, Tunables, WasmFuncType};
 
 #[cfg(feature = "x64")]
 pub(crate) mod x64;
@@ -163,6 +163,7 @@ pub trait TargetIsa: Send + Sync {
         types: &ModuleTypesBuilder,
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
+        tunables: &Tunables,
     ) -> Result<CompiledFunction>;
 
     /// Get the default calling convention of the underlying target triple.

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -19,7 +19,7 @@ use cranelift_codegen::{MachTextSectionBuilder, TextSectionBuilder};
 use target_lexicon::Triple;
 use wasmparser::{FuncValidator, FunctionBody, ValidatorResources};
 use wasmtime_cranelift::CompiledFunction;
-use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, VMOffsets, WasmFuncType};
+use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, Tunables, VMOffsets, WasmFuncType};
 
 use self::regs::{ALL_FPR, ALL_GPR, MAX_FPR, MAX_GPR, NON_ALLOCATABLE_FPR, NON_ALLOCATABLE_GPR};
 
@@ -94,6 +94,7 @@ impl TargetIsa for X64 {
         types: &ModuleTypesBuilder,
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
+        tunables: &Tunables,
     ) -> Result<CompiledFunction> {
         let pointer_bytes = self.pointer_bytes();
         let vmoffsets = VMOffsets::new(pointer_bytes, &translation.module);
@@ -133,7 +134,7 @@ impl TargetIsa for X64 {
 
         let regalloc = RegAlloc::from(gpr, fpr);
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
-        let mut codegen = CodeGen::new(&mut masm, codegen_context, env, abi_sig);
+        let mut codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
 
         codegen.emit(&mut body, validator)?;
         let base = codegen.source_location.base;

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1721,6 +1721,11 @@ where
             self.masm,
             &mut self.context,
         ));
+
+        // Emit fuel check right after binding the loop header.
+        if self.tunables.consume_fuel {
+            self.emit_fuel_check();
+        }
     }
 
     fn visit_br(&mut self, depth: u32) {


### PR DESCRIPTION
Closes: https://github.com/bytecodealliance/wasmtime/issues/8090

This commit introduces the initial implementation of fuel-based interruption in Winch.

To maintain consistency with existing fuel semantics, this implementation closely follows the Wasmtime/Cranelift approach, with the following exception:

* Local Fuel Cache: Given Winch's emphasis on compilation speed, this implementation does not optimize for minimizing loads and stores. As a result, checking and incrementing fuel currently requires explicit loads and stores. Future optimizations may be considered to improve this aspect.

This commit also includes a small refactoring in the visitor, which introduces more generic "visitor hook" which enable handling the invariants that need to happen before and after emitting machine code for each Wasm operator.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
