### PR TITLE
wasi-nn: update OpenVINO bindings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -766,10 +766,8 @@ jobs:
     - uses: ./.github/actions/install-rust
 
     # Install OpenVINO
-    - uses: abrown/install-openvino-action@v8
+    - uses: abrown/install-openvino-action@v9
       if: runner.arch == 'X64'
-      with:
-        version: 2024.4.0
 
     # Install WinML for testing wasi-nn WinML backend. WinML is only available
     # on Windows clients and Windows Server with desktop experience enabled.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -768,6 +768,8 @@ jobs:
     # Install OpenVINO
     - uses: abrown/install-openvino-action@v8
       if: runner.arch == 'X64'
+      with:
+        version: 2024.4.0
 
     # Install WinML for testing wasi-nn WinML backend. WinML is only available
     # on Windows clients and Windows Server with desktop experience enabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,20 +2070,19 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openvino"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee013796927eec6012a344f10ecdc06bf26de79c626a2395e3f115464907ef6"
+checksum = "8f03a664ab0b6917131f5c1a787795fa4d19ad6a334caf9c96284453abdf23fd"
 dependencies = [
  "openvino-finder",
  "openvino-sys",
- "thiserror",
 ]
 
 [[package]]
 name = "openvino-finder"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4c6841df4cd60fef743015f3348f81b6b225bd255ed0c4cab6e8c479e45eaa"
+checksum = "34d6bbb3e00d9ad3cd60bca1341665a9cfb2b6764df37c58d921627368ae32fc"
 dependencies = [
  "cfg-if",
  "log",
@@ -2091,11 +2090,11 @@ dependencies = [
 
 [[package]]
 name = "openvino-sys"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62fc2bd6882f2300a6b5017eaad292586d70995d333582aabcf1f1121cd147c"
+checksum = "04315994236727c3573f7e8d8bf857e93ff373ee2e063f08aa78aceac58e3bc5"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger 0.11.5",
  "libloading",
  "once_cell",
  "openvino-finder",

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -30,7 +30,7 @@ wasmtime = { workspace = true, features = [
 # These dependencies are necessary for the wasi-nn implementation:
 tracing = { workspace = true }
 thiserror = { workspace = true }
-openvino = { version = "0.7.2", features = [
+openvino = { version = "0.8.0", features = [
     "runtime-linking",
 ], optional = true }
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2274,6 +2274,12 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.7.2"
 
+[[audits.openvino]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.2 -> 0.8.0"
+notes = "No new unsafe functionality, just brings in openvino-sys changes and other minor improvements."
+
 [[audits.openvino-finder]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -2297,6 +2303,12 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.7.2"
 
+[[audits.openvino-finder]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.2 -> 0.8.0"
+notes = "No logic changes in version bump."
+
 [[audits.openvino-sys]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -2319,6 +2331,12 @@ delta = "0.5.0 -> 0.6.0"
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.7.2"
+
+[[audits.openvino-sys]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.2 -> 0.8.0"
+notes = "This diff simply re-generates slightly newer C headers with a slightly newer version of bindgen."
 
 [[audits.ort]]
 who = "Andrew Brown <andrew.brown@intel.com>"


### PR DESCRIPTION
Recent changes to OpenVINO's C bindings introduced breaking changes that prevent use of older OpenVINO libraries with newer bindings (see [openvino-rs#143] if you're interested in the details). This updates both the bindings and the version of OpenVINO used to test against.

Fixes https://github.com/bytecodealliance/wasmtime/issues/9379.

[openvino-rs#143]: https://github.com/intel/openvino-rs/issues/143
