### PR TITLE
Don't generate 128-bit atomics in fuzzing

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1051,6 +1051,12 @@ static OPCODE_SIGNATURES: Lazy<Vec<OpcodeSignature>> = Lazy::new(|| {
                 (Opcode::FcvtFromSint, &[I8X16], &[F64X2]),
                 (Opcode::FcvtFromSint, &[I16X8], &[F64X2]),
                 (Opcode::FcvtFromSint, &[I32X4], &[F64X2]),
+                // Only supported on x64 with a feature at this time, so 128-bit
+                // atomics are not suitable to fuzz yet.
+                (Opcode::AtomicRmw, _, &[I128]),
+                (Opcode::AtomicCas, _, &[I128]),
+                (Opcode::AtomicLoad, _, &[I128]),
+                (Opcode::AtomicStore, &[I128, _], _),
             )
         })
         .filter(|(op, ..)| {


### PR DESCRIPTION
This commit fixes some issues cropping up due to fuzzing 128-bit atomics in `cranelift-{icache,fuzzgen}`. Not all backends support these operations and x64 only supports them with a feature enabled, so for now disable fuzzing until it's ready to fuzz later.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
