### PR TITLE
A couple minor Wasm GC codegen improvements

### DIFF
--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -1119,8 +1119,8 @@ impl FuncEnvironment<'_> {
         self.gc_layout(type_index).unwrap_struct()
     }
 
-    /// Get the GC heap's base pointer and bound.
-    fn get_gc_heap_base_bound(&mut self, builder: &mut FunctionBuilder) -> (ir::Value, ir::Value) {
+    /// Get the GC heap's base pointer.
+    fn get_gc_heap_base(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
         let ptr_ty = self.pointer_type();
         let flags = ir::MemFlags::trusted().with_readonly();
 
@@ -1130,12 +1130,27 @@ impl FuncEnvironment<'_> {
         let base_offset = self.offsets.ptr.vmctx_gc_heap_base();
         let base_offset = i32::from(base_offset);
 
+        builder.ins().load(ptr_ty, flags, vmctx, base_offset)
+    }
+
+    /// Get the GC heap's bound.
+    fn get_gc_heap_bound(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
+        let ptr_ty = self.pointer_type();
+        let flags = ir::MemFlags::trusted().with_readonly();
+
+        let vmctx = self.vmctx(builder.func);
+        let vmctx = builder.ins().global_value(ptr_ty, vmctx);
+
         let bound_offset = self.offsets.ptr.vmctx_gc_heap_bound();
         let bound_offset = i32::from(bound_offset);
 
-        let base = builder.ins().load(ptr_ty, flags, vmctx, base_offset);
-        let bound = builder.ins().load(ptr_ty, flags, vmctx, bound_offset);
+        builder.ins().load(ptr_ty, flags, vmctx, bound_offset)
+    }
 
+    /// Get the GC heap's base pointer and bound.
+    fn get_gc_heap_base_bound(&mut self, builder: &mut FunctionBuilder) -> (ir::Value, ir::Value) {
+        let base = self.get_gc_heap_base(builder);
+        let bound = self.get_gc_heap_bound(builder);
         (base, bound)
     }
 

--- a/crates/cranelift/src/gc/enabled/drc.rs
+++ b/crates/cranelift/src/gc/enabled/drc.rs
@@ -388,7 +388,7 @@ impl GcCompiler for DrcCompiler {
         //
         // Note: we don't need to bounds-check the GC ref access here, since we
         // trust the results of the allocation libcall.
-        let (base, _bound) = func_env.get_gc_heap_base_bound(builder);
+        let base = func_env.get_gc_heap_base(builder);
         let extended_array_ref =
             uextend_i32_to_pointer_type(builder, func_env.pointer_type(), array_ref);
         let object_addr = builder.ins().iadd(base, extended_array_ref);

--- a/crates/cranelift/src/gc/enabled/drc.rs
+++ b/crates/cranelift/src/gc/enabled/drc.rs
@@ -385,12 +385,14 @@ impl GcCompiler for DrcCompiler {
         );
 
         // Write the array's length into the appropriate slot.
-        let len_addr = func_env.prepare_gc_ref_access(
-            builder,
-            array_ref,
-            Offset::Static(len_offset),
-            BoundsCheck::Object(size),
-        );
+        //
+        // Note: we don't need to bounds-check the GC ref access here, since we
+        // trust the results of the allocation libcall.
+        let (base, _bound) = func_env.get_gc_heap_base_bound(builder);
+        let extended_array_ref =
+            uextend_i32_to_pointer_type(builder, func_env.pointer_type(), array_ref);
+        let object_addr = builder.ins().iadd(base, extended_array_ref);
+        let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
         let len = match init {
             ArrayInit::Fill { len, .. } => len,
             ArrayInit::Elems(e) => {

--- a/crates/cranelift/src/gc/enabled/drc.rs
+++ b/crates/cranelift/src/gc/enabled/drc.rs
@@ -100,7 +100,7 @@ impl DrcCompiler {
         let vmctx = builder.ins().global_value(ptr_ty, vmctx);
         let activations_table = builder.ins().load(
             ptr_ty,
-            ir::MemFlags::trusted(),
+            ir::MemFlags::trusted().with_readonly(),
             vmctx,
             i32::from(func_env.offsets.ptr.vmctx_gc_heap_data()),
         );

--- a/tests/disas/gc/array-fill.wat
+++ b/tests/disas/gc/array-fill.wat
@@ -18,53 +18,53 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v9 = uextend.i64 v2
-;; @0027                               v10 = iconst.i64 16
-;; @0027                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
-;; @0027                               v12 = iconst.i64 4
-;; @0027                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0027                               v8 = load.i64 notrap aligned readonly v0+48
-;; @0027                               v14 = icmp ule v13, v8
-;; @0027                               trapz v14, user1
+;; @0027                               v10 = uextend.i64 v2
+;; @0027                               v11 = iconst.i64 16
+;; @0027                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
+;; @0027                               v13 = iconst.i64 4
+;; @0027                               v14 = uadd_overflow_trap v12, v13, user1  ; v13 = 4
+;; @0027                               v9 = load.i64 notrap aligned readonly v0+48
+;; @0027                               v15 = icmp ule v14, v9
+;; @0027                               trapz v15, user1
 ;; @0027                               v7 = load.i64 notrap aligned readonly v0+40
-;; @0027                               v15 = iadd v7, v11
-;; @0027                               v16 = load.i32 notrap aligned v15
-;; @0027                               v17 = uadd_overflow_trap v3, v5, user17
-;; @0027                               v18 = icmp ugt v17, v16
-;; @0027                               trapnz v18, user17
-;; @0027                               v20 = uextend.i64 v16
-;;                                     v46 = iconst.i64 3
-;;                                     v47 = ishl v20, v46  ; v46 = 3
-;;                                     v45 = iconst.i64 32
-;; @0027                               v22 = ushr v47, v45  ; v45 = 32
-;; @0027                               trapnz v22, user1
-;;                                     v56 = iconst.i32 3
-;;                                     v57 = ishl v16, v56  ; v56 = 3
-;; @0027                               v24 = iconst.i32 24
-;; @0027                               v25 = uadd_overflow_trap v57, v24, user1  ; v24 = 24
-;;                                     v64 = ishl v3, v56  ; v56 = 3
-;;                                     v66 = iadd v64, v24  ; v24 = 24
-;; @0027                               v33 = uextend.i64 v66
-;; @0027                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0027                               v35 = uextend.i64 v25
-;; @0027                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0027                               v37 = icmp ule v36, v8
-;; @0027                               trapz v37, user1
-;; @0027                               v38 = iadd v7, v34
-;; @0027                               v39 = uextend.i64 v64
-;; @0027                               v40 = iadd v38, v39
-;; @0027                               v19 = iconst.i64 8
-;; @0027                               jump block2(v38)
+;; @0027                               v16 = iadd v7, v12
+;; @0027                               v17 = load.i32 notrap aligned v16
+;; @0027                               v18 = uadd_overflow_trap v3, v5, user17
+;; @0027                               v19 = icmp ugt v18, v17
+;; @0027                               trapnz v19, user17
+;; @0027                               v21 = uextend.i64 v17
+;;                                     v48 = iconst.i64 3
+;;                                     v49 = ishl v21, v48  ; v48 = 3
+;;                                     v47 = iconst.i64 32
+;; @0027                               v23 = ushr v49, v47  ; v47 = 32
+;; @0027                               trapnz v23, user1
+;;                                     v58 = iconst.i32 3
+;;                                     v59 = ishl v17, v58  ; v58 = 3
+;; @0027                               v25 = iconst.i32 24
+;; @0027                               v26 = uadd_overflow_trap v59, v25, user1  ; v25 = 24
+;;                                     v66 = ishl v3, v58  ; v58 = 3
+;;                                     v68 = iadd v66, v25  ; v25 = 24
+;; @0027                               v35 = uextend.i64 v68
+;; @0027                               v36 = uadd_overflow_trap v10, v35, user1
+;; @0027                               v37 = uextend.i64 v26
+;; @0027                               v38 = uadd_overflow_trap v10, v37, user1
+;; @0027                               v39 = icmp ule v38, v9
+;; @0027                               trapz v39, user1
+;; @0027                               v40 = iadd v7, v36
+;; @0027                               v41 = uextend.i64 v66
+;; @0027                               v42 = iadd v40, v41
+;; @0027                               v20 = iconst.i64 8
+;; @0027                               jump block2(v40)
 ;;
-;;                                 block2(v42: i64):
-;; @0027                               v43 = icmp eq v42, v40
-;; @0027                               brif v43, block4, block3
+;;                                 block2(v44: i64):
+;; @0027                               v45 = icmp eq v44, v42
+;; @0027                               brif v45, block4, block3
 ;;
 ;;                                 block3:
-;; @0027                               store.i64 notrap aligned little v4, v42
-;;                                     v68 = iconst.i64 8
-;;                                     v69 = iadd.i64 v42, v68  ; v68 = 8
-;; @0027                               jump block2(v69)
+;; @0027                               store.i64 notrap aligned little v4, v44
+;;                                     v70 = iconst.i64 8
+;;                                     v71 = iadd.i64 v44, v70  ; v70 = 8
+;; @0027                               jump block2(v71)
 ;;
 ;;                                 block4:
 ;; @002a                               jump block1

--- a/tests/disas/gc/array-get-s.wat
+++ b/tests/disas/gc/array-get-s.wat
@@ -18,37 +18,37 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v8 = uextend.i64 v2
-;; @0022                               v9 = iconst.i64 16
-;; @0022                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;; @0022                               v11 = iconst.i64 4
-;; @0022                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @0022                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0022                               v13 = icmp ule v12, v7
-;; @0022                               trapz v13, user1
+;; @0022                               v9 = uextend.i64 v2
+;; @0022                               v10 = iconst.i64 16
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0022                               v12 = iconst.i64 4
+;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
+;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v14 = icmp ule v13, v8
+;; @0022                               trapz v14, user1
 ;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0022                               v14 = iadd v6, v10
-;; @0022                               v15 = load.i32 notrap aligned v14
-;; @0022                               v16 = icmp ult v3, v15
-;; @0022                               trapz v16, user17
-;; @0022                               v18 = uextend.i64 v15
-;;                                     v39 = iconst.i64 32
-;; @0022                               v20 = ushr v18, v39  ; v39 = 32
-;; @0022                               trapnz v20, user1
-;; @0022                               v22 = iconst.i32 20
-;; @0022                               v23 = uadd_overflow_trap v15, v22, user1  ; v22 = 20
-;; @0022                               v26 = iadd v3, v22  ; v22 = 20
-;; @0022                               v31 = uextend.i64 v26
-;; @0022                               v32 = uadd_overflow_trap v8, v31, user1
-;; @0022                               v33 = uextend.i64 v23
-;; @0022                               v34 = uadd_overflow_trap v8, v33, user1
-;; @0022                               v35 = icmp ule v34, v7
-;; @0022                               trapz v35, user1
-;; @0022                               v36 = iadd v6, v32
-;; @0022                               v37 = load.i8 notrap aligned little v36
+;; @0022                               v15 = iadd v6, v11
+;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v17 = icmp ult v3, v16
+;; @0022                               trapz v17, user17
+;; @0022                               v19 = uextend.i64 v16
+;;                                     v41 = iconst.i64 32
+;; @0022                               v21 = ushr v19, v41  ; v41 = 32
+;; @0022                               trapnz v21, user1
+;; @0022                               v23 = iconst.i32 20
+;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 20
+;; @0022                               v27 = iadd v3, v23  ; v23 = 20
+;; @0022                               v33 = uextend.i64 v27
+;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
+;; @0022                               v35 = uextend.i64 v24
+;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
+;; @0022                               v37 = icmp ule v36, v8
+;; @0022                               trapz v37, user1
+;; @0022                               v38 = iadd v6, v34
+;; @0022                               v39 = load.i8 notrap aligned little v38
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v38 = sextend.i32 v37
-;; @0025                               return v38
+;; @0022                               v40 = sextend.i32 v39
+;; @0025                               return v40
 ;; }

--- a/tests/disas/gc/array-get-u.wat
+++ b/tests/disas/gc/array-get-u.wat
@@ -18,37 +18,37 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v8 = uextend.i64 v2
-;; @0022                               v9 = iconst.i64 16
-;; @0022                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;; @0022                               v11 = iconst.i64 4
-;; @0022                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @0022                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0022                               v13 = icmp ule v12, v7
-;; @0022                               trapz v13, user1
+;; @0022                               v9 = uextend.i64 v2
+;; @0022                               v10 = iconst.i64 16
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0022                               v12 = iconst.i64 4
+;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
+;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v14 = icmp ule v13, v8
+;; @0022                               trapz v14, user1
 ;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0022                               v14 = iadd v6, v10
-;; @0022                               v15 = load.i32 notrap aligned v14
-;; @0022                               v16 = icmp ult v3, v15
-;; @0022                               trapz v16, user17
-;; @0022                               v18 = uextend.i64 v15
-;;                                     v39 = iconst.i64 32
-;; @0022                               v20 = ushr v18, v39  ; v39 = 32
-;; @0022                               trapnz v20, user1
-;; @0022                               v22 = iconst.i32 20
-;; @0022                               v23 = uadd_overflow_trap v15, v22, user1  ; v22 = 20
-;; @0022                               v26 = iadd v3, v22  ; v22 = 20
-;; @0022                               v31 = uextend.i64 v26
-;; @0022                               v32 = uadd_overflow_trap v8, v31, user1
-;; @0022                               v33 = uextend.i64 v23
-;; @0022                               v34 = uadd_overflow_trap v8, v33, user1
-;; @0022                               v35 = icmp ule v34, v7
-;; @0022                               trapz v35, user1
-;; @0022                               v36 = iadd v6, v32
-;; @0022                               v37 = load.i8 notrap aligned little v36
+;; @0022                               v15 = iadd v6, v11
+;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v17 = icmp ult v3, v16
+;; @0022                               trapz v17, user17
+;; @0022                               v19 = uextend.i64 v16
+;;                                     v41 = iconst.i64 32
+;; @0022                               v21 = ushr v19, v41  ; v41 = 32
+;; @0022                               trapnz v21, user1
+;; @0022                               v23 = iconst.i32 20
+;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 20
+;; @0022                               v27 = iadd v3, v23  ; v23 = 20
+;; @0022                               v33 = uextend.i64 v27
+;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
+;; @0022                               v35 = uextend.i64 v24
+;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
+;; @0022                               v37 = icmp ule v36, v8
+;; @0022                               trapz v37, user1
+;; @0022                               v38 = iadd v6, v34
+;; @0022                               v39 = load.i8 notrap aligned little v38
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               v38 = uextend.i32 v37
-;; @0025                               return v38
+;; @0022                               v40 = uextend.i32 v39
+;; @0025                               return v40
 ;; }

--- a/tests/disas/gc/array-get.wat
+++ b/tests/disas/gc/array-get.wat
@@ -18,41 +18,41 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v8 = uextend.i64 v2
-;; @0022                               v9 = iconst.i64 16
-;; @0022                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;; @0022                               v11 = iconst.i64 4
-;; @0022                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @0022                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0022                               v13 = icmp ule v12, v7
-;; @0022                               trapz v13, user1
+;; @0022                               v9 = uextend.i64 v2
+;; @0022                               v10 = iconst.i64 16
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0022                               v12 = iconst.i64 4
+;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
+;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v14 = icmp ule v13, v8
+;; @0022                               trapz v14, user1
 ;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0022                               v14 = iadd v6, v10
-;; @0022                               v15 = load.i32 notrap aligned v14
-;; @0022                               v16 = icmp ult v3, v15
-;; @0022                               trapz v16, user17
-;; @0022                               v18 = uextend.i64 v15
-;;                                     v39 = iconst.i64 3
-;;                                     v40 = ishl v18, v39  ; v39 = 3
-;;                                     v38 = iconst.i64 32
-;; @0022                               v20 = ushr v40, v38  ; v38 = 32
-;; @0022                               trapnz v20, user1
-;;                                     v49 = iconst.i32 3
-;;                                     v50 = ishl v15, v49  ; v49 = 3
-;; @0022                               v22 = iconst.i32 24
-;; @0022                               v23 = uadd_overflow_trap v50, v22, user1  ; v22 = 24
-;;                                     v57 = ishl v3, v49  ; v49 = 3
-;; @0022                               v26 = iadd v57, v22  ; v22 = 24
-;; @0022                               v31 = uextend.i64 v26
-;; @0022                               v32 = uadd_overflow_trap v8, v31, user1
-;; @0022                               v33 = uextend.i64 v23
-;; @0022                               v34 = uadd_overflow_trap v8, v33, user1
-;; @0022                               v35 = icmp ule v34, v7
-;; @0022                               trapz v35, user1
-;; @0022                               v36 = iadd v6, v32
-;; @0022                               v37 = load.i64 notrap aligned little v36
+;; @0022                               v15 = iadd v6, v11
+;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v17 = icmp ult v3, v16
+;; @0022                               trapz v17, user17
+;; @0022                               v19 = uextend.i64 v16
+;;                                     v41 = iconst.i64 3
+;;                                     v42 = ishl v19, v41  ; v41 = 3
+;;                                     v40 = iconst.i64 32
+;; @0022                               v21 = ushr v42, v40  ; v40 = 32
+;; @0022                               trapnz v21, user1
+;;                                     v51 = iconst.i32 3
+;;                                     v52 = ishl v16, v51  ; v51 = 3
+;; @0022                               v23 = iconst.i32 24
+;; @0022                               v24 = uadd_overflow_trap v52, v23, user1  ; v23 = 24
+;;                                     v59 = ishl v3, v51  ; v51 = 3
+;; @0022                               v27 = iadd v59, v23  ; v23 = 24
+;; @0022                               v33 = uextend.i64 v27
+;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
+;; @0022                               v35 = uextend.i64 v24
+;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
+;; @0022                               v37 = icmp ule v36, v8
+;; @0022                               trapz v37, user1
+;; @0022                               v38 = iadd v6, v34
+;; @0022                               v39 = load.i64 notrap aligned little v38
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v37
+;; @0025                               return v39
 ;; }

--- a/tests/disas/gc/array-len.wat
+++ b/tests/disas/gc/array-len.wat
@@ -18,19 +18,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
-;; @001f                               v7 = uextend.i64 v2
-;; @001f                               v8 = iconst.i64 16
-;; @001f                               v9 = uadd_overflow_trap v7, v8, user1  ; v8 = 16
-;; @001f                               v10 = iconst.i64 4
-;; @001f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 4
-;; @001f                               v6 = load.i64 notrap aligned readonly v0+48
-;; @001f                               v12 = icmp ule v11, v6
-;; @001f                               trapz v12, user1
+;; @001f                               v8 = uextend.i64 v2
+;; @001f                               v9 = iconst.i64 16
+;; @001f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
+;; @001f                               v11 = iconst.i64 4
+;; @001f                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
+;; @001f                               v7 = load.i64 notrap aligned readonly v0+48
+;; @001f                               v13 = icmp ule v12, v7
+;; @001f                               trapz v13, user1
 ;; @001f                               v5 = load.i64 notrap aligned readonly v0+40
-;; @001f                               v13 = iadd v5, v9
-;; @001f                               v14 = load.i32 notrap aligned v13
+;; @001f                               v14 = iadd v5, v10
+;; @001f                               v15 = load.i32 notrap aligned v14
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v14
+;; @0021                               return v15
 ;; }

--- a/tests/disas/gc/array-new-fixed.wat
+++ b/tests/disas/gc/array-new-fixed.wat
@@ -19,8 +19,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v43 = iconst.i64 0
-;; @0025                               trapnz v43, user18  ; v43 = 0
+;;                                     v42 = iconst.i64 0
+;; @0025                               trapnz v42, user18  ; v42 = 0
 ;; @0025                               v6 = iconst.i32 24
 ;; @0025                               v12 = uadd_overflow_trap v6, v6, user18  ; v6 = 24, v6 = 24
 ;; @0025                               v14 = iconst.i32 -1476395008
@@ -29,20 +29,20 @@
 ;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16)  ; v14 = -1476395008, v15 = 0, v16 = 8
 ;; @0025                               v7 = iconst.i32 3
 ;; @0025                               v19 = load.i64 notrap aligned readonly v0+40
-;; @0025                               v21 = uextend.i64 v17
-;; @0025                               v22 = iadd v19, v21
-;;                                     v33 = iconst.i64 16
-;; @0025                               v23 = iadd v22, v33  ; v33 = 16
-;; @0025                               store notrap aligned v7, v23  ; v7 = 3
-;;                                     v35 = iconst.i64 24
-;;                                     v50 = iadd v22, v35  ; v35 = 24
-;; @0025                               store notrap aligned little v2, v50
-;;                                     v32 = iconst.i64 32
-;;                                     v57 = iadd v22, v32  ; v32 = 32
-;; @0025                               store notrap aligned little v3, v57
-;;                                     v59 = iconst.i64 40
-;;                                     v65 = iadd v22, v59  ; v59 = 40
-;; @0025                               store notrap aligned little v4, v65
+;; @0025                               v20 = uextend.i64 v17
+;; @0025                               v21 = iadd v19, v20
+;;                                     v32 = iconst.i64 16
+;; @0025                               v22 = iadd v21, v32  ; v32 = 16
+;; @0025                               store notrap aligned v7, v22  ; v7 = 3
+;;                                     v34 = iconst.i64 24
+;;                                     v49 = iadd v21, v34  ; v34 = 24
+;; @0025                               store notrap aligned little v2, v49
+;;                                     v31 = iconst.i64 32
+;;                                     v56 = iadd v21, v31  ; v31 = 32
+;; @0025                               store notrap aligned little v3, v56
+;;                                     v58 = iconst.i64 40
+;;                                     v64 = iadd v21, v58  ; v58 = 40
+;; @0025                               store notrap aligned little v4, v64
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new-fixed.wat
+++ b/tests/disas/gc/array-new-fixed.wat
@@ -19,34 +19,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v46 = iconst.i64 0
-;; @0025                               trapnz v46, user18  ; v46 = 0
+;;                                     v43 = iconst.i64 0
+;; @0025                               trapnz v43, user18  ; v43 = 0
 ;; @0025                               v6 = iconst.i32 24
 ;; @0025                               v12 = uadd_overflow_trap v6, v6, user18  ; v6 = 24, v6 = 24
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v15 = iconst.i32 0
 ;; @0025                               v16 = iconst.i32 8
 ;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16)  ; v14 = -1476395008, v15 = 0, v16 = 8
-;; @0025                               v21 = uextend.i64 v17
-;; @0025                               v22 = iconst.i64 16
-;; @0025                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 16
-;; @0025                               v24 = uextend.i64 v12
-;; @0025                               v25 = uadd_overflow_trap v21, v24, user1
-;; @0025                               v20 = load.i64 notrap aligned readonly v0+48
-;; @0025                               v26 = icmp ule v25, v20
-;; @0025                               trapz v26, user1
 ;; @0025                               v7 = iconst.i32 3
 ;; @0025                               v19 = load.i64 notrap aligned readonly v0+40
-;; @0025                               v27 = iadd v19, v23
-;; @0025                               store notrap aligned v7, v27  ; v7 = 3
-;;                                     v35 = iconst.i64 8
-;; @0025                               v30 = iadd v27, v35  ; v35 = 8
-;; @0025                               store notrap aligned little v2, v30
-;;                                     v53 = iadd v27, v22  ; v22 = 16
-;; @0025                               store notrap aligned little v3, v53
-;;                                     v38 = iconst.i64 24
-;;                                     v60 = iadd v27, v38  ; v38 = 24
-;; @0025                               store notrap aligned little v4, v60
+;; @0025                               v21 = uextend.i64 v17
+;; @0025                               v22 = iadd v19, v21
+;;                                     v33 = iconst.i64 16
+;; @0025                               v23 = iadd v22, v33  ; v33 = 16
+;; @0025                               store notrap aligned v7, v23  ; v7 = 3
+;;                                     v35 = iconst.i64 24
+;;                                     v50 = iadd v22, v35  ; v35 = 24
+;; @0025                               store notrap aligned little v2, v50
+;;                                     v32 = iconst.i64 32
+;;                                     v57 = iadd v22, v32  ; v32 = 32
+;; @0025                               store notrap aligned little v3, v57
+;;                                     v59 = iconst.i64 40
+;;                                     v65 = iadd v22, v59  ; v59 = 40
+;; @0025                               store notrap aligned little v4, v65
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new.wat
+++ b/tests/disas/gc/array-new.wat
@@ -20,41 +20,41 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v35 = iconst.i64 3
-;;                                     v36 = ishl v6, v35  ; v35 = 3
-;;                                     v33 = iconst.i64 32
-;; @0022                               v8 = ushr v36, v33  ; v33 = 32
+;;                                     v34 = iconst.i64 3
+;;                                     v35 = ishl v6, v34  ; v34 = 3
+;;                                     v32 = iconst.i64 32
+;; @0022                               v8 = ushr v35, v32  ; v32 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 24
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v3, v42  ; v42 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v43, user18  ; v5 = 24
+;;                                     v41 = iconst.i32 3
+;;                                     v42 = ishl v3, v41  ; v41 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v42, user18  ; v5 = 24
 ;; @0022                               v12 = iconst.i32 -1476395008
 ;; @0022                               v13 = iconst.i32 0
-;;                                     v40 = iconst.i32 8
-;; @0022                               v15 = call fn0(v0, v12, v13, v10, v40)  ; v12 = -1476395008, v13 = 0, v40 = 8
+;;                                     v39 = iconst.i32 8
+;; @0022                               v15 = call fn0(v0, v12, v13, v10, v39)  ; v12 = -1476395008, v13 = 0, v39 = 8
 ;; @0022                               v17 = load.i64 notrap aligned readonly v0+40
-;; @0022                               v19 = uextend.i64 v15
-;; @0022                               v20 = iadd v17, v19
-;;                                     v34 = iconst.i64 16
-;; @0022                               v21 = iadd v20, v34  ; v34 = 16
-;; @0022                               store notrap aligned v3, v21
-;;                                     v47 = iconst.i64 24
-;;                                     v53 = iadd v20, v47  ; v47 = 24
-;; @0022                               v27 = uextend.i64 v10
-;; @0022                               v28 = iadd v20, v27
-;;                                     v32 = iconst.i64 8
-;; @0022                               jump block2(v53)
+;; @0022                               v18 = uextend.i64 v15
+;; @0022                               v19 = iadd v17, v18
+;;                                     v33 = iconst.i64 16
+;; @0022                               v20 = iadd v19, v33  ; v33 = 16
+;; @0022                               store notrap aligned v3, v20
+;;                                     v46 = iconst.i64 24
+;;                                     v52 = iadd v19, v46  ; v46 = 24
+;; @0022                               v26 = uextend.i64 v10
+;; @0022                               v27 = iadd v19, v26
+;;                                     v31 = iconst.i64 8
+;; @0022                               jump block2(v52)
 ;;
-;;                                 block2(v29: i64):
-;; @0022                               v30 = icmp eq v29, v28
-;; @0022                               brif v30, block4, block3
+;;                                 block2(v28: i64):
+;; @0022                               v29 = icmp eq v28, v27
+;; @0022                               brif v29, block4, block3
 ;;
 ;;                                 block3:
-;; @0022                               store.i64 notrap aligned little v2, v29
-;;                                     v65 = iconst.i64 8
-;;                                     v66 = iadd.i64 v29, v65  ; v65 = 8
-;; @0022                               jump block2(v66)
+;; @0022                               store.i64 notrap aligned little v2, v28
+;;                                     v64 = iconst.i64 8
+;;                                     v65 = iadd.i64 v28, v64  ; v64 = 8
+;; @0022                               jump block2(v65)
 ;;
 ;;                                 block4:
 ;; @0025                               jump block1

--- a/tests/disas/gc/array-new.wat
+++ b/tests/disas/gc/array-new.wat
@@ -20,46 +20,41 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v38 = iconst.i64 3
-;;                                     v39 = ishl v6, v38  ; v38 = 3
-;;                                     v37 = iconst.i64 32
-;; @0022                               v8 = ushr v39, v37  ; v37 = 32
+;;                                     v35 = iconst.i64 3
+;;                                     v36 = ishl v6, v35  ; v35 = 3
+;;                                     v33 = iconst.i64 32
+;; @0022                               v8 = ushr v36, v33  ; v33 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 24
-;;                                     v45 = iconst.i32 3
-;;                                     v46 = ishl v3, v45  ; v45 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v46, user18  ; v5 = 24
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v3, v42  ; v42 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v43, user18  ; v5 = 24
 ;; @0022                               v12 = iconst.i32 -1476395008
 ;; @0022                               v13 = iconst.i32 0
-;;                                     v43 = iconst.i32 8
-;; @0022                               v15 = call fn0(v0, v12, v13, v10, v43)  ; v12 = -1476395008, v13 = 0, v43 = 8
-;; @0022                               v19 = uextend.i64 v15
-;; @0022                               v20 = iconst.i64 16
-;; @0022                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 16
-;; @0022                               v22 = uextend.i64 v10
-;; @0022                               v23 = uadd_overflow_trap v19, v22, user1
-;; @0022                               v18 = load.i64 notrap aligned readonly v0+48
-;; @0022                               v24 = icmp ule v23, v18
-;; @0022                               trapz v24, user1
+;;                                     v40 = iconst.i32 8
+;; @0022                               v15 = call fn0(v0, v12, v13, v10, v40)  ; v12 = -1476395008, v13 = 0, v40 = 8
 ;; @0022                               v17 = load.i64 notrap aligned readonly v0+40
-;; @0022                               v25 = iadd v17, v21
-;; @0022                               store notrap aligned v3, v25
-;;                                     v36 = iconst.i64 8
-;; @0022                               v27 = iadd v25, v36  ; v36 = 8
-;;                                     v51 = iconst.i64 -16
-;;                                     v63 = iadd v22, v51  ; v51 = -16
-;;                                     v65 = iadd v25, v63
-;; @0022                               jump block2(v27)
+;; @0022                               v19 = uextend.i64 v15
+;; @0022                               v20 = iadd v17, v19
+;;                                     v34 = iconst.i64 16
+;; @0022                               v21 = iadd v20, v34  ; v34 = 16
+;; @0022                               store notrap aligned v3, v21
+;;                                     v47 = iconst.i64 24
+;;                                     v53 = iadd v20, v47  ; v47 = 24
+;; @0022                               v27 = uextend.i64 v10
+;; @0022                               v28 = iadd v20, v27
+;;                                     v32 = iconst.i64 8
+;; @0022                               jump block2(v53)
 ;;
-;;                                 block2(v33: i64):
-;; @0022                               v34 = icmp eq v33, v65
-;; @0022                               brif v34, block4, block3
+;;                                 block2(v29: i64):
+;; @0022                               v30 = icmp eq v29, v28
+;; @0022                               brif v30, block4, block3
 ;;
 ;;                                 block3:
-;; @0022                               store.i64 notrap aligned little v2, v33
-;;                                     v66 = iconst.i64 8
-;;                                     v67 = iadd.i64 v33, v66  ; v66 = 8
-;; @0022                               jump block2(v67)
+;; @0022                               store.i64 notrap aligned little v2, v29
+;;                                     v65 = iconst.i64 8
+;;                                     v66 = iadd.i64 v29, v65  ; v65 = 8
+;; @0022                               jump block2(v66)
 ;;
 ;;                                 block4:
 ;; @0025                               jump block1

--- a/tests/disas/gc/array-set.wat
+++ b/tests/disas/gc/array-set.wat
@@ -18,39 +18,39 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v8 = uextend.i64 v2
-;; @0024                               v9 = iconst.i64 16
-;; @0024                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;; @0024                               v11 = iconst.i64 4
-;; @0024                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @0024                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0024                               v13 = icmp ule v12, v7
-;; @0024                               trapz v13, user1
+;; @0024                               v9 = uextend.i64 v2
+;; @0024                               v10 = iconst.i64 16
+;; @0024                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0024                               v12 = iconst.i64 4
+;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
+;; @0024                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0024                               v14 = icmp ule v13, v8
+;; @0024                               trapz v14, user1
 ;; @0024                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0024                               v14 = iadd v6, v10
-;; @0024                               v15 = load.i32 notrap aligned v14
-;; @0024                               v16 = icmp ult v3, v15
-;; @0024                               trapz v16, user17
-;; @0024                               v18 = uextend.i64 v15
-;;                                     v38 = iconst.i64 3
-;;                                     v39 = ishl v18, v38  ; v38 = 3
-;;                                     v37 = iconst.i64 32
-;; @0024                               v20 = ushr v39, v37  ; v37 = 32
-;; @0024                               trapnz v20, user1
-;;                                     v48 = iconst.i32 3
-;;                                     v49 = ishl v15, v48  ; v48 = 3
-;; @0024                               v22 = iconst.i32 24
-;; @0024                               v23 = uadd_overflow_trap v49, v22, user1  ; v22 = 24
-;;                                     v56 = ishl v3, v48  ; v48 = 3
-;; @0024                               v26 = iadd v56, v22  ; v22 = 24
-;; @0024                               v31 = uextend.i64 v26
-;; @0024                               v32 = uadd_overflow_trap v8, v31, user1
-;; @0024                               v33 = uextend.i64 v23
-;; @0024                               v34 = uadd_overflow_trap v8, v33, user1
-;; @0024                               v35 = icmp ule v34, v7
-;; @0024                               trapz v35, user1
-;; @0024                               v36 = iadd v6, v32
-;; @0024                               store notrap aligned little v4, v36
+;; @0024                               v15 = iadd v6, v11
+;; @0024                               v16 = load.i32 notrap aligned v15
+;; @0024                               v17 = icmp ult v3, v16
+;; @0024                               trapz v17, user17
+;; @0024                               v19 = uextend.i64 v16
+;;                                     v40 = iconst.i64 3
+;;                                     v41 = ishl v19, v40  ; v40 = 3
+;;                                     v39 = iconst.i64 32
+;; @0024                               v21 = ushr v41, v39  ; v39 = 32
+;; @0024                               trapnz v21, user1
+;;                                     v50 = iconst.i32 3
+;;                                     v51 = ishl v16, v50  ; v50 = 3
+;; @0024                               v23 = iconst.i32 24
+;; @0024                               v24 = uadd_overflow_trap v51, v23, user1  ; v23 = 24
+;;                                     v58 = ishl v3, v50  ; v50 = 3
+;; @0024                               v27 = iadd v58, v23  ; v23 = 24
+;; @0024                               v33 = uextend.i64 v27
+;; @0024                               v34 = uadd_overflow_trap v9, v33, user1
+;; @0024                               v35 = uextend.i64 v24
+;; @0024                               v36 = uadd_overflow_trap v9, v35, user1
+;; @0024                               v37 = icmp ule v36, v8
+;; @0024                               trapz v37, user1
+;; @0024                               v38 = iadd v6, v34
+;; @0024                               store notrap aligned little v4, v38
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/br-on-cast-fail.wat
+++ b/tests/disas/gc/br-on-cast-fail.wat
@@ -31,60 +31,60 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v44 = stack_addr.i64 ss0
-;;                                     store notrap v2, v44
-;;                                     v46 = iconst.i32 0
-;; @002e                               v4 = icmp eq v2, v46  ; v46 = 0
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     store notrap v2, v45
+;;                                     v47 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v47  ; v47 = 0
 ;; @002e                               v5 = uextend.i32 v4
 ;; @002e                               v7 = iconst.i32 1
-;;                                     v54 = select v2, v7, v46  ; v7 = 1, v46 = 0
-;; @002e                               brif v5, block5(v54), block3
+;;                                     v55 = select v2, v7, v47  ; v7 = 1, v47 = 0
+;; @002e                               brif v5, block5(v55), block3
 ;;
 ;;                                 block3:
-;;                                     v61 = iconst.i32 1
-;;                                     v62 = band.i32 v2, v61  ; v61 = 1
-;;                                     v63 = iconst.i32 0
-;;                                     v64 = select v62, v63, v61  ; v63 = 0, v61 = 1
-;; @002e                               brif v62, block5(v64), block4
+;;                                     v62 = iconst.i32 1
+;;                                     v63 = band.i32 v2, v62  ; v62 = 1
+;;                                     v64 = iconst.i32 0
+;;                                     v65 = select v63, v64, v62  ; v64 = 0, v62 = 1
+;; @002e                               brif v63, block5(v65), block4
 ;;
 ;;                                 block4:
-;; @002e                               v20 = uextend.i64 v2
-;; @002e                               v21 = iconst.i64 4
-;; @002e                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 4
-;; @002e                               v23 = iconst.i64 8
-;; @002e                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
-;; @002e                               v19 = load.i64 notrap aligned readonly v0+48
-;; @002e                               v25 = icmp ule v24, v19
-;; @002e                               trapz v25, user1
+;; @002e                               v21 = uextend.i64 v2
+;; @002e                               v22 = iconst.i64 4
+;; @002e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
+;; @002e                               v24 = iconst.i64 8
+;; @002e                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @002e                               v20 = load.i64 notrap aligned readonly v0+48
+;; @002e                               v26 = icmp ule v25, v20
+;; @002e                               trapz v26, user1
 ;; @002e                               v18 = load.i64 notrap aligned readonly v0+40
-;; @002e                               v26 = iadd v18, v22
-;; @002e                               v27 = load.i32 notrap aligned readonly v26
+;; @002e                               v27 = iadd v18, v23
+;; @002e                               v28 = load.i32 notrap aligned readonly v27
 ;; @002e                               v15 = load.i64 notrap aligned readonly v0+80
 ;; @002e                               v16 = load.i32 notrap aligned readonly v15
-;; @002e                               v28 = icmp eq v27, v16
-;; @002e                               v29 = uextend.i32 v28
-;; @002e                               brif v29, block7(v29), block6
+;; @002e                               v29 = icmp eq v28, v16
+;; @002e                               v30 = uextend.i32 v29
+;; @002e                               brif v30, block7(v30), block6
 ;;
 ;;                                 block6:
-;; @002e                               v31 = call fn0(v0, v27, v16), stack_map=[i32 @ ss0+0]
-;; @002e                               jump block7(v31)
+;; @002e                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
+;; @002e                               jump block7(v32)
 ;;
-;;                                 block7(v32: i32):
-;; @002e                               jump block5(v32)
+;;                                 block7(v33: i32):
+;; @002e                               jump block5(v33)
 ;;
-;;                                 block5(v33: i32):
-;;                                     v40 = load.i32 notrap v44
-;; @002e                               brif v33, block8, block2
+;;                                 block5(v34: i32):
+;;                                     v41 = load.i32 notrap v45
+;; @002e                               brif v34, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v35 = load.i64 notrap aligned readonly v0+88
-;; @0034                               v36 = load.i64 notrap aligned readonly v0+104
-;; @0034                               call_indirect sig1, v35(v36, v0)
+;; @0034                               v36 = load.i64 notrap aligned readonly v0+88
+;; @0034                               v37 = load.i64 notrap aligned readonly v0+104
+;; @0034                               call_indirect sig1, v36(v37, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v38 = load.i64 notrap aligned readonly v0+112
-;; @0038                               v39 = load.i64 notrap aligned readonly v0+128
-;; @0038                               call_indirect sig2, v38(v39, v0)
+;; @0038                               v39 = load.i64 notrap aligned readonly v0+112
+;; @0038                               v40 = load.i64 notrap aligned readonly v0+128
+;; @0038                               call_indirect sig2, v39(v40, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/br-on-cast.wat
+++ b/tests/disas/gc/br-on-cast.wat
@@ -31,60 +31,60 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v44 = stack_addr.i64 ss0
-;;                                     store notrap v2, v44
-;;                                     v46 = iconst.i32 0
-;; @002f                               v4 = icmp eq v2, v46  ; v46 = 0
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     store notrap v2, v45
+;;                                     v47 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v47  ; v47 = 0
 ;; @002f                               v5 = uextend.i32 v4
 ;; @002f                               v7 = iconst.i32 1
-;;                                     v54 = select v2, v7, v46  ; v7 = 1, v46 = 0
-;; @002f                               brif v5, block5(v54), block3
+;;                                     v55 = select v2, v7, v47  ; v7 = 1, v47 = 0
+;; @002f                               brif v5, block5(v55), block3
 ;;
 ;;                                 block3:
-;;                                     v61 = iconst.i32 1
-;;                                     v62 = band.i32 v2, v61  ; v61 = 1
-;;                                     v63 = iconst.i32 0
-;;                                     v64 = select v62, v63, v61  ; v63 = 0, v61 = 1
-;; @002f                               brif v62, block5(v64), block4
+;;                                     v62 = iconst.i32 1
+;;                                     v63 = band.i32 v2, v62  ; v62 = 1
+;;                                     v64 = iconst.i32 0
+;;                                     v65 = select v63, v64, v62  ; v64 = 0, v62 = 1
+;; @002f                               brif v63, block5(v65), block4
 ;;
 ;;                                 block4:
-;; @002f                               v20 = uextend.i64 v2
-;; @002f                               v21 = iconst.i64 4
-;; @002f                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 4
-;; @002f                               v23 = iconst.i64 8
-;; @002f                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
-;; @002f                               v19 = load.i64 notrap aligned readonly v0+48
-;; @002f                               v25 = icmp ule v24, v19
-;; @002f                               trapz v25, user1
+;; @002f                               v21 = uextend.i64 v2
+;; @002f                               v22 = iconst.i64 4
+;; @002f                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
+;; @002f                               v24 = iconst.i64 8
+;; @002f                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @002f                               v20 = load.i64 notrap aligned readonly v0+48
+;; @002f                               v26 = icmp ule v25, v20
+;; @002f                               trapz v26, user1
 ;; @002f                               v18 = load.i64 notrap aligned readonly v0+40
-;; @002f                               v26 = iadd v18, v22
-;; @002f                               v27 = load.i32 notrap aligned readonly v26
+;; @002f                               v27 = iadd v18, v23
+;; @002f                               v28 = load.i32 notrap aligned readonly v27
 ;; @002f                               v15 = load.i64 notrap aligned readonly v0+80
 ;; @002f                               v16 = load.i32 notrap aligned readonly v15
-;; @002f                               v28 = icmp eq v27, v16
-;; @002f                               v29 = uextend.i32 v28
-;; @002f                               brif v29, block7(v29), block6
+;; @002f                               v29 = icmp eq v28, v16
+;; @002f                               v30 = uextend.i32 v29
+;; @002f                               brif v30, block7(v30), block6
 ;;
 ;;                                 block6:
-;; @002f                               v31 = call fn0(v0, v27, v16), stack_map=[i32 @ ss0+0]
-;; @002f                               jump block7(v31)
+;; @002f                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
+;; @002f                               jump block7(v32)
 ;;
-;;                                 block7(v32: i32):
-;; @002f                               jump block5(v32)
+;;                                 block7(v33: i32):
+;; @002f                               jump block5(v33)
 ;;
-;;                                 block5(v33: i32):
-;;                                     v40 = load.i32 notrap v44
-;; @002f                               brif v33, block2, block8
+;;                                 block5(v34: i32):
+;;                                     v41 = load.i32 notrap v45
+;; @002f                               brif v34, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v35 = load.i64 notrap aligned readonly v0+88
-;; @0035                               v36 = load.i64 notrap aligned readonly v0+104
-;; @0035                               call_indirect sig1, v35(v36, v0)
+;; @0035                               v36 = load.i64 notrap aligned readonly v0+88
+;; @0035                               v37 = load.i64 notrap aligned readonly v0+104
+;; @0035                               call_indirect sig1, v36(v37, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v38 = load.i64 notrap aligned readonly v0+112
-;; @0039                               v39 = load.i64 notrap aligned readonly v0+128
-;; @0039                               call_indirect sig2, v38(v39, v0)
+;; @0039                               v39 = load.i64 notrap aligned readonly v0+112
+;; @0039                               v40 = load.i64 notrap aligned readonly v0+128
+;; @0039                               call_indirect sig2, v39(v40, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/externref-globals.wat
+++ b/tests/disas/gc/externref-globals.wat
@@ -33,7 +33,7 @@
 ;; @0034                               brif v6, block5, block2
 ;;
 ;;                                 block2:
-;; @0034                               v8 = load.i64 notrap aligned v0+56
+;; @0034                               v8 = load.i64 notrap aligned readonly v0+56
 ;; @0034                               v9 = load.i64 notrap aligned v8
 ;; @0034                               v10 = load.i64 notrap aligned v8+8
 ;; @0034                               v11 = icmp eq v9, v10

--- a/tests/disas/gc/externref-globals.wat
+++ b/tests/disas/gc/externref-globals.wat
@@ -23,13 +23,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v43 = iconst.i64 96
-;; @0034                               v4 = iadd v0, v43  ; v43 = 96
+;;                                     v45 = iconst.i64 96
+;; @0034                               v4 = iadd v0, v45  ; v45 = 96
 ;; @0034                               v5 = load.i32 notrap aligned v4
-;;                                     v44 = stack_addr.i64 ss0
-;;                                     store notrap v5, v44
-;;                                     v46 = iconst.i32 0
-;; @0034                               v6 = icmp eq v5, v46  ; v46 = 0
+;;                                     v46 = stack_addr.i64 ss0
+;;                                     store notrap v5, v46
+;;                                     v48 = iconst.i32 0
+;; @0034                               v6 = icmp eq v5, v48  ; v48 = 0
 ;; @0034                               brif v6, block5, block2
 ;;
 ;;                                 block2:
@@ -40,43 +40,43 @@
 ;; @0034                               brif v11, block3, block4
 ;;
 ;;                                 block4:
-;; @0034                               v15 = uextend.i64 v5
-;; @0034                               v16 = iconst.i64 8
-;; @0034                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 8
-;; @0034                               v19 = uadd_overflow_trap v17, v16, user1  ; v16 = 8
-;; @0034                               v14 = load.i64 notrap aligned readonly v0+48
-;; @0034                               v20 = icmp ule v19, v14
-;; @0034                               trapz v20, user1
+;; @0034                               v16 = uextend.i64 v5
+;; @0034                               v17 = iconst.i64 8
+;; @0034                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 8
+;; @0034                               v20 = uadd_overflow_trap v18, v17, user1  ; v17 = 8
+;; @0034                               v15 = load.i64 notrap aligned readonly v0+48
+;; @0034                               v21 = icmp ule v20, v15
+;; @0034                               trapz v21, user1
 ;; @0034                               v13 = load.i64 notrap aligned readonly v0+40
-;; @0034                               v21 = iadd v13, v17
-;; @0034                               v22 = load.i64 notrap aligned v21
-;;                                     v40 = load.i32 notrap v44
-;; @0034                               v27 = uextend.i64 v40
-;; @0034                               v29 = uadd_overflow_trap v27, v16, user1  ; v16 = 8
-;; @0034                               v31 = uadd_overflow_trap v29, v16, user1  ; v16 = 8
-;; @0034                               v32 = icmp ule v31, v14
-;; @0034                               trapz v32, user1
-;;                                     v48 = iconst.i64 1
-;; @0034                               v23 = iadd v22, v48  ; v48 = 1
-;; @0034                               v33 = iadd v13, v29
-;; @0034                               store notrap aligned v23, v33
-;;                                     v39 = load.i32 notrap v44
-;; @0034                               store notrap aligned v39, v9
-;;                                     v51 = iconst.i64 4
-;; @0034                               v34 = iadd.i64 v9, v51  ; v51 = 4
-;; @0034                               store notrap aligned v34, v8
+;; @0034                               v22 = iadd v13, v18
+;; @0034                               v23 = load.i64 notrap aligned v22
+;;                                     v42 = load.i32 notrap v46
+;; @0034                               v29 = uextend.i64 v42
+;; @0034                               v31 = uadd_overflow_trap v29, v17, user1  ; v17 = 8
+;; @0034                               v33 = uadd_overflow_trap v31, v17, user1  ; v17 = 8
+;; @0034                               v34 = icmp ule v33, v15
+;; @0034                               trapz v34, user1
+;;                                     v50 = iconst.i64 1
+;; @0034                               v24 = iadd v23, v50  ; v50 = 1
+;; @0034                               v35 = iadd v13, v31
+;; @0034                               store notrap aligned v24, v35
+;;                                     v41 = load.i32 notrap v46
+;; @0034                               store notrap aligned v41, v9
+;;                                     v53 = iconst.i64 4
+;; @0034                               v36 = iadd.i64 v9, v53  ; v53 = 4
+;; @0034                               store notrap aligned v36, v8
 ;; @0034                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @0034                               v36 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]
+;; @0034                               v38 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v37 = load.i32 notrap v44
+;;                                     v39 = load.i32 notrap v46
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v37
+;; @0036                               return v39
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -89,62 +89,62 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v54 = iconst.i64 96
-;; @003b                               v4 = iadd v0, v54  ; v54 = 96
+;;                                     v58 = iconst.i64 96
+;; @003b                               v4 = iadd v0, v58  ; v58 = 96
 ;; @003b                               v5 = load.i32 notrap aligned v4
-;;                                     v55 = iconst.i32 0
-;; @003b                               v6 = icmp eq v2, v55  ; v55 = 0
+;;                                     v59 = iconst.i32 0
+;; @003b                               v6 = icmp eq v2, v59  ; v59 = 0
 ;; @003b                               brif v6, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v10 = uextend.i64 v2
-;; @003b                               v34 = iconst.i64 8
-;; @003b                               v12 = uadd_overflow_trap v10, v34, user1  ; v34 = 8
-;; @003b                               v14 = uadd_overflow_trap v12, v34, user1  ; v34 = 8
-;; @003b                               v32 = load.i64 notrap aligned readonly v0+48
-;; @003b                               v15 = icmp ule v14, v32
-;; @003b                               trapz v15, user1
-;; @003b                               v31 = load.i64 notrap aligned readonly v0+40
-;; @003b                               v16 = iadd v31, v12
-;; @003b                               v17 = load.i64 notrap aligned v16
-;; @003b                               trapz v15, user1
-;;                                     v56 = iconst.i64 1
-;; @003b                               v18 = iadd v17, v56  ; v56 = 1
-;; @003b                               store notrap aligned v18, v16
+;; @003b                               v11 = uextend.i64 v2
+;; @003b                               v37 = iconst.i64 8
+;; @003b                               v13 = uadd_overflow_trap v11, v37, user1  ; v37 = 8
+;; @003b                               v15 = uadd_overflow_trap v13, v37, user1  ; v37 = 8
+;; @003b                               v35 = load.i64 notrap aligned readonly v0+48
+;; @003b                               v16 = icmp ule v15, v35
+;; @003b                               trapz v16, user1
+;; @003b                               v33 = load.i64 notrap aligned readonly v0+40
+;; @003b                               v17 = iadd v33, v13
+;; @003b                               v18 = load.i64 notrap aligned v17
+;; @003b                               trapz v16, user1
+;;                                     v60 = iconst.i64 1
+;; @003b                               v19 = iadd v18, v60  ; v60 = 1
+;; @003b                               store notrap aligned v19, v17
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v60 = iadd.i64 v0, v54  ; v54 = 96
-;; @003b                               store.i32 notrap aligned v2, v60
-;;                                     v61 = iconst.i32 0
-;;                                     v62 = icmp.i32 eq v5, v61  ; v61 = 0
-;; @003b                               brif v62, block7, block4
+;;                                     v64 = iadd.i64 v0, v58  ; v58 = 96
+;; @003b                               store.i32 notrap aligned v2, v64
+;;                                     v65 = iconst.i32 0
+;;                                     v66 = icmp.i32 eq v5, v65  ; v65 = 0
+;; @003b                               brif v66, block7, block4
 ;;
 ;;                                 block4:
-;; @003b                               v33 = uextend.i64 v5
-;;                                     v63 = iconst.i64 8
-;; @003b                               v35 = uadd_overflow_trap v33, v63, user1  ; v63 = 8
-;; @003b                               v37 = uadd_overflow_trap v35, v63, user1  ; v63 = 8
-;;                                     v64 = load.i64 notrap aligned readonly v0+48
-;; @003b                               v38 = icmp ule v37, v64
-;; @003b                               trapz v38, user1
-;;                                     v65 = load.i64 notrap aligned readonly v0+40
-;; @003b                               v39 = iadd v65, v35
-;; @003b                               v40 = load.i64 notrap aligned v39
-;;                                     v58 = iconst.i64 -1
-;; @003b                               v41 = iadd v40, v58  ; v58 = -1
-;;                                     v59 = iconst.i64 0
-;; @003b                               v42 = icmp eq v41, v59  ; v59 = 0
-;; @003b                               brif v42, block5, block6
+;; @003b                               v36 = uextend.i64 v5
+;;                                     v67 = iconst.i64 8
+;; @003b                               v38 = uadd_overflow_trap v36, v67, user1  ; v67 = 8
+;; @003b                               v40 = uadd_overflow_trap v38, v67, user1  ; v67 = 8
+;;                                     v68 = load.i64 notrap aligned readonly v0+48
+;; @003b                               v41 = icmp ule v40, v68
+;; @003b                               trapz v41, user1
+;;                                     v69 = load.i64 notrap aligned readonly v0+40
+;; @003b                               v42 = iadd v69, v38
+;; @003b                               v43 = load.i64 notrap aligned v42
+;;                                     v62 = iconst.i64 -1
+;; @003b                               v44 = iadd v43, v62  ; v62 = -1
+;;                                     v63 = iconst.i64 0
+;; @003b                               v45 = icmp eq v44, v63  ; v63 = 0
+;; @003b                               brif v45, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @003b                               call fn0(v0, v5)
 ;; @003b                               jump block7
 ;;
 ;;                                 block6:
-;; @003b                               trapz.i8 v38, user1
-;;                                     v66 = iadd.i64 v40, v58  ; v58 = -1
-;; @003b                               store notrap aligned v66, v39
+;; @003b                               trapz.i8 v41, user1
+;;                                     v70 = iadd.i64 v43, v62  ; v62 = -1
+;; @003b                               store notrap aligned v70, v42
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/funcref-in-gc-heap-get.wat
@@ -20,21 +20,21 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
-;; @0020                               v8 = uextend.i64 v2
-;; @0020                               v9 = iconst.i64 16
-;; @0020                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;;                                     v19 = iconst.i64 24
-;; @0020                               v12 = uadd_overflow_trap v8, v19, user1  ; v19 = 24
-;; @0020                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0020                               v13 = icmp ule v12, v7
-;; @0020                               trapz v13, user1
+;; @0020                               v9 = uextend.i64 v2
+;; @0020                               v10 = iconst.i64 16
+;; @0020                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;;                                     v20 = iconst.i64 24
+;; @0020                               v13 = uadd_overflow_trap v9, v20, user1  ; v20 = 24
+;; @0020                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0020                               v14 = icmp ule v13, v8
+;; @0020                               trapz v14, user1
 ;; @0020                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0020                               v14 = iadd v6, v10
-;; @0020                               v17 = load.i32 notrap aligned little v14
-;; @0020                               v15 = iconst.i32 -1
-;; @0020                               v18 = call fn0(v0, v17, v15)  ; v15 = -1
+;; @0020                               v15 = iadd v6, v11
+;; @0020                               v18 = load.i32 notrap aligned little v15
+;; @0020                               v16 = iconst.i32 -1
+;; @0020                               v19 = call fn0(v0, v18, v16)  ; v16 = -1
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v18
+;; @0024                               return v19
 ;; }

--- a/tests/disas/gc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/funcref-in-gc-heap-new.wat
@@ -27,23 +27,23 @@
 ;; @0020                               v4 = iconst.i32 24
 ;; @0020                               v8 = iconst.i32 8
 ;; @0020                               v9 = call fn0(v0, v6, v7, v4, v8)  ; v6 = -1342177280, v7 = 0, v4 = 24, v8 = 8
-;;                                     v24 = stack_addr.i64 ss0
-;;                                     store notrap v9, v24
-;; @0020                               v13 = uextend.i64 v9
-;; @0020                               v14 = iconst.i64 16
-;; @0020                               v15 = uadd_overflow_trap v13, v14, user1  ; v14 = 16
-;;                                     v27 = iconst.i64 24
-;; @0020                               v17 = uadd_overflow_trap v13, v27, user1  ; v27 = 24
-;; @0020                               v12 = load.i64 notrap aligned readonly v0+48
-;; @0020                               v18 = icmp ule v17, v12
-;; @0020                               trapz v18, user1
-;; @0020                               v21 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;;                                     v25 = stack_addr.i64 ss0
+;;                                     store notrap v9, v25
+;; @0020                               v14 = uextend.i64 v9
+;; @0020                               v15 = iconst.i64 16
+;; @0020                               v16 = uadd_overflow_trap v14, v15, user1  ; v15 = 16
+;;                                     v28 = iconst.i64 24
+;; @0020                               v18 = uadd_overflow_trap v14, v28, user1  ; v28 = 24
+;; @0020                               v13 = load.i64 notrap aligned readonly v0+48
+;; @0020                               v19 = icmp ule v18, v13
+;; @0020                               trapz v19, user1
+;; @0020                               v22 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v11 = load.i64 notrap aligned readonly v0+40
-;; @0020                               v19 = iadd v11, v15
-;; @0020                               store notrap aligned little v21, v19
-;;                                     v22 = load.i32 notrap v24
+;; @0020                               v20 = iadd v11, v16
+;; @0020                               store notrap aligned little v22, v20
+;;                                     v23 = load.i32 notrap v25
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v22
+;; @0023                               return v23
 ;; }

--- a/tests/disas/gc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/funcref-in-gc-heap-set.wat
@@ -20,18 +20,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
-;; @0022                               v8 = uextend.i64 v2
-;; @0022                               v9 = iconst.i64 16
-;; @0022                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;;                                     v17 = iconst.i64 24
-;; @0022                               v12 = uadd_overflow_trap v8, v17, user1  ; v17 = 24
-;; @0022                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0022                               v13 = icmp ule v12, v7
-;; @0022                               trapz v13, user1
-;; @0022                               v16 = call fn0(v0, v3)
+;; @0022                               v9 = uextend.i64 v2
+;; @0022                               v10 = iconst.i64 16
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;;                                     v18 = iconst.i64 24
+;; @0022                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 24
+;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v14 = icmp ule v13, v8
+;; @0022                               trapz v14, user1
+;; @0022                               v17 = call fn0(v0, v3)
 ;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0022                               v14 = iadd v6, v10
-;; @0022                               store notrap aligned little v16, v14
+;; @0022                               v15 = iadd v6, v11
+;; @0022                               store notrap aligned little v17, v15
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/multiple-array-get.wat
+++ b/tests/disas/gc/multiple-array-get.wat
@@ -19,62 +19,62 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v10 = uextend.i64 v2
-;; @0024                               v11 = iconst.i64 16
-;; @0024                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
-;; @0024                               v13 = iconst.i64 4
-;; @0024                               v14 = uadd_overflow_trap v12, v13, user1  ; v13 = 4
-;; @0024                               v9 = load.i64 notrap aligned readonly v0+48
-;; @0024                               v15 = icmp ule v14, v9
-;; @0024                               trapz v15, user1
+;; @0024                               v11 = uextend.i64 v2
+;; @0024                               v12 = iconst.i64 16
+;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 16
+;; @0024                               v14 = iconst.i64 4
+;; @0024                               v15 = uadd_overflow_trap v13, v14, user1  ; v14 = 4
+;; @0024                               v10 = load.i64 notrap aligned readonly v0+48
+;; @0024                               v16 = icmp ule v15, v10
+;; @0024                               trapz v16, user1
 ;; @0024                               v8 = load.i64 notrap aligned readonly v0+40
-;; @0024                               v16 = iadd v8, v12
-;; @0024                               v17 = load.i32 notrap aligned v16
-;; @0024                               v18 = icmp ult v3, v17
-;; @0024                               trapz v18, user17
-;; @0024                               v20 = uextend.i64 v17
-;;                                     v75 = iconst.i64 3
-;;                                     v76 = ishl v20, v75  ; v75 = 3
-;;                                     v73 = iconst.i64 32
-;; @0024                               v22 = ushr v76, v73  ; v73 = 32
-;; @0024                               trapnz v22, user1
-;;                                     v85 = iconst.i32 3
-;;                                     v86 = ishl v17, v85  ; v85 = 3
-;; @0024                               v24 = iconst.i32 24
-;; @0024                               v25 = uadd_overflow_trap v86, v24, user1  ; v24 = 24
-;;                                     v93 = ishl v3, v85  ; v85 = 3
-;; @0024                               v28 = iadd v93, v24  ; v24 = 24
-;; @0024                               v33 = uextend.i64 v28
-;; @0024                               v34 = uadd_overflow_trap v10, v33, user1
-;; @0024                               v35 = uextend.i64 v25
-;; @0024                               v36 = uadd_overflow_trap v10, v35, user1
-;; @0024                               v37 = icmp ule v36, v9
-;; @0024                               trapz v37, user1
-;; @0024                               v38 = iadd v8, v34
-;; @0024                               v39 = load.i64 notrap aligned little v38
+;; @0024                               v17 = iadd v8, v13
+;; @0024                               v18 = load.i32 notrap aligned v17
+;; @0024                               v19 = icmp ult v3, v18
+;; @0024                               trapz v19, user17
+;; @0024                               v21 = uextend.i64 v18
+;;                                     v79 = iconst.i64 3
+;;                                     v80 = ishl v21, v79  ; v79 = 3
+;;                                     v77 = iconst.i64 32
+;; @0024                               v23 = ushr v80, v77  ; v77 = 32
+;; @0024                               trapnz v23, user1
+;;                                     v89 = iconst.i32 3
+;;                                     v90 = ishl v18, v89  ; v89 = 3
+;; @0024                               v25 = iconst.i32 24
+;; @0024                               v26 = uadd_overflow_trap v90, v25, user1  ; v25 = 24
+;;                                     v97 = ishl v3, v89  ; v89 = 3
+;; @0024                               v29 = iadd v97, v25  ; v25 = 24
+;; @0024                               v35 = uextend.i64 v29
+;; @0024                               v36 = uadd_overflow_trap v11, v35, user1
+;; @0024                               v37 = uextend.i64 v26
+;; @0024                               v38 = uadd_overflow_trap v11, v37, user1
+;; @0024                               v39 = icmp ule v38, v10
+;; @0024                               trapz v39, user1
+;; @0024                               v40 = iadd v8, v36
+;; @0024                               v41 = load.i64 notrap aligned little v40
 ;; @002b                               trapz v2, user16
-;; @002b                               trapz v15, user1
-;; @002b                               v50 = load.i32 notrap aligned v16
-;; @002b                               v51 = icmp ult v4, v50
-;; @002b                               trapz v51, user17
-;; @002b                               v53 = uextend.i64 v50
-;;                                     v95 = ishl v53, v75  ; v75 = 3
-;; @002b                               v55 = ushr v95, v73  ; v73 = 32
-;; @002b                               trapnz v55, user1
-;;                                     v102 = ishl v50, v85  ; v85 = 3
-;; @002b                               v58 = uadd_overflow_trap v102, v24, user1  ; v24 = 24
-;;                                     v109 = ishl v4, v85  ; v85 = 3
-;; @002b                               v61 = iadd v109, v24  ; v24 = 24
-;; @002b                               v66 = uextend.i64 v61
-;; @002b                               v67 = uadd_overflow_trap v10, v66, user1
-;; @002b                               v68 = uextend.i64 v58
-;; @002b                               v69 = uadd_overflow_trap v10, v68, user1
-;; @002b                               v70 = icmp ule v69, v9
-;; @002b                               trapz v70, user1
-;; @002b                               v71 = iadd v8, v67
-;; @002b                               v72 = load.i64 notrap aligned little v71
+;; @002b                               trapz v16, user1
+;; @002b                               v53 = load.i32 notrap aligned v17
+;; @002b                               v54 = icmp ult v4, v53
+;; @002b                               trapz v54, user17
+;; @002b                               v56 = uextend.i64 v53
+;;                                     v99 = ishl v56, v79  ; v79 = 3
+;; @002b                               v58 = ushr v99, v77  ; v77 = 32
+;; @002b                               trapnz v58, user1
+;;                                     v106 = ishl v53, v89  ; v89 = 3
+;; @002b                               v61 = uadd_overflow_trap v106, v25, user1  ; v25 = 24
+;;                                     v113 = ishl v4, v89  ; v89 = 3
+;; @002b                               v64 = iadd v113, v25  ; v25 = 24
+;; @002b                               v70 = uextend.i64 v64
+;; @002b                               v71 = uadd_overflow_trap v11, v70, user1
+;; @002b                               v72 = uextend.i64 v61
+;; @002b                               v73 = uadd_overflow_trap v11, v72, user1
+;; @002b                               v74 = icmp ule v73, v10
+;; @002b                               trapz v74, user1
+;; @002b                               v75 = iadd v8, v71
+;; @002b                               v76 = load.i64 notrap aligned little v75
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002e                               return v39, v72
+;; @002e                               return v41, v76
 ;; }

--- a/tests/disas/gc/multiple-struct-get.wat
+++ b/tests/disas/gc/multiple-struct-get.wat
@@ -20,26 +20,26 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v9 = uextend.i64 v2
-;; @0023                               v10 = iconst.i64 16
-;; @0023                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
-;;                                     v30 = iconst.i64 24
-;; @0023                               v13 = uadd_overflow_trap v9, v30, user1  ; v30 = 24
-;; @0023                               v8 = load.i64 notrap aligned readonly v0+48
-;; @0023                               v14 = icmp ule v13, v8
-;; @0023                               trapz v14, user1
+;; @0023                               v10 = uextend.i64 v2
+;; @0023                               v11 = iconst.i64 16
+;; @0023                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
+;;                                     v32 = iconst.i64 24
+;; @0023                               v14 = uadd_overflow_trap v10, v32, user1  ; v32 = 24
+;; @0023                               v9 = load.i64 notrap aligned readonly v0+48
+;; @0023                               v15 = icmp ule v14, v9
+;; @0023                               trapz v15, user1
 ;; @0023                               v7 = load.i64 notrap aligned readonly v0+40
-;; @0023                               v15 = iadd v7, v11
-;; @0023                               v16 = load.f32 notrap aligned little v15
+;; @0023                               v16 = iadd v7, v12
+;; @0023                               v17 = load.f32 notrap aligned little v16
 ;; @0029                               trapz v2, user16
-;; @0029                               v22 = iconst.i64 20
-;; @0029                               v23 = uadd_overflow_trap v9, v22, user1  ; v22 = 20
-;; @0029                               trapz v14, user1
-;; @0029                               v27 = iadd v7, v23
-;; @0029                               v28 = load.i8 notrap aligned little v27
+;; @0029                               v24 = iconst.i64 20
+;; @0029                               v25 = uadd_overflow_trap v10, v24, user1  ; v24 = 20
+;; @0029                               trapz v15, user1
+;; @0029                               v29 = iadd v7, v25
+;; @0029                               v30 = load.i8 notrap aligned little v29
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               v29 = sextend.i32 v28
-;; @002d                               return v16, v29
+;; @0029                               v31 = sextend.i32 v30
+;; @002d                               return v17, v31
 ;; }

--- a/tests/disas/gc/ref-cast.wat
+++ b/tests/disas/gc/ref-cast.wat
@@ -19,52 +19,52 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v38 = stack_addr.i64 ss0
-;;                                     store notrap v2, v38
-;;                                     v40 = iconst.i32 0
-;; @001e                               v4 = icmp eq v2, v40  ; v40 = 0
+;;                                     v39 = stack_addr.i64 ss0
+;;                                     store notrap v2, v39
+;;                                     v41 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v41  ; v41 = 0
 ;; @001e                               v5 = uextend.i32 v4
 ;; @001e                               v7 = iconst.i32 1
-;;                                     v48 = select v2, v7, v40  ; v7 = 1, v40 = 0
-;; @001e                               brif v5, block4(v48), block2
+;;                                     v49 = select v2, v7, v41  ; v7 = 1, v41 = 0
+;; @001e                               brif v5, block4(v49), block2
 ;;
 ;;                                 block2:
-;;                                     v55 = iconst.i32 1
-;;                                     v56 = band.i32 v2, v55  ; v55 = 1
-;;                                     v57 = iconst.i32 0
-;;                                     v58 = select v56, v57, v55  ; v57 = 0, v55 = 1
-;; @001e                               brif v56, block4(v58), block3
+;;                                     v56 = iconst.i32 1
+;;                                     v57 = band.i32 v2, v56  ; v56 = 1
+;;                                     v58 = iconst.i32 0
+;;                                     v59 = select v57, v58, v56  ; v58 = 0, v56 = 1
+;; @001e                               brif v57, block4(v59), block3
 ;;
 ;;                                 block3:
-;; @001e                               v20 = uextend.i64 v2
-;; @001e                               v21 = iconst.i64 4
-;; @001e                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 4
-;; @001e                               v23 = iconst.i64 8
-;; @001e                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
-;; @001e                               v19 = load.i64 notrap aligned readonly v0+48
-;; @001e                               v25 = icmp ule v24, v19
-;; @001e                               trapz v25, user1
+;; @001e                               v21 = uextend.i64 v2
+;; @001e                               v22 = iconst.i64 4
+;; @001e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
+;; @001e                               v24 = iconst.i64 8
+;; @001e                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @001e                               v20 = load.i64 notrap aligned readonly v0+48
+;; @001e                               v26 = icmp ule v25, v20
+;; @001e                               trapz v26, user1
 ;; @001e                               v18 = load.i64 notrap aligned readonly v0+40
-;; @001e                               v26 = iadd v18, v22
-;; @001e                               v27 = load.i32 notrap aligned readonly v26
+;; @001e                               v27 = iadd v18, v23
+;; @001e                               v28 = load.i32 notrap aligned readonly v27
 ;; @001e                               v15 = load.i64 notrap aligned readonly v0+80
 ;; @001e                               v16 = load.i32 notrap aligned readonly v15
-;; @001e                               v28 = icmp eq v27, v16
-;; @001e                               v29 = uextend.i32 v28
-;; @001e                               brif v29, block6(v29), block5
+;; @001e                               v29 = icmp eq v28, v16
+;; @001e                               v30 = uextend.i32 v29
+;; @001e                               brif v30, block6(v30), block5
 ;;
 ;;                                 block5:
-;; @001e                               v31 = call fn0(v0, v27, v16), stack_map=[i32 @ ss0+0]
-;; @001e                               jump block6(v31)
+;; @001e                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
+;; @001e                               jump block6(v32)
 ;;
-;;                                 block6(v32: i32):
-;; @001e                               jump block4(v32)
+;;                                 block6(v33: i32):
+;; @001e                               jump block4(v33)
 ;;
-;;                                 block4(v33: i32):
-;; @001e                               trapz v33, user19
-;;                                     v34 = load.i32 notrap v38
+;;                                 block4(v34: i32):
+;; @001e                               trapz v34, user19
+;;                                     v35 = load.i32 notrap v39
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v34
+;; @0021                               return v35
 ;; }

--- a/tests/disas/gc/ref-test-array.wat
+++ b/tests/disas/gc/ref-test-array.wat
@@ -15,40 +15,40 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v31 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v31  ; v31 = 0
+;;                                     v32 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v32  ; v32 = 0
 ;; @001b                               v5 = uextend.i32 v4
 ;; @001b                               v7 = iconst.i32 1
-;;                                     v36 = select v2, v7, v31  ; v7 = 1, v31 = 0
-;; @001b                               brif v5, block4(v36), block2
+;;                                     v37 = select v2, v7, v32  ; v7 = 1, v32 = 0
+;; @001b                               brif v5, block4(v37), block2
 ;;
 ;;                                 block2:
-;;                                     v44 = iconst.i32 1
-;;                                     v45 = band.i32 v2, v44  ; v44 = 1
-;;                                     v46 = iconst.i32 0
-;;                                     v47 = select v45, v46, v44  ; v46 = 0, v44 = 1
-;; @001b                               brif v45, block4(v47), block3
+;;                                     v45 = iconst.i32 1
+;;                                     v46 = band.i32 v2, v45  ; v45 = 1
+;;                                     v47 = iconst.i32 0
+;;                                     v48 = select v46, v47, v45  ; v47 = 0, v45 = 1
+;; @001b                               brif v46, block4(v48), block3
 ;;
 ;;                                 block3:
-;; @001b                               v18 = uextend.i64 v2
-;; @001b                               v19 = iconst.i64 0
-;; @001b                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 0
-;;                                     v43 = iconst.i64 8
-;; @001b                               v22 = uadd_overflow_trap v18, v43, user1  ; v43 = 8
-;; @001b                               v17 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v23 = icmp ule v22, v17
-;; @001b                               trapz v23, user1
+;; @001b                               v19 = uextend.i64 v2
+;; @001b                               v20 = iconst.i64 0
+;; @001b                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 0
+;;                                     v44 = iconst.i64 8
+;; @001b                               v23 = uadd_overflow_trap v19, v44, user1  ; v44 = 8
+;; @001b                               v18 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v24 = icmp ule v23, v18
+;; @001b                               trapz v24, user1
 ;; @001b                               v16 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v24 = iadd v16, v20
-;; @001b                               v25 = load.i32 notrap aligned readonly v24
-;; @001b                               v26 = iconst.i32 -1476395008
-;; @001b                               v27 = band v25, v26  ; v26 = -1476395008
-;; @001b                               v28 = icmp eq v27, v26  ; v26 = -1476395008
-;; @001b                               v29 = uextend.i32 v28
-;; @001b                               jump block4(v29)
+;; @001b                               v25 = iadd v16, v21
+;; @001b                               v26 = load.i32 notrap aligned readonly v25
+;; @001b                               v27 = iconst.i32 -1476395008
+;; @001b                               v28 = band v26, v27  ; v27 = -1476395008
+;; @001b                               v29 = icmp eq v28, v27  ; v27 = -1476395008
+;; @001b                               v30 = uextend.i32 v29
+;; @001b                               jump block4(v30)
 ;;
-;;                                 block4(v30: i32):
-;; @001e                               jump block1(v30)
+;;                                 block4(v31: i32):
+;; @001e                               jump block1(v31)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/ref-test-concrete-type.wat
@@ -18,47 +18,47 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v34 = iconst.i32 0
-;; @001d                               v4 = icmp eq v2, v34  ; v34 = 0
+;;                                     v35 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v35  ; v35 = 0
 ;; @001d                               v5 = uextend.i32 v4
 ;; @001d                               v7 = iconst.i32 1
-;;                                     v39 = select v2, v7, v34  ; v7 = 1, v34 = 0
-;; @001d                               brif v5, block4(v39), block2
+;;                                     v40 = select v2, v7, v35  ; v7 = 1, v35 = 0
+;; @001d                               brif v5, block4(v40), block2
 ;;
 ;;                                 block2:
-;;                                     v46 = iconst.i32 1
-;;                                     v47 = band.i32 v2, v46  ; v46 = 1
-;;                                     v48 = iconst.i32 0
-;;                                     v49 = select v47, v48, v46  ; v48 = 0, v46 = 1
-;; @001d                               brif v47, block4(v49), block3
+;;                                     v47 = iconst.i32 1
+;;                                     v48 = band.i32 v2, v47  ; v47 = 1
+;;                                     v49 = iconst.i32 0
+;;                                     v50 = select v48, v49, v47  ; v49 = 0, v47 = 1
+;; @001d                               brif v48, block4(v50), block3
 ;;
 ;;                                 block3:
-;; @001d                               v20 = uextend.i64 v2
-;; @001d                               v21 = iconst.i64 4
-;; @001d                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 4
-;; @001d                               v23 = iconst.i64 8
-;; @001d                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
-;; @001d                               v19 = load.i64 notrap aligned readonly v0+48
-;; @001d                               v25 = icmp ule v24, v19
-;; @001d                               trapz v25, user1
+;; @001d                               v21 = uextend.i64 v2
+;; @001d                               v22 = iconst.i64 4
+;; @001d                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
+;; @001d                               v24 = iconst.i64 8
+;; @001d                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @001d                               v20 = load.i64 notrap aligned readonly v0+48
+;; @001d                               v26 = icmp ule v25, v20
+;; @001d                               trapz v26, user1
 ;; @001d                               v18 = load.i64 notrap aligned readonly v0+40
-;; @001d                               v26 = iadd v18, v22
-;; @001d                               v27 = load.i32 notrap aligned readonly v26
+;; @001d                               v27 = iadd v18, v23
+;; @001d                               v28 = load.i32 notrap aligned readonly v27
 ;; @001d                               v15 = load.i64 notrap aligned readonly v0+80
 ;; @001d                               v16 = load.i32 notrap aligned readonly v15
-;; @001d                               v28 = icmp eq v27, v16
-;; @001d                               v29 = uextend.i32 v28
-;; @001d                               brif v29, block6(v29), block5
+;; @001d                               v29 = icmp eq v28, v16
+;; @001d                               v30 = uextend.i32 v29
+;; @001d                               brif v30, block6(v30), block5
 ;;
 ;;                                 block5:
-;; @001d                               v31 = call fn0(v0, v27, v16)
-;; @001d                               jump block6(v31)
+;; @001d                               v32 = call fn0(v0, v28, v16)
+;; @001d                               jump block6(v32)
 ;;
-;;                                 block6(v32: i32):
-;; @001d                               jump block4(v32)
+;;                                 block6(v33: i32):
+;; @001d                               jump block4(v33)
 ;;
-;;                                 block4(v33: i32):
-;; @0020                               jump block1(v33)
+;;                                 block4(v34: i32):
+;; @0020                               jump block1(v34)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/ref-test-eq.wat
+++ b/tests/disas/gc/ref-test-eq.wat
@@ -15,38 +15,38 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v28 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v28  ; v28 = 0
+;;                                     v29 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v29  ; v29 = 0
 ;; @001b                               v5 = uextend.i32 v4
 ;; @001b                               v7 = iconst.i32 1
-;;                                     v33 = select v2, v7, v28  ; v7 = 1, v28 = 0
-;; @001b                               brif v5, block4(v33), block2
+;;                                     v34 = select v2, v7, v29  ; v7 = 1, v29 = 0
+;; @001b                               brif v5, block4(v34), block2
 ;;
 ;;                                 block2:
-;;                                     v41 = iconst.i32 1
-;;                                     v42 = band.i32 v2, v41  ; v41 = 1
-;; @001b                               brif v42, block4(v42), block3
+;;                                     v42 = iconst.i32 1
+;;                                     v43 = band.i32 v2, v42  ; v42 = 1
+;; @001b                               brif v43, block4(v43), block3
 ;;
 ;;                                 block3:
-;; @001b                               v15 = uextend.i64 v2
-;; @001b                               v16 = iconst.i64 0
-;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
-;;                                     v40 = iconst.i64 8
-;; @001b                               v19 = uadd_overflow_trap v15, v40, user1  ; v40 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v20 = icmp ule v19, v14
-;; @001b                               trapz v20, user1
+;; @001b                               v16 = uextend.i64 v2
+;; @001b                               v17 = iconst.i64 0
+;; @001b                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 0
+;;                                     v41 = iconst.i64 8
+;; @001b                               v20 = uadd_overflow_trap v16, v41, user1  ; v41 = 8
+;; @001b                               v15 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v21 = icmp ule v20, v15
+;; @001b                               trapz v21, user1
 ;; @001b                               v13 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v21 = iadd v13, v17
-;; @001b                               v22 = load.i32 notrap aligned readonly v21
-;; @001b                               v23 = iconst.i32 -1610612736
-;; @001b                               v24 = band v22, v23  ; v23 = -1610612736
-;; @001b                               v25 = icmp eq v24, v23  ; v23 = -1610612736
-;; @001b                               v26 = uextend.i32 v25
-;; @001b                               jump block4(v26)
+;; @001b                               v22 = iadd v13, v18
+;; @001b                               v23 = load.i32 notrap aligned readonly v22
+;; @001b                               v24 = iconst.i32 -1610612736
+;; @001b                               v25 = band v23, v24  ; v24 = -1610612736
+;; @001b                               v26 = icmp eq v25, v24  ; v24 = -1610612736
+;; @001b                               v27 = uextend.i32 v26
+;; @001b                               jump block4(v27)
 ;;
-;;                                 block4(v27: i32):
-;; @001e                               jump block1(v27)
+;;                                 block4(v28: i32):
+;; @001e                               jump block1(v28)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/ref-test-struct.wat
+++ b/tests/disas/gc/ref-test-struct.wat
@@ -15,40 +15,40 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v31 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v31  ; v31 = 0
+;;                                     v32 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v32  ; v32 = 0
 ;; @001b                               v5 = uextend.i32 v4
 ;; @001b                               v7 = iconst.i32 1
-;;                                     v36 = select v2, v7, v31  ; v7 = 1, v31 = 0
-;; @001b                               brif v5, block4(v36), block2
+;;                                     v37 = select v2, v7, v32  ; v7 = 1, v32 = 0
+;; @001b                               brif v5, block4(v37), block2
 ;;
 ;;                                 block2:
-;;                                     v44 = iconst.i32 1
-;;                                     v45 = band.i32 v2, v44  ; v44 = 1
-;;                                     v46 = iconst.i32 0
-;;                                     v47 = select v45, v46, v44  ; v46 = 0, v44 = 1
-;; @001b                               brif v45, block4(v47), block3
+;;                                     v45 = iconst.i32 1
+;;                                     v46 = band.i32 v2, v45  ; v45 = 1
+;;                                     v47 = iconst.i32 0
+;;                                     v48 = select v46, v47, v45  ; v47 = 0, v45 = 1
+;; @001b                               brif v46, block4(v48), block3
 ;;
 ;;                                 block3:
-;; @001b                               v18 = uextend.i64 v2
-;; @001b                               v19 = iconst.i64 0
-;; @001b                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 0
-;;                                     v43 = iconst.i64 8
-;; @001b                               v22 = uadd_overflow_trap v18, v43, user1  ; v43 = 8
-;; @001b                               v17 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v23 = icmp ule v22, v17
-;; @001b                               trapz v23, user1
+;; @001b                               v19 = uextend.i64 v2
+;; @001b                               v20 = iconst.i64 0
+;; @001b                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 0
+;;                                     v44 = iconst.i64 8
+;; @001b                               v23 = uadd_overflow_trap v19, v44, user1  ; v44 = 8
+;; @001b                               v18 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v24 = icmp ule v23, v18
+;; @001b                               trapz v24, user1
 ;; @001b                               v16 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v24 = iadd v16, v20
-;; @001b                               v25 = load.i32 notrap aligned readonly v24
-;; @001b                               v26 = iconst.i32 -1342177280
-;; @001b                               v27 = band v25, v26  ; v26 = -1342177280
-;; @001b                               v28 = icmp eq v27, v26  ; v26 = -1342177280
-;; @001b                               v29 = uextend.i32 v28
-;; @001b                               jump block4(v29)
+;; @001b                               v25 = iadd v16, v21
+;; @001b                               v26 = load.i32 notrap aligned readonly v25
+;; @001b                               v27 = iconst.i32 -1342177280
+;; @001b                               v28 = band v26, v27  ; v27 = -1342177280
+;; @001b                               v29 = icmp eq v28, v27  ; v27 = -1342177280
+;; @001b                               v30 = uextend.i32 v29
+;; @001b                               jump block4(v30)
 ;;
-;;                                 block4(v30: i32):
-;; @001e                               jump block1(v30)
+;;                                 block4(v31: i32):
+;; @001e                               jump block1(v31)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/struct-get.wat
+++ b/tests/disas/gc/struct-get.wat
@@ -32,21 +32,21 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
-;; @0033                               v8 = uextend.i64 v2
-;; @0033                               v9 = iconst.i64 16
-;; @0033                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;;                                     v16 = iconst.i64 32
-;; @0033                               v12 = uadd_overflow_trap v8, v16, user1  ; v16 = 32
-;; @0033                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0033                               v13 = icmp ule v12, v7
-;; @0033                               trapz v13, user1
+;; @0033                               v9 = uextend.i64 v2
+;; @0033                               v10 = iconst.i64 16
+;; @0033                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;;                                     v17 = iconst.i64 32
+;; @0033                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 32
+;; @0033                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0033                               v14 = icmp ule v13, v8
+;; @0033                               trapz v14, user1
 ;; @0033                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0033                               v14 = iadd v6, v10
-;; @0033                               v15 = load.f32 notrap aligned little v14
+;; @0033                               v15 = iadd v6, v11
+;; @0033                               v16 = load.f32 notrap aligned little v15
 ;; @0037                               jump block1
 ;;
 ;;                                 block1:
-;; @0037                               return v15
+;; @0037                               return v16
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -58,22 +58,22 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
-;; @003c                               v8 = uextend.i64 v2
-;; @003c                               v9 = iconst.i64 20
-;; @003c                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 20
-;;                                     v17 = iconst.i64 32
-;; @003c                               v12 = uadd_overflow_trap v8, v17, user1  ; v17 = 32
-;; @003c                               v7 = load.i64 notrap aligned readonly v0+48
-;; @003c                               v13 = icmp ule v12, v7
-;; @003c                               trapz v13, user1
+;; @003c                               v9 = uextend.i64 v2
+;; @003c                               v10 = iconst.i64 20
+;; @003c                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
+;;                                     v18 = iconst.i64 32
+;; @003c                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
+;; @003c                               v8 = load.i64 notrap aligned readonly v0+48
+;; @003c                               v14 = icmp ule v13, v8
+;; @003c                               trapz v14, user1
 ;; @003c                               v6 = load.i64 notrap aligned readonly v0+40
-;; @003c                               v14 = iadd v6, v10
-;; @003c                               v15 = load.i8 notrap aligned little v14
+;; @003c                               v15 = iadd v6, v11
+;; @003c                               v16 = load.i8 notrap aligned little v15
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:
-;; @003c                               v16 = sextend.i32 v15
-;; @0040                               return v16
+;; @003c                               v17 = sextend.i32 v16
+;; @0040                               return v17
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -85,22 +85,22 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v8 = uextend.i64 v2
-;; @0045                               v9 = iconst.i64 20
-;; @0045                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 20
-;;                                     v17 = iconst.i64 32
-;; @0045                               v12 = uadd_overflow_trap v8, v17, user1  ; v17 = 32
-;; @0045                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0045                               v13 = icmp ule v12, v7
-;; @0045                               trapz v13, user1
+;; @0045                               v9 = uextend.i64 v2
+;; @0045                               v10 = iconst.i64 20
+;; @0045                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
+;;                                     v18 = iconst.i64 32
+;; @0045                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
+;; @0045                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0045                               v14 = icmp ule v13, v8
+;; @0045                               trapz v14, user1
 ;; @0045                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0045                               v14 = iadd v6, v10
-;; @0045                               v15 = load.i8 notrap aligned little v14
+;; @0045                               v15 = iadd v6, v11
+;; @0045                               v16 = load.i8 notrap aligned little v15
 ;; @0049                               jump block1
 ;;
 ;;                                 block1:
-;; @0045                               v16 = uextend.i32 v15
-;; @0049                               return v16
+;; @0045                               v17 = uextend.i32 v16
+;; @0049                               return v17
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -115,66 +115,66 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v8 = uextend.i64 v2
-;; @004e                               v9 = iconst.i64 24
-;; @004e                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 24
-;;                                     v65 = iconst.i64 32
-;; @004e                               v12 = uadd_overflow_trap v8, v65, user1  ; v65 = 32
-;; @004e                               v7 = load.i64 notrap aligned readonly v0+48
-;; @004e                               v13 = icmp ule v12, v7
-;; @004e                               trapz v13, user1
+;; @004e                               v9 = uextend.i64 v2
+;; @004e                               v10 = iconst.i64 24
+;; @004e                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
+;;                                     v68 = iconst.i64 32
+;; @004e                               v13 = uadd_overflow_trap v9, v68, user1  ; v68 = 32
+;; @004e                               v8 = load.i64 notrap aligned readonly v0+48
+;; @004e                               v14 = icmp ule v13, v8
+;; @004e                               trapz v14, user1
 ;; @004e                               v6 = load.i64 notrap aligned readonly v0+40
-;; @004e                               v14 = iadd v6, v10
-;; @004e                               v15 = load.i32 notrap aligned little v14
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     store notrap v15, v55
-;; @004e                               v16 = iconst.i32 -2
-;; @004e                               v17 = band v15, v16  ; v16 = -2
-;;                                     v57 = iconst.i32 0
-;; @004e                               v18 = icmp eq v17, v57  ; v57 = 0
-;; @004e                               brif v18, block5, block2
+;; @004e                               v15 = iadd v6, v11
+;; @004e                               v16 = load.i32 notrap aligned little v15
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     store notrap v16, v58
+;; @004e                               v17 = iconst.i32 -2
+;; @004e                               v18 = band v16, v17  ; v17 = -2
+;;                                     v60 = iconst.i32 0
+;; @004e                               v19 = icmp eq v18, v60  ; v60 = 0
+;; @004e                               brif v19, block5, block2
 ;;
 ;;                                 block2:
-;; @004e                               v20 = load.i64 notrap aligned v0+56
-;; @004e                               v21 = load.i64 notrap aligned v20
-;; @004e                               v22 = load.i64 notrap aligned v20+8
-;; @004e                               v23 = icmp eq v21, v22
-;; @004e                               brif v23, block3, block4
+;; @004e                               v21 = load.i64 notrap aligned v0+56
+;; @004e                               v22 = load.i64 notrap aligned v21
+;; @004e                               v23 = load.i64 notrap aligned v21+8
+;; @004e                               v24 = icmp eq v22, v23
+;; @004e                               brif v24, block3, block4
 ;;
 ;;                                 block4:
-;; @004e                               v27 = uextend.i64 v15
-;; @004e                               v28 = iconst.i64 8
-;; @004e                               v29 = uadd_overflow_trap v27, v28, user1  ; v28 = 8
-;; @004e                               v31 = uadd_overflow_trap v29, v28, user1  ; v28 = 8
-;; @004e                               v32 = icmp ule v31, v7
-;; @004e                               trapz v32, user1
-;; @004e                               v33 = iadd.i64 v6, v29
-;; @004e                               v34 = load.i64 notrap aligned v33
-;;                                     v52 = load.i32 notrap v55
-;; @004e                               v39 = uextend.i64 v52
-;; @004e                               v41 = uadd_overflow_trap v39, v28, user1  ; v28 = 8
-;; @004e                               v43 = uadd_overflow_trap v41, v28, user1  ; v28 = 8
-;; @004e                               v44 = icmp ule v43, v7
-;; @004e                               trapz v44, user1
-;;                                     v59 = iconst.i64 1
-;; @004e                               v35 = iadd v34, v59  ; v59 = 1
-;; @004e                               v45 = iadd.i64 v6, v41
-;; @004e                               store notrap aligned v35, v45
-;;                                     v51 = load.i32 notrap v55
-;; @004e                               store notrap aligned v51, v21
-;;                                     v62 = iconst.i64 4
-;; @004e                               v46 = iadd.i64 v21, v62  ; v62 = 4
-;; @004e                               store notrap aligned v46, v20
+;; @004e                               v29 = uextend.i64 v16
+;; @004e                               v30 = iconst.i64 8
+;; @004e                               v31 = uadd_overflow_trap v29, v30, user1  ; v30 = 8
+;; @004e                               v33 = uadd_overflow_trap v31, v30, user1  ; v30 = 8
+;; @004e                               v34 = icmp ule v33, v8
+;; @004e                               trapz v34, user1
+;; @004e                               v35 = iadd.i64 v6, v31
+;; @004e                               v36 = load.i64 notrap aligned v35
+;;                                     v55 = load.i32 notrap v58
+;; @004e                               v42 = uextend.i64 v55
+;; @004e                               v44 = uadd_overflow_trap v42, v30, user1  ; v30 = 8
+;; @004e                               v46 = uadd_overflow_trap v44, v30, user1  ; v30 = 8
+;; @004e                               v47 = icmp ule v46, v8
+;; @004e                               trapz v47, user1
+;;                                     v62 = iconst.i64 1
+;; @004e                               v37 = iadd v36, v62  ; v62 = 1
+;; @004e                               v48 = iadd.i64 v6, v44
+;; @004e                               store notrap aligned v37, v48
+;;                                     v54 = load.i32 notrap v58
+;; @004e                               store notrap aligned v54, v22
+;;                                     v65 = iconst.i64 4
+;; @004e                               v49 = iadd.i64 v22, v65  ; v65 = 4
+;; @004e                               store notrap aligned v49, v21
 ;; @004e                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @004e                               v48 = call fn0(v0, v15), stack_map=[i32 @ ss0+0]
+;; @004e                               v51 = call fn0(v0, v16), stack_map=[i32 @ ss0+0]
 ;; @004e                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v49 = load.i32 notrap v55
+;;                                     v52 = load.i32 notrap v58
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v49
+;; @0052                               return v52
 ;; }

--- a/tests/disas/gc/struct-get.wat
+++ b/tests/disas/gc/struct-get.wat
@@ -135,7 +135,7 @@
 ;; @004e                               brif v19, block5, block2
 ;;
 ;;                                 block2:
-;; @004e                               v21 = load.i64 notrap aligned v0+56
+;; @004e                               v21 = load.i64 notrap aligned readonly v0+56
 ;; @004e                               v22 = load.i64 notrap aligned v21
 ;; @004e                               v23 = load.i64 notrap aligned v21+8
 ;; @004e                               v24 = icmp eq v22, v23

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -26,48 +26,48 @@
 ;; @0021                               v6 = iconst.i32 32
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
-;; @0021                               v15 = uextend.i64 v11
-;; @0021                               v16 = iconst.i64 16
-;; @0021                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 16
-;;                                     v69 = iconst.i64 32
-;; @0021                               v19 = uadd_overflow_trap v15, v69, user1  ; v69 = 32
-;; @0021                               v14 = load.i64 notrap aligned readonly v0+48
-;; @0021                               v20 = icmp ule v19, v14
-;; @0021                               trapz v20, user1
+;; @0021                               v16 = uextend.i64 v11
+;; @0021                               v17 = iconst.i64 16
+;; @0021                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 16
+;;                                     v74 = iconst.i64 32
+;; @0021                               v20 = uadd_overflow_trap v16, v74, user1  ; v74 = 32
+;; @0021                               v15 = load.i64 notrap aligned readonly v0+48
+;; @0021                               v21 = icmp ule v20, v15
+;; @0021                               trapz v21, user1
 ;; @0021                               v3 = f32const 0.0
 ;; @0021                               v13 = load.i64 notrap aligned readonly v0+40
-;; @0021                               v21 = iadd v13, v17
-;; @0021                               store notrap aligned little v3, v21  ; v3 = 0.0
-;; @0021                               v26 = iconst.i64 20
-;; @0021                               v27 = uadd_overflow_trap v15, v26, user1  ; v26 = 20
-;; @0021                               trapz v20, user1
-;; @0021                               v31 = iadd v13, v27
-;; @0021                               istore8 notrap aligned little v4, v31  ; v4 = 0
-;; @0021                               v36 = iconst.i64 24
-;; @0021                               v37 = uadd_overflow_trap v15, v36, user1  ; v36 = 24
-;; @0021                               trapz v20, user1
-;;                                     v76 = iconst.i8 1
-;; @0021                               brif v76, block3, block2  ; v76 = 1
+;; @0021                               v22 = iadd v13, v18
+;; @0021                               store notrap aligned little v3, v22  ; v3 = 0.0
+;; @0021                               v28 = iconst.i64 20
+;; @0021                               v29 = uadd_overflow_trap v16, v28, user1  ; v28 = 20
+;; @0021                               trapz v21, user1
+;; @0021                               v33 = iadd v13, v29
+;; @0021                               istore8 notrap aligned little v4, v33  ; v4 = 0
+;; @0021                               v39 = iconst.i64 24
+;; @0021                               v40 = uadd_overflow_trap v16, v39, user1  ; v39 = 24
+;; @0021                               trapz v21, user1
+;;                                     v81 = iconst.i8 1
+;; @0021                               brif v81, block3, block2  ; v81 = 1
 ;;
 ;;                                 block2:
-;;                                     v83 = iconst.i64 0
-;; @0021                               v49 = iconst.i64 8
-;; @0021                               v50 = uadd_overflow_trap v83, v49, user1  ; v83 = 0, v49 = 8
-;; @0021                               v52 = uadd_overflow_trap v50, v49, user1  ; v49 = 8
-;; @0021                               v53 = icmp ule v52, v14
-;; @0021                               trapz v53, user1
-;; @0021                               v54 = iadd.i64 v13, v50
-;; @0021                               v55 = load.i64 notrap aligned v54
-;; @0021                               trapz v53, user1
-;;                                     v68 = iconst.i64 1
-;; @0021                               v56 = iadd v55, v68  ; v68 = 1
-;; @0021                               store notrap aligned v56, v54
+;;                                     v88 = iconst.i64 0
+;; @0021                               v53 = iconst.i64 8
+;; @0021                               v54 = uadd_overflow_trap v88, v53, user1  ; v88 = 0, v53 = 8
+;; @0021                               v56 = uadd_overflow_trap v54, v53, user1  ; v53 = 8
+;; @0021                               v57 = icmp ule v56, v15
+;; @0021                               trapz v57, user1
+;; @0021                               v58 = iadd.i64 v13, v54
+;; @0021                               v59 = load.i64 notrap aligned v58
+;; @0021                               trapz v57, user1
+;;                                     v73 = iconst.i64 1
+;; @0021                               v60 = iadd v59, v73  ; v73 = 1
+;; @0021                               store notrap aligned v60, v58
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v84 = iconst.i32 0
-;; @0021                               v41 = iadd.i64 v13, v37
-;; @0021                               store notrap aligned little v84, v41  ; v84 = 0
+;;                                     v89 = iconst.i32 0
+;; @0021                               v44 = iadd.i64 v13, v40
+;; @0021                               store notrap aligned little v89, v44  ; v89 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -22,63 +22,63 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v71 = stack_addr.i64 ss0
-;;                                     store notrap v4, v71
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v4, v76
 ;; @002a                               v8 = iconst.i32 -1342177280
 ;; @002a                               v9 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v15 = uextend.i64 v11
-;; @002a                               v16 = iconst.i64 16
-;; @002a                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 16
-;;                                     v78 = iconst.i64 32
-;; @002a                               v19 = uadd_overflow_trap v15, v78, user1  ; v78 = 32
-;; @002a                               v14 = load.i64 notrap aligned readonly v0+48
-;; @002a                               v20 = icmp ule v19, v14
-;; @002a                               trapz v20, user1
+;; @002a                               v16 = uextend.i64 v11
+;; @002a                               v17 = iconst.i64 16
+;; @002a                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 16
+;;                                     v83 = iconst.i64 32
+;; @002a                               v20 = uadd_overflow_trap v16, v83, user1  ; v83 = 32
+;; @002a                               v15 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v21 = icmp ule v20, v15
+;; @002a                               trapz v21, user1
 ;; @002a                               v13 = load.i64 notrap aligned readonly v0+40
-;; @002a                               v21 = iadd v13, v17
-;; @002a                               store notrap aligned little v2, v21
-;; @002a                               v26 = iconst.i64 20
-;; @002a                               v27 = uadd_overflow_trap v15, v26, user1  ; v26 = 20
-;; @002a                               trapz v20, user1
-;; @002a                               v31 = iadd v13, v27
-;; @002a                               istore8 notrap aligned little v3, v31
-;; @002a                               v36 = iconst.i64 24
-;; @002a                               v37 = uadd_overflow_trap v15, v36, user1  ; v36 = 24
-;; @002a                               trapz v20, user1
-;;                                     v70 = load.i32 notrap v71
-;; @002a                               v42 = iconst.i32 -2
-;; @002a                               v43 = band v70, v42  ; v42 = -2
-;; @002a                               v44 = icmp eq v43, v9  ; v9 = 0
-;; @002a                               brif v44, block3, block2
+;; @002a                               v22 = iadd v13, v18
+;; @002a                               store notrap aligned little v2, v22
+;; @002a                               v28 = iconst.i64 20
+;; @002a                               v29 = uadd_overflow_trap v16, v28, user1  ; v28 = 20
+;; @002a                               trapz v21, user1
+;; @002a                               v33 = iadd v13, v29
+;; @002a                               istore8 notrap aligned little v3, v33
+;; @002a                               v39 = iconst.i64 24
+;; @002a                               v40 = uadd_overflow_trap v16, v39, user1  ; v39 = 24
+;; @002a                               trapz v21, user1
+;;                                     v75 = load.i32 notrap v76
+;; @002a                               v45 = iconst.i32 -2
+;; @002a                               v46 = band v75, v45  ; v45 = -2
+;; @002a                               v47 = icmp eq v46, v9  ; v9 = 0
+;; @002a                               brif v47, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v48 = uextend.i64 v70
-;; @002a                               v49 = iconst.i64 8
-;; @002a                               v50 = uadd_overflow_trap v48, v49, user1  ; v49 = 8
-;; @002a                               v52 = uadd_overflow_trap v50, v49, user1  ; v49 = 8
-;; @002a                               v53 = icmp ule v52, v14
-;; @002a                               trapz v53, user1
-;; @002a                               v54 = iadd.i64 v13, v50
-;; @002a                               v55 = load.i64 notrap aligned v54
-;;                                     v68 = load.i32 notrap v71
-;; @002a                               v60 = uextend.i64 v68
-;; @002a                               v62 = uadd_overflow_trap v60, v49, user1  ; v49 = 8
-;; @002a                               v64 = uadd_overflow_trap v62, v49, user1  ; v49 = 8
-;; @002a                               v65 = icmp ule v64, v14
-;; @002a                               trapz v65, user1
-;;                                     v75 = iconst.i64 1
-;; @002a                               v56 = iadd v55, v75  ; v75 = 1
-;; @002a                               v66 = iadd.i64 v13, v62
-;; @002a                               store notrap aligned v56, v66
+;; @002a                               v52 = uextend.i64 v75
+;; @002a                               v53 = iconst.i64 8
+;; @002a                               v54 = uadd_overflow_trap v52, v53, user1  ; v53 = 8
+;; @002a                               v56 = uadd_overflow_trap v54, v53, user1  ; v53 = 8
+;; @002a                               v57 = icmp ule v56, v15
+;; @002a                               trapz v57, user1
+;; @002a                               v58 = iadd.i64 v13, v54
+;; @002a                               v59 = load.i64 notrap aligned v58
+;;                                     v73 = load.i32 notrap v76
+;; @002a                               v65 = uextend.i64 v73
+;; @002a                               v67 = uadd_overflow_trap v65, v53, user1  ; v53 = 8
+;; @002a                               v69 = uadd_overflow_trap v67, v53, user1  ; v53 = 8
+;; @002a                               v70 = icmp ule v69, v15
+;; @002a                               trapz v70, user1
+;;                                     v80 = iconst.i64 1
+;; @002a                               v60 = iadd v59, v80  ; v80 = 1
+;; @002a                               v71 = iadd.i64 v13, v67
+;; @002a                               store notrap aligned v60, v71
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v67 = load.i32 notrap v71
-;; @002a                               v41 = iadd.i64 v13, v37
-;; @002a                               store notrap aligned little v67, v41
+;;                                     v72 = load.i32 notrap v76
+;; @002a                               v44 = iadd.i64 v13, v40
+;; @002a                               store notrap aligned little v72, v44
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-set.wat
+++ b/tests/disas/gc/struct-set.wat
@@ -28,17 +28,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
-;; @0034                               v8 = uextend.i64 v2
-;; @0034                               v9 = iconst.i64 16
-;; @0034                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
-;;                                     v15 = iconst.i64 32
-;; @0034                               v12 = uadd_overflow_trap v8, v15, user1  ; v15 = 32
-;; @0034                               v7 = load.i64 notrap aligned readonly v0+48
-;; @0034                               v13 = icmp ule v12, v7
-;; @0034                               trapz v13, user1
+;; @0034                               v9 = uextend.i64 v2
+;; @0034                               v10 = iconst.i64 16
+;; @0034                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;;                                     v16 = iconst.i64 32
+;; @0034                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
+;; @0034                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0034                               v14 = icmp ule v13, v8
+;; @0034                               trapz v14, user1
 ;; @0034                               v6 = load.i64 notrap aligned readonly v0+40
-;; @0034                               v14 = iadd v6, v10
-;; @0034                               store notrap aligned little v3, v14
+;; @0034                               v15 = iadd v6, v11
+;; @0034                               store notrap aligned little v3, v15
 ;; @0038                               jump block1
 ;;
 ;;                                 block1:
@@ -54,17 +54,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v8 = uextend.i64 v2
-;; @003f                               v9 = iconst.i64 20
-;; @003f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 20
-;;                                     v15 = iconst.i64 32
-;; @003f                               v12 = uadd_overflow_trap v8, v15, user1  ; v15 = 32
-;; @003f                               v7 = load.i64 notrap aligned readonly v0+48
-;; @003f                               v13 = icmp ule v12, v7
-;; @003f                               trapz v13, user1
+;; @003f                               v9 = uextend.i64 v2
+;; @003f                               v10 = iconst.i64 20
+;; @003f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
+;;                                     v16 = iconst.i64 32
+;; @003f                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
+;; @003f                               v8 = load.i64 notrap aligned readonly v0+48
+;; @003f                               v14 = icmp ule v13, v8
+;; @003f                               trapz v14, user1
 ;; @003f                               v6 = load.i64 notrap aligned readonly v0+40
-;; @003f                               v14 = iadd v6, v10
-;; @003f                               istore8 notrap aligned little v3, v14
+;; @003f                               v15 = iadd v6, v11
+;; @003f                               istore8 notrap aligned little v3, v15
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -82,69 +82,69 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v8 = uextend.i64 v2
-;; @004a                               v9 = iconst.i64 24
-;; @004a                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 24
-;;                                     v73 = iconst.i64 32
-;; @004a                               v12 = uadd_overflow_trap v8, v73, user1  ; v73 = 32
-;; @004a                               v7 = load.i64 notrap aligned readonly v0+48
-;; @004a                               v13 = icmp ule v12, v7
-;; @004a                               trapz v13, user1
+;; @004a                               v9 = uextend.i64 v2
+;; @004a                               v10 = iconst.i64 24
+;; @004a                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
+;;                                     v78 = iconst.i64 32
+;; @004a                               v13 = uadd_overflow_trap v9, v78, user1  ; v78 = 32
+;; @004a                               v8 = load.i64 notrap aligned readonly v0+48
+;; @004a                               v14 = icmp ule v13, v8
+;; @004a                               trapz v14, user1
 ;; @004a                               v6 = load.i64 notrap aligned readonly v0+40
-;; @004a                               v14 = iadd v6, v10
-;; @004a                               v15 = load.i32 notrap aligned little v14
-;; @004a                               v16 = iconst.i32 -2
-;; @004a                               v17 = band v3, v16  ; v16 = -2
-;;                                     v68 = iconst.i32 0
-;; @004a                               v18 = icmp eq v17, v68  ; v68 = 0
-;; @004a                               brif v18, block3, block2
+;; @004a                               v15 = iadd v6, v11
+;; @004a                               v16 = load.i32 notrap aligned little v15
+;; @004a                               v17 = iconst.i32 -2
+;; @004a                               v18 = band v3, v17  ; v17 = -2
+;;                                     v73 = iconst.i32 0
+;; @004a                               v19 = icmp eq v18, v73  ; v73 = 0
+;; @004a                               brif v19, block3, block2
 ;;
 ;;                                 block2:
-;; @004a                               v22 = uextend.i64 v3
-;; @004a                               v48 = iconst.i64 8
-;; @004a                               v24 = uadd_overflow_trap v22, v48, user1  ; v48 = 8
-;; @004a                               v26 = uadd_overflow_trap v24, v48, user1  ; v48 = 8
-;; @004a                               v27 = icmp ule v26, v7
-;; @004a                               trapz v27, user1
-;; @004a                               v28 = iadd.i64 v6, v24
-;; @004a                               v29 = load.i64 notrap aligned v28
-;; @004a                               trapz v27, user1
-;;                                     v69 = iconst.i64 1
-;; @004a                               v30 = iadd v29, v69  ; v69 = 1
-;; @004a                               store notrap aligned v30, v28
+;; @004a                               v24 = uextend.i64 v3
+;; @004a                               v52 = iconst.i64 8
+;; @004a                               v26 = uadd_overflow_trap v24, v52, user1  ; v52 = 8
+;; @004a                               v28 = uadd_overflow_trap v26, v52, user1  ; v52 = 8
+;; @004a                               v29 = icmp ule v28, v8
+;; @004a                               trapz v29, user1
+;; @004a                               v30 = iadd.i64 v6, v26
+;; @004a                               v31 = load.i64 notrap aligned v30
+;; @004a                               trapz v29, user1
+;;                                     v74 = iconst.i64 1
+;; @004a                               v32 = iadd v31, v74  ; v74 = 1
+;; @004a                               store notrap aligned v32, v30
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
-;; @004a                               store.i32 notrap aligned little v3, v14
-;;                                     v74 = iconst.i32 -2
-;;                                     v75 = band.i32 v15, v74  ; v74 = -2
-;;                                     v76 = iconst.i32 0
-;;                                     v77 = icmp eq v75, v76  ; v76 = 0
-;; @004a                               brif v77, block7, block4
+;; @004a                               store.i32 notrap aligned little v3, v15
+;;                                     v79 = iconst.i32 -2
+;;                                     v80 = band.i32 v16, v79  ; v79 = -2
+;;                                     v81 = iconst.i32 0
+;;                                     v82 = icmp eq v80, v81  ; v81 = 0
+;; @004a                               brif v82, block7, block4
 ;;
 ;;                                 block4:
-;; @004a                               v47 = uextend.i64 v15
-;;                                     v78 = iconst.i64 8
-;; @004a                               v49 = uadd_overflow_trap v47, v78, user1  ; v78 = 8
-;; @004a                               v51 = uadd_overflow_trap v49, v78, user1  ; v78 = 8
-;; @004a                               v52 = icmp ule v51, v7
-;; @004a                               trapz v52, user1
-;; @004a                               v53 = iadd.i64 v6, v49
-;; @004a                               v54 = load.i64 notrap aligned v53
-;;                                     v71 = iconst.i64 -1
-;; @004a                               v55 = iadd v54, v71  ; v71 = -1
-;;                                     v72 = iconst.i64 0
-;; @004a                               v56 = icmp eq v55, v72  ; v72 = 0
-;; @004a                               brif v56, block5, block6
+;; @004a                               v51 = uextend.i64 v16
+;;                                     v83 = iconst.i64 8
+;; @004a                               v53 = uadd_overflow_trap v51, v83, user1  ; v83 = 8
+;; @004a                               v55 = uadd_overflow_trap v53, v83, user1  ; v83 = 8
+;; @004a                               v56 = icmp ule v55, v8
+;; @004a                               trapz v56, user1
+;; @004a                               v57 = iadd.i64 v6, v53
+;; @004a                               v58 = load.i64 notrap aligned v57
+;;                                     v76 = iconst.i64 -1
+;; @004a                               v59 = iadd v58, v76  ; v76 = -1
+;;                                     v77 = iconst.i64 0
+;; @004a                               v60 = icmp eq v59, v77  ; v77 = 0
+;; @004a                               brif v60, block5, block6
 ;;
 ;;                                 block5 cold:
-;; @004a                               call fn0(v0, v15)
+;; @004a                               call fn0(v0, v16)
 ;; @004a                               jump block7
 ;;
 ;;                                 block6:
-;; @004a                               trapz.i8 v52, user1
-;;                                     v79 = iadd.i64 v54, v71  ; v71 = -1
-;; @004a                               store notrap aligned v79, v53
+;; @004a                               trapz.i8 v56, user1
+;;                                     v84 = iadd.i64 v58, v76  ; v76 = -1
+;; @004a                               store notrap aligned v84, v57
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -35,7 +35,7 @@
 ;;
 ;;                                 block2:
 ;; @008f                               v10 = global_value.i64 gv3
-;; @008f                               v11 = load.i64 notrap aligned v10+56
+;; @008f                               v11 = load.i64 notrap aligned readonly v10+56
 ;; @008f                               v12 = load.i64 notrap aligned v11
 ;; @008f                               v13 = load.i64 notrap aligned v11+8
 ;; @008f                               v14 = icmp eq v12, v13
@@ -94,7 +94,7 @@
 ;;
 ;;                                 block6:
 ;; @0091                               v46 = global_value.i64 gv3
-;; @0091                               v47 = load.i64 notrap aligned v46+56
+;; @0091                               v47 = load.i64 notrap aligned readonly v46+56
 ;; @0091                               v48 = load.i64 notrap aligned v47
 ;; @0091                               v49 = load.i64 notrap aligned v47+8
 ;; @0091                               v50 = icmp eq v48, v49

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -29,8 +29,8 @@
 ;; @008f                               v7 = iadd_imm v6, 112
 ;; @008f                               v8 = load.i32 notrap aligned v7
 ;;                                     stack_store v8, ss0
-;;                                     v89 = stack_load.i32 ss0
-;; @008f                               v9 = icmp_imm eq v89, 0
+;;                                     v93 = stack_load.i32 ss0
+;; @008f                               v9 = icmp_imm eq v93, 0
 ;; @008f                               brif v9, block5, block2
 ;;
 ;;                                 block2:
@@ -44,108 +44,112 @@
 ;;                                 block4:
 ;; @008f                               v15 = global_value.i64 gv3
 ;; @008f                               v16 = load.i64 notrap aligned readonly v15+40
-;; @008f                               v17 = load.i64 notrap aligned readonly v15+48
-;;                                     v88 = stack_load.i32 ss0
-;; @008f                               v18 = uextend.i64 v88
-;; @008f                               v19 = iconst.i64 8
-;; @008f                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
-;; @008f                               v21 = iconst.i64 8
-;; @008f                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 8
-;; @008f                               v23 = icmp ule v22, v17
-;; @008f                               trapz v23, user1
-;; @008f                               v24 = iadd v16, v20
-;; @008f                               v25 = load.i64 notrap aligned v24
-;; @008f                               v26 = iadd_imm v25, 1
-;; @008f                               v27 = global_value.i64 gv3
-;; @008f                               v28 = load.i64 notrap aligned readonly v27+40
-;; @008f                               v29 = load.i64 notrap aligned readonly v27+48
-;;                                     v87 = stack_load.i32 ss0
-;; @008f                               v30 = uextend.i64 v87
-;; @008f                               v31 = iconst.i64 8
-;; @008f                               v32 = uadd_overflow_trap v30, v31, user1  ; v31 = 8
+;; @008f                               v17 = global_value.i64 gv3
+;; @008f                               v18 = load.i64 notrap aligned readonly v17+48
+;;                                     v92 = stack_load.i32 ss0
+;; @008f                               v19 = uextend.i64 v92
+;; @008f                               v20 = iconst.i64 8
+;; @008f                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @008f                               v22 = iconst.i64 8
+;; @008f                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
+;; @008f                               v24 = icmp ule v23, v18
+;; @008f                               trapz v24, user1
+;; @008f                               v25 = iadd v16, v21
+;; @008f                               v26 = load.i64 notrap aligned v25
+;; @008f                               v27 = iadd_imm v26, 1
+;; @008f                               v28 = global_value.i64 gv3
+;; @008f                               v29 = load.i64 notrap aligned readonly v28+40
+;; @008f                               v30 = global_value.i64 gv3
+;; @008f                               v31 = load.i64 notrap aligned readonly v30+48
+;;                                     v91 = stack_load.i32 ss0
+;; @008f                               v32 = uextend.i64 v91
 ;; @008f                               v33 = iconst.i64 8
 ;; @008f                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
-;; @008f                               v35 = icmp ule v34, v29
-;; @008f                               trapz v35, user1
-;; @008f                               v36 = iadd v28, v32
-;; @008f                               store notrap aligned v26, v36
-;;                                     v86 = stack_load.i32 ss0
-;; @008f                               store notrap aligned v86, v12
-;; @008f                               v37 = iadd_imm.i64 v12, 4
-;; @008f                               store notrap aligned v37, v11
+;; @008f                               v35 = iconst.i64 8
+;; @008f                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
+;; @008f                               v37 = icmp ule v36, v31
+;; @008f                               trapz v37, user1
+;; @008f                               v38 = iadd v29, v34
+;; @008f                               store notrap aligned v27, v38
+;;                                     v90 = stack_load.i32 ss0
+;; @008f                               store notrap aligned v90, v12
+;; @008f                               v39 = iadd_imm.i64 v12, 4
+;; @008f                               store notrap aligned v39, v11
 ;; @008f                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @008f                               v38 = global_value.i64 gv3
-;;                                     v85 = stack_load.i32 ss0
-;; @008f                               v39 = call fn0(v38, v85), stack_map=[i32 @ ss0+0]
+;; @008f                               v40 = global_value.i64 gv3
+;;                                     v89 = stack_load.i32 ss0
+;; @008f                               v41 = call fn0(v40, v89), stack_map=[i32 @ ss0+0]
 ;; @008f                               jump block5
 ;;
 ;;                                 block5:
-;; @0091                               v40 = global_value.i64 gv3
-;; @0091                               v41 = iadd_imm v40, 128
-;; @0091                               v42 = load.i32 notrap aligned v41
-;;                                     stack_store v42, ss1
-;;                                     v84 = stack_load.i32 ss1
-;; @0091                               v43 = icmp_imm eq v84, 0
-;; @0091                               brif v43, block9, block6
+;; @0091                               v42 = global_value.i64 gv3
+;; @0091                               v43 = iadd_imm v42, 128
+;; @0091                               v44 = load.i32 notrap aligned v43
+;;                                     stack_store v44, ss1
+;;                                     v88 = stack_load.i32 ss1
+;; @0091                               v45 = icmp_imm eq v88, 0
+;; @0091                               brif v45, block9, block6
 ;;
 ;;                                 block6:
-;; @0091                               v44 = global_value.i64 gv3
-;; @0091                               v45 = load.i64 notrap aligned v44+56
-;; @0091                               v46 = load.i64 notrap aligned v45
-;; @0091                               v47 = load.i64 notrap aligned v45+8
-;; @0091                               v48 = icmp eq v46, v47
-;; @0091                               brif v48, block7, block8
+;; @0091                               v46 = global_value.i64 gv3
+;; @0091                               v47 = load.i64 notrap aligned v46+56
+;; @0091                               v48 = load.i64 notrap aligned v47
+;; @0091                               v49 = load.i64 notrap aligned v47+8
+;; @0091                               v50 = icmp eq v48, v49
+;; @0091                               brif v50, block7, block8
 ;;
 ;;                                 block8:
-;; @0091                               v49 = global_value.i64 gv3
-;; @0091                               v50 = load.i64 notrap aligned readonly v49+40
-;; @0091                               v51 = load.i64 notrap aligned readonly v49+48
-;;                                     v83 = stack_load.i32 ss1
-;; @0091                               v52 = uextend.i64 v83
-;; @0091                               v53 = iconst.i64 8
-;; @0091                               v54 = uadd_overflow_trap v52, v53, user1  ; v53 = 8
-;; @0091                               v55 = iconst.i64 8
-;; @0091                               v56 = uadd_overflow_trap v54, v55, user1  ; v55 = 8
-;; @0091                               v57 = icmp ule v56, v51
-;; @0091                               trapz v57, user1
-;; @0091                               v58 = iadd v50, v54
-;; @0091                               v59 = load.i64 notrap aligned v58
-;; @0091                               v60 = iadd_imm v59, 1
-;; @0091                               v61 = global_value.i64 gv3
-;; @0091                               v62 = load.i64 notrap aligned readonly v61+40
-;; @0091                               v63 = load.i64 notrap aligned readonly v61+48
-;;                                     v82 = stack_load.i32 ss1
-;; @0091                               v64 = uextend.i64 v82
-;; @0091                               v65 = iconst.i64 8
-;; @0091                               v66 = uadd_overflow_trap v64, v65, user1  ; v65 = 8
-;; @0091                               v67 = iconst.i64 8
-;; @0091                               v68 = uadd_overflow_trap v66, v67, user1  ; v67 = 8
-;; @0091                               v69 = icmp ule v68, v63
-;; @0091                               trapz v69, user1
-;; @0091                               v70 = iadd v62, v66
-;; @0091                               store notrap aligned v60, v70
-;;                                     v81 = stack_load.i32 ss1
-;; @0091                               store notrap aligned v81, v46
-;; @0091                               v71 = iadd_imm.i64 v46, 4
-;; @0091                               store notrap aligned v71, v45
+;; @0091                               v51 = global_value.i64 gv3
+;; @0091                               v52 = load.i64 notrap aligned readonly v51+40
+;; @0091                               v53 = global_value.i64 gv3
+;; @0091                               v54 = load.i64 notrap aligned readonly v53+48
+;;                                     v87 = stack_load.i32 ss1
+;; @0091                               v55 = uextend.i64 v87
+;; @0091                               v56 = iconst.i64 8
+;; @0091                               v57 = uadd_overflow_trap v55, v56, user1  ; v56 = 8
+;; @0091                               v58 = iconst.i64 8
+;; @0091                               v59 = uadd_overflow_trap v57, v58, user1  ; v58 = 8
+;; @0091                               v60 = icmp ule v59, v54
+;; @0091                               trapz v60, user1
+;; @0091                               v61 = iadd v52, v57
+;; @0091                               v62 = load.i64 notrap aligned v61
+;; @0091                               v63 = iadd_imm v62, 1
+;; @0091                               v64 = global_value.i64 gv3
+;; @0091                               v65 = load.i64 notrap aligned readonly v64+40
+;; @0091                               v66 = global_value.i64 gv3
+;; @0091                               v67 = load.i64 notrap aligned readonly v66+48
+;;                                     v86 = stack_load.i32 ss1
+;; @0091                               v68 = uextend.i64 v86
+;; @0091                               v69 = iconst.i64 8
+;; @0091                               v70 = uadd_overflow_trap v68, v69, user1  ; v69 = 8
+;; @0091                               v71 = iconst.i64 8
+;; @0091                               v72 = uadd_overflow_trap v70, v71, user1  ; v71 = 8
+;; @0091                               v73 = icmp ule v72, v67
+;; @0091                               trapz v73, user1
+;; @0091                               v74 = iadd v65, v70
+;; @0091                               store notrap aligned v63, v74
+;;                                     v85 = stack_load.i32 ss1
+;; @0091                               store notrap aligned v85, v48
+;; @0091                               v75 = iadd_imm.i64 v48, 4
+;; @0091                               store notrap aligned v75, v47
 ;; @0091                               jump block9
 ;;
 ;;                                 block7 cold:
-;; @0091                               v72 = global_value.i64 gv3
-;;                                     v80 = stack_load.i32 ss1
-;; @0091                               v73 = call fn0(v72, v80), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @0091                               v76 = global_value.i64 gv3
+;;                                     v84 = stack_load.i32 ss1
+;; @0091                               v77 = call fn0(v76, v84), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0091                               jump block9
 ;;
 ;;                                 block9:
-;; @0093                               v74 = global_value.i64 gv3
-;; @0093                               v75 = load.i64 notrap aligned table v74+144
-;; @0095                               v76 = global_value.i64 gv3
-;; @0095                               v77 = load.i64 notrap aligned table v76+160
-;;                                     v78 = stack_load.i32 ss0
-;;                                     v79 = stack_load.i32 ss1
-;; @0097                               jump block1(v78, v79, v75, v77)
+;; @0093                               v78 = global_value.i64 gv3
+;; @0093                               v79 = load.i64 notrap aligned table v78+144
+;; @0095                               v80 = global_value.i64 gv3
+;; @0095                               v81 = load.i64 notrap aligned table v80+160
+;;                                     v82 = stack_load.i32 ss0
+;;                                     v83 = stack_load.i32 ss1
+;; @0097                               jump block1(v82, v83, v79, v81)
 ;;
 ;;                                 block1(v2: i32, v3: i32, v4: i64, v5: i64):
 ;; @0097                               return v2, v3, v4, v5

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -47,7 +47,7 @@
 ;; @0054                               brif v13, block5, block2
 ;;
 ;;                                 block2:
-;; @0054                               v15 = load.i64 notrap aligned v0+56
+;; @0054                               v15 = load.i64 notrap aligned readonly v0+56
 ;; @0054                               v16 = load.i64 notrap aligned v15
 ;; @0054                               v17 = load.i64 notrap aligned v15+8
 ;; @0054                               v18 = icmp eq v16, v17
@@ -136,7 +136,7 @@
 ;; @005b                               brif v13, block5, block2
 ;;
 ;;                                 block2:
-;; @005b                               v15 = load.i64 notrap aligned v0+56
+;; @005b                               v15 = load.i64 notrap aligned readonly v0+56
 ;; @005b                               v16 = load.i64 notrap aligned v15
 ;; @005b                               v17 = load.i64 notrap aligned v15+8
 ;; @005b                               v18 = icmp eq v16, v17

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -32,18 +32,18 @@
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0054                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v51 = iconst.i64 2
-;; @0054                               v8 = ishl v6, v51  ; v51 = 2
+;;                                     v53 = iconst.i64 2
+;; @0054                               v8 = ishl v6, v53  ; v53 = 2
 ;; @0054                               v9 = iadd v7, v8
 ;; @0054                               v10 = iconst.i64 0
 ;; @0054                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0054                               v12 = load.i32 user5 aligned table v11
-;;                                     v52 = stack_addr.i64 ss0
-;;                                     store notrap v12, v52
-;;                                     v53 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v53
-;;                                     v54 = iconst.i32 0
-;; @0054                               v13 = icmp eq v49, v54  ; v54 = 0
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     store notrap v12, v54
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     v51 = load.i32 notrap v55
+;;                                     v56 = iconst.i32 0
+;; @0054                               v13 = icmp eq v51, v56  ; v56 = 0
 ;; @0054                               brif v13, block5, block2
 ;;
 ;;                                 block2:
@@ -55,54 +55,54 @@
 ;;
 ;;                                 block4:
 ;; @0054                               v20 = load.i64 notrap aligned readonly v0+40
-;; @0054                               v21 = load.i64 notrap aligned readonly v0+48
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v55
-;; @0054                               v22 = uextend.i64 v48
-;; @0054                               v23 = iconst.i64 8
-;; @0054                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
-;; @0054                               v25 = iconst.i64 8
-;; @0054                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
-;; @0054                               v27 = icmp ule v26, v21
-;; @0054                               trapz v27, user1
-;; @0054                               v28 = iadd v20, v24
-;; @0054                               v29 = load.i64 notrap aligned v28
-;;                                     v56 = iconst.i64 1
-;; @0054                               v30 = iadd v29, v56  ; v56 = 1
-;; @0054                               v32 = load.i64 notrap aligned readonly v0+40
-;; @0054                               v33 = load.i64 notrap aligned readonly v0+48
+;; @0054                               v22 = load.i64 notrap aligned readonly v0+48
 ;;                                     v57 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v57
-;; @0054                               v34 = uextend.i64 v47
-;; @0054                               v35 = iconst.i64 8
-;; @0054                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
+;;                                     v50 = load.i32 notrap v57
+;; @0054                               v23 = uextend.i64 v50
+;; @0054                               v24 = iconst.i64 8
+;; @0054                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @0054                               v26 = iconst.i64 8
+;; @0054                               v27 = uadd_overflow_trap v25, v26, user1  ; v26 = 8
+;; @0054                               v28 = icmp ule v27, v22
+;; @0054                               trapz v28, user1
+;; @0054                               v29 = iadd v20, v25
+;; @0054                               v30 = load.i64 notrap aligned v29
+;;                                     v58 = iconst.i64 1
+;; @0054                               v31 = iadd v30, v58  ; v58 = 1
+;; @0054                               v33 = load.i64 notrap aligned readonly v0+40
+;; @0054                               v35 = load.i64 notrap aligned readonly v0+48
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v59
+;; @0054                               v36 = uextend.i64 v49
 ;; @0054                               v37 = iconst.i64 8
 ;; @0054                               v38 = uadd_overflow_trap v36, v37, user1  ; v37 = 8
-;; @0054                               v39 = icmp ule v38, v33
-;; @0054                               trapz v39, user1
-;; @0054                               v40 = iadd v32, v36
-;; @0054                               store notrap aligned v30, v40
-;;                                     v58 = stack_addr.i64 ss0
-;;                                     v46 = load.i32 notrap v58
-;; @0054                               store notrap aligned v46, v16
-;;                                     v59 = iconst.i64 4
-;; @0054                               v41 = iadd.i64 v16, v59  ; v59 = 4
-;; @0054                               store notrap aligned v41, v15
+;; @0054                               v39 = iconst.i64 8
+;; @0054                               v40 = uadd_overflow_trap v38, v39, user1  ; v39 = 8
+;; @0054                               v41 = icmp ule v40, v35
+;; @0054                               trapz v41, user1
+;; @0054                               v42 = iadd v33, v38
+;; @0054                               store notrap aligned v31, v42
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v60
+;; @0054                               store notrap aligned v48, v16
+;;                                     v61 = iconst.i64 4
+;; @0054                               v43 = iadd.i64 v16, v61  ; v61 = 4
+;; @0054                               store notrap aligned v43, v15
 ;; @0054                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v45 = load.i32 notrap v60
-;; @0054                               v43 = call fn0(v0, v45), stack_map=[i32 @ ss0+0]
+;;                                     v62 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v62
+;; @0054                               v45 = call fn0(v0, v47), stack_map=[i32 @ ss0+0]
 ;; @0054                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v61 = stack_addr.i64 ss0
-;;                                     v44 = load.i32 notrap v61
+;;                                     v63 = stack_addr.i64 ss0
+;;                                     v46 = load.i32 notrap v63
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v44
+;; @0056                               return v46
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -121,18 +121,18 @@
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v51 = iconst.i64 2
-;; @005b                               v8 = ishl v6, v51  ; v51 = 2
+;;                                     v53 = iconst.i64 2
+;; @005b                               v8 = ishl v6, v53  ; v53 = 2
 ;; @005b                               v9 = iadd v7, v8
 ;; @005b                               v10 = iconst.i64 0
 ;; @005b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005b                               v12 = load.i32 user5 aligned table v11
-;;                                     v52 = stack_addr.i64 ss0
-;;                                     store notrap v12, v52
-;;                                     v53 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v53
-;;                                     v54 = iconst.i32 0
-;; @005b                               v13 = icmp eq v49, v54  ; v54 = 0
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     store notrap v12, v54
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     v51 = load.i32 notrap v55
+;;                                     v56 = iconst.i32 0
+;; @005b                               v13 = icmp eq v51, v56  ; v56 = 0
 ;; @005b                               brif v13, block5, block2
 ;;
 ;;                                 block2:
@@ -144,52 +144,52 @@
 ;;
 ;;                                 block4:
 ;; @005b                               v20 = load.i64 notrap aligned readonly v0+40
-;; @005b                               v21 = load.i64 notrap aligned readonly v0+48
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v55
-;; @005b                               v22 = uextend.i64 v48
-;; @005b                               v23 = iconst.i64 8
-;; @005b                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
-;; @005b                               v25 = iconst.i64 8
-;; @005b                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
-;; @005b                               v27 = icmp ule v26, v21
-;; @005b                               trapz v27, user1
-;; @005b                               v28 = iadd v20, v24
-;; @005b                               v29 = load.i64 notrap aligned v28
-;;                                     v56 = iconst.i64 1
-;; @005b                               v30 = iadd v29, v56  ; v56 = 1
-;; @005b                               v32 = load.i64 notrap aligned readonly v0+40
-;; @005b                               v33 = load.i64 notrap aligned readonly v0+48
+;; @005b                               v22 = load.i64 notrap aligned readonly v0+48
 ;;                                     v57 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v57
-;; @005b                               v34 = uextend.i64 v47
-;; @005b                               v35 = iconst.i64 8
-;; @005b                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
+;;                                     v50 = load.i32 notrap v57
+;; @005b                               v23 = uextend.i64 v50
+;; @005b                               v24 = iconst.i64 8
+;; @005b                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @005b                               v26 = iconst.i64 8
+;; @005b                               v27 = uadd_overflow_trap v25, v26, user1  ; v26 = 8
+;; @005b                               v28 = icmp ule v27, v22
+;; @005b                               trapz v28, user1
+;; @005b                               v29 = iadd v20, v25
+;; @005b                               v30 = load.i64 notrap aligned v29
+;;                                     v58 = iconst.i64 1
+;; @005b                               v31 = iadd v30, v58  ; v58 = 1
+;; @005b                               v33 = load.i64 notrap aligned readonly v0+40
+;; @005b                               v35 = load.i64 notrap aligned readonly v0+48
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v59
+;; @005b                               v36 = uextend.i64 v49
 ;; @005b                               v37 = iconst.i64 8
 ;; @005b                               v38 = uadd_overflow_trap v36, v37, user1  ; v37 = 8
-;; @005b                               v39 = icmp ule v38, v33
-;; @005b                               trapz v39, user1
-;; @005b                               v40 = iadd v32, v36
-;; @005b                               store notrap aligned v30, v40
-;;                                     v58 = stack_addr.i64 ss0
-;;                                     v46 = load.i32 notrap v58
-;; @005b                               store notrap aligned v46, v16
-;;                                     v59 = iconst.i64 4
-;; @005b                               v41 = iadd.i64 v16, v59  ; v59 = 4
-;; @005b                               store notrap aligned v41, v15
+;; @005b                               v39 = iconst.i64 8
+;; @005b                               v40 = uadd_overflow_trap v38, v39, user1  ; v39 = 8
+;; @005b                               v41 = icmp ule v40, v35
+;; @005b                               trapz v41, user1
+;; @005b                               v42 = iadd v33, v38
+;; @005b                               store notrap aligned v31, v42
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v60
+;; @005b                               store notrap aligned v48, v16
+;;                                     v61 = iconst.i64 4
+;; @005b                               v43 = iadd.i64 v16, v61  ; v61 = 4
+;; @005b                               store notrap aligned v43, v15
 ;; @005b                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v45 = load.i32 notrap v60
-;; @005b                               v43 = call fn0(v0, v45), stack_map=[i32 @ ss0+0]
+;;                                     v62 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v62
+;; @005b                               v45 = call fn0(v0, v47), stack_map=[i32 @ ss0+0]
 ;; @005b                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v61 = stack_addr.i64 ss0
-;;                                     v44 = load.i32 notrap v61
+;;                                     v63 = stack_addr.i64 ss0
+;;                                     v46 = load.i32 notrap v63
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:
-;; @005d                               return v44
+;; @005d                               return v46
 ;; }

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -33,18 +33,18 @@
 ;; @0053                               v6 = icmp uge v3, v5  ; v3 = 0
 ;; @0053                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0053                               v8 = load.i64 notrap aligned v0+88
-;;                                     v53 = iconst.i64 2
-;; @0053                               v9 = ishl v7, v53  ; v53 = 2
+;;                                     v55 = iconst.i64 2
+;; @0053                               v9 = ishl v7, v55  ; v55 = 2
 ;; @0053                               v10 = iadd v8, v9
 ;; @0053                               v11 = iconst.i64 0
 ;; @0053                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0053                               v13 = load.i32 user5 aligned table v12
-;;                                     v54 = stack_addr.i64 ss0
-;;                                     store notrap v13, v54
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v50 = load.i32 notrap v55
-;;                                     v56 = iconst.i32 0
-;; @0053                               v14 = icmp eq v50, v56  ; v56 = 0
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     store notrap v13, v56
+;;                                     v57 = stack_addr.i64 ss0
+;;                                     v52 = load.i32 notrap v57
+;;                                     v58 = iconst.i32 0
+;; @0053                               v14 = icmp eq v52, v58  ; v58 = 0
 ;; @0053                               brif v14, block5, block2
 ;;
 ;;                                 block2:
@@ -56,54 +56,54 @@
 ;;
 ;;                                 block4:
 ;; @0053                               v21 = load.i64 notrap aligned readonly v0+40
-;; @0053                               v22 = load.i64 notrap aligned readonly v0+48
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v57
-;; @0053                               v23 = uextend.i64 v49
-;; @0053                               v24 = iconst.i64 8
-;; @0053                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @0053                               v26 = iconst.i64 8
-;; @0053                               v27 = uadd_overflow_trap v25, v26, user1  ; v26 = 8
-;; @0053                               v28 = icmp ule v27, v22
-;; @0053                               trapz v28, user1
-;; @0053                               v29 = iadd v21, v25
-;; @0053                               v30 = load.i64 notrap aligned v29
-;;                                     v58 = iconst.i64 1
-;; @0053                               v31 = iadd v30, v58  ; v58 = 1
-;; @0053                               v33 = load.i64 notrap aligned readonly v0+40
-;; @0053                               v34 = load.i64 notrap aligned readonly v0+48
+;; @0053                               v23 = load.i64 notrap aligned readonly v0+48
 ;;                                     v59 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v59
-;; @0053                               v35 = uextend.i64 v48
-;; @0053                               v36 = iconst.i64 8
-;; @0053                               v37 = uadd_overflow_trap v35, v36, user1  ; v36 = 8
+;;                                     v51 = load.i32 notrap v59
+;; @0053                               v24 = uextend.i64 v51
+;; @0053                               v25 = iconst.i64 8
+;; @0053                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
+;; @0053                               v27 = iconst.i64 8
+;; @0053                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
+;; @0053                               v29 = icmp ule v28, v23
+;; @0053                               trapz v29, user1
+;; @0053                               v30 = iadd v21, v26
+;; @0053                               v31 = load.i64 notrap aligned v30
+;;                                     v60 = iconst.i64 1
+;; @0053                               v32 = iadd v31, v60  ; v60 = 1
+;; @0053                               v34 = load.i64 notrap aligned readonly v0+40
+;; @0053                               v36 = load.i64 notrap aligned readonly v0+48
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v50 = load.i32 notrap v61
+;; @0053                               v37 = uextend.i64 v50
 ;; @0053                               v38 = iconst.i64 8
 ;; @0053                               v39 = uadd_overflow_trap v37, v38, user1  ; v38 = 8
-;; @0053                               v40 = icmp ule v39, v34
-;; @0053                               trapz v40, user1
-;; @0053                               v41 = iadd v33, v37
-;; @0053                               store notrap aligned v31, v41
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v60
-;; @0053                               store notrap aligned v47, v17
-;;                                     v61 = iconst.i64 4
-;; @0053                               v42 = iadd.i64 v17, v61  ; v61 = 4
-;; @0053                               store notrap aligned v42, v16
+;; @0053                               v40 = iconst.i64 8
+;; @0053                               v41 = uadd_overflow_trap v39, v40, user1  ; v40 = 8
+;; @0053                               v42 = icmp ule v41, v36
+;; @0053                               trapz v42, user1
+;; @0053                               v43 = iadd v34, v39
+;; @0053                               store notrap aligned v32, v43
+;;                                     v62 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v62
+;; @0053                               store notrap aligned v49, v17
+;;                                     v63 = iconst.i64 4
+;; @0053                               v44 = iadd.i64 v17, v63  ; v63 = 4
+;; @0053                               store notrap aligned v44, v16
 ;; @0053                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v46 = load.i32 notrap v62
-;; @0053                               v44 = call fn0(v0, v46), stack_map=[i32 @ ss0+0]
+;;                                     v64 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v64
+;; @0053                               v46 = call fn0(v0, v48), stack_map=[i32 @ ss0+0]
 ;; @0053                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v63 = stack_addr.i64 ss0
-;;                                     v45 = load.i32 notrap v63
+;;                                     v65 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v65
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
-;; @0055                               return v45
+;; @0055                               return v47
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -124,18 +124,18 @@
 ;; @005a                               v6 = icmp uge v2, v5
 ;; @005a                               v7 = uextend.i64 v2
 ;; @005a                               v8 = load.i64 notrap aligned v0+88
-;;                                     v53 = iconst.i64 2
-;; @005a                               v9 = ishl v7, v53  ; v53 = 2
+;;                                     v55 = iconst.i64 2
+;; @005a                               v9 = ishl v7, v55  ; v55 = 2
 ;; @005a                               v10 = iadd v8, v9
 ;; @005a                               v11 = iconst.i64 0
 ;; @005a                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @005a                               v13 = load.i32 user5 aligned table v12
-;;                                     v54 = stack_addr.i64 ss0
-;;                                     store notrap v13, v54
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v50 = load.i32 notrap v55
-;;                                     v56 = iconst.i32 0
-;; @005a                               v14 = icmp eq v50, v56  ; v56 = 0
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     store notrap v13, v56
+;;                                     v57 = stack_addr.i64 ss0
+;;                                     v52 = load.i32 notrap v57
+;;                                     v58 = iconst.i32 0
+;; @005a                               v14 = icmp eq v52, v58  ; v58 = 0
 ;; @005a                               brif v14, block5, block2
 ;;
 ;;                                 block2:
@@ -147,52 +147,52 @@
 ;;
 ;;                                 block4:
 ;; @005a                               v21 = load.i64 notrap aligned readonly v0+40
-;; @005a                               v22 = load.i64 notrap aligned readonly v0+48
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v57
-;; @005a                               v23 = uextend.i64 v49
-;; @005a                               v24 = iconst.i64 8
-;; @005a                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @005a                               v26 = iconst.i64 8
-;; @005a                               v27 = uadd_overflow_trap v25, v26, user1  ; v26 = 8
-;; @005a                               v28 = icmp ule v27, v22
-;; @005a                               trapz v28, user1
-;; @005a                               v29 = iadd v21, v25
-;; @005a                               v30 = load.i64 notrap aligned v29
-;;                                     v58 = iconst.i64 1
-;; @005a                               v31 = iadd v30, v58  ; v58 = 1
-;; @005a                               v33 = load.i64 notrap aligned readonly v0+40
-;; @005a                               v34 = load.i64 notrap aligned readonly v0+48
+;; @005a                               v23 = load.i64 notrap aligned readonly v0+48
 ;;                                     v59 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v59
-;; @005a                               v35 = uextend.i64 v48
-;; @005a                               v36 = iconst.i64 8
-;; @005a                               v37 = uadd_overflow_trap v35, v36, user1  ; v36 = 8
+;;                                     v51 = load.i32 notrap v59
+;; @005a                               v24 = uextend.i64 v51
+;; @005a                               v25 = iconst.i64 8
+;; @005a                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
+;; @005a                               v27 = iconst.i64 8
+;; @005a                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
+;; @005a                               v29 = icmp ule v28, v23
+;; @005a                               trapz v29, user1
+;; @005a                               v30 = iadd v21, v26
+;; @005a                               v31 = load.i64 notrap aligned v30
+;;                                     v60 = iconst.i64 1
+;; @005a                               v32 = iadd v31, v60  ; v60 = 1
+;; @005a                               v34 = load.i64 notrap aligned readonly v0+40
+;; @005a                               v36 = load.i64 notrap aligned readonly v0+48
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v50 = load.i32 notrap v61
+;; @005a                               v37 = uextend.i64 v50
 ;; @005a                               v38 = iconst.i64 8
 ;; @005a                               v39 = uadd_overflow_trap v37, v38, user1  ; v38 = 8
-;; @005a                               v40 = icmp ule v39, v34
-;; @005a                               trapz v40, user1
-;; @005a                               v41 = iadd v33, v37
-;; @005a                               store notrap aligned v31, v41
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v60
-;; @005a                               store notrap aligned v47, v17
-;;                                     v61 = iconst.i64 4
-;; @005a                               v42 = iadd.i64 v17, v61  ; v61 = 4
-;; @005a                               store notrap aligned v42, v16
+;; @005a                               v40 = iconst.i64 8
+;; @005a                               v41 = uadd_overflow_trap v39, v40, user1  ; v40 = 8
+;; @005a                               v42 = icmp ule v41, v36
+;; @005a                               trapz v42, user1
+;; @005a                               v43 = iadd v34, v39
+;; @005a                               store notrap aligned v32, v43
+;;                                     v62 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v62
+;; @005a                               store notrap aligned v49, v17
+;;                                     v63 = iconst.i64 4
+;; @005a                               v44 = iadd.i64 v17, v63  ; v63 = 4
+;; @005a                               store notrap aligned v44, v16
 ;; @005a                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v46 = load.i32 notrap v62
-;; @005a                               v44 = call fn0(v0, v46), stack_map=[i32 @ ss0+0]
+;;                                     v64 = stack_addr.i64 ss0
+;;                                     v48 = load.i32 notrap v64
+;; @005a                               v46 = call fn0(v0, v48), stack_map=[i32 @ ss0+0]
 ;; @005a                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v63 = stack_addr.i64 ss0
-;;                                     v45 = load.i32 notrap v63
+;;                                     v65 = stack_addr.i64 ss0
+;;                                     v47 = load.i32 notrap v65
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:
-;; @005c                               return v45
+;; @005c                               return v47
 ;; }

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -48,7 +48,7 @@
 ;; @0053                               brif v14, block5, block2
 ;;
 ;;                                 block2:
-;; @0053                               v16 = load.i64 notrap aligned v0+56
+;; @0053                               v16 = load.i64 notrap aligned readonly v0+56
 ;; @0053                               v17 = load.i64 notrap aligned v16
 ;; @0053                               v18 = load.i64 notrap aligned v16+8
 ;; @0053                               v19 = icmp eq v17, v18
@@ -139,7 +139,7 @@
 ;; @005a                               brif v14, block5, block2
 ;;
 ;;                                 block2:
-;; @005a                               v16 = load.i64 notrap aligned v0+56
+;; @005a                               v16 = load.i64 notrap aligned readonly v0+56
 ;; @005a                               v17 = load.i64 notrap aligned v16
 ;; @005a                               v18 = load.i64 notrap aligned v16+8
 ;; @005a                               v19 = icmp eq v17, v18

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -32,83 +32,83 @@
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0056                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v62 = iconst.i64 2
-;; @0056                               v8 = ishl v6, v62  ; v62 = 2
+;;                                     v66 = iconst.i64 2
+;; @0056                               v8 = ishl v6, v66  ; v66 = 2
 ;; @0056                               v9 = iadd v7, v8
 ;; @0056                               v10 = iconst.i64 0
 ;; @0056                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0056                               v12 = load.i32 user5 aligned table v11
-;;                                     v63 = iconst.i32 0
-;; @0056                               v13 = icmp eq v2, v63  ; v63 = 0
+;;                                     v67 = iconst.i32 0
+;; @0056                               v13 = icmp eq v2, v67  ; v67 = 0
 ;; @0056                               brif v13, block3, block2
 ;;
 ;;                                 block2:
 ;; @0056                               v15 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v16 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v17 = uextend.i64 v2
-;; @0056                               v18 = iconst.i64 8
-;; @0056                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 8
-;; @0056                               v20 = iconst.i64 8
-;; @0056                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
-;; @0056                               v22 = icmp ule v21, v16
-;; @0056                               trapz v22, user1
-;; @0056                               v23 = iadd v15, v19
-;; @0056                               v24 = load.i64 notrap aligned v23
-;;                                     v64 = iconst.i64 1
-;; @0056                               v25 = iadd v24, v64  ; v64 = 1
-;; @0056                               v27 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v28 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v29 = uextend.i64 v2
-;; @0056                               v30 = iconst.i64 8
-;; @0056                               v31 = uadd_overflow_trap v29, v30, user1  ; v30 = 8
+;; @0056                               v17 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v18 = uextend.i64 v2
+;; @0056                               v19 = iconst.i64 8
+;; @0056                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
+;; @0056                               v21 = iconst.i64 8
+;; @0056                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 8
+;; @0056                               v23 = icmp ule v22, v17
+;; @0056                               trapz v23, user1
+;; @0056                               v24 = iadd v15, v20
+;; @0056                               v25 = load.i64 notrap aligned v24
+;;                                     v68 = iconst.i64 1
+;; @0056                               v26 = iadd v25, v68  ; v68 = 1
+;; @0056                               v28 = load.i64 notrap aligned readonly v0+40
+;; @0056                               v30 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v31 = uextend.i64 v2
 ;; @0056                               v32 = iconst.i64 8
 ;; @0056                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
-;; @0056                               v34 = icmp ule v33, v28
-;; @0056                               trapz v34, user1
-;; @0056                               v35 = iadd v27, v31
-;; @0056                               store notrap aligned v25, v35
+;; @0056                               v34 = iconst.i64 8
+;; @0056                               v35 = uadd_overflow_trap v33, v34, user1  ; v34 = 8
+;; @0056                               v36 = icmp ule v35, v30
+;; @0056                               trapz v36, user1
+;; @0056                               v37 = iadd v28, v33
+;; @0056                               store notrap aligned v26, v37
 ;; @0056                               jump block3
 ;;
 ;;                                 block3:
 ;; @0056                               store.i32 user5 aligned table v2, v11
-;;                                     v65 = iconst.i32 0
-;; @0056                               v36 = icmp.i32 eq v12, v65  ; v65 = 0
-;; @0056                               brif v36, block7, block4
+;;                                     v69 = iconst.i32 0
+;; @0056                               v38 = icmp.i32 eq v12, v69  ; v69 = 0
+;; @0056                               brif v38, block7, block4
 ;;
 ;;                                 block4:
-;; @0056                               v38 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v39 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v40 = uextend.i64 v12
-;; @0056                               v41 = iconst.i64 8
-;; @0056                               v42 = uadd_overflow_trap v40, v41, user1  ; v41 = 8
-;; @0056                               v43 = iconst.i64 8
-;; @0056                               v44 = uadd_overflow_trap v42, v43, user1  ; v43 = 8
-;; @0056                               v45 = icmp ule v44, v39
-;; @0056                               trapz v45, user1
-;; @0056                               v46 = iadd v38, v42
-;; @0056                               v47 = load.i64 notrap aligned v46
-;;                                     v66 = iconst.i64 -1
-;; @0056                               v48 = iadd v47, v66  ; v66 = -1
-;;                                     v67 = iconst.i64 0
-;; @0056                               v49 = icmp eq v48, v67  ; v67 = 0
-;; @0056                               brif v49, block5, block6
+;; @0056                               v40 = load.i64 notrap aligned readonly v0+40
+;; @0056                               v42 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v43 = uextend.i64 v12
+;; @0056                               v44 = iconst.i64 8
+;; @0056                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
+;; @0056                               v46 = iconst.i64 8
+;; @0056                               v47 = uadd_overflow_trap v45, v46, user1  ; v46 = 8
+;; @0056                               v48 = icmp ule v47, v42
+;; @0056                               trapz v48, user1
+;; @0056                               v49 = iadd v40, v45
+;; @0056                               v50 = load.i64 notrap aligned v49
+;;                                     v70 = iconst.i64 -1
+;; @0056                               v51 = iadd v50, v70  ; v70 = -1
+;;                                     v71 = iconst.i64 0
+;; @0056                               v52 = icmp eq v51, v71  ; v71 = 0
+;; @0056                               brif v52, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @0056                               call fn0(v0, v12)
 ;; @0056                               jump block7
 ;;
 ;;                                 block6:
-;; @0056                               v52 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v53 = load.i64 notrap aligned readonly v0+48
-;; @0056                               v54 = uextend.i64 v12
-;; @0056                               v55 = iconst.i64 8
-;; @0056                               v56 = uadd_overflow_trap v54, v55, user1  ; v55 = 8
-;; @0056                               v57 = iconst.i64 8
-;; @0056                               v58 = uadd_overflow_trap v56, v57, user1  ; v57 = 8
-;; @0056                               v59 = icmp ule v58, v53
-;; @0056                               trapz v59, user1
-;; @0056                               v60 = iadd v52, v56
-;; @0056                               store.i64 notrap aligned v48, v60
+;; @0056                               v55 = load.i64 notrap aligned readonly v0+40
+;; @0056                               v57 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v58 = uextend.i64 v12
+;; @0056                               v59 = iconst.i64 8
+;; @0056                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8
+;; @0056                               v61 = iconst.i64 8
+;; @0056                               v62 = uadd_overflow_trap v60, v61, user1  ; v61 = 8
+;; @0056                               v63 = icmp ule v62, v57
+;; @0056                               trapz v63, user1
+;; @0056                               v64 = iadd v55, v60
+;; @0056                               store.i64 notrap aligned v51, v64
 ;; @0056                               jump block7
 ;;
 ;;                                 block7:
@@ -133,83 +133,83 @@
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2
 ;; @005f                               v7 = load.i64 notrap aligned readonly v0+88
-;;                                     v62 = iconst.i64 2
-;; @005f                               v8 = ishl v6, v62  ; v62 = 2
+;;                                     v66 = iconst.i64 2
+;; @005f                               v8 = ishl v6, v66  ; v66 = 2
 ;; @005f                               v9 = iadd v7, v8
 ;; @005f                               v10 = iconst.i64 0
 ;; @005f                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005f                               v12 = load.i32 user5 aligned table v11
-;;                                     v63 = iconst.i32 0
-;; @005f                               v13 = icmp eq v3, v63  ; v63 = 0
+;;                                     v67 = iconst.i32 0
+;; @005f                               v13 = icmp eq v3, v67  ; v67 = 0
 ;; @005f                               brif v13, block3, block2
 ;;
 ;;                                 block2:
 ;; @005f                               v15 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v16 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v17 = uextend.i64 v3
-;; @005f                               v18 = iconst.i64 8
-;; @005f                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 8
-;; @005f                               v20 = iconst.i64 8
-;; @005f                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
-;; @005f                               v22 = icmp ule v21, v16
-;; @005f                               trapz v22, user1
-;; @005f                               v23 = iadd v15, v19
-;; @005f                               v24 = load.i64 notrap aligned v23
-;;                                     v64 = iconst.i64 1
-;; @005f                               v25 = iadd v24, v64  ; v64 = 1
-;; @005f                               v27 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v28 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v29 = uextend.i64 v3
-;; @005f                               v30 = iconst.i64 8
-;; @005f                               v31 = uadd_overflow_trap v29, v30, user1  ; v30 = 8
+;; @005f                               v17 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v18 = uextend.i64 v3
+;; @005f                               v19 = iconst.i64 8
+;; @005f                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
+;; @005f                               v21 = iconst.i64 8
+;; @005f                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 8
+;; @005f                               v23 = icmp ule v22, v17
+;; @005f                               trapz v23, user1
+;; @005f                               v24 = iadd v15, v20
+;; @005f                               v25 = load.i64 notrap aligned v24
+;;                                     v68 = iconst.i64 1
+;; @005f                               v26 = iadd v25, v68  ; v68 = 1
+;; @005f                               v28 = load.i64 notrap aligned readonly v0+40
+;; @005f                               v30 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v31 = uextend.i64 v3
 ;; @005f                               v32 = iconst.i64 8
 ;; @005f                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
-;; @005f                               v34 = icmp ule v33, v28
-;; @005f                               trapz v34, user1
-;; @005f                               v35 = iadd v27, v31
-;; @005f                               store notrap aligned v25, v35
+;; @005f                               v34 = iconst.i64 8
+;; @005f                               v35 = uadd_overflow_trap v33, v34, user1  ; v34 = 8
+;; @005f                               v36 = icmp ule v35, v30
+;; @005f                               trapz v36, user1
+;; @005f                               v37 = iadd v28, v33
+;; @005f                               store notrap aligned v26, v37
 ;; @005f                               jump block3
 ;;
 ;;                                 block3:
 ;; @005f                               store.i32 user5 aligned table v3, v11
-;;                                     v65 = iconst.i32 0
-;; @005f                               v36 = icmp.i32 eq v12, v65  ; v65 = 0
-;; @005f                               brif v36, block7, block4
+;;                                     v69 = iconst.i32 0
+;; @005f                               v38 = icmp.i32 eq v12, v69  ; v69 = 0
+;; @005f                               brif v38, block7, block4
 ;;
 ;;                                 block4:
-;; @005f                               v38 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v39 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v40 = uextend.i64 v12
-;; @005f                               v41 = iconst.i64 8
-;; @005f                               v42 = uadd_overflow_trap v40, v41, user1  ; v41 = 8
-;; @005f                               v43 = iconst.i64 8
-;; @005f                               v44 = uadd_overflow_trap v42, v43, user1  ; v43 = 8
-;; @005f                               v45 = icmp ule v44, v39
-;; @005f                               trapz v45, user1
-;; @005f                               v46 = iadd v38, v42
-;; @005f                               v47 = load.i64 notrap aligned v46
-;;                                     v66 = iconst.i64 -1
-;; @005f                               v48 = iadd v47, v66  ; v66 = -1
-;;                                     v67 = iconst.i64 0
-;; @005f                               v49 = icmp eq v48, v67  ; v67 = 0
-;; @005f                               brif v49, block5, block6
+;; @005f                               v40 = load.i64 notrap aligned readonly v0+40
+;; @005f                               v42 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v43 = uextend.i64 v12
+;; @005f                               v44 = iconst.i64 8
+;; @005f                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
+;; @005f                               v46 = iconst.i64 8
+;; @005f                               v47 = uadd_overflow_trap v45, v46, user1  ; v46 = 8
+;; @005f                               v48 = icmp ule v47, v42
+;; @005f                               trapz v48, user1
+;; @005f                               v49 = iadd v40, v45
+;; @005f                               v50 = load.i64 notrap aligned v49
+;;                                     v70 = iconst.i64 -1
+;; @005f                               v51 = iadd v50, v70  ; v70 = -1
+;;                                     v71 = iconst.i64 0
+;; @005f                               v52 = icmp eq v51, v71  ; v71 = 0
+;; @005f                               brif v52, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @005f                               call fn0(v0, v12)
 ;; @005f                               jump block7
 ;;
 ;;                                 block6:
-;; @005f                               v52 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v53 = load.i64 notrap aligned readonly v0+48
-;; @005f                               v54 = uextend.i64 v12
-;; @005f                               v55 = iconst.i64 8
-;; @005f                               v56 = uadd_overflow_trap v54, v55, user1  ; v55 = 8
-;; @005f                               v57 = iconst.i64 8
-;; @005f                               v58 = uadd_overflow_trap v56, v57, user1  ; v57 = 8
-;; @005f                               v59 = icmp ule v58, v53
-;; @005f                               trapz v59, user1
-;; @005f                               v60 = iadd v52, v56
-;; @005f                               store.i64 notrap aligned v48, v60
+;; @005f                               v55 = load.i64 notrap aligned readonly v0+40
+;; @005f                               v57 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v58 = uextend.i64 v12
+;; @005f                               v59 = iconst.i64 8
+;; @005f                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8
+;; @005f                               v61 = iconst.i64 8
+;; @005f                               v62 = uadd_overflow_trap v60, v61, user1  ; v61 = 8
+;; @005f                               v63 = icmp ule v62, v57
+;; @005f                               trapz v63, user1
+;; @005f                               v64 = iadd v55, v60
+;; @005f                               store.i64 notrap aligned v51, v64
 ;; @005f                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -34,83 +34,83 @@
 ;; @0055                               v6 = icmp uge v3, v5  ; v3 = 0
 ;; @0055                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0055                               v8 = load.i64 notrap aligned v0+88
-;;                                     v64 = iconst.i64 2
-;; @0055                               v9 = ishl v7, v64  ; v64 = 2
+;;                                     v68 = iconst.i64 2
+;; @0055                               v9 = ishl v7, v68  ; v68 = 2
 ;; @0055                               v10 = iadd v8, v9
 ;; @0055                               v11 = iconst.i64 0
 ;; @0055                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0055                               v13 = load.i32 user5 aligned table v12
-;;                                     v65 = iconst.i32 0
-;; @0055                               v14 = icmp eq v2, v65  ; v65 = 0
+;;                                     v69 = iconst.i32 0
+;; @0055                               v14 = icmp eq v2, v69  ; v69 = 0
 ;; @0055                               brif v14, block3, block2
 ;;
 ;;                                 block2:
 ;; @0055                               v16 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v17 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v18 = uextend.i64 v2
-;; @0055                               v19 = iconst.i64 8
-;; @0055                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
-;; @0055                               v21 = iconst.i64 8
-;; @0055                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 8
-;; @0055                               v23 = icmp ule v22, v17
-;; @0055                               trapz v23, user1
-;; @0055                               v24 = iadd v16, v20
-;; @0055                               v25 = load.i64 notrap aligned v24
-;;                                     v66 = iconst.i64 1
-;; @0055                               v26 = iadd v25, v66  ; v66 = 1
-;; @0055                               v28 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v29 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v30 = uextend.i64 v2
-;; @0055                               v31 = iconst.i64 8
-;; @0055                               v32 = uadd_overflow_trap v30, v31, user1  ; v31 = 8
+;; @0055                               v18 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v19 = uextend.i64 v2
+;; @0055                               v20 = iconst.i64 8
+;; @0055                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @0055                               v22 = iconst.i64 8
+;; @0055                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
+;; @0055                               v24 = icmp ule v23, v18
+;; @0055                               trapz v24, user1
+;; @0055                               v25 = iadd v16, v21
+;; @0055                               v26 = load.i64 notrap aligned v25
+;;                                     v70 = iconst.i64 1
+;; @0055                               v27 = iadd v26, v70  ; v70 = 1
+;; @0055                               v29 = load.i64 notrap aligned readonly v0+40
+;; @0055                               v31 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v32 = uextend.i64 v2
 ;; @0055                               v33 = iconst.i64 8
 ;; @0055                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
-;; @0055                               v35 = icmp ule v34, v29
-;; @0055                               trapz v35, user1
-;; @0055                               v36 = iadd v28, v32
-;; @0055                               store notrap aligned v26, v36
+;; @0055                               v35 = iconst.i64 8
+;; @0055                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
+;; @0055                               v37 = icmp ule v36, v31
+;; @0055                               trapz v37, user1
+;; @0055                               v38 = iadd v29, v34
+;; @0055                               store notrap aligned v27, v38
 ;; @0055                               jump block3
 ;;
 ;;                                 block3:
 ;; @0055                               store.i32 user5 aligned table v2, v12
-;;                                     v67 = iconst.i32 0
-;; @0055                               v37 = icmp.i32 eq v13, v67  ; v67 = 0
-;; @0055                               brif v37, block7, block4
+;;                                     v71 = iconst.i32 0
+;; @0055                               v39 = icmp.i32 eq v13, v71  ; v71 = 0
+;; @0055                               brif v39, block7, block4
 ;;
 ;;                                 block4:
-;; @0055                               v39 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v40 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v41 = uextend.i64 v13
-;; @0055                               v42 = iconst.i64 8
-;; @0055                               v43 = uadd_overflow_trap v41, v42, user1  ; v42 = 8
-;; @0055                               v44 = iconst.i64 8
-;; @0055                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
-;; @0055                               v46 = icmp ule v45, v40
-;; @0055                               trapz v46, user1
-;; @0055                               v47 = iadd v39, v43
-;; @0055                               v48 = load.i64 notrap aligned v47
-;;                                     v68 = iconst.i64 -1
-;; @0055                               v49 = iadd v48, v68  ; v68 = -1
-;;                                     v69 = iconst.i64 0
-;; @0055                               v50 = icmp eq v49, v69  ; v69 = 0
-;; @0055                               brif v50, block5, block6
+;; @0055                               v41 = load.i64 notrap aligned readonly v0+40
+;; @0055                               v43 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v44 = uextend.i64 v13
+;; @0055                               v45 = iconst.i64 8
+;; @0055                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
+;; @0055                               v47 = iconst.i64 8
+;; @0055                               v48 = uadd_overflow_trap v46, v47, user1  ; v47 = 8
+;; @0055                               v49 = icmp ule v48, v43
+;; @0055                               trapz v49, user1
+;; @0055                               v50 = iadd v41, v46
+;; @0055                               v51 = load.i64 notrap aligned v50
+;;                                     v72 = iconst.i64 -1
+;; @0055                               v52 = iadd v51, v72  ; v72 = -1
+;;                                     v73 = iconst.i64 0
+;; @0055                               v53 = icmp eq v52, v73  ; v73 = 0
+;; @0055                               brif v53, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @0055                               call fn0(v0, v13)
 ;; @0055                               jump block7
 ;;
 ;;                                 block6:
-;; @0055                               v53 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v54 = load.i64 notrap aligned readonly v0+48
-;; @0055                               v55 = uextend.i64 v13
-;; @0055                               v56 = iconst.i64 8
-;; @0055                               v57 = uadd_overflow_trap v55, v56, user1  ; v56 = 8
-;; @0055                               v58 = iconst.i64 8
-;; @0055                               v59 = uadd_overflow_trap v57, v58, user1  ; v58 = 8
-;; @0055                               v60 = icmp ule v59, v54
-;; @0055                               trapz v60, user1
-;; @0055                               v61 = iadd v53, v57
-;; @0055                               store.i64 notrap aligned v49, v61
+;; @0055                               v56 = load.i64 notrap aligned readonly v0+40
+;; @0055                               v58 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v59 = uextend.i64 v13
+;; @0055                               v60 = iconst.i64 8
+;; @0055                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8
+;; @0055                               v62 = iconst.i64 8
+;; @0055                               v63 = uadd_overflow_trap v61, v62, user1  ; v62 = 8
+;; @0055                               v64 = icmp ule v63, v58
+;; @0055                               trapz v64, user1
+;; @0055                               v65 = iadd v56, v61
+;; @0055                               store.i64 notrap aligned v52, v65
 ;; @0055                               jump block7
 ;;
 ;;                                 block7:
@@ -137,83 +137,83 @@
 ;; @005e                               v6 = icmp uge v2, v5
 ;; @005e                               v7 = uextend.i64 v2
 ;; @005e                               v8 = load.i64 notrap aligned v0+88
-;;                                     v64 = iconst.i64 2
-;; @005e                               v9 = ishl v7, v64  ; v64 = 2
+;;                                     v68 = iconst.i64 2
+;; @005e                               v9 = ishl v7, v68  ; v68 = 2
 ;; @005e                               v10 = iadd v8, v9
 ;; @005e                               v11 = iconst.i64 0
 ;; @005e                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @005e                               v13 = load.i32 user5 aligned table v12
-;;                                     v65 = iconst.i32 0
-;; @005e                               v14 = icmp eq v3, v65  ; v65 = 0
+;;                                     v69 = iconst.i32 0
+;; @005e                               v14 = icmp eq v3, v69  ; v69 = 0
 ;; @005e                               brif v14, block3, block2
 ;;
 ;;                                 block2:
 ;; @005e                               v16 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v17 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v18 = uextend.i64 v3
-;; @005e                               v19 = iconst.i64 8
-;; @005e                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
-;; @005e                               v21 = iconst.i64 8
-;; @005e                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 8
-;; @005e                               v23 = icmp ule v22, v17
-;; @005e                               trapz v23, user1
-;; @005e                               v24 = iadd v16, v20
-;; @005e                               v25 = load.i64 notrap aligned v24
-;;                                     v66 = iconst.i64 1
-;; @005e                               v26 = iadd v25, v66  ; v66 = 1
-;; @005e                               v28 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v29 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v30 = uextend.i64 v3
-;; @005e                               v31 = iconst.i64 8
-;; @005e                               v32 = uadd_overflow_trap v30, v31, user1  ; v31 = 8
+;; @005e                               v18 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v19 = uextend.i64 v3
+;; @005e                               v20 = iconst.i64 8
+;; @005e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @005e                               v22 = iconst.i64 8
+;; @005e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
+;; @005e                               v24 = icmp ule v23, v18
+;; @005e                               trapz v24, user1
+;; @005e                               v25 = iadd v16, v21
+;; @005e                               v26 = load.i64 notrap aligned v25
+;;                                     v70 = iconst.i64 1
+;; @005e                               v27 = iadd v26, v70  ; v70 = 1
+;; @005e                               v29 = load.i64 notrap aligned readonly v0+40
+;; @005e                               v31 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v32 = uextend.i64 v3
 ;; @005e                               v33 = iconst.i64 8
 ;; @005e                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
-;; @005e                               v35 = icmp ule v34, v29
-;; @005e                               trapz v35, user1
-;; @005e                               v36 = iadd v28, v32
-;; @005e                               store notrap aligned v26, v36
+;; @005e                               v35 = iconst.i64 8
+;; @005e                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
+;; @005e                               v37 = icmp ule v36, v31
+;; @005e                               trapz v37, user1
+;; @005e                               v38 = iadd v29, v34
+;; @005e                               store notrap aligned v27, v38
 ;; @005e                               jump block3
 ;;
 ;;                                 block3:
 ;; @005e                               store.i32 user5 aligned table v3, v12
-;;                                     v67 = iconst.i32 0
-;; @005e                               v37 = icmp.i32 eq v13, v67  ; v67 = 0
-;; @005e                               brif v37, block7, block4
+;;                                     v71 = iconst.i32 0
+;; @005e                               v39 = icmp.i32 eq v13, v71  ; v71 = 0
+;; @005e                               brif v39, block7, block4
 ;;
 ;;                                 block4:
-;; @005e                               v39 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v40 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v41 = uextend.i64 v13
-;; @005e                               v42 = iconst.i64 8
-;; @005e                               v43 = uadd_overflow_trap v41, v42, user1  ; v42 = 8
-;; @005e                               v44 = iconst.i64 8
-;; @005e                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
-;; @005e                               v46 = icmp ule v45, v40
-;; @005e                               trapz v46, user1
-;; @005e                               v47 = iadd v39, v43
-;; @005e                               v48 = load.i64 notrap aligned v47
-;;                                     v68 = iconst.i64 -1
-;; @005e                               v49 = iadd v48, v68  ; v68 = -1
-;;                                     v69 = iconst.i64 0
-;; @005e                               v50 = icmp eq v49, v69  ; v69 = 0
-;; @005e                               brif v50, block5, block6
+;; @005e                               v41 = load.i64 notrap aligned readonly v0+40
+;; @005e                               v43 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v44 = uextend.i64 v13
+;; @005e                               v45 = iconst.i64 8
+;; @005e                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
+;; @005e                               v47 = iconst.i64 8
+;; @005e                               v48 = uadd_overflow_trap v46, v47, user1  ; v47 = 8
+;; @005e                               v49 = icmp ule v48, v43
+;; @005e                               trapz v49, user1
+;; @005e                               v50 = iadd v41, v46
+;; @005e                               v51 = load.i64 notrap aligned v50
+;;                                     v72 = iconst.i64 -1
+;; @005e                               v52 = iadd v51, v72  ; v72 = -1
+;;                                     v73 = iconst.i64 0
+;; @005e                               v53 = icmp eq v52, v73  ; v73 = 0
+;; @005e                               brif v53, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @005e                               call fn0(v0, v13)
 ;; @005e                               jump block7
 ;;
 ;;                                 block6:
-;; @005e                               v53 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v54 = load.i64 notrap aligned readonly v0+48
-;; @005e                               v55 = uextend.i64 v13
-;; @005e                               v56 = iconst.i64 8
-;; @005e                               v57 = uadd_overflow_trap v55, v56, user1  ; v56 = 8
-;; @005e                               v58 = iconst.i64 8
-;; @005e                               v59 = uadd_overflow_trap v57, v58, user1  ; v58 = 8
-;; @005e                               v60 = icmp ule v59, v54
-;; @005e                               trapz v60, user1
-;; @005e                               v61 = iadd v53, v57
-;; @005e                               store.i64 notrap aligned v49, v61
+;; @005e                               v56 = load.i64 notrap aligned readonly v0+40
+;; @005e                               v58 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v59 = uextend.i64 v13
+;; @005e                               v60 = iconst.i64 8
+;; @005e                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8
+;; @005e                               v62 = iconst.i64 8
+;; @005e                               v63 = uadd_overflow_trap v61, v62, user1  ; v62 = 8
+;; @005e                               v64 = icmp ule v63, v58
+;; @005e                               trapz v64, user1
+;; @005e                               v65 = iadd v56, v61
+;; @005e                               store.i64 notrap aligned v52, v65
 ;; @005e                               jump block7
 ;;
 ;;                                 block7:


### PR DESCRIPTION
1. Don't bounds-check GC refs that are returned from trusted libcalls
2. Mark loading the DRC collector's activations table pointer from the `vmctx` as `readonly`

Also a minor refactor to emitting code to get the GC heap base and bound that resulted in a mechanical value renumbering in the GC disas tests. See each commit in isolation for better diffs.