### PR TITLE
Add permissions to `wasi_config_preopen_dir` C API

### DIFF
--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -171,12 +171,27 @@ WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t *config);
  * filesystem, but only that directory (its whole contents but nothing above
  * it).
  *
- * The `path` argument here is a path name on the host filesystem, and
+ * The `host_path` argument here is a path name on the host filesystem, and
  * `guest_path` is the name by which it will be known in wasm.
+ *
+ * The `dir_perms` argument is the permissions that wasm will have to operate on
+ * `guest_path`. This can be used, for example, to provide readonly access to a
+ * directory. This argument is a bitmask with the following flag values:
+ * - 0b01: This directory can be read, for example its entries can be iterated
+           over and files can be opened.
+ * - 0b10: This directory can be mutated, for example by creating new files within it.
+ *
+ * The `file_perms` argument is similar to `dir_perms` but corresponds to the maximum
+ * set of permissions that can be used for any file in this directory.
+ * This argument is a bitmask with the following flag values:
+ * - 0b01: This file can be read.
+ * - 0b10: This file can be written to.
  */
 WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t *config,
-                                             const char *path,
-                                             const char *guest_path);
+                                             const char *host_path,
+                                             const char *guest_path,
+                                             size_t dir_perms,
+                                             size_t file_perms);
 
 #undef own
 

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -172,6 +172,8 @@ pub unsafe extern "C" fn wasi_config_preopen_dir(
     config: &mut wasi_config_t,
     path: *const c_char,
     guest_path: *const c_char,
+    dir_perms: usize,
+    file_perms: usize,
 ) -> bool {
     let guest_path = match cstr_to_str(guest_path) {
         Some(p) => p,
@@ -183,13 +185,16 @@ pub unsafe extern "C" fn wasi_config_preopen_dir(
         None => return false,
     };
 
+    let dir_perms = wasmtime_wasi::DirPerms::from_bits_truncate(dir_perms);
+    let file_perms = wasmtime_wasi::FilePerms::from_bits_truncate(file_perms);
+
     config
         .builder
         .preopened_dir(
             host_path,
             guest_path,
-            wasmtime_wasi::DirPerms::all(),
-            wasmtime_wasi::FilePerms::all(),
+            dir_perms,
+            file_perms,
         )
         .is_ok()
 }

--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -282,13 +282,13 @@ impl WasiCtxBuilder {
     /// Configures a "preopened directory" to be available to WebAssembly.
     ///
     /// By default WebAssembly does not have access to the filesystem because
-    /// the are no preopened directories. All filesystem operations, such as
+    /// there are no preopened directories. All filesystem operations, such as
     /// opening a file, are done through a preexisting handle. This means that
     /// to provide WebAssembly access to a directory it must be configured
     /// through this API.
     ///
     /// WASI will also prevent access outside of files provided here. For
-    /// example `..` can't be used to traverse up from the `dir` provided here
+    /// example `..` can't be used to traverse up from the `host_path` provided here
     /// to the containing directory.
     ///
     /// * `host_path` - a path to a directory on the host to open and make
@@ -298,9 +298,9 @@ impl WasiCtxBuilder {
     ///   perspective. Note that this does not need to match the host's name for
     ///   the directory.
     /// * `dir_perms` - this is the permissions that wasm will have to operate on
-    ///   `dir`. This can be used, for example, to provide readonly access to a
+    ///   `guest_path`. This can be used, for example, to provide readonly access to a
     ///   directory.
-    /// * `file_perms` - similar to `perms` but corresponds to the maximum set
+    /// * `file_perms` - similar to `dir_perms` but corresponds to the maximum set
     ///   of permissions that can be used for any file in this directory.
     ///
     /// # Errors


### PR DESCRIPTION
The current `wasi_config_preopen_dir` function does not expose the `dir_perms` and `file_perms` parameters that were added to `preopened_dir`. This commit adds them and updates the docs for those functions to reflect the current signature.

This is a prerequisite for https://github.com/bytecodealliance/wasmtime-py/issues/251

This change isn't backwards compatible, so please let me know if there's anything I need to do differently. 