### PR TITLE
Switch libunwind detection to using weak symbols

### DIFF
--- a/crates/wasmtime/src/runtime/vm/helpers.c
+++ b/crates/wasmtime/src/runtime/vm/helpers.c
@@ -6,6 +6,7 @@
 #include <setjmp.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #if (defined(__GNUC__) && !defined(__clang__))
 #define WASMTIME_GCC 1
@@ -116,3 +117,15 @@ __attribute__((weak))
 struct JITDescriptor *VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)() {
   return &__jit_debug_descriptor;
 }
+
+// For more information about this see `unix/unwind.rs` and the
+// `using_libunwind` function. The basic idea is that weak symbols aren't stable
+// in Rust so we use a bit of C to work around that.
+#ifndef CFG_TARGET_OS_windows
+__attribute__((weak))
+extern void __unw_add_dynamic_fde();
+
+bool VERSIONED_SYMBOL(wasmtime_using_libunwind)() {
+  return __unw_add_dynamic_fde != NULL;
+}
+#endif

--- a/crates/wasmtime/src/runtime/vm/helpers.c
+++ b/crates/wasmtime/src/runtime/vm/helpers.c
@@ -4,9 +4,9 @@
 #undef _FORTIFY_SOURCE
 
 #include <setjmp.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdbool.h>
 
 #if (defined(__GNUC__) && !defined(__clang__))
 #define WASMTIME_GCC 1
@@ -122,8 +122,7 @@ struct JITDescriptor *VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)() {
 // `using_libunwind` function. The basic idea is that weak symbols aren't stable
 // in Rust so we use a bit of C to work around that.
 #ifndef CFG_TARGET_OS_windows
-__attribute__((weak))
-extern void __unw_add_dynamic_fde();
+__attribute__((weak)) extern void __unw_add_dynamic_fde();
 
 bool VERSIONED_SYMBOL(wasmtime_using_libunwind)() {
   return __unw_add_dynamic_fde != NULL;

--- a/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
@@ -2,8 +2,7 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::SendSyncPtr;
-use core::ptr::{self, NonNull};
-use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use core::ptr::NonNull;
 
 /// Represents a registration of function unwind information for System V ABI.
 pub struct UnwindRegistration {


### PR DESCRIPTION
This is an attempt to resolve #8897.

Closes https://github.com/bytecodealliance/wasmtime/issues/8897.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
