### PR TITLE
winch: Remove some `#[allow(dead_code)]` directives

### DIFF
--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -41,8 +41,6 @@ pub(crate) fn isa_builder(triple: Triple) -> Builder {
 }
 
 /// Aarch64 ISA.
-// Until Aarch64 emission is supported.
-#[allow(dead_code)]
 pub(crate) struct Aarch64 {
     /// The target triple.
     triple: Triple,

--- a/winch/codegen/src/isa/reg.rs
+++ b/winch/codegen/src/isa/reg.rs
@@ -40,7 +40,6 @@ impl Reg {
     }
 
     /// Create a new floating point register from encoding.
-    #[allow(dead_code)]
     pub fn float(enc: usize) -> Self {
         Self::new(PReg::new(enc, RegClass::Float))
     }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -459,15 +459,11 @@ impl RegImm {
     }
 
     /// F32 immediate, stored using its bits representation.
-    // Temporary until support for f32.const is added.
-    #[allow(dead_code)]
     pub fn f32(bits: u32) -> Self {
         RegImm::Imm(Imm::f32(bits))
     }
 
     /// F64 immediate, stored using its bits representation.
-    // Temporary until support for f64.const is added.
-    #[allow(dead_code)]
     pub fn f64(bits: u64) -> Self {
         RegImm::Imm(Imm::f64(bits))
     }


### PR DESCRIPTION
This commit simply removes some `#[allow(dead_code)]` which are no longer needed as well as the the notion of callee-saved registers.

The notion of callee-saved registers was primarily used in the early days when Winch generated its own trampolines, however, trampolines are now emitted through Cranelift.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
