### PR TITLE
Fix a Cranelift panic on aarch64 vector constants

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -3527,7 +3527,7 @@
         (c_lo Reg (value_regs_get c 0))
         (c_hi Reg (value_regs_get c 1))
         (c_test Reg (orr $I64 c_lo c_hi)))
-      (side_effect 
+      (side_effect
        (SideEffectNoResult.Inst
         (MInst.TrapIf (zero_cond_to_cond_br zero_cond c_test) trap_code)))))
 
@@ -4036,8 +4036,14 @@
         (fpu_extend (vec_dup_imm imm $false (VectorSize.Size64x2)) (ScalarSize.Size64)))
 
 (rule 1 (splat_const n size)
+        (if-let $true (vec_dup_fp_imm_supports_lane_size (vector_lane_size size)))
         (if-let imm (asimd_fp_mod_imm_from_u64 n (vector_lane_size size)))
         (vec_dup_fp_imm imm size))
+
+(decl pure vec_dup_fp_imm_supports_lane_size (ScalarSize) bool)
+(rule 1 (vec_dup_fp_imm_supports_lane_size (ScalarSize.Size32)) $true)
+(rule 1 (vec_dup_fp_imm_supports_lane_size (ScalarSize.Size64)) $true)
+(rule (vec_dup_fp_imm_supports_lane_size _) $false)
 
 ;; The base case for splat is to use `vec_dup` with the immediate loaded into a
 ;; register.

--- a/tests/misc_testsuite/simd/interesting-float-splat.wast
+++ b/tests/misc_testsuite/simd/interesting-float-splat.wast
@@ -1,0 +1,7 @@
+(module
+  (func (export "") (result v128)
+    v128.const i32x4 0x3f803f80 0x3f803f80 0x3f803f80 0x3f803f80
+  )
+)
+
+(assert_return (invoke "") (v128.const i32x4 0x3f803f80 0x3f803f80 0x3f803f80 0x3f803f80))


### PR DESCRIPTION
This commit adds a guard to `splat_const` lowering on AArch64 to ensure that unsupported sizes don't make their way to the backend to avoid a panic. The included test here currently panics on `main` when passed to `wasmtime compile` and succeeds afterwards.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
