### PR TITLE
Don't bounds-check the struct-ref result of the trusted allocation libcall

### DIFF
--- a/tests/disas/gc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/funcref-in-gc-heap-new.wat
@@ -27,23 +27,18 @@
 ;; @0020                               v4 = iconst.i32 24
 ;; @0020                               v8 = iconst.i32 8
 ;; @0020                               v9 = call fn0(v0, v6, v7, v4, v8)  ; v6 = -1342177280, v7 = 0, v4 = 24, v8 = 8
-;;                                     v25 = stack_addr.i64 ss0
-;;                                     store notrap v9, v25
-;; @0020                               v14 = uextend.i64 v9
-;; @0020                               v15 = iconst.i64 16
-;; @0020                               v16 = uadd_overflow_trap v14, v15, user1  ; v15 = 16
-;;                                     v28 = iconst.i64 24
-;; @0020                               v18 = uadd_overflow_trap v14, v28, user1  ; v28 = 24
-;; @0020                               v13 = load.i64 notrap aligned readonly v0+48
-;; @0020                               v19 = icmp ule v18, v13
-;; @0020                               trapz v19, user1
-;; @0020                               v22 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;;                                     v19 = stack_addr.i64 ss0
+;;                                     store notrap v9, v19
+;; @0020                               v16 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v11 = load.i64 notrap aligned readonly v0+40
-;; @0020                               v20 = iadd v11, v16
-;; @0020                               store notrap aligned little v22, v20
-;;                                     v23 = load.i32 notrap v25
+;; @0020                               v12 = uextend.i64 v9
+;; @0020                               v13 = iadd v11, v12
+;;                                     v21 = iconst.i64 16
+;; @0020                               v14 = iadd v13, v21  ; v21 = 16
+;; @0020                               store notrap aligned little v16, v14
+;;                                     v17 = load.i32 notrap v19
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v23
+;; @0023                               return v17
 ;; }

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -26,48 +26,40 @@
 ;; @0021                               v6 = iconst.i32 32
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
-;; @0021                               v16 = uextend.i64 v11
-;; @0021                               v17 = iconst.i64 16
-;; @0021                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 16
-;;                                     v74 = iconst.i64 32
-;; @0021                               v20 = uadd_overflow_trap v16, v74, user1  ; v74 = 32
-;; @0021                               v15 = load.i64 notrap aligned readonly v0+48
-;; @0021                               v21 = icmp ule v20, v15
-;; @0021                               trapz v21, user1
 ;; @0021                               v3 = f32const 0.0
 ;; @0021                               v13 = load.i64 notrap aligned readonly v0+40
-;; @0021                               v22 = iadd v13, v18
-;; @0021                               store notrap aligned little v3, v22  ; v3 = 0.0
-;; @0021                               v28 = iconst.i64 20
-;; @0021                               v29 = uadd_overflow_trap v16, v28, user1  ; v28 = 20
-;; @0021                               trapz v21, user1
-;; @0021                               v33 = iadd v13, v29
-;; @0021                               istore8 notrap aligned little v4, v33  ; v4 = 0
-;; @0021                               v39 = iconst.i64 24
-;; @0021                               v40 = uadd_overflow_trap v16, v39, user1  ; v39 = 24
-;; @0021                               trapz v21, user1
-;;                                     v81 = iconst.i8 1
-;; @0021                               brif v81, block3, block2  ; v81 = 1
+;; @0021                               v14 = uextend.i64 v11
+;; @0021                               v15 = iadd v13, v14
+;;                                     v46 = iconst.i64 16
+;; @0021                               v16 = iadd v15, v46  ; v46 = 16
+;; @0021                               store notrap aligned little v3, v16  ; v3 = 0.0
+;;                                     v47 = iconst.i64 20
+;; @0021                               v17 = iadd v15, v47  ; v47 = 20
+;; @0021                               istore8 notrap aligned little v4, v17  ; v4 = 0
+;;                                     v57 = iconst.i8 1
+;; @0021                               brif v57, block3, block2  ; v57 = 1
 ;;
 ;;                                 block2:
-;;                                     v88 = iconst.i64 0
-;; @0021                               v53 = iconst.i64 8
-;; @0021                               v54 = uadd_overflow_trap v88, v53, user1  ; v88 = 0, v53 = 8
-;; @0021                               v56 = uadd_overflow_trap v54, v53, user1  ; v53 = 8
-;; @0021                               v57 = icmp ule v56, v15
-;; @0021                               trapz v57, user1
-;; @0021                               v58 = iadd.i64 v13, v54
-;; @0021                               v59 = load.i64 notrap aligned v58
-;; @0021                               trapz v57, user1
-;;                                     v73 = iconst.i64 1
-;; @0021                               v60 = iadd v59, v73  ; v73 = 1
-;; @0021                               store notrap aligned v60, v58
+;;                                     v64 = iconst.i64 0
+;; @0021                               v27 = iconst.i64 8
+;; @0021                               v28 = uadd_overflow_trap v64, v27, user1  ; v64 = 0, v27 = 8
+;; @0021                               v30 = uadd_overflow_trap v28, v27, user1  ; v27 = 8
+;; @0021                               v25 = load.i64 notrap aligned readonly v0+48
+;; @0021                               v31 = icmp ule v30, v25
+;; @0021                               trapz v31, user1
+;; @0021                               v32 = iadd.i64 v13, v28
+;; @0021                               v33 = load.i64 notrap aligned v32
+;; @0021                               trapz v31, user1
+;;                                     v50 = iconst.i64 1
+;; @0021                               v34 = iadd v33, v50  ; v50 = 1
+;; @0021                               store notrap aligned v34, v32
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v89 = iconst.i32 0
-;; @0021                               v44 = iadd.i64 v13, v40
-;; @0021                               store notrap aligned little v89, v44  ; v89 = 0
+;;                                     v65 = iconst.i32 0
+;;                                     v48 = iconst.i64 24
+;; @0021                               v18 = iadd.i64 v15, v48  ; v48 = 24
+;; @0021                               store notrap aligned little v65, v18  ; v65 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -22,63 +22,55 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v76 = stack_addr.i64 ss0
-;;                                     store notrap v4, v76
+;;                                     v50 = stack_addr.i64 ss0
+;;                                     store notrap v4, v50
 ;; @002a                               v8 = iconst.i32 -1342177280
 ;; @002a                               v9 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v16 = uextend.i64 v11
-;; @002a                               v17 = iconst.i64 16
-;; @002a                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 16
-;;                                     v83 = iconst.i64 32
-;; @002a                               v20 = uadd_overflow_trap v16, v83, user1  ; v83 = 32
-;; @002a                               v15 = load.i64 notrap aligned readonly v0+48
-;; @002a                               v21 = icmp ule v20, v15
-;; @002a                               trapz v21, user1
 ;; @002a                               v13 = load.i64 notrap aligned readonly v0+40
-;; @002a                               v22 = iadd v13, v18
-;; @002a                               store notrap aligned little v2, v22
-;; @002a                               v28 = iconst.i64 20
-;; @002a                               v29 = uadd_overflow_trap v16, v28, user1  ; v28 = 20
-;; @002a                               trapz v21, user1
-;; @002a                               v33 = iadd v13, v29
-;; @002a                               istore8 notrap aligned little v3, v33
-;; @002a                               v39 = iconst.i64 24
-;; @002a                               v40 = uadd_overflow_trap v16, v39, user1  ; v39 = 24
-;; @002a                               trapz v21, user1
-;;                                     v75 = load.i32 notrap v76
-;; @002a                               v45 = iconst.i32 -2
-;; @002a                               v46 = band v75, v45  ; v45 = -2
-;; @002a                               v47 = icmp eq v46, v9  ; v9 = 0
-;; @002a                               brif v47, block3, block2
+;; @002a                               v14 = uextend.i64 v11
+;; @002a                               v15 = iadd v13, v14
+;;                                     v51 = iconst.i64 16
+;; @002a                               v16 = iadd v15, v51  ; v51 = 16
+;; @002a                               store notrap aligned little v2, v16
+;;                                     v52 = iconst.i64 20
+;; @002a                               v17 = iadd v15, v52  ; v52 = 20
+;; @002a                               istore8 notrap aligned little v3, v17
+;;                                     v49 = load.i32 notrap v50
+;; @002a                               v19 = iconst.i32 -2
+;; @002a                               v20 = band v49, v19  ; v19 = -2
+;; @002a                               v21 = icmp eq v20, v9  ; v9 = 0
+;; @002a                               brif v21, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v52 = uextend.i64 v75
-;; @002a                               v53 = iconst.i64 8
-;; @002a                               v54 = uadd_overflow_trap v52, v53, user1  ; v53 = 8
-;; @002a                               v56 = uadd_overflow_trap v54, v53, user1  ; v53 = 8
-;; @002a                               v57 = icmp ule v56, v15
-;; @002a                               trapz v57, user1
-;; @002a                               v58 = iadd.i64 v13, v54
-;; @002a                               v59 = load.i64 notrap aligned v58
-;;                                     v73 = load.i32 notrap v76
-;; @002a                               v65 = uextend.i64 v73
-;; @002a                               v67 = uadd_overflow_trap v65, v53, user1  ; v53 = 8
-;; @002a                               v69 = uadd_overflow_trap v67, v53, user1  ; v53 = 8
-;; @002a                               v70 = icmp ule v69, v15
-;; @002a                               trapz v70, user1
-;;                                     v80 = iconst.i64 1
-;; @002a                               v60 = iadd v59, v80  ; v80 = 1
-;; @002a                               v71 = iadd.i64 v13, v67
-;; @002a                               store notrap aligned v60, v71
+;; @002a                               v26 = uextend.i64 v49
+;; @002a                               v27 = iconst.i64 8
+;; @002a                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
+;; @002a                               v30 = uadd_overflow_trap v28, v27, user1  ; v27 = 8
+;; @002a                               v25 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v31 = icmp ule v30, v25
+;; @002a                               trapz v31, user1
+;; @002a                               v32 = iadd.i64 v13, v28
+;; @002a                               v33 = load.i64 notrap aligned v32
+;;                                     v47 = load.i32 notrap v50
+;; @002a                               v39 = uextend.i64 v47
+;; @002a                               v41 = uadd_overflow_trap v39, v27, user1  ; v27 = 8
+;; @002a                               v43 = uadd_overflow_trap v41, v27, user1  ; v27 = 8
+;; @002a                               v44 = icmp ule v43, v25
+;; @002a                               trapz v44, user1
+;;                                     v57 = iconst.i64 1
+;; @002a                               v34 = iadd v33, v57  ; v57 = 1
+;; @002a                               v45 = iadd.i64 v13, v41
+;; @002a                               store notrap aligned v34, v45
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v72 = load.i32 notrap v76
-;; @002a                               v44 = iadd.i64 v13, v40
-;; @002a                               store notrap aligned little v72, v44
+;;                                     v46 = load.i32 notrap v50
+;;                                     v53 = iconst.i64 24
+;; @002a                               v18 = iadd.i64 v15, v53  ; v53 = 24
+;; @002a                               store notrap aligned little v46, v18
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:


### PR DESCRIPTION
It is unnecessary for Wasm code to do this bounds check because the libcall is trusted. We already avoided it for arrays, but forgot to do structs as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
