### PR TITLE
Wasmtime toplevel module: re-export wasmparser.

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -278,3 +278,19 @@ call-hook = []
 # Enables support for "memory protection keys" which can be used in conjunction
 # with the pooling allocator on x64 to compact linear memory allocations.
 memory-protection-keys = ["pooling-allocator"]
+
+# Enables a re-export of wasmparser, so that an embedder of Wasmtime can use
+# exactly the version of the parser library that Wasmtime does. Sometimes this
+# is necessary, e.g. to guarantee that there will not be any mismatches in
+# which modules are accepted due to Wasm feature configuration or support
+# levels.
+#
+# Note that when this feature is enabled, the version of wasmparser that is
+# re-exported is *not subject to semver*: we reserve the right to make patch
+# releases of Wasmtime that bump the version of wasmparser used, and hence the
+# version re-exported, in semver-incompatible ways. This is the tradeoff that
+# the embedder needs to opt into: in order to stay exactly in sync with an
+# internal detail of Wasmtime, the cost is visibility into potential internal
+# version changes. This is why the re-export is guarded by a feature flag which
+# is off by default.
+reexport-wasmparser = []

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -393,6 +393,24 @@ use sync_nostd as sync;
 #[doc(no_inline)]
 pub use anyhow::{Error, Result};
 
+/// A re-exported instance of Wasmtime's `wasmparser` dependency.
+///
+/// This may be useful for embedders that also use `wasmparser`
+/// directly: it allows embedders to ensure that they are using the same
+/// version as Wasmtime, both to eliminate redundant dependencies on
+/// multiple versions of the library, and to ensure compatibility in
+/// validation and feature support.
+///
+/// Note that this re-export is *not subject to semver*: we reserve the
+/// right to make patch releases of Wasmtime that bump the version of
+/// wasmparser used, and hence the version re-exported, in
+/// semver-incompatible ways. This is the tradeoff that the embedder
+/// needs to opt into: in order to stay exactly in sync with an internal
+/// detail of Wasmtime, the cost is visibility into potential internal
+/// version changes.
+#[cfg(feature = "reexport-wasmparser")]
+pub use wasmparser;
+
 fn _assert_send_and_sync<T: Send + Sync>() {}
 
 fn _assertions_lib() {


### PR DESCRIPTION
In some use-cases, an embedder might also use wasmparser directly. It might be useful in these cases to keep the version the embedder uses in sync with the version that Wasmtime uses, both for exact feature-support compatibility reasons and to remove the redundancy in the dependency tree.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
