### PR TITLE
Release Wasmtime 26.0.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 ## 26.0.0
 
-Released 2024-10-20.
+Released 2024-10-22.
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 ## 26.0.0
 
-Unreleased.
+Released 2024-10-20.
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,99 @@ Released 2024-10-20.
 
 ### Added
 
+* The "table64" extension of the memory64 proposals to WebAssembly has been
+  implemented.
+  [#9206](https://github.com/bytecodealliance/wasmtime/pull/9206)
+
+* Initial support has been added for compiling WebAssembly modules with Pulley,
+  Wasmtime's interpreter. Note that the interpreter is not feature complete yet.
+  [#9240](https://github.com/bytecodealliance/wasmtime/pull/9240)
+
+* Wasmtime can now execute code without relying on host-based signal handlers.
+  [#9230](https://github.com/bytecodealliance/wasmtime/pull/9230)
+
+* Work has continued on implementing the GC proposals in Wasmtime.
+  [#9246](https://github.com/bytecodealliance/wasmtime/pull/9246)
+  [#9244](https://github.com/bytecodealliance/wasmtime/pull/9244)
+  [#9271](https://github.com/bytecodealliance/wasmtime/pull/9271)
+  [#9275](https://github.com/bytecodealliance/wasmtime/pull/9275)
+  [#9278](https://github.com/bytecodealliance/wasmtime/pull/9278)
+  [#9282](https://github.com/bytecodealliance/wasmtime/pull/9282)
+  [#9285](https://github.com/bytecodealliance/wasmtime/pull/9285)
+  [#9326](https://github.com/bytecodealliance/wasmtime/pull/9326)
+  [#9341](https://github.com/bytecodealliance/wasmtime/pull/9341)
+  [#9358](https://github.com/bytecodealliance/wasmtime/pull/9358)
+
+* Support for ARM64 Windows has been finished with support for unwinding.
+  Release binaries are now also available for this platform.
+  [#9266](https://github.com/bytecodealliance/wasmtime/pull/9266)
+  [#9283](https://github.com/bytecodealliance/wasmtime/pull/9283)
+
+* The `bindgen!` macro now supports multiple paths to load WIT from.
+  [#9288](https://github.com/bytecodealliance/wasmtime/pull/9288)
+
+* A new `-W async-stack-size=N` argument has been added to the CLI.
+  [#9302](https://github.com/bytecodealliance/wasmtime/pull/9302)
+
+* A new `wasmtime completion` subcommand can be used to generate a completion
+  script for the Wasmtime CLI.
+  [#9312](https://github.com/bytecodealliance/wasmtime/pull/9312)
+
+* Components now support `initialize_copy_on_write_image` like core modules.
+  [#9357](https://github.com/bytecodealliance/wasmtime/pull/9357)
+
+* Initial support for the ISLE verifier Crocus has landed.
+  [#9178](https://github.com/bytecodealliance/wasmtime/pull/9178)
+
 ### Changed
+
+* Wasmtime now requires Rust 1.79.0 to compile.
+  [#9202](https://github.com/bytecodealliance/wasmtime/pull/9202)
+
+* The `future-trailers.get` in `wasi-http` now returns `none` when trailers are
+  absent.
+  [#9208](https://github.com/bytecodealliance/wasmtime/pull/9208)
+
+* The Cranelift instructions `iadd_cin` and `isub_bin` were removed. The
+  `isub_borrow` and `iadd_carry` instructions were renamed to `{u,s}add_carry`
+  and `{u,s}sub_borrow`.
+  [#9199](https://github.com/bytecodealliance/wasmtime/pull/9199)
+
+* Winch now supports multi-value results on AArch64.
+  [#9218](https://github.com/bytecodealliance/wasmtime/pull/9218)
+
+* Some issues related to `shutdown` have been fixed with WASI sockets.
+  [#9225](https://github.com/bytecodealliance/wasmtime/pull/9225)
+
+* Cranelift now has a Cargo feature to enable support for all native ISAs and
+  not Pulley.
+  [#9237](https://github.com/bytecodealliance/wasmtime/pull/9237)
+
+* Cranelift support for `StructArgument` in the arm64, riscv64, and s390x
+  backends has been removed.
+  [#9258](https://github.com/bytecodealliance/wasmtime/pull/9258)
+
+* The pooling allocator no longer limits instances/memories/tables by default.
+  [#9257](https://github.com/bytecodealliance/wasmtime/pull/9257)
+
+* Stack overflow on an async stack will now print a message that this happened.
+  [#9304](https://github.com/bytecodealliance/wasmtime/pull/9304)
+
+* Cranelift's `cranelift-wasm` crate has been removed and folded directly into
+  `wasmtime-cranelift`.
+  [#9313](https://github.com/bytecodealliance/wasmtime/pull/9313)
+
+* Cranelift's `TrapCode` type is now represented with a single byte.
+  [#9338](https://github.com/bytecodealliance/wasmtime/pull/9338)
+
+### Fixed
+
+* Stack slots in Cranelift are now aligned from the start instead of the end.
+  [#9279](https://github.com/bytecodealliance/wasmtime/pull/9279)
+
+* The WASIp1 adapter now correctly handles allocations where the initial
+  alignment consumes the entire allocation.
+  [#9356](https://github.com/bytecodealliance/wasmtime/pull/9356)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which is intended to notify maintainers that it's time to release Wasmtime 26.0.0. The [release branch][branch] was created roughly two weeks ago and it's now time for it to be published and released.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-26.0.0/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-26.0.0
