### PR TITLE
Enable --all-features and display feature requirements in Cranelift docs on docs.rs

### DIFF
--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -13,13 +13,21 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+# Ask Cargo to build docs with `--all-features` set to true
+all-features = true
+
 [[bin]]
 name = "clif-util"
 path = "src/clif-util.rs"
 
 [dependencies]
 cfg-if = { workspace = true }
-cranelift-codegen = { workspace = true, features = ["disas", "trace-log", "timing"] }
+cranelift-codegen = { workspace = true, features = [
+    "disas",
+    "trace-log",
+    "timing",
+] }
 cranelift-entity = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-reader = { workspace = true }
@@ -44,13 +52,18 @@ clap = { workspace = true, features = ['default'] }
 similar = { workspace = true }
 toml = { workspace = true }
 serde = { workspace = true }
-rustc-hash  = { workspace = true }
+rustc-hash = { workspace = true }
 # Note that this just enables `trace-log` for `clif-util` and doesn't turn it on
 # for all of Cranelift, which would be bad.
 regalloc2 = { workspace = true, features = ["trace-log"] }
 
 [features]
-default = ["disas", "cranelift-codegen/all-arch", "cranelift-codegen/trace-log", "souper-harvest"]
+default = [
+    "disas",
+    "cranelift-codegen/all-arch",
+    "cranelift-codegen/trace-log",
+    "souper-harvest",
+]
 disas = ["capstone"]
 souper-harvest = ["cranelift-codegen/souper-harvest", "rayon"]
 all-arch = ["cranelift-codegen/all-arch"]

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -1,5 +1,7 @@
 //! Cranelift code generation library.
 #![deny(missing_docs)]
+// Display feature requirements in the documentation when building on docs.rs
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 // Various bits and pieces of this crate might only be used for one platform or
 // another, but it's not really too useful to learn about that all the time. On


### PR DESCRIPTION
### Summary
- Enabled `--all-features` for Cranelift documentation via:
  ```toml
  [package.metadata.docs.rs]
  all-features = true
  ```
- Added `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to display feature requirements in documentation when building on `docs.rs`.
- Verified functionality using:
  ```bash
  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --open
  ```