### PR TITLE
Add CLI flag `-Cnative-unwind-info`

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -192,6 +192,9 @@ wasmtime_option_group! {
         pub parallel_compilation: Option<bool>,
         /// Whether to enable proof-carrying code (PCC)-based validation.
         pub pcc: Option<bool>,
+        /// Controls whether native unwind information is present in compiled
+        /// object files.
+        pub native_unwind_info: Option<bool>,
 
         #[prefixed = "cranelift"]
         /// Set a cranelift-specific option. Use `wasmtime settings` to see
@@ -651,6 +654,9 @@ impl CommonOptions {
         }
         if let Some(enable) = self.opts.signals_based_traps {
             config.signals_based_traps(enable);
+        }
+        if let Some(enable) = self.codegen.native_unwind_info {
+            config.native_unwind_info(enable);
         }
 
         match_feature! {


### PR DESCRIPTION
Currently this can't be tuned on the CLI and can be useful for local testing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
