### PR TITLE
Improve `atomic_rmw` lowering on `x86`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -24,7 +24,8 @@
        (AluRM (size OperandSize) ;; 1, 2, 4 or 8
               (op AluRmiROpcode)
               (src1_dst SyntheticAmode)
-              (src2 Gpr))
+              (src2 Gpr)
+              (lock bool))
 
        ;; Integer arithmetic binary op that relies on the VEX prefix.
        ;; NOTE: we don't currently support emitting VEX instructions with memory
@@ -682,6 +683,18 @@
                        (dst_old_low WritableReg)
                        (dst_old_high WritableReg))
 
+       ;; A standard (native) `lock xadd src, (amode)`
+       (LockXadd (size OperandSize)
+                 (operand Reg)
+                 (mem SyntheticAmode)
+                 (dst_old WritableReg))
+
+       ;; A standard (native) `xchg src, (amode)`
+       (Xchg (size OperandSize)
+                 (operand Reg)
+                 (mem SyntheticAmode)
+                 (dst_old WritableReg))
+
        ;; A synthetic instruction, based on a loop around a native `lock
        ;; cmpxchg` instruction.
        ;;
@@ -708,7 +721,7 @@
        ;; - %rflags is written.  Do not assume anything about it after the
        ;;   instruction.
        (AtomicRmwSeq (ty Type) ;; I8, I16, I32, or I64
-                     (op MachAtomicRmwOp)
+                     (op AtomicRmwSeqOp)
                      (mem SyntheticAmode)
                      (operand Reg)
                      (temp WritableReg)
@@ -719,7 +732,7 @@
        ;;
        ;; This is the same as `AtomicRmwSeq`, but for 128-bit integers.
        ;;
-       ;; For `MachAtomicRmwOp::Xchg`, use `Atomic128XchgSeq` instead.
+       ;; For `AtomicRmwOp::Xchg`, use `Atomic128XchgSeq` instead.
        ;;
        ;; This instruction sequence has fixed register uses as follows:
        ;; - %rax (low), %rdx (high)  (written) the old value at `mem`
@@ -727,7 +740,7 @@
        ;;   the replacement value
        ;; - %rflags is written.  Do not assume anything about it after the
        ;;   instruction.
-       (Atomic128RmwSeq (op MachAtomicRmwOp)
+       (Atomic128RmwSeq (op Atomic128RmwSeqOp)
                         (mem BoxSyntheticAmode)
                         (operand_low Reg)
                         (operand_high Reg)
@@ -739,8 +752,8 @@
        ;; A synthetic instruction, based on a loop around a native `lock
        ;; cmpxchg16b` instruction.
        ;;
-       ;; This is `Atomic128XchgSeq` but only for `MachAtomicRmwOp::Xchg`. As
-       ;; the replacement value is the same every time, this instruction doesn't
+       ;; This is `Atomic128XchgSeq` but only for `AtomicRmwOp::Xchg`. As the
+       ;; replacement value is the same every time, this instruction doesn't
        ;; require any temporary registers.
        ;;
        ;; This instruction sequence has fixed register uses as follows:
@@ -4899,7 +4912,7 @@
 (decl alu_rm (Type AluRmiROpcode Amode Gpr) SideEffectNoResult)
 (rule (alu_rm ty opcode src1_dst src2)
       (let ((size OperandSize (operand_size_of_type_32_64 ty)))
-        (SideEffectNoResult.Inst (MInst.AluRM size opcode src1_dst src2))))
+        (SideEffectNoResult.Inst (MInst.AluRM size opcode src1_dst src2 $false))))
 
 (decl x64_add_mem (Type Amode Gpr) SideEffectNoResult)
 (spec (x64_add_mem ty addr val)
@@ -5291,14 +5304,51 @@
             (_ Unit (emit (MInst.LockCmpxchg16b replacement_low replacement_high expected_low expected_high addr dst_low dst_high))))
         (value_regs dst_low dst_high)))
 
-(decl x64_atomic_rmw_seq (Type MachAtomicRmwOp SyntheticAmode Gpr) Gpr)
+(decl x64_xadd (OperandSize SyntheticAmode Gpr) Gpr)
+(rule (x64_xadd size addr operand)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.LockXadd size operand addr dst))))
+        dst))
+
+(decl x64_xchg (OperandSize SyntheticAmode Gpr) Gpr)
+(rule (x64_xchg size addr operand)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.Xchg size operand addr dst))))
+        dst))
+
+(decl lock_alu_rm (OperandSize AluRmiROpcode SyntheticAmode Gpr) Reg)
+(rule (lock_alu_rm size opcode addr operand)
+      (let ((_ Unit (emit (MInst.AluRM size opcode addr operand $true))))
+        (invalid_reg)))
+
+(decl x64_lock_add (OperandSize SyntheticAmode Gpr) Reg)
+(rule (x64_lock_add size addr operand)
+      (lock_alu_rm size (AluRmiROpcode.Add) addr operand))
+
+(decl x64_lock_sub (OperandSize SyntheticAmode Gpr) Reg)
+(rule (x64_lock_sub size addr operand)
+      (lock_alu_rm size (AluRmiROpcode.Sub) addr operand))
+
+(decl x64_lock_and (OperandSize SyntheticAmode Gpr) Reg)
+(rule (x64_lock_and size addr operand)
+      (lock_alu_rm size (AluRmiROpcode.And) addr operand))
+
+(decl x64_lock_or (OperandSize SyntheticAmode Gpr) Reg)
+(rule (x64_lock_or size addr operand)
+      (lock_alu_rm size (AluRmiROpcode.Or) addr operand))
+
+(decl x64_lock_xor (OperandSize SyntheticAmode Gpr) Reg)
+(rule (x64_lock_xor size addr operand)
+      (lock_alu_rm size (AluRmiROpcode.Xor) addr operand))
+
+(decl x64_atomic_rmw_seq (Type AtomicRmwSeqOp SyntheticAmode Gpr) Gpr)
 (rule (x64_atomic_rmw_seq ty op mem input)
       (let ((dst WritableGpr (temp_writable_gpr))
             (tmp WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.AtomicRmwSeq ty op mem input tmp dst))))
         dst))
 
-(decl x64_atomic_128_rmw_seq (MachAtomicRmwOp SyntheticAmode ValueRegs) ValueRegs)
+(decl x64_atomic_128_rmw_seq (AtomicRmwOp SyntheticAmode ValueRegs) ValueRegs)
 (rule (x64_atomic_128_rmw_seq op mem input)
       (let ((dst_low WritableGpr (temp_writable_gpr))
             (dst_high WritableGpr (temp_writable_gpr))
@@ -5306,10 +5356,10 @@
             (tmp_high WritableGpr (temp_writable_gpr))
             (input_low Gpr (value_regs_get_gpr input 0))
             (input_high Gpr (value_regs_get_gpr input 1))
-            (_ Unit (emit (MInst.Atomic128RmwSeq op mem input_low input_high tmp_low tmp_high dst_low dst_high))))
+            (_ Unit (emit (MInst.Atomic128RmwSeq (atomic_128_rmw_seq_op op) mem input_low input_high tmp_low tmp_high dst_low dst_high))))
         (value_regs dst_low dst_high)))
 
-(rule 1 (x64_atomic_128_rmw_seq (mach_atomic_rmw_op_xchg) mem input)
+(rule 1 (x64_atomic_128_rmw_seq (AtomicRmwOp.Xchg) mem input)
         (let ((dst_low WritableGpr (temp_writable_gpr))
               (dst_high WritableGpr (temp_writable_gpr))
               (input_low Gpr (value_regs_get_gpr input 0))
@@ -5325,14 +5375,50 @@
               (input_high Gpr (value_regs_get_gpr input 1)))
           (SideEffectNoResult.Inst (MInst.Atomic128XchgSeq mem input_low input_high dst_low dst_high))))
 
-(decl mach_atomic_rmw_op_xchg () MachAtomicRmwOp)
-(extern extractor mach_atomic_rmw_op_xchg mach_atomic_rmw_op_is_xchg)
 
-;; CLIF IR has one enumeration for atomic operations (`AtomicRmwOp`) while the
-;; mach backend has another (`MachAtomicRmwOp`)--this converts one to the other.
-(type MachAtomicRmwOp extern (enum))
-(decl atomic_rmw_op_to_mach_atomic_rmw_op (AtomicRmwOp) MachAtomicRmwOp)
-(extern constructor atomic_rmw_op_to_mach_atomic_rmw_op atomic_rmw_op_to_mach_atomic_rmw_op)
+(type AtomicRmwSeqOp
+      (enum And
+            Nand
+            Or
+            Xor
+            Umin
+            Umax
+            Smin
+            Smax))
+
+(decl atomic_rmw_seq_op (AtomicRmwOp) AtomicRmwSeqOp)
+(rule (atomic_rmw_seq_op (AtomicRmwOp.And)) (AtomicRmwSeqOp.And))
+(rule (atomic_rmw_seq_op (AtomicRmwOp.Nand)) (AtomicRmwSeqOp.Nand))
+(rule (atomic_rmw_seq_op (AtomicRmwOp.Or)) (AtomicRmwSeqOp.Or))
+(rule (atomic_rmw_seq_op (AtomicRmwOp.Xor)) (AtomicRmwSeqOp.Xor))
+(rule (atomic_rmw_seq_op (AtomicRmwOp.Umin)) (AtomicRmwSeqOp.Umin))
+(rule (atomic_rmw_seq_op (AtomicRmwOp.Umax)) (AtomicRmwSeqOp.Umax))
+(rule (atomic_rmw_seq_op (AtomicRmwOp.Smin)) (AtomicRmwSeqOp.Smin))
+(rule (atomic_rmw_seq_op (AtomicRmwOp.Smax)) (AtomicRmwSeqOp.Smax))
+
+(type Atomic128RmwSeqOp
+      (enum Add
+            Sub
+            And
+            Nand
+            Or
+            Xor
+            Umin
+            Umax
+            Smin
+            Smax))
+
+(decl atomic_128_rmw_seq_op (AtomicRmwOp) Atomic128RmwSeqOp)
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Add)) (Atomic128RmwSeqOp.Add))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Sub)) (Atomic128RmwSeqOp.Sub))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.And)) (Atomic128RmwSeqOp.And))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Nand)) (Atomic128RmwSeqOp.Nand))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Or)) (Atomic128RmwSeqOp.Or))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Xor)) (Atomic128RmwSeqOp.Xor))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Umin)) (Atomic128RmwSeqOp.Umin))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Umax)) (Atomic128RmwSeqOp.Umax))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Smin)) (Atomic128RmwSeqOp.Smin))
+(rule (atomic_128_rmw_seq_op (AtomicRmwOp.Smax)) (Atomic128RmwSeqOp.Smax))
 
 ;;;; Casting ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -5559,7 +5645,6 @@
 (convert VCodeConstant RegMem const_to_reg_mem)
 
 (convert IntCC CC intcc_to_cc)
-(convert AtomicRmwOp MachAtomicRmwOp atomic_rmw_op_to_mach_atomic_rmw_op)
 
 (convert SinkableLoad RegMem sink_load_to_reg_mem)
 (convert SinkableLoad GprMem sink_load_to_gpr_mem)

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -15,6 +15,7 @@
 use super::*;
 use crate::ir::{MemFlags, UserExternalNameRef};
 use crate::isa::x64;
+use crate::isa::x64::lower::isle::generated_code::{Atomic128RmwSeqOp, AtomicRmwSeqOp};
 use alloc::vec::Vec;
 use cranelift_entity::EntityRef as _;
 
@@ -194,7 +195,7 @@ fn test_x64_emit() {
     let _w_rbp = Writable::<Reg>::from_reg(rbp);
     let w_r8 = Writable::<Reg>::from_reg(r8);
     let w_r9 = Writable::<Reg>::from_reg(r9);
-    let _w_r10 = Writable::<Reg>::from_reg(r10);
+    let w_r10 = Writable::<Reg>::from_reg(r10);
     let w_r11 = Writable::<Reg>::from_reg(r11);
     let w_r12 = Writable::<Reg>::from_reg(r12);
     let w_r13 = Writable::<Reg>::from_reg(r13);
@@ -1481,7 +1482,7 @@ fn test_x64_emit() {
             OperandSize::Size8,
             AluRmiROpcode::Xor,
             RegMemImm::imm(10),
-            _w_r10,
+            w_r10,
         ),
         "4180F20A",
         "xorb    %r10b, $10, %r10b",
@@ -1491,7 +1492,7 @@ fn test_x64_emit() {
             OperandSize::Size8,
             AluRmiROpcode::Xor,
             RegMemImm::reg(rcx),
-            _w_r10,
+            w_r10,
         ),
         "4130CA",
         "xorb    %r10b, %cl, %r10b",
@@ -1501,7 +1502,7 @@ fn test_x64_emit() {
             OperandSize::Size8,
             AluRmiROpcode::Xor,
             RegMemImm::reg(rsi),
-            _w_r10,
+            w_r10,
         ),
         "4130F2",
         "xorb    %r10b, %sil, %r10b",
@@ -1511,7 +1512,7 @@ fn test_x64_emit() {
             OperandSize::Size8,
             AluRmiROpcode::Xor,
             RegMemImm::reg(r11),
-            _w_r10,
+            w_r10,
         ),
         "4530DA",
         "xorb    %r10b, %r11b, %r10b",
@@ -1521,7 +1522,7 @@ fn test_x64_emit() {
             OperandSize::Size8,
             AluRmiROpcode::Xor,
             RegMemImm::reg(r15),
-            _w_r10,
+            w_r10,
         ),
         "4530FA",
         "xorb    %r10b, %r15b, %r10b",
@@ -1637,6 +1638,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Add,
             src1_dst: Amode::imm_reg(99, rdi).into(),
             src2: Gpr::unwrap_new(r12),
+            lock: false,
         },
         "44016763",
         "addl    %r12d, 99(%rdi)",
@@ -1649,6 +1651,7 @@ fn test_x64_emit() {
             src1_dst: Amode::imm_reg_reg_shift(0, Gpr::unwrap_new(rbp), Gpr::unwrap_new(rax), 3)
                 .into(),
             src2: Gpr::unwrap_new(rax),
+            lock: false,
         },
         "480144C500",
         "addq    %rax, 0(%rbp,%rax,8)",
@@ -1660,6 +1663,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rsp).into(),
             src2: Gpr::unwrap_new(rcx),
+            lock: false,
         },
         "290C24",
         "subl    %ecx, 0(%rsp)",
@@ -1671,6 +1675,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(rax),
+            lock: false,
         },
         "48294500",
         "subq    %rax, 0(%rbp)",
@@ -1682,6 +1687,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::And,
             src1_dst: Amode::imm_reg(0, rsp).into(),
             src2: Gpr::unwrap_new(rcx),
+            lock: false,
         },
         "210C24",
         "andl    %ecx, 0(%rsp)",
@@ -1693,6 +1699,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::And,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(rax),
+            lock: false,
         },
         "48214500",
         "andq    %rax, 0(%rbp)",
@@ -1704,6 +1711,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Or,
             src1_dst: Amode::imm_reg(0, rsp).into(),
             src2: Gpr::unwrap_new(rcx),
+            lock: false,
         },
         "090C24",
         "orl     %ecx, 0(%rsp)",
@@ -1715,6 +1723,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Or,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(rax),
+            lock: false,
         },
         "48094500",
         "orq     %rax, 0(%rbp)",
@@ -1726,6 +1735,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Xor,
             src1_dst: Amode::imm_reg(0, rsp).into(),
             src2: Gpr::unwrap_new(rcx),
+            lock: false,
         },
         "310C24",
         "xorl    %ecx, 0(%rsp)",
@@ -1737,6 +1747,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Xor,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(rax),
+            lock: false,
         },
         "48314500",
         "xorq    %rax, 0(%rbp)",
@@ -1748,6 +1759,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Add,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(rax),
+            lock: false,
         },
         "66014500",
         "addw    %ax, 0(%rbp)",
@@ -1758,6 +1770,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(r12),
+            lock: false,
         },
         "6644296500",
         "subw    %r12w, 0(%rbp)",
@@ -1769,6 +1782,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Add,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(rax),
+            lock: false,
         },
         "004500",
         "addb    %al, 0(%rbp)",
@@ -1779,6 +1793,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Sub,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(rbp),
+            lock: false,
         },
         "40286D00",
         "subb    %bpl, 0(%rbp)",
@@ -1789,6 +1804,7 @@ fn test_x64_emit() {
             op: AluRmiROpcode::Xor,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(r10),
+            lock: false,
         },
         "44305500",
         "xorb    %r10b, 0(%rbp)",
@@ -1799,9 +1815,55 @@ fn test_x64_emit() {
             op: AluRmiROpcode::And,
             src1_dst: Amode::imm_reg(0, rbp).into(),
             src2: Gpr::unwrap_new(r15),
+            lock: false,
         },
         "44207D00",
         "andb    %r15b, 0(%rbp)",
+    ));
+
+    insns.push((
+        Inst::AluRM {
+            size: OperandSize::Size64,
+            op: AluRmiROpcode::And,
+            src1_dst: Amode::imm_reg(0, rdx).into(),
+            src2: Gpr::unwrap_new(rax),
+            lock: true,
+        },
+        "F0482102",
+        "lock andq    %rax, 0(%rdx)",
+    ));
+    insns.push((
+        Inst::AluRM {
+            size: OperandSize::Size32,
+            op: AluRmiROpcode::Or,
+            src1_dst: Amode::imm_reg(0, rdx).into(),
+            src2: Gpr::unwrap_new(rax),
+            lock: true,
+        },
+        "F00902",
+        "lock orl     %eax, 0(%rdx)",
+    ));
+    insns.push((
+        Inst::AluRM {
+            size: OperandSize::Size16,
+            op: AluRmiROpcode::Xor,
+            src1_dst: Amode::imm_reg(0, rdx).into(),
+            src2: Gpr::unwrap_new(rax),
+            lock: true,
+        },
+        "66F03102",
+        "lock xorw    %ax, 0(%rdx)",
+    ));
+    insns.push((
+        Inst::AluRM {
+            size: OperandSize::Size8,
+            op: AluRmiROpcode::Add,
+            src1_dst: Amode::imm_reg(0, r9).into(),
+            src2: Gpr::unwrap_new(rax),
+            lock: true,
+        },
+        "F0410001",
+        "lock addb    %al, 0(%r9)",
     ));
 
     // ========================================================
@@ -4998,72 +5060,156 @@ fn test_x64_emit() {
         "lock cmpxchg16b -12345(%rcx,%rsi,8), replacement=%rcx:%rbx, expected=%rdx:%rax, dst_old=%rdx:%rax",
     ));
 
+    // LockXadd
+    insns.push((
+        Inst::LockXadd {
+            size: OperandSize::Size64,
+            operand: r10,
+            mem: am3.clone(),
+            dst_old: w_r10,
+        },
+        "F04D0FC111",
+        "lock xaddq %r10, 0(%r9), dst_old=%r10",
+    ));
+    insns.push((
+        Inst::LockXadd {
+            size: OperandSize::Size32,
+            operand: r11,
+            mem: am3.clone(),
+            dst_old: w_r11,
+        },
+        "F0450FC119",
+        "lock xaddl %r11d, 0(%r9), dst_old=%r11d",
+    ));
+    insns.push((
+        Inst::LockXadd {
+            size: OperandSize::Size16,
+            operand: r12,
+            mem: am3.clone(),
+            dst_old: w_r12,
+        },
+        "66F0450FC121",
+        "lock xaddw %r12w, 0(%r9), dst_old=%r12w",
+    ));
+    insns.push((
+        Inst::LockXadd {
+            size: OperandSize::Size8,
+            operand: r13,
+            mem: am3.clone(),
+            dst_old: w_r13,
+        },
+        "F0450FC029",
+        "lock xaddb %r13b, 0(%r9), dst_old=%r13b",
+    ));
+
+    // Xchg
+    insns.push((
+        Inst::Xchg {
+            size: OperandSize::Size64,
+            operand: r10,
+            mem: am3.clone(),
+            dst_old: w_r10,
+        },
+        "4D8711",
+        "xchgq %r10, 0(%r9), dst_old=%r10",
+    ));
+    insns.push((
+        Inst::Xchg {
+            size: OperandSize::Size32,
+            operand: r11,
+            mem: am3.clone(),
+            dst_old: w_r11,
+        },
+        "458719",
+        "xchgl %r11d, 0(%r9), dst_old=%r11d",
+    ));
+    insns.push((
+        Inst::Xchg {
+            size: OperandSize::Size16,
+            operand: r12,
+            mem: am3.clone(),
+            dst_old: w_r12,
+        },
+        "66458721",
+        "xchgw %r12w, 0(%r9), dst_old=%r12w",
+    ));
+    insns.push((
+        Inst::Xchg {
+            size: OperandSize::Size8,
+            operand: r13,
+            mem: am3.clone(),
+            dst_old: w_r13,
+        },
+        "458629",
+        "xchgb %r13b, 0(%r9), dst_old=%r13b",
+    ));
+
     // AtomicRmwSeq
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I8,
-            op: inst_common::MachAtomicRmwOp::Or,
+            op: AtomicRmwSeqOp::Or,
             mem: am3.clone(),
             operand: r10,
             temp: w_r11,
-            dst_old: w_rax
+            dst_old: w_rax,
         },
         "490FB6014989C34D09D3F0450FB0190F85EFFFFFFF",
-        "atomically { 8_bits_at_[%r9]) Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
+        "atomically { 8_bits_at_[%r9] Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }",
     ));
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I16,
-            op: inst_common::MachAtomicRmwOp::And,
+            op: AtomicRmwSeqOp::And,
             mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
         },
         "490FB7014989C34D21D366F0450FB1190F85EEFFFFFF",
-        "atomically { 16_bits_at_[%r9]) And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
+        "atomically { 16_bits_at_[%r9] And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I32,
-            op: inst_common::MachAtomicRmwOp::Xchg,
+            op: AtomicRmwSeqOp::Nand,
             mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
         },
-        "418B014989C34D89D3F0450FB1190F85EFFFFFFF",
-        "atomically { 32_bits_at_[%r9]) Xchg= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
+        "418B014989C34D21D349F7D3F0450FB1190F85ECFFFFFF",
+        "atomically { 32_bits_at_[%r9] Nand= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I32,
-            op: inst_common::MachAtomicRmwOp::Umin,
+            op: AtomicRmwSeqOp::Umin,
             mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
         },
         "418B014989C34539DA4D0F46DAF0450FB1190F85EBFFFFFF",
-        "atomically { 32_bits_at_[%r9]) Umin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
+        "atomically { 32_bits_at_[%r9] Umin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I64,
-            op: inst_common::MachAtomicRmwOp::Add,
+            op: AtomicRmwSeqOp::Smax,
             mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
         },
-        "498B014989C34D01D3F04D0FB1190F85EFFFFFFF",
-        "atomically { 64_bits_at_[%r9]) Add= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
+        "498B014989C34D39DA4D0F4DDAF04D0FB1190F85EBFFFFFF",
+        "atomically { 64_bits_at_[%r9] Smax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
 
     // Atomic128RmwSeq
     insns.push((
         Inst::Atomic128RmwSeq {
-            op: inst_common::MachAtomicRmwOp::Or,
+            op: Atomic128RmwSeqOp::Or,
             mem: Box::new(am3.clone()),
             operand_low: r10,
             operand_high: r11,
@@ -5077,7 +5223,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::Atomic128RmwSeq {
-            op: inst_common::MachAtomicRmwOp::And,
+            op: Atomic128RmwSeqOp::And,
             mem: Box::new(am3.clone()),
             operand_low: r10,
             operand_high: r11,
@@ -5091,7 +5237,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::Atomic128RmwSeq {
-            op: inst_common::MachAtomicRmwOp::Umin,
+            op: Atomic128RmwSeqOp::Umin,
             mem: Box::new(am3.clone()),
             operand_low: r10,
             operand_high: r11,
@@ -5105,7 +5251,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::Atomic128RmwSeq {
-            op: inst_common::MachAtomicRmwOp::Add,
+            op: Atomic128RmwSeqOp::Add,
             mem: Box::new(am3.clone()),
             operand_low: r10,
             operand_high: r11,

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3386,19 +3386,53 @@
 ;; Rules for `atomic_rmw` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; This is a simple, general-case atomic update, based on a loop involving
-;; `cmpxchg`.  Note that we could do much better than this in the case where the
-;; old value at the location (that is to say, the SSA `Value` computed by this
-;; CLIF instruction) is not required.  In that case, we could instead implement
-;; this using a single `lock`-prefixed x64 read-modify-write instruction.  Also,
-;; even in the case where the old value is required, for the `add` and `sub`
-;; cases, we can use the single instruction `lock xadd`.  However, those
-;; improvements have been left for another day. TODO: filed as
-;; https://github.com/bytecodealliance/wasmtime/issues/2153.
-
+;; `cmpxchg`.
 (rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_rmw flags op address input)))
-      (x64_atomic_rmw_seq ty op (to_amode flags address (zero_offset)) input))
-(rule 1 (lower (has_type $I128 (atomic_rmw flags op address input)))
+      (x64_atomic_rmw_seq ty (atomic_rmw_seq_op op) (to_amode flags address (zero_offset)) input))
+
+;; `Add` and `Sub` can use `lock xadd`
+(rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
+                  (atomic_rmw flags (AtomicRmwOp.Add) address input)))
+      (x64_xadd (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+(rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
+                  (atomic_rmw flags (AtomicRmwOp.Sub) address input)))
+      (x64_xadd (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) (x64_neg ty input)))
+;; `Xchg` can use `xchg`
+(rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
+                  (atomic_rmw flags (AtomicRmwOp.Xchg) address input)))
+      (x64_xchg (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+
+;; `Add`, `Sub`, `And`, `Or` and `Xor` can use `lock`-prefixed instructions if
+;; the old value is not required.
+(rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
+                  (atomic_rmw flags (AtomicRmwOp.Add) address input)))
+      (if-let (first_result res) i)
+      (if-let $true (value_is_unused res))
+      (x64_lock_add (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+(rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
+                  (atomic_rmw flags (AtomicRmwOp.Sub) address input)))
+      (if-let (first_result res) i)
+      (if-let $true (value_is_unused res))
+      (x64_lock_sub (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+(rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
+                  (atomic_rmw flags (AtomicRmwOp.And) address input)))
+      (if-let (first_result res) i)
+      (if-let $true (value_is_unused res))
+      (x64_lock_and (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+(rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
+                  (atomic_rmw flags (AtomicRmwOp.Or) address input)))
+      (if-let (first_result res) i)
+      (if-let $true (value_is_unused res))
+      (x64_lock_or (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+(rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
+                  (atomic_rmw flags (AtomicRmwOp.Xor) address input)))
+      (if-let (first_result res) i)
+      (if-let $true (value_is_unused res))
+      (x64_lock_xor (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+
+;; 128-bit integers always use a `lock cmpxchg16b` loop.
+(rule 3 (lower (has_type $I128 (atomic_rmw flags op address input)))
         (if-let $true (use_cmpxchg16b))
         (x64_atomic_128_rmw_seq op (to_amode flags address (zero_offset)) input))
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -22,8 +22,8 @@ use crate::{
         inst::{args::*, regs, ReturnCallInfo},
     },
     machinst::{
-        isle::*, ArgPair, CallInfo, InsnInput, InstOutput, IsTailCall, MachAtomicRmwOp, MachInst,
-        VCodeConstant, VCodeConstantData,
+        isle::*, ArgPair, CallInfo, InsnInput, InstOutput, IsTailCall, MachInst, VCodeConstant,
+        VCodeConstantData,
     },
 };
 use alloc::vec::Vec;
@@ -613,20 +613,6 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     #[inline]
     fn zero_offset(&mut self) -> Offset32 {
         Offset32::new(0)
-    }
-
-    #[inline]
-    fn atomic_rmw_op_to_mach_atomic_rmw_op(&mut self, op: &AtomicRmwOp) -> MachAtomicRmwOp {
-        MachAtomicRmwOp::from(*op)
-    }
-
-    #[inline]
-    fn mach_atomic_rmw_op_is_xchg(&mut self, op: &MachAtomicRmwOp) -> Option<()> {
-        if *op == MachAtomicRmwOp::Xchg {
-            Some(())
-        } else {
-            None
-        }
     }
 
     #[inline]

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -163,6 +163,7 @@ pub(crate) fn check(
             op: _,
             ref src1_dst,
             src2: _,
+            lock: _,
         } => {
             check_load(ctx, None, src1_dst, vcode, size.to_type(), 64)?;
             check_store(ctx, None, src1_dst, vcode, size.to_type())
@@ -895,6 +896,28 @@ pub(crate) fn check(
             ensure_no_fact(vcode, dst_old_low.to_reg())?;
             ensure_no_fact(vcode, dst_old_high.to_reg())?;
             check_store(ctx, None, mem, vcode, I128)?;
+            Ok(())
+        }
+
+        Inst::LockXadd {
+            size,
+            ref mem,
+            dst_old,
+            operand: _,
+        } => {
+            ensure_no_fact(vcode, dst_old.to_reg())?;
+            check_store(ctx, None, mem, vcode, size.to_type())?;
+            Ok(())
+        }
+
+        Inst::Xchg {
+            size,
+            ref mem,
+            dst_old,
+            operand: _,
+        } => {
+            ensure_no_fact(vcode, dst_old.to_reg())?;
+            check_store(ctx, None, mem, vcode, size.to_type())?;
             Ok(())
         }
 

--- a/cranelift/codegen/src/machinst/inst_common.rs
+++ b/cranelift/codegen/src/machinst/inst_common.rs
@@ -1,6 +1,6 @@
 //! A place to park MachInst::Inst fragments which are common across multiple architectures.
 
-use crate::ir::{self, Inst as IRInst};
+use crate::ir::Inst as IRInst;
 
 //============================================================================
 // Instruction input "slots".
@@ -21,55 +21,4 @@ pub(crate) struct InsnInput {
 pub(crate) struct InsnOutput {
     pub(crate) insn: IRInst,
     pub(crate) output: usize,
-}
-
-//============================================================================
-// Atomic instructions.
-
-/// Atomic memory update operations.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-pub enum MachAtomicRmwOp {
-    /// Add
-    Add,
-    /// Sub
-    Sub,
-    /// And
-    And,
-    /// Nand
-    Nand,
-    /// Or
-    Or,
-    /// Exclusive Or
-    Xor,
-    /// Exchange (swap operands)
-    Xchg,
-    /// Unsigned min
-    Umin,
-    /// Unsigned max
-    Umax,
-    /// Signed min
-    Smin,
-    /// Signed max
-    Smax,
-}
-
-impl MachAtomicRmwOp {
-    /// Converts an `ir::AtomicRmwOp` to the corresponding
-    /// `inst_common::AtomicRmwOp`.
-    pub fn from(ir_op: ir::AtomicRmwOp) -> Self {
-        match ir_op {
-            ir::AtomicRmwOp::Add => MachAtomicRmwOp::Add,
-            ir::AtomicRmwOp::Sub => MachAtomicRmwOp::Sub,
-            ir::AtomicRmwOp::And => MachAtomicRmwOp::And,
-            ir::AtomicRmwOp::Nand => MachAtomicRmwOp::Nand,
-            ir::AtomicRmwOp::Or => MachAtomicRmwOp::Or,
-            ir::AtomicRmwOp::Xor => MachAtomicRmwOp::Xor,
-            ir::AtomicRmwOp::Xchg => MachAtomicRmwOp::Xchg,
-            ir::AtomicRmwOp::Umin => MachAtomicRmwOp::Umin,
-            ir::AtomicRmwOp::Umax => MachAtomicRmwOp::Umax,
-            ir::AtomicRmwOp::Smin => MachAtomicRmwOp::Smin,
-            ir::AtomicRmwOp::Smax => MachAtomicRmwOp::Smax,
-        }
-    }
 }

--- a/cranelift/filetests/filetests/egraph/not_a_load.clif
+++ b/cranelift/filetests/filetests/egraph/not_a_load.clif
@@ -16,7 +16,7 @@ function u0:1302(i64) -> i64 system_v {
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   atomically { 64_bits_at_[%r9]) Add= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   lock addq    %rdi, 0(%rdi)
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -27,11 +27,7 @@ function u0:1302(i64) -> i64 system_v {
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq (%rdi), %rax ; trap: heap_oob
-;   movq %rax, %rcx
-;   addq %rdi, %rcx
-;   lock cmpxchgq %rcx, (%rdi) ; trap: heap_oob
-;   jne 7
+;   lock addq %rdi, (%rdi) ; trap: heap_oob
 ;   movq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/x64/atomic-rmw.clif
@@ -1,0 +1,1783 @@
+test compile precise-output
+target x86_64
+
+function %add_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 add v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   lock xaddq %rax, 0(%rdi), dst_old=%rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   lock xaddq %rax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 add v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   lock xaddl %eax, 0(%rdi), dst_old=%eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   lock xaddl %eax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 add v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   lock xaddw %ax, 0(%rdi), dst_old=%ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   lock xaddw %ax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 add v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   lock xaddb %al, 0(%rdi), dst_old=%al
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   lock xaddb %al, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_i64_no_res(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 add v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock addq    %rsi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock addq %rsi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_i32_no_res(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 add v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock addl    %esi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock addl %esi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_i16_no_res(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 add v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock addw    %si, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock addw %si, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %add_i8_no_res(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 add v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock addb    %sil, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock addb %sil, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 sub v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   negq    %rsi, %rsi
+;   movq    %rsi, %rax
+;   lock xaddq %rax, 0(%rdi), dst_old=%rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   negq %rsi
+;   movq %rsi, %rax
+;   lock xaddq %rax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 sub v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   negl    %esi, %esi
+;   movq    %rsi, %rax
+;   lock xaddl %eax, 0(%rdi), dst_old=%eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   negl %esi
+;   movq %rsi, %rax
+;   lock xaddl %eax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 sub v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   negw    %si, %si
+;   movq    %rsi, %rax
+;   lock xaddw %ax, 0(%rdi), dst_old=%ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   negw %si
+;   movq %rsi, %rax
+;   lock xaddw %ax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 sub v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   negb    %sil, %sil
+;   movq    %rsi, %rax
+;   lock xaddb %al, 0(%rdi), dst_old=%al
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   negb %sil
+;   movq %rsi, %rax
+;   lock xaddb %al, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i64_no_res(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 sub v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock subq    %rsi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock subq %rsi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i32_no_res(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 sub v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock subl    %esi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock subl %esi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i16_no_res(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 sub v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock subw    %si, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock subw %si, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sub_i8_no_res(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 sub v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock subb    %sil, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock subb %sil, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 and v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 and v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 and v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 and v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i64_no_res(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 and v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock andq    %rsi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock andq %rsi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i32_no_res(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 and v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock andl    %esi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock andl %esi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i16_no_res(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 and v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock andw    %si, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock andw %si, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %and_i8_no_res(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 and v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock andb    %sil, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock andb %sil, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %nand_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 nand v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] Nand= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   notq %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %nand_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 nand v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] Nand= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   notq %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %nand_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 nand v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] Nand= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   notq %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %nand_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 nand v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] Nand= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   andq %rsi, %rdx
+;   notq %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 or v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   orq %rsi, %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 or v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   orq %rsi, %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 or v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   orq %rsi, %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 or v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   orq %rsi, %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i64_no_res(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 or v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock orq     %rsi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock orq %rsi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i32_no_res(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 or v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock orl     %esi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock orl %esi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i16_no_res(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 or v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock orw     %si, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock orw %si, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %or_i8_no_res(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 or v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock orb     %sil, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock orb %sil, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 xor v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] Xor= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   xorq %rsi, %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 xor v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] Xor= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   xorq %rsi, %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 xor v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] Xor= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   xorq %rsi, %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 xor v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] Xor= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   xorq %rsi, %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i64_no_res(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 xor v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock xorq    %rsi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock xorq %rsi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i32_no_res(i64, i32) {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 xor v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock xorl    %esi, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock xorl %esi, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i16_no_res(i64, i16) {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 xor v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock xorw    %si, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock xorw %si, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xor_i8_no_res(i64, i8) {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 xor v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   lock xorb    %sil, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   lock xorb %sil, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xchg_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 xchg v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   xchgq %rax, 0(%rdi), dst_old=%rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   xchgq %rax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xchg_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 xchg v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   xchgl %eax, 0(%rdi), dst_old=%eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   xchgl %eax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xchg_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 xchg v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   xchgw %ax, 0(%rdi), dst_old=%ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   xchgw %ax, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %xchg_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 xchg v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   xchgb %al, 0(%rdi), dst_old=%al
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   xchgb %al, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umin_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 umin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] Umin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpq %rdx, %rsi
+;   cmovbeq %rsi, %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umin_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 umin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] Umin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpl %edx, %esi
+;   cmovbeq %rsi, %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umin_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 umin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] Umin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpw %dx, %si
+;   cmovbeq %rsi, %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umin_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 umin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] Umin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpb %dl, %sil
+;   cmovbeq %rsi, %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umax_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 umax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] Umax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpq %rdx, %rsi
+;   cmovaeq %rsi, %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umax_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 umax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] Umax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpl %edx, %esi
+;   cmovaeq %rsi, %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umax_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 umax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] Umax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpw %dx, %si
+;   cmovaeq %rsi, %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %umax_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 umax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] Umax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpb %dl, %sil
+;   cmovaeq %rsi, %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smin_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 smin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] Smin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpq %rdx, %rsi
+;   cmovleq %rsi, %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smin_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 smin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] Smin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpl %edx, %esi
+;   cmovleq %rsi, %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smin_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 smin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] Smin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpw %dx, %si
+;   cmovleq %rsi, %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smin_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 smin v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] Smin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpb %dl, %sil
+;   cmovleq %rsi, %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smax_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = atomic_rmw.i64 smax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 64_bits_at_[%r9] Smax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpq %rdx, %rsi
+;   cmovgeq %rsi, %rdx
+;   lock cmpxchgq %rdx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smax_i32(i64, i32) -> i32 {
+block0(v0: i64, v1: i32):
+    v2 = atomic_rmw.i32 smax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 32_bits_at_[%r9] Smax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl (%rdi), %eax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpl %edx, %esi
+;   cmovgeq %rsi, %rdx
+;   lock cmpxchgl %edx, (%rdi) ; trap: heap_oob
+;   jne 6
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smax_i16(i64, i16) -> i16 {
+block0(v0: i64, v1: i16):
+    v2 = atomic_rmw.i16 smax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 16_bits_at_[%r9] Smax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzwq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpw %dx, %si
+;   cmovgeq %rsi, %rdx
+;   lock cmpxchgw %dx, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %smax_i8(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = atomic_rmw.i8 smax v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   atomically { 8_bits_at_[%r9] Smax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rdx
+;   cmpb %dl, %sil
+;   cmovgeq %rsi, %rdx
+;   lock cmpxchgb %dl, (%rdi) ; trap: heap_oob
+;   jne 8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
@@ -11,7 +11,25 @@ target riscv64 has_c has_zcb
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly
 
-function %atomic_rmw_add_i64(i64, i64) -> i64 {
+function %atomic_rmw_add_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little add v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_add_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_add_i64(1, 0) == [1, 1]
+; run: %atomic_rmw_add_i64(0, 1) == [0, 1]
+; run: %atomic_rmw_add_i64(1, 1) == [1, 2]
+; run: %atomic_rmw_add_i64(0xC0FFEEEE_C0FFEEEE, 0x1DCB1111_1DCB1111) == [0xC0FFEEEE_C0FFEEEE, 0xDECAFFFF_DECAFFFF]
+
+function %atomic_rmw_add_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -23,13 +41,31 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_add_i64(0, 0) == 0
-; run: %atomic_rmw_add_i64(1, 0) == 1
-; run: %atomic_rmw_add_i64(0, 1) == 1
-; run: %atomic_rmw_add_i64(1, 1) == 2
-; run: %atomic_rmw_add_i64(0xC0FFEEEE_C0FFEEEE, 0x1DCB1111_1DCB1111) == 0xDECAFFFF_DECAFFFF
+; run: %atomic_rmw_add_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_add_i64_no_res(1, 0) == 1
+; run: %atomic_rmw_add_i64_no_res(0, 1) == 1
+; run: %atomic_rmw_add_i64_no_res(1, 1) == 2
+; run: %atomic_rmw_add_i64_no_res(0xC0FFEEEE_C0FFEEEE, 0x1DCB1111_1DCB1111) == 0xDECAFFFF_DECAFFFF
 
-function %atomic_rmw_add_i32(i32, i32) -> i32 {
+function %atomic_rmw_add_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little add v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_add_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_add_i32(1, 0) == [1, 1]
+; run: %atomic_rmw_add_i32(0, 1) == [0, 1]
+; run: %atomic_rmw_add_i32(1, 1) == [1, 2]
+; run: %atomic_rmw_add_i32(0xC0FFEEEE, 0x1DCB1111) == [0xC0FFEEEE, 0xDECAFFFF]
+
+function %atomic_rmw_add_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -41,15 +77,33 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_add_i32(0, 0) == 0
-; run: %atomic_rmw_add_i32(1, 0) == 1
-; run: %atomic_rmw_add_i32(0, 1) == 1
-; run: %atomic_rmw_add_i32(1, 1) == 2
-; run: %atomic_rmw_add_i32(0xC0FFEEEE, 0x1DCB1111) == 0xDECAFFFF
+; run: %atomic_rmw_add_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_add_i32_no_res(1, 0) == 1
+; run: %atomic_rmw_add_i32_no_res(0, 1) == 1
+; run: %atomic_rmw_add_i32_no_res(1, 1) == 2
+; run: %atomic_rmw_add_i32_no_res(0xC0FFEEEE, 0x1DCB1111) == 0xDECAFFFF
 
 
 
-function %atomic_rmw_sub_i64(i64, i64) -> i64 {
+function %atomic_rmw_sub_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little sub v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_sub_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_sub_i64(1, 0) == [1, 1]
+; run: %atomic_rmw_sub_i64(0, 1) == [0, -1]
+; run: %atomic_rmw_sub_i64(1, 1) == [1, 0]
+; run: %atomic_rmw_sub_i64(0xDECAFFFF_DECAFFFF, 0x1DCB1111_1DCB1111) == [0xDECAFFFF_DECAFFFF, 0xC0FFEEEE_C0FFEEEE]
+
+function %atomic_rmw_sub_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -61,13 +115,31 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_sub_i64(0, 0) == 0
-; run: %atomic_rmw_sub_i64(1, 0) == 1
-; run: %atomic_rmw_sub_i64(0, 1) == -1
-; run: %atomic_rmw_sub_i64(1, 1) == 0
-; run: %atomic_rmw_sub_i64(0xDECAFFFF_DECAFFFF, 0x1DCB1111_1DCB1111) == 0xC0FFEEEE_C0FFEEEE
+; run: %atomic_rmw_sub_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_sub_i64_no_res(1, 0) == 1
+; run: %atomic_rmw_sub_i64_no_res(0, 1) == -1
+; run: %atomic_rmw_sub_i64_no_res(1, 1) == 0
+; run: %atomic_rmw_sub_i64_no_res(0xDECAFFFF_DECAFFFF, 0x1DCB1111_1DCB1111) == 0xC0FFEEEE_C0FFEEEE
 
-function %atomic_rmw_sub_i32(i32, i32) -> i32 {
+function %atomic_rmw_sub_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little sub v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_sub_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_sub_i32(1, 0) == [1, 1]
+; run: %atomic_rmw_sub_i32(0, 1) == [0, -1]
+; run: %atomic_rmw_sub_i32(1, 1) == [1, 0]
+; run: %atomic_rmw_sub_i32(0xDECAFFFF, 0x1DCB1111) == [0xDECAFFFF, 0xC0FFEEEE]
+
+function %atomic_rmw_sub_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -79,15 +151,33 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_sub_i32(0, 0) == 0
-; run: %atomic_rmw_sub_i32(1, 0) == 1
-; run: %atomic_rmw_sub_i32(0, 1) == -1
-; run: %atomic_rmw_sub_i32(1, 1) == 0
-; run: %atomic_rmw_sub_i32(0xDECAFFFF, 0x1DCB1111) == 0xC0FFEEEE
+; run: %atomic_rmw_sub_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_sub_i32_no_res(1, 0) == 1
+; run: %atomic_rmw_sub_i32_no_res(0, 1) == -1
+; run: %atomic_rmw_sub_i32_no_res(1, 1) == 0
+; run: %atomic_rmw_sub_i32_no_res(0xDECAFFFF, 0x1DCB1111) == 0xC0FFEEEE
 
 
 
-function %atomic_rmw_and_i64(i64, i64) -> i64 {
+function %atomic_rmw_and_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little and v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_and_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_and_i64(1, 0) == [1, 0]
+; run: %atomic_rmw_and_i64(0, 1) == [0, 0]
+; run: %atomic_rmw_and_i64(1, 1) == [1, 1]
+; run: %atomic_rmw_and_i64(0xF1FFFEFE_FEEEFFFF, 0xCEFFEFEF_DFDBFFFF) == [0xF1FFFEFE_FEEEFFFF, 0xC0FFEEEE_DECAFFFF]
+
+function %atomic_rmw_and_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -99,13 +189,32 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_and_i64(0, 0) == 0
-; run: %atomic_rmw_and_i64(1, 0) == 0
-; run: %atomic_rmw_and_i64(0, 1) == 0
-; run: %atomic_rmw_and_i64(1, 1) == 1
-; run: %atomic_rmw_and_i64(0xF1FFFEFE_FEEEFFFF, 0xCEFFEFEF_DFDBFFFF) == 0xC0FFEEEE_DECAFFFF
+; run: %atomic_rmw_and_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_and_i64_no_res(1, 0) == 0
+; run: %atomic_rmw_and_i64_no_res(0, 1) == 0
+; run: %atomic_rmw_and_i64_no_res(1, 1) == 1
+; run: %atomic_rmw_and_i64_no_res(0xF1FFFEFE_FEEEFFFF, 0xCEFFEFEF_DFDBFFFF) == 0xC0FFEEEE_DECAFFFF
 
-function %atomic_rmw_and_i32(i32, i32) -> i32 {
+function %atomic_rmw_and_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little and v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+
+; run: %atomic_rmw_and_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_and_i32(1, 0) == [1, 0]
+; run: %atomic_rmw_and_i32(0, 1) == [0, 0]
+; run: %atomic_rmw_and_i32(1, 1) == [1, 1]
+; run: %atomic_rmw_and_i32(0xF1FFFEFE, 0xCEFFEFEF) == [0xF1FFFEFE, 0xC0FFEEEE]
+
+function %atomic_rmw_and_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -118,15 +227,33 @@ block0(v0: i32, v1: i32):
     return v4
 }
 
-; run: %atomic_rmw_and_i32(0, 0) == 0
-; run: %atomic_rmw_and_i32(1, 0) == 0
-; run: %atomic_rmw_and_i32(0, 1) == 0
-; run: %atomic_rmw_and_i32(1, 1) == 1
-; run: %atomic_rmw_and_i32(0xF1FFFEFE, 0xCEFFEFEF) == 0xC0FFEEEE
+; run: %atomic_rmw_and_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_and_i32_no_res(1, 0) == 0
+; run: %atomic_rmw_and_i32_no_res(0, 1) == 0
+; run: %atomic_rmw_and_i32_no_res(1, 1) == 1
+; run: %atomic_rmw_and_i32_no_res(0xF1FFFEFE, 0xCEFFEFEF) == 0xC0FFEEEE
 
 
 
-function %atomic_rmw_or_i64(i64, i64) -> i64 {
+function %atomic_rmw_or_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little or v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_or_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_or_i64(1, 0) == [1, 1]
+; run: %atomic_rmw_or_i64(0, 1) == [0, 1]
+; run: %atomic_rmw_or_i64(1, 1) == [1, 1]
+; run: %atomic_rmw_or_i64(0x80AAAAAA_8A8AAAAA, 0x40554444_54405555) == [0x80AAAAAA_8A8AAAAA, 0xC0FFEEEE_DECAFFFF]
+
+function %atomic_rmw_or_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -138,13 +265,32 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_or_i64(0, 0) == 0
-; run: %atomic_rmw_or_i64(1, 0) == 1
-; run: %atomic_rmw_or_i64(0, 1) == 1
-; run: %atomic_rmw_or_i64(1, 1) == 1
-; run: %atomic_rmw_or_i64(0x80AAAAAA_8A8AAAAA, 0x40554444_54405555) == 0xC0FFEEEE_DECAFFFF
+; run: %atomic_rmw_or_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_or_i64_no_res(1, 0) == 1
+; run: %atomic_rmw_or_i64_no_res(0, 1) == 1
+; run: %atomic_rmw_or_i64_no_res(1, 1) == 1
+; run: %atomic_rmw_or_i64_no_res(0x80AAAAAA_8A8AAAAA, 0x40554444_54405555) == 0xC0FFEEEE_DECAFFFF
 
-function %atomic_rmw_or_i32(i32, i32) -> i32 {
+function %atomic_rmw_or_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little or v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+
+; run: %atomic_rmw_or_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_or_i32(1, 0) == [1, 1]
+; run: %atomic_rmw_or_i32(0, 1) == [0, 1]
+; run: %atomic_rmw_or_i32(1, 1) == [1, 1]
+; run: %atomic_rmw_or_i32(0x80AAAAAA, 0x40554444) == [0x80AAAAAA, 0xC0FFEEEE]
+
+function %atomic_rmw_or_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -157,15 +303,33 @@ block0(v0: i32, v1: i32):
     return v4
 }
 
-; run: %atomic_rmw_or_i32(0, 0) == 0
-; run: %atomic_rmw_or_i32(1, 0) == 1
-; run: %atomic_rmw_or_i32(0, 1) == 1
-; run: %atomic_rmw_or_i32(1, 1) == 1
-; run: %atomic_rmw_or_i32(0x80AAAAAA, 0x40554444) == 0xC0FFEEEE
+; run: %atomic_rmw_or_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_or_i32_no_res(1, 0) == 1
+; run: %atomic_rmw_or_i32_no_res(0, 1) == 1
+; run: %atomic_rmw_or_i32_no_res(1, 1) == 1
+; run: %atomic_rmw_or_i32_no_res(0x80AAAAAA, 0x40554444) == 0xC0FFEEEE
 
 
 
-function %atomic_rmw_xor_i64(i64, i64) -> i64 {
+function %atomic_rmw_xor_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little xor v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_xor_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_xor_i64(1, 0) == [1, 1]
+; run: %atomic_rmw_xor_i64(0, 1) == [0, 1]
+; run: %atomic_rmw_xor_i64(1, 1) == [1, 0]
+; run: %atomic_rmw_xor_i64(0x8FA50A64_9440A07D, 0x4F5AE48A_4A8A5F82) == [0x8FA50A64_9440A07D, 0xC0FFEEEE_DECAFFFF]
+
+function %atomic_rmw_xor_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -177,13 +341,31 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_xor_i64(0, 0) == 0
-; run: %atomic_rmw_xor_i64(1, 0) == 1
-; run: %atomic_rmw_xor_i64(0, 1) == 1
-; run: %atomic_rmw_xor_i64(1, 1) == 0
-; run: %atomic_rmw_xor_i64(0x8FA50A64_9440A07D, 0x4F5AE48A_4A8A5F82) == 0xC0FFEEEE_DECAFFFF
+; run: %atomic_rmw_xor_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_xor_i64_no_res(1, 0) == 1
+; run: %atomic_rmw_xor_i64_no_res(0, 1) == 1
+; run: %atomic_rmw_xor_i64_no_res(1, 1) == 0
+; run: %atomic_rmw_xor_i64_no_res(0x8FA50A64_9440A07D, 0x4F5AE48A_4A8A5F82) == 0xC0FFEEEE_DECAFFFF
 
-function %atomic_rmw_xor_i32(i32, i32) -> i32 {
+function %atomic_rmw_xor_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little xor v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_xor_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_xor_i32(1, 0) == [1, 1]
+; run: %atomic_rmw_xor_i32(0, 1) == [0, 1]
+; run: %atomic_rmw_xor_i32(1, 1) == [1, 0]
+; run: %atomic_rmw_xor_i32(0x8FA50A64, 0x4F5AE48A) == [0x8FA50A64, 0xC0FFEEEE]
+
+function %atomic_rmw_xor_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -195,15 +377,33 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_xor_i32(0, 0) == 0
-; run: %atomic_rmw_xor_i32(1, 0) == 1
-; run: %atomic_rmw_xor_i32(0, 1) == 1
-; run: %atomic_rmw_xor_i32(1, 1) == 0
-; run: %atomic_rmw_xor_i32(0x8FA50A64, 0x4F5AE48A) == 0xC0FFEEEE
+; run: %atomic_rmw_xor_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_xor_i32_no_res(1, 0) == 1
+; run: %atomic_rmw_xor_i32_no_res(0, 1) == 1
+; run: %atomic_rmw_xor_i32_no_res(1, 1) == 0
+; run: %atomic_rmw_xor_i32_no_res(0x8FA50A64, 0x4F5AE48A) == 0xC0FFEEEE
 
 
 
-function %atomic_rmw_nand_i64(i64, i64) -> i64 {
+function %atomic_rmw_nand_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little nand v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_nand_i64(0, 0) == [0, -1]
+; run: %atomic_rmw_nand_i64(1, 0) == [1, -1]
+; run: %atomic_rmw_nand_i64(0, 1) == [0, -1]
+; run: %atomic_rmw_nand_i64(1, 1) == [1, -2]
+; run: %atomic_rmw_nand_i64(0xC0FFEEEE_DECAFFFF, 0x7DCB5691_7DCB5691) == [0xC0FFEEEE_DECAFFFF, 0xBF34B97F_A335A96E]
+
+function %atomic_rmw_nand_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -215,13 +415,31 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_nand_i64(0, 0) == -1
-; run: %atomic_rmw_nand_i64(1, 0) == -1
-; run: %atomic_rmw_nand_i64(0, 1) == -1
-; run: %atomic_rmw_nand_i64(1, 1) == -2
-; run: %atomic_rmw_nand_i64(0xC0FFEEEE_DECAFFFF, 0x7DCB5691_7DCB5691) == 0xBF34B97F_A335A96E
+; run: %atomic_rmw_nand_i64_no_res(0, 0) == -1
+; run: %atomic_rmw_nand_i64_no_res(1, 0) == -1
+; run: %atomic_rmw_nand_i64_no_res(0, 1) == -1
+; run: %atomic_rmw_nand_i64_no_res(1, 1) == -2
+; run: %atomic_rmw_nand_i64_no_res(0xC0FFEEEE_DECAFFFF, 0x7DCB5691_7DCB5691) == 0xBF34B97F_A335A96E
 
-function %atomic_rmw_nand_i32(i32, i32) -> i32 {
+function %atomic_rmw_nand_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little nand v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_nand_i32(0, 0) == [0, -1]
+; run: %atomic_rmw_nand_i32(1, 0) == [1, -1]
+; run: %atomic_rmw_nand_i32(0, 1) == [0, -1]
+; run: %atomic_rmw_nand_i32(1, 1) == [1, -2]
+; run: %atomic_rmw_nand_i32(0xC0FFEEEE, 0x7DCB5691) == [0xC0FFEEEE, 0xBF34B97F]
+
+function %atomic_rmw_nand_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -233,15 +451,34 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_nand_i32(0, 0) == -1
-; run: %atomic_rmw_nand_i32(1, 0) == -1
-; run: %atomic_rmw_nand_i32(0, 1) == -1
-; run: %atomic_rmw_nand_i32(1, 1) == -2
-; run: %atomic_rmw_nand_i32(0xC0FFEEEE, 0x7DCB5691) == 0xBF34B97F
+; run: %atomic_rmw_nand_i32_no_res(0, 0) == -1
+; run: %atomic_rmw_nand_i32_no_res(1, 0) == -1
+; run: %atomic_rmw_nand_i32_no_res(0, 1) == -1
+; run: %atomic_rmw_nand_i32_no_res(1, 1) == -2
+; run: %atomic_rmw_nand_i32_no_res(0xC0FFEEEE, 0x7DCB5691) == 0xBF34B97F
 
 
 
-function %atomic_rmw_umin_i64(i64, i64) -> i64 {
+function %atomic_rmw_umin_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little umin v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_umin_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_umin_i64(1, 0) == [1, 0]
+; run: %atomic_rmw_umin_i64(0, 1) == [0, 0]
+; run: %atomic_rmw_umin_i64(1, 1) == [1, 1]
+; run: %atomic_rmw_umin_i64(-1, 1) == [-1, 1]
+; run: %atomic_rmw_umin_i64(-1, -3) == [-1, -3]
+
+function %atomic_rmw_umin_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -253,14 +490,33 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_umin_i64(0, 0) == 0
-; run: %atomic_rmw_umin_i64(1, 0) == 0
-; run: %atomic_rmw_umin_i64(0, 1) == 0
-; run: %atomic_rmw_umin_i64(1, 1) == 1
-; run: %atomic_rmw_umin_i64(-1, 1) == 1
-; run: %atomic_rmw_umin_i64(-1, -3) == -3
+; run: %atomic_rmw_umin_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_umin_i64_no_res(1, 0) == 0
+; run: %atomic_rmw_umin_i64_no_res(0, 1) == 0
+; run: %atomic_rmw_umin_i64_no_res(1, 1) == 1
+; run: %atomic_rmw_umin_i64_no_res(-1, 1) == 1
+; run: %atomic_rmw_umin_i64_no_res(-1, -3) == -3
 
-function %atomic_rmw_umin_i32(i32, i32) -> i32 {
+function %atomic_rmw_umin_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little umin v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_umin_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_umin_i32(1, 0) == [1, 0]
+; run: %atomic_rmw_umin_i32(0, 1) == [0, 0]
+; run: %atomic_rmw_umin_i32(1, 1) == [1, 1]
+; run: %atomic_rmw_umin_i32(-1, 1) == [-1, 1]
+; run: %atomic_rmw_umin_i32(-1, -3) == [-1, -3]
+
+function %atomic_rmw_umin_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -272,16 +528,35 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_umin_i32(0, 0) == 0
-; run: %atomic_rmw_umin_i32(1, 0) == 0
-; run: %atomic_rmw_umin_i32(0, 1) == 0
-; run: %atomic_rmw_umin_i32(1, 1) == 1
-; run: %atomic_rmw_umin_i32(-1, 1) == 1
-; run: %atomic_rmw_umin_i32(-1, -3) == -3
+; run: %atomic_rmw_umin_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_umin_i32_no_res(1, 0) == 0
+; run: %atomic_rmw_umin_i32_no_res(0, 1) == 0
+; run: %atomic_rmw_umin_i32_no_res(1, 1) == 1
+; run: %atomic_rmw_umin_i32_no_res(-1, 1) == 1
+; run: %atomic_rmw_umin_i32_no_res(-1, -3) == -3
 
 
 
-function %atomic_rmw_umax_i64(i64, i64) -> i64 {
+function %atomic_rmw_umax_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little umax v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_umax_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_umax_i64(1, 0) == [1, 1]
+; run: %atomic_rmw_umax_i64(0, 1) == [0, 1]
+; run: %atomic_rmw_umax_i64(1, 1) == [1, 1]
+; run: %atomic_rmw_umax_i64(-1, 1) == [-1, -1]
+; run: %atomic_rmw_umax_i64(-1, -3) == [-1, -1]
+
+function %atomic_rmw_umax_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -293,14 +568,33 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_umax_i64(0, 0) == 0
-; run: %atomic_rmw_umax_i64(1, 0) == 1
-; run: %atomic_rmw_umax_i64(0, 1) == 1
-; run: %atomic_rmw_umax_i64(1, 1) == 1
-; run: %atomic_rmw_umax_i64(-1, 1) == -1
-; run: %atomic_rmw_umax_i64(-1, -3) == -1
+; run: %atomic_rmw_umax_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_umax_i64_no_res(1, 0) == 1
+; run: %atomic_rmw_umax_i64_no_res(0, 1) == 1
+; run: %atomic_rmw_umax_i64_no_res(1, 1) == 1
+; run: %atomic_rmw_umax_i64_no_res(-1, 1) == -1
+; run: %atomic_rmw_umax_i64_no_res(-1, -3) == -1
 
-function %atomic_rmw_umax_i32(i32, i32) -> i32 {
+function %atomic_rmw_umax_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little umax v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_umax_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_umax_i32(1, 0) == [1, 1]
+; run: %atomic_rmw_umax_i32(0, 1) == [0, 1]
+; run: %atomic_rmw_umax_i32(1, 1) == [1, 1]
+; run: %atomic_rmw_umax_i32(-1, 1) == [-1, -1]
+; run: %atomic_rmw_umax_i32(-1, -3) == [-1, -1]
+
+function %atomic_rmw_umax_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -312,16 +606,35 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_umax_i32(0, 0) == 0
-; run: %atomic_rmw_umax_i32(1, 0) == 1
-; run: %atomic_rmw_umax_i32(0, 1) == 1
-; run: %atomic_rmw_umax_i32(1, 1) == 1
-; run: %atomic_rmw_umax_i32(-1, 1) == -1
-; run: %atomic_rmw_umax_i32(-1, -3) == -1
+; run: %atomic_rmw_umax_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_umax_i32_no_res(1, 0) == 1
+; run: %atomic_rmw_umax_i32_no_res(0, 1) == 1
+; run: %atomic_rmw_umax_i32_no_res(1, 1) == 1
+; run: %atomic_rmw_umax_i32_no_res(-1, 1) == -1
+; run: %atomic_rmw_umax_i32_no_res(-1, -3) == -1
 
 
 
-function %atomic_rmw_smin_i64(i64, i64) -> i64 {
+function %atomic_rmw_smin_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little smin v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_smin_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_smin_i64(1, 0) == [1, 0]
+; run: %atomic_rmw_smin_i64(0, 1) == [0, 0]
+; run: %atomic_rmw_smin_i64(1, 1) == [1, 1]
+; run: %atomic_rmw_smin_i64(-1, 1) == [-1, -1]
+; run: %atomic_rmw_smin_i64(-1, -3) == [-1, -3]
+
+function %atomic_rmw_smin_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -333,14 +646,33 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_smin_i64(0, 0) == 0
-; run: %atomic_rmw_smin_i64(1, 0) == 0
-; run: %atomic_rmw_smin_i64(0, 1) == 0
-; run: %atomic_rmw_smin_i64(1, 1) == 1
-; run: %atomic_rmw_smin_i64(-1, 1) == -1
-; run: %atomic_rmw_smin_i64(-1, -3) == -3
+; run: %atomic_rmw_smin_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_smin_i64_no_res(1, 0) == 0
+; run: %atomic_rmw_smin_i64_no_res(0, 1) == 0
+; run: %atomic_rmw_smin_i64_no_res(1, 1) == 1
+; run: %atomic_rmw_smin_i64_no_res(-1, 1) == -1
+; run: %atomic_rmw_smin_i64_no_res(-1, -3) == -3
 
-function %atomic_rmw_smin_i32(i32, i32) -> i32 {
+function %atomic_rmw_smin_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little smin v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_smin_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_smin_i32(1, 0) == [1, 0]
+; run: %atomic_rmw_smin_i32(0, 1) == [0, 0]
+; run: %atomic_rmw_smin_i32(1, 1) == [1, 1]
+; run: %atomic_rmw_smin_i32(-1, -1) == [-1, -1]
+; run: %atomic_rmw_smin_i32(-1, -3) == [-1, -3]
+
+function %atomic_rmw_smin_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -352,16 +684,35 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_smin_i32(0, 0) == 0
-; run: %atomic_rmw_smin_i32(1, 0) == 0
-; run: %atomic_rmw_smin_i32(0, 1) == 0
-; run: %atomic_rmw_smin_i32(1, 1) == 1
-; run: %atomic_rmw_smin_i32(-1, -1) == -1
-; run: %atomic_rmw_smin_i32(-1, -3) == -3
+; run: %atomic_rmw_smin_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_smin_i32_no_res(1, 0) == 0
+; run: %atomic_rmw_smin_i32_no_res(0, 1) == 0
+; run: %atomic_rmw_smin_i32_no_res(1, 1) == 1
+; run: %atomic_rmw_smin_i32_no_res(-1, -1) == -1
+; run: %atomic_rmw_smin_i32_no_res(-1, -3) == -3
 
 
 
-function %atomic_rmw_smax_i64(i64, i64) -> i64 {
+function %atomic_rmw_smax_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little smax v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_smax_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_smax_i64(1, 0) == [1, 1]
+; run: %atomic_rmw_smax_i64(0, 1) == [0, 1]
+; run: %atomic_rmw_smax_i64(1, 1) == [1, 1]
+; run: %atomic_rmw_smax_i64(-1, 1) == [-1, 1]
+; run: %atomic_rmw_smax_i64(-1, -3) == [-1, -1]
+
+function %atomic_rmw_smax_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -373,14 +724,33 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_smax_i64(0, 0) == 0
-; run: %atomic_rmw_smax_i64(1, 0) == 1
-; run: %atomic_rmw_smax_i64(0, 1) == 1
-; run: %atomic_rmw_smax_i64(1, 1) == 1
-; run: %atomic_rmw_smax_i64(-1, 1) == 1
-; run: %atomic_rmw_smax_i64(-1, -3) == -1
+; run: %atomic_rmw_smax_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_smax_i64_no_res(1, 0) == 1
+; run: %atomic_rmw_smax_i64_no_res(0, 1) == 1
+; run: %atomic_rmw_smax_i64_no_res(1, 1) == 1
+; run: %atomic_rmw_smax_i64_no_res(-1, 1) == 1
+; run: %atomic_rmw_smax_i64_no_res(-1, -3) == -1
 
-function %atomic_rmw_smax_i32(i32, i32) -> i32 {
+function %atomic_rmw_smax_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little smax v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_smax_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_smax_i32(1, 0) == [1, 1]
+; run: %atomic_rmw_smax_i32(0, 1) == [0, 1]
+; run: %atomic_rmw_smax_i32(1, 1) == [1, 1]
+; run: %atomic_rmw_smax_i32(-1, 1) == [-1, 1]
+; run: %atomic_rmw_smax_i32(-1, -3) == [-1, -1]
+
+function %atomic_rmw_smax_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -392,16 +762,33 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_smax_i32(0, 0) == 0
-; run: %atomic_rmw_smax_i32(1, 0) == 1
-; run: %atomic_rmw_smax_i32(0, 1) == 1
-; run: %atomic_rmw_smax_i32(1, 1) == 1
-; run: %atomic_rmw_smax_i32(-1, 1) == 1
-; run: %atomic_rmw_smax_i32(-1, -3) == -1
+; run: %atomic_rmw_smax_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_smax_i32_no_res(1, 0) == 1
+; run: %atomic_rmw_smax_i32_no_res(0, 1) == 1
+; run: %atomic_rmw_smax_i32_no_res(1, 1) == 1
+; run: %atomic_rmw_smax_i32_no_res(-1, 1) == 1
+; run: %atomic_rmw_smax_i32_no_res(-1, -3) == -1
 
 
 
-function %atomic_rmw_xchg_i64(i64, i64) -> i64 {
+function %atomic_rmw_xchg_i64(i64, i64) -> i64, i64 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i64):
+    v2 = stack_addr.i64 ss0
+    store.i64 little v0, v2
+
+    v3 = atomic_rmw.i64 little xchg v2, v1
+
+    v4 = load.i64 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_xchg_i64(0, 0) == [0, 0]
+; run: %atomic_rmw_xchg_i64(1, 0) == [1, 0]
+; run: %atomic_rmw_xchg_i64(0, 1) == [0, 1]
+; run: %atomic_rmw_xchg_i64(0, 0xC0FFEEEE_DECAFFFF) == [0, 0xC0FFEEEE_DECAFFFF]
+
+function %atomic_rmw_xchg_i64_no_res(i64, i64) -> i64 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i64):
@@ -413,12 +800,29 @@ block0(v0: i64, v1: i64):
     v4 = load.i64 little v2
     return v4
 }
-; run: %atomic_rmw_xchg_i64(0, 0) == 0
-; run: %atomic_rmw_xchg_i64(1, 0) == 0
-; run: %atomic_rmw_xchg_i64(0, 1) == 1
-; run: %atomic_rmw_xchg_i64(0, 0xC0FFEEEE_DECAFFFF) == 0xC0FFEEEE_DECAFFFF
+; run: %atomic_rmw_xchg_i64_no_res(0, 0) == 0
+; run: %atomic_rmw_xchg_i64_no_res(1, 0) == 0
+; run: %atomic_rmw_xchg_i64_no_res(0, 1) == 1
+; run: %atomic_rmw_xchg_i64_no_res(0, 0xC0FFEEEE_DECAFFFF) == 0xC0FFEEEE_DECAFFFF
 
-function %atomic_rmw_xchg_i32(i32, i32) -> i32 {
+function %atomic_rmw_xchg_i32(i32, i32) -> i32, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i32):
+    v2 = stack_addr.i64 ss0
+    store.i32 little v0, v2
+
+    v3 = atomic_rmw.i32 little xchg v2, v1
+
+    v4 = load.i32 little v2
+    return v3, v4
+}
+; run: %atomic_rmw_xchg_i32(0, 0) == [0, 0]
+; run: %atomic_rmw_xchg_i32(1, 0) == [1, 0]
+; run: %atomic_rmw_xchg_i32(0, 1) == [0, 1]
+; run: %atomic_rmw_xchg_i32(0, 0xC0FFEEEE) == [0, 0xC0FFEEEE]
+
+function %atomic_rmw_xchg_i32_no_res(i32, i32) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i32):
@@ -430,7 +834,7 @@ block0(v0: i32, v1: i32):
     v4 = load.i32 little v2
     return v4
 }
-; run: %atomic_rmw_xchg_i32(0, 0) == 0
-; run: %atomic_rmw_xchg_i32(1, 0) == 0
-; run: %atomic_rmw_xchg_i32(0, 1) == 1
-; run: %atomic_rmw_xchg_i32(0, 0xC0FFEEEE) == 0xC0FFEEEE
+; run: %atomic_rmw_xchg_i32_no_res(0, 0) == 0
+; run: %atomic_rmw_xchg_i32_no_res(1, 0) == 0
+; run: %atomic_rmw_xchg_i32_no_res(0, 1) == 1
+; run: %atomic_rmw_xchg_i32_no_res(0, 0xC0FFEEEE) == 0xC0FFEEEE

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
@@ -6,7 +6,25 @@ target s390x has_mie2
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly
 
-function %atomic_rmw_add_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_add_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big add v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_add_big_i16(0x12345678, 0, 0x1111) == [0x1234, 0x23455678]
+; run: %atomic_rmw_add_big_i16(0x12345678, 0, 0xffff) == [0x1234, 0x12335678]
+; run: %atomic_rmw_add_big_i16(0x12345678, 2, 0x1111) == [0x5678, 0x12346789]
+; run: %atomic_rmw_add_big_i16(0x12345678, 2, 0xffff) == [0x5678, 0x12345677]
+
+function %atomic_rmw_add_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -19,12 +37,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_add_big_i16(0x12345678, 0, 0x1111) == 0x23455678
-; run: %atomic_rmw_add_big_i16(0x12345678, 0, 0xffff) == 0x12335678
-; run: %atomic_rmw_add_big_i16(0x12345678, 2, 0x1111) == 0x12346789
-; run: %atomic_rmw_add_big_i16(0x12345678, 2, 0xffff) == 0x12345677
+; run: %atomic_rmw_add_big_i16_no_res(0x12345678, 0, 0x1111) == 0x23455678
+; run: %atomic_rmw_add_big_i16_no_res(0x12345678, 0, 0xffff) == 0x12335678
+; run: %atomic_rmw_add_big_i16_no_res(0x12345678, 2, 0x1111) == 0x12346789
+; run: %atomic_rmw_add_big_i16_no_res(0x12345678, 2, 0xffff) == 0x12345677
 
-function %atomic_rmw_add_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_add_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big add v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_add_big_i8(0x12345678, 0, 0x11) == [0x12, 0x23345678]
+; run: %atomic_rmw_add_big_i8(0x12345678, 0, 0xff) == [0x12, 0x11345678]
+; run: %atomic_rmw_add_big_i8(0x12345678, 1, 0x11) == [0x34, 0x12455678]
+; run: %atomic_rmw_add_big_i8(0x12345678, 1, 0xff) == [0x34, 0x12335678]
+; run: %atomic_rmw_add_big_i8(0x12345678, 2, 0x11) == [0x56, 0x12346778]
+; run: %atomic_rmw_add_big_i8(0x12345678, 2, 0xff) == [0x56, 0x12345578]
+; run: %atomic_rmw_add_big_i8(0x12345678, 3, 0x11) == [0x78, 0x12345689]
+; run: %atomic_rmw_add_big_i8(0x12345678, 3, 0xff) == [0x78, 0x12345677]
+
+function %atomic_rmw_add_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -37,16 +77,34 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_add_big_i8(0x12345678, 0, 0x11) == 0x23345678
-; run: %atomic_rmw_add_big_i8(0x12345678, 0, 0xff) == 0x11345678
-; run: %atomic_rmw_add_big_i8(0x12345678, 1, 0x11) == 0x12455678
-; run: %atomic_rmw_add_big_i8(0x12345678, 1, 0xff) == 0x12335678
-; run: %atomic_rmw_add_big_i8(0x12345678, 2, 0x11) == 0x12346778
-; run: %atomic_rmw_add_big_i8(0x12345678, 2, 0xff) == 0x12345578
-; run: %atomic_rmw_add_big_i8(0x12345678, 3, 0x11) == 0x12345689
-; run: %atomic_rmw_add_big_i8(0x12345678, 3, 0xff) == 0x12345677
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 0, 0x11) == 0x23345678
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 0, 0xff) == 0x11345678
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 1, 0x11) == 0x12455678
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 1, 0xff) == 0x12335678
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 2, 0x11) == 0x12346778
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 2, 0xff) == 0x12345578
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 3, 0x11) == 0x12345689
+; run: %atomic_rmw_add_big_i8_no_res(0x12345678, 3, 0xff) == 0x12345677
 
-function %atomic_rmw_sub_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_sub_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big sub v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_sub_big_i16(0x12345678, 0, 0x1111) == [0x1234, 0x01235678]
+; run: %atomic_rmw_sub_big_i16(0x12345678, 0, 0xffff) == [0x1234, 0x12355678]
+; run: %atomic_rmw_sub_big_i16(0x12345678, 2, 0x1111) == [0x5678, 0x12344567]
+; run: %atomic_rmw_sub_big_i16(0x12345678, 2, 0xffff) == [0x5678, 0x12345679]
+
+function %atomic_rmw_sub_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -59,13 +117,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_sub_big_i16(0x12345678, 0, 0x1111) == 0x01235678
-; run: %atomic_rmw_sub_big_i16(0x12345678, 0, 0xffff) == 0x12355678
-; run: %atomic_rmw_sub_big_i16(0x12345678, 2, 0x1111) == 0x12344567
-; run: %atomic_rmw_sub_big_i16(0x12345678, 2, 0xffff) == 0x12345679
+; run: %atomic_rmw_sub_big_i16_no_res(0x12345678, 0, 0x1111) == 0x01235678
+; run: %atomic_rmw_sub_big_i16_no_res(0x12345678, 0, 0xffff) == 0x12355678
+; run: %atomic_rmw_sub_big_i16_no_res(0x12345678, 2, 0x1111) == 0x12344567
+; run: %atomic_rmw_sub_big_i16_no_res(0x12345678, 2, 0xffff) == 0x12345679
 
 
-function %atomic_rmw_sub_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_sub_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big sub v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_sub_big_i8(0x12345678, 0, 0x11) == [0x12, 0x01345678]
+; run: %atomic_rmw_sub_big_i8(0x12345678, 0, 0xff) == [0x12, 0x13345678]
+; run: %atomic_rmw_sub_big_i8(0x12345678, 1, 0x11) == [0x34, 0x12235678]
+; run: %atomic_rmw_sub_big_i8(0x12345678, 1, 0xff) == [0x34, 0x12355678]
+; run: %atomic_rmw_sub_big_i8(0x12345678, 2, 0x11) == [0x56, 0x12344578]
+; run: %atomic_rmw_sub_big_i8(0x12345678, 2, 0xff) == [0x56, 0x12345778]
+; run: %atomic_rmw_sub_big_i8(0x12345678, 3, 0x11) == [0x78, 0x12345667]
+; run: %atomic_rmw_sub_big_i8(0x12345678, 3, 0xff) == [0x78, 0x12345679]
+
+function %atomic_rmw_sub_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -78,17 +158,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_sub_big_i8(0x12345678, 0, 0x11) == 0x01345678
-; run: %atomic_rmw_sub_big_i8(0x12345678, 0, 0xff) == 0x13345678
-; run: %atomic_rmw_sub_big_i8(0x12345678, 1, 0x11) == 0x12235678
-; run: %atomic_rmw_sub_big_i8(0x12345678, 1, 0xff) == 0x12355678
-; run: %atomic_rmw_sub_big_i8(0x12345678, 2, 0x11) == 0x12344578
-; run: %atomic_rmw_sub_big_i8(0x12345678, 2, 0xff) == 0x12345778
-; run: %atomic_rmw_sub_big_i8(0x12345678, 3, 0x11) == 0x12345667
-; run: %atomic_rmw_sub_big_i8(0x12345678, 3, 0xff) == 0x12345679
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 0, 0x11) == 0x01345678
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 0, 0xff) == 0x13345678
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 1, 0x11) == 0x12235678
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 1, 0xff) == 0x12355678
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 2, 0x11) == 0x12344578
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 2, 0xff) == 0x12345778
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 3, 0x11) == 0x12345667
+; run: %atomic_rmw_sub_big_i8_no_res(0x12345678, 3, 0xff) == 0x12345679
 
 
-function %atomic_rmw_and_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_and_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big and v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_and_big_i16(0x12345678, 0, 0xf000) == [0x1234, 0x10005678]
+; run: %atomic_rmw_and_big_i16(0x12345678, 0, 0x000f) == [0x1234, 0x00045678]
+; run: %atomic_rmw_and_big_i16(0x12345678, 2, 0xf000) == [0x5678, 0x12345000]
+; run: %atomic_rmw_and_big_i16(0x12345678, 2, 0x000f) == [0x5678, 0x12340008]
+
+function %atomic_rmw_and_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -101,13 +199,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_and_big_i16(0x12345678, 0, 0xf000) == 0x10005678
-; run: %atomic_rmw_and_big_i16(0x12345678, 0, 0x000f) == 0x00045678
-; run: %atomic_rmw_and_big_i16(0x12345678, 2, 0xf000) == 0x12345000
-; run: %atomic_rmw_and_big_i16(0x12345678, 2, 0x000f) == 0x12340008
+; run: %atomic_rmw_and_big_i16_no_res(0x12345678, 0, 0xf000) == 0x10005678
+; run: %atomic_rmw_and_big_i16_no_res(0x12345678, 0, 0x000f) == 0x00045678
+; run: %atomic_rmw_and_big_i16_no_res(0x12345678, 2, 0xf000) == 0x12345000
+; run: %atomic_rmw_and_big_i16_no_res(0x12345678, 2, 0x000f) == 0x12340008
 
 
-function %atomic_rmw_and_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_and_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big and v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_and_big_i8(0x12345678, 0, 0xf0) == [0x12, 0x10345678]
+; run: %atomic_rmw_and_big_i8(0x12345678, 0, 0x0f) == [0x12, 0x02345678]
+; run: %atomic_rmw_and_big_i8(0x12345678, 1, 0xf0) == [0x34, 0x12305678]
+; run: %atomic_rmw_and_big_i8(0x12345678, 1, 0x0f) == [0x34, 0x12045678]
+; run: %atomic_rmw_and_big_i8(0x12345678, 2, 0xf0) == [0x56, 0x12345078]
+; run: %atomic_rmw_and_big_i8(0x12345678, 2, 0x0f) == [0x56, 0x12340678]
+; run: %atomic_rmw_and_big_i8(0x12345678, 3, 0xf0) == [0x78, 0x12345670]
+; run: %atomic_rmw_and_big_i8(0x12345678, 3, 0x0f) == [0x78, 0x12345608]
+
+function %atomic_rmw_and_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -120,17 +240,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_and_big_i8(0x12345678, 0, 0xf0) == 0x10345678
-; run: %atomic_rmw_and_big_i8(0x12345678, 0, 0x0f) == 0x02345678
-; run: %atomic_rmw_and_big_i8(0x12345678, 1, 0xf0) == 0x12305678
-; run: %atomic_rmw_and_big_i8(0x12345678, 1, 0x0f) == 0x12045678
-; run: %atomic_rmw_and_big_i8(0x12345678, 2, 0xf0) == 0x12345078
-; run: %atomic_rmw_and_big_i8(0x12345678, 2, 0x0f) == 0x12340678
-; run: %atomic_rmw_and_big_i8(0x12345678, 3, 0xf0) == 0x12345670
-; run: %atomic_rmw_and_big_i8(0x12345678, 3, 0x0f) == 0x12345608
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 0, 0xf0) == 0x10345678
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 0, 0x0f) == 0x02345678
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 1, 0xf0) == 0x12305678
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 1, 0x0f) == 0x12045678
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 2, 0xf0) == 0x12345078
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 2, 0x0f) == 0x12340678
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 3, 0xf0) == 0x12345670
+; run: %atomic_rmw_and_big_i8_no_res(0x12345678, 3, 0x0f) == 0x12345608
 
 
-function %atomic_rmw_or_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_or_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big or v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_or_big_i16(0x12345678, 0, 0xf000) == [0x1234, 0xf2345678]
+; run: %atomic_rmw_or_big_i16(0x12345678, 0, 0x000f) == [0x1234, 0x123f5678]
+; run: %atomic_rmw_or_big_i16(0x12345678, 2, 0xf000) == [0x5678, 0x1234f678]
+; run: %atomic_rmw_or_big_i16(0x12345678, 2, 0x000f) == [0x5678, 0x1234567f]
+
+function %atomic_rmw_or_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -143,13 +281,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_or_big_i16(0x12345678, 0, 0xf000) == 0xf2345678
-; run: %atomic_rmw_or_big_i16(0x12345678, 0, 0x000f) == 0x123f5678
-; run: %atomic_rmw_or_big_i16(0x12345678, 2, 0xf000) == 0x1234f678
-; run: %atomic_rmw_or_big_i16(0x12345678, 2, 0x000f) == 0x1234567f
+; run: %atomic_rmw_or_big_i16_no_res(0x12345678, 0, 0xf000) == 0xf2345678
+; run: %atomic_rmw_or_big_i16_no_res(0x12345678, 0, 0x000f) == 0x123f5678
+; run: %atomic_rmw_or_big_i16_no_res(0x12345678, 2, 0xf000) == 0x1234f678
+; run: %atomic_rmw_or_big_i16_no_res(0x12345678, 2, 0x000f) == 0x1234567f
 
 
-function %atomic_rmw_or_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_or_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big or v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_or_big_i8(0x12345678, 0, 0xf0) == [0x12, 0xf2345678]
+; run: %atomic_rmw_or_big_i8(0x12345678, 0, 0x0f) == [0x12, 0x1f345678]
+; run: %atomic_rmw_or_big_i8(0x12345678, 1, 0xf0) == [0x34, 0x12f45678]
+; run: %atomic_rmw_or_big_i8(0x12345678, 1, 0x0f) == [0x34, 0x123f5678]
+; run: %atomic_rmw_or_big_i8(0x12345678, 2, 0xf0) == [0x56, 0x1234f678]
+; run: %atomic_rmw_or_big_i8(0x12345678, 2, 0x0f) == [0x56, 0x12345f78]
+; run: %atomic_rmw_or_big_i8(0x12345678, 3, 0xf0) == [0x78, 0x123456f8]
+; run: %atomic_rmw_or_big_i8(0x12345678, 3, 0x0f) == [0x78, 0x1234567f]
+
+function %atomic_rmw_or_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -162,17 +322,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_or_big_i8(0x12345678, 0, 0xf0) == 0xf2345678
-; run: %atomic_rmw_or_big_i8(0x12345678, 0, 0x0f) == 0x1f345678
-; run: %atomic_rmw_or_big_i8(0x12345678, 1, 0xf0) == 0x12f45678
-; run: %atomic_rmw_or_big_i8(0x12345678, 1, 0x0f) == 0x123f5678
-; run: %atomic_rmw_or_big_i8(0x12345678, 2, 0xf0) == 0x1234f678
-; run: %atomic_rmw_or_big_i8(0x12345678, 2, 0x0f) == 0x12345f78
-; run: %atomic_rmw_or_big_i8(0x12345678, 3, 0xf0) == 0x123456f8
-; run: %atomic_rmw_or_big_i8(0x12345678, 3, 0x0f) == 0x1234567f
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 0, 0xf0) == 0xf2345678
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 0, 0x0f) == 0x1f345678
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 1, 0xf0) == 0x12f45678
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 1, 0x0f) == 0x123f5678
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 2, 0xf0) == 0x1234f678
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 2, 0x0f) == 0x12345f78
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 3, 0xf0) == 0x123456f8
+; run: %atomic_rmw_or_big_i8_no_res(0x12345678, 3, 0x0f) == 0x1234567f
 
 
-function %atomic_rmw_xor_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_xor_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big xor v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_xor_big_i16(0x12345678, 0, 0xf000) == [0x1234, 0xe2345678]
+; run: %atomic_rmw_xor_big_i16(0x12345678, 0, 0x000f) == [0x1234, 0x123b5678]
+; run: %atomic_rmw_xor_big_i16(0x12345678, 2, 0xf000) == [0x5678, 0x1234a678]
+; run: %atomic_rmw_xor_big_i16(0x12345678, 2, 0x000f) == [0x5678, 0x12345677]
+
+function %atomic_rmw_xor_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -185,13 +363,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_xor_big_i16(0x12345678, 0, 0xf000) == 0xe2345678
-; run: %atomic_rmw_xor_big_i16(0x12345678, 0, 0x000f) == 0x123b5678
-; run: %atomic_rmw_xor_big_i16(0x12345678, 2, 0xf000) == 0x1234a678
-; run: %atomic_rmw_xor_big_i16(0x12345678, 2, 0x000f) == 0x12345677
+; run: %atomic_rmw_xor_big_i16_no_res(0x12345678, 0, 0xf000) == 0xe2345678
+; run: %atomic_rmw_xor_big_i16_no_res(0x12345678, 0, 0x000f) == 0x123b5678
+; run: %atomic_rmw_xor_big_i16_no_res(0x12345678, 2, 0xf000) == 0x1234a678
+; run: %atomic_rmw_xor_big_i16_no_res(0x12345678, 2, 0x000f) == 0x12345677
 
 
-function %atomic_rmw_xor_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_xor_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big xor v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_xor_big_i8(0x12345678, 0, 0xf0) == [0x12, 0xe2345678]
+; run: %atomic_rmw_xor_big_i8(0x12345678, 0, 0x0f) == [0x12, 0x1d345678]
+; run: %atomic_rmw_xor_big_i8(0x12345678, 1, 0xf0) == [0x34, 0x12c45678]
+; run: %atomic_rmw_xor_big_i8(0x12345678, 1, 0x0f) == [0x34, 0x123b5678]
+; run: %atomic_rmw_xor_big_i8(0x12345678, 2, 0xf0) == [0x56, 0x1234a678]
+; run: %atomic_rmw_xor_big_i8(0x12345678, 2, 0x0f) == [0x56, 0x12345978]
+; run: %atomic_rmw_xor_big_i8(0x12345678, 3, 0xf0) == [0x78, 0x12345688]
+; run: %atomic_rmw_xor_big_i8(0x12345678, 3, 0x0f) == [0x78, 0x12345677]
+
+function %atomic_rmw_xor_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -204,16 +404,34 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_xor_big_i8(0x12345678, 0, 0xf0) == 0xe2345678
-; run: %atomic_rmw_xor_big_i8(0x12345678, 0, 0x0f) == 0x1d345678
-; run: %atomic_rmw_xor_big_i8(0x12345678, 1, 0xf0) == 0x12c45678
-; run: %atomic_rmw_xor_big_i8(0x12345678, 1, 0x0f) == 0x123b5678
-; run: %atomic_rmw_xor_big_i8(0x12345678, 2, 0xf0) == 0x1234a678
-; run: %atomic_rmw_xor_big_i8(0x12345678, 2, 0x0f) == 0x12345978
-; run: %atomic_rmw_xor_big_i8(0x12345678, 3, 0xf0) == 0x12345688
-; run: %atomic_rmw_xor_big_i8(0x12345678, 3, 0x0f) == 0x12345677
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 0, 0xf0) == 0xe2345678
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 0, 0x0f) == 0x1d345678
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 1, 0xf0) == 0x12c45678
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 1, 0x0f) == 0x123b5678
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 2, 0xf0) == 0x1234a678
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 2, 0x0f) == 0x12345978
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 3, 0xf0) == 0x12345688
+; run: %atomic_rmw_xor_big_i8_no_res(0x12345678, 3, 0x0f) == 0x12345677
 
-function %atomic_rmw_nand_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_nand_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big nand v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_nand_big_i16(0x12345678, 0, 0xf000) == [0x1234, 0xefff5678]
+; run: %atomic_rmw_nand_big_i16(0x12345678, 0, 0x000f) == [0x1234, 0xfffb5678]
+; run: %atomic_rmw_nand_big_i16(0x12345678, 2, 0xf000) == [0x5678, 0x1234afff]
+; run: %atomic_rmw_nand_big_i16(0x12345678, 2, 0x000f) == [0x5678, 0x1234fff7]
+
+function %atomic_rmw_nand_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -226,12 +444,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_nand_big_i16(0x12345678, 0, 0xf000) == 0xefff5678
-; run: %atomic_rmw_nand_big_i16(0x12345678, 0, 0x000f) == 0xfffb5678
-; run: %atomic_rmw_nand_big_i16(0x12345678, 2, 0xf000) == 0x1234afff
-; run: %atomic_rmw_nand_big_i16(0x12345678, 2, 0x000f) == 0x1234fff7
+; run: %atomic_rmw_nand_big_i16_no_res(0x12345678, 0, 0xf000) == 0xefff5678
+; run: %atomic_rmw_nand_big_i16_no_res(0x12345678, 0, 0x000f) == 0xfffb5678
+; run: %atomic_rmw_nand_big_i16_no_res(0x12345678, 2, 0xf000) == 0x1234afff
+; run: %atomic_rmw_nand_big_i16_no_res(0x12345678, 2, 0x000f) == 0x1234fff7
 
-function %atomic_rmw_nand_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_nand_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big nand v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_nand_big_i8(0x12345678, 0, 0xf0) == [0x12, 0xef345678]
+; run: %atomic_rmw_nand_big_i8(0x12345678, 0, 0x0f) == [0x12, 0xfd345678]
+; run: %atomic_rmw_nand_big_i8(0x12345678, 1, 0xf0) == [0x34, 0x12cf5678]
+; run: %atomic_rmw_nand_big_i8(0x12345678, 1, 0x0f) == [0x34, 0x12fb5678]
+; run: %atomic_rmw_nand_big_i8(0x12345678, 2, 0xf0) == [0x56, 0x1234af78]
+; run: %atomic_rmw_nand_big_i8(0x12345678, 2, 0x0f) == [0x56, 0x1234f978]
+; run: %atomic_rmw_nand_big_i8(0x12345678, 3, 0xf0) == [0x78, 0x1234568f]
+; run: %atomic_rmw_nand_big_i8(0x12345678, 3, 0x0f) == [0x78, 0x123456f7]
+
+function %atomic_rmw_nand_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -244,17 +484,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_nand_big_i8(0x12345678, 0, 0xf0) == 0xef345678
-; run: %atomic_rmw_nand_big_i8(0x12345678, 0, 0x0f) == 0xfd345678
-; run: %atomic_rmw_nand_big_i8(0x12345678, 1, 0xf0) == 0x12cf5678
-; run: %atomic_rmw_nand_big_i8(0x12345678, 1, 0x0f) == 0x12fb5678
-; run: %atomic_rmw_nand_big_i8(0x12345678, 2, 0xf0) == 0x1234af78
-; run: %atomic_rmw_nand_big_i8(0x12345678, 2, 0x0f) == 0x1234f978
-; run: %atomic_rmw_nand_big_i8(0x12345678, 3, 0xf0) == 0x1234568f
-; run: %atomic_rmw_nand_big_i8(0x12345678, 3, 0x0f) == 0x123456f7
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 0, 0xf0) == 0xef345678
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 0, 0x0f) == 0xfd345678
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 1, 0xf0) == 0x12cf5678
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 1, 0x0f) == 0x12fb5678
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 2, 0xf0) == 0x1234af78
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 2, 0x0f) == 0x1234f978
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 3, 0xf0) == 0x1234568f
+; run: %atomic_rmw_nand_big_i8_no_res(0x12345678, 3, 0x0f) == 0x123456f7
 
 
-function %atomic_rmw_umin_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_umin_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big umin v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_umin_big_i16(0x12345678, 0, 0x1111) == [0x1234, 0x11115678]
+; run: %atomic_rmw_umin_big_i16(0x12345678, 0, 0xffff) == [0x1234, 0x12345678]
+; run: %atomic_rmw_umin_big_i16(0x12345678, 2, 0x1111) == [0x5678, 0x12341111]
+; run: %atomic_rmw_umin_big_i16(0x12345678, 2, 0xffff) == [0x5678, 0x12345678]
+
+function %atomic_rmw_umin_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -267,12 +525,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_umin_big_i16(0x12345678, 0, 0x1111) == 0x11115678
-; run: %atomic_rmw_umin_big_i16(0x12345678, 0, 0xffff) == 0x12345678
-; run: %atomic_rmw_umin_big_i16(0x12345678, 2, 0x1111) == 0x12341111
-; run: %atomic_rmw_umin_big_i16(0x12345678, 2, 0xffff) == 0x12345678
+; run: %atomic_rmw_umin_big_i16_no_res(0x12345678, 0, 0x1111) == 0x11115678
+; run: %atomic_rmw_umin_big_i16_no_res(0x12345678, 0, 0xffff) == 0x12345678
+; run: %atomic_rmw_umin_big_i16_no_res(0x12345678, 2, 0x1111) == 0x12341111
+; run: %atomic_rmw_umin_big_i16_no_res(0x12345678, 2, 0xffff) == 0x12345678
 
-function %atomic_rmw_umin_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_umin_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big umin v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_umin_big_i8(0x12345678, 0, 0x11) == [0x12, 0x11345678]
+; run: %atomic_rmw_umin_big_i8(0x12345678, 0, 0xff) == [0x12, 0x12345678]
+; run: %atomic_rmw_umin_big_i8(0x12345678, 1, 0x11) == [0x34, 0x12115678]
+; run: %atomic_rmw_umin_big_i8(0x12345678, 1, 0xff) == [0x34, 0x12345678]
+; run: %atomic_rmw_umin_big_i8(0x12345678, 2, 0x11) == [0x56, 0x12341178]
+; run: %atomic_rmw_umin_big_i8(0x12345678, 2, 0xff) == [0x56, 0x12345678]
+; run: %atomic_rmw_umin_big_i8(0x12345678, 3, 0x11) == [0x78, 0x12345611]
+; run: %atomic_rmw_umin_big_i8(0x12345678, 3, 0xff) == [0x78, 0x12345678]
+
+function %atomic_rmw_umin_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -285,17 +565,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_umin_big_i8(0x12345678, 0, 0x11) == 0x11345678
-; run: %atomic_rmw_umin_big_i8(0x12345678, 0, 0xff) == 0x12345678
-; run: %atomic_rmw_umin_big_i8(0x12345678, 1, 0x11) == 0x12115678
-; run: %atomic_rmw_umin_big_i8(0x12345678, 1, 0xff) == 0x12345678
-; run: %atomic_rmw_umin_big_i8(0x12345678, 2, 0x11) == 0x12341178
-; run: %atomic_rmw_umin_big_i8(0x12345678, 2, 0xff) == 0x12345678
-; run: %atomic_rmw_umin_big_i8(0x12345678, 3, 0x11) == 0x12345611
-; run: %atomic_rmw_umin_big_i8(0x12345678, 3, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 0, 0x11) == 0x11345678
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 0, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 1, 0x11) == 0x12115678
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 1, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 2, 0x11) == 0x12341178
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 2, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 3, 0x11) == 0x12345611
+; run: %atomic_rmw_umin_big_i8_no_res(0x12345678, 3, 0xff) == 0x12345678
 
 
-function %atomic_rmw_umax_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_umax_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big umax v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_umax_big_i16(0x12345678, 0, 0x1111) == [0x1234, 0x12345678]
+; run: %atomic_rmw_umax_big_i16(0x12345678, 0, 0xffff) == [0x1234, 0xffff5678]
+; run: %atomic_rmw_umax_big_i16(0x12345678, 2, 0x1111) == [0x5678, 0x12345678]
+; run: %atomic_rmw_umax_big_i16(0x12345678, 2, 0xffff) == [0x5678, 0x1234ffff]
+
+function %atomic_rmw_umax_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -308,12 +606,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_umax_big_i16(0x12345678, 0, 0x1111) == 0x12345678
-; run: %atomic_rmw_umax_big_i16(0x12345678, 0, 0xffff) == 0xffff5678
-; run: %atomic_rmw_umax_big_i16(0x12345678, 2, 0x1111) == 0x12345678
-; run: %atomic_rmw_umax_big_i16(0x12345678, 2, 0xffff) == 0x1234ffff
+; run: %atomic_rmw_umax_big_i16_no_res(0x12345678, 0, 0x1111) == 0x12345678
+; run: %atomic_rmw_umax_big_i16_no_res(0x12345678, 0, 0xffff) == 0xffff5678
+; run: %atomic_rmw_umax_big_i16_no_res(0x12345678, 2, 0x1111) == 0x12345678
+; run: %atomic_rmw_umax_big_i16_no_res(0x12345678, 2, 0xffff) == 0x1234ffff
 
-function %atomic_rmw_umax_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_umax_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big umax v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_umax_big_i8(0x12345678, 0, 0x11) == [0x12, 0x12345678]
+; run: %atomic_rmw_umax_big_i8(0x12345678, 0, 0xff) == [0x12, 0xff345678]
+; run: %atomic_rmw_umax_big_i8(0x12345678, 1, 0x11) == [0x34, 0x12345678]
+; run: %atomic_rmw_umax_big_i8(0x12345678, 1, 0xff) == [0x34, 0x12ff5678]
+; run: %atomic_rmw_umax_big_i8(0x12345678, 2, 0x11) == [0x56, 0x12345678]
+; run: %atomic_rmw_umax_big_i8(0x12345678, 2, 0xff) == [0x56, 0x1234ff78]
+; run: %atomic_rmw_umax_big_i8(0x12345678, 3, 0x11) == [0x78, 0x12345678]
+; run: %atomic_rmw_umax_big_i8(0x12345678, 3, 0xff) == [0x78, 0x123456ff]
+
+function %atomic_rmw_umax_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -326,17 +646,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_umax_big_i8(0x12345678, 0, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_big_i8(0x12345678, 0, 0xff) == 0xff345678
-; run: %atomic_rmw_umax_big_i8(0x12345678, 1, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_big_i8(0x12345678, 1, 0xff) == 0x12ff5678
-; run: %atomic_rmw_umax_big_i8(0x12345678, 2, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_big_i8(0x12345678, 2, 0xff) == 0x1234ff78
-; run: %atomic_rmw_umax_big_i8(0x12345678, 3, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_big_i8(0x12345678, 3, 0xff) == 0x123456ff
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 0, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 0, 0xff) == 0xff345678
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 1, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 1, 0xff) == 0x12ff5678
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 2, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 2, 0xff) == 0x1234ff78
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 3, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_big_i8_no_res(0x12345678, 3, 0xff) == 0x123456ff
 
 
-function %atomic_rmw_smin_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_smin_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big smin v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_smin_big_i16(0x12345678, 0, 0x1111) == [0x1234, 0x11115678]
+; run: %atomic_rmw_smin_big_i16(0x12345678, 0, 0xffff) == [0x1234, 0xffff5678]
+; run: %atomic_rmw_smin_big_i16(0x12345678, 2, 0x1111) == [0x5678, 0x12341111]
+; run: %atomic_rmw_smin_big_i16(0x12345678, 2, 0xffff) == [0x5678, 0x1234ffff]
+
+function %atomic_rmw_smin_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -349,12 +687,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_smin_big_i16(0x12345678, 0, 0x1111) == 0x11115678
-; run: %atomic_rmw_smin_big_i16(0x12345678, 0, 0xffff) == 0xffff5678
-; run: %atomic_rmw_smin_big_i16(0x12345678, 2, 0x1111) == 0x12341111
-; run: %atomic_rmw_smin_big_i16(0x12345678, 2, 0xffff) == 0x1234ffff
+; run: %atomic_rmw_smin_big_i16_no_res(0x12345678, 0, 0x1111) == 0x11115678
+; run: %atomic_rmw_smin_big_i16_no_res(0x12345678, 0, 0xffff) == 0xffff5678
+; run: %atomic_rmw_smin_big_i16_no_res(0x12345678, 2, 0x1111) == 0x12341111
+; run: %atomic_rmw_smin_big_i16_no_res(0x12345678, 2, 0xffff) == 0x1234ffff
 
-function %atomic_rmw_smin_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_smin_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big smin v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_smin_big_i8(0x12345678, 0, 0x11) == [0x12, 0x11345678]
+; run: %atomic_rmw_smin_big_i8(0x12345678, 0, 0xff) == [0x12, 0xff345678]
+; run: %atomic_rmw_smin_big_i8(0x12345678, 1, 0x11) == [0x34, 0x12115678]
+; run: %atomic_rmw_smin_big_i8(0x12345678, 1, 0xff) == [0x34, 0x12ff5678]
+; run: %atomic_rmw_smin_big_i8(0x12345678, 2, 0x11) == [0x56, 0x12341178]
+; run: %atomic_rmw_smin_big_i8(0x12345678, 2, 0xff) == [0x56, 0x1234ff78]
+; run: %atomic_rmw_smin_big_i8(0x12345678, 3, 0x11) == [0x78, 0x12345611]
+; run: %atomic_rmw_smin_big_i8(0x12345678, 3, 0xff) == [0x78, 0x123456ff]
+
+function %atomic_rmw_smin_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -367,17 +727,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_smin_big_i8(0x12345678, 0, 0x11) == 0x11345678
-; run: %atomic_rmw_smin_big_i8(0x12345678, 0, 0xff) == 0xff345678
-; run: %atomic_rmw_smin_big_i8(0x12345678, 1, 0x11) == 0x12115678
-; run: %atomic_rmw_smin_big_i8(0x12345678, 1, 0xff) == 0x12ff5678
-; run: %atomic_rmw_smin_big_i8(0x12345678, 2, 0x11) == 0x12341178
-; run: %atomic_rmw_smin_big_i8(0x12345678, 2, 0xff) == 0x1234ff78
-; run: %atomic_rmw_smin_big_i8(0x12345678, 3, 0x11) == 0x12345611
-; run: %atomic_rmw_smin_big_i8(0x12345678, 3, 0xff) == 0x123456ff
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 0, 0x11) == 0x11345678
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 0, 0xff) == 0xff345678
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 1, 0x11) == 0x12115678
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 1, 0xff) == 0x12ff5678
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 2, 0x11) == 0x12341178
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 2, 0xff) == 0x1234ff78
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 3, 0x11) == 0x12345611
+; run: %atomic_rmw_smin_big_i8_no_res(0x12345678, 3, 0xff) == 0x123456ff
 
 
-function %atomic_rmw_smax_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_smax_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big smax v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_smax_big_i16(0x12345678, 0, 0xffff) == [0x1234, 0x12345678]
+; run: %atomic_rmw_smax_big_i16(0x12345678, 0, 0x7fff) == [0x1234, 0x7fff5678]
+; run: %atomic_rmw_smax_big_i16(0x12345678, 2, 0xffff) == [0x5678, 0x12345678]
+; run: %atomic_rmw_smax_big_i16(0x12345678, 2, 0x7fff) == [0x5678, 0x12347fff]
+
+function %atomic_rmw_smax_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -390,13 +768,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_smax_big_i16(0x12345678, 0, 0xffff) == 0x12345678
-; run: %atomic_rmw_smax_big_i16(0x12345678, 0, 0x7fff) == 0x7fff5678
-; run: %atomic_rmw_smax_big_i16(0x12345678, 2, 0xffff) == 0x12345678
-; run: %atomic_rmw_smax_big_i16(0x12345678, 2, 0x7fff) == 0x12347fff
+; run: %atomic_rmw_smax_big_i16_no_res(0x12345678, 0, 0xffff) == 0x12345678
+; run: %atomic_rmw_smax_big_i16_no_res(0x12345678, 0, 0x7fff) == 0x7fff5678
+; run: %atomic_rmw_smax_big_i16_no_res(0x12345678, 2, 0xffff) == 0x12345678
+; run: %atomic_rmw_smax_big_i16_no_res(0x12345678, 2, 0x7fff) == 0x12347fff
 
 
-function %atomic_rmw_smax_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_smax_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big smax v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_smax_big_i8(0x12345678, 0, 0xff) == [0x12, 0x12345678]
+; run: %atomic_rmw_smax_big_i8(0x12345678, 0, 0x7f) == [0x12, 0x7f345678]
+; run: %atomic_rmw_smax_big_i8(0x12345678, 1, 0xff) == [0x34, 0x12345678]
+; run: %atomic_rmw_smax_big_i8(0x12345678, 1, 0x7f) == [0x34, 0x127f5678]
+; run: %atomic_rmw_smax_big_i8(0x12345678, 2, 0xff) == [0x56, 0x12345678]
+; run: %atomic_rmw_smax_big_i8(0x12345678, 2, 0x7f) == [0x56, 0x12347f78]
+; run: %atomic_rmw_smax_big_i8(0x12345678, 3, 0xff) == [0x78, 0x12345678]
+; run: %atomic_rmw_smax_big_i8(0x12345678, 3, 0x7f) == [0x78, 0x1234567f]
+
+function %atomic_rmw_smax_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -409,17 +809,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_smax_big_i8(0x12345678, 0, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_big_i8(0x12345678, 0, 0x7f) == 0x7f345678
-; run: %atomic_rmw_smax_big_i8(0x12345678, 1, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_big_i8(0x12345678, 1, 0x7f) == 0x127f5678
-; run: %atomic_rmw_smax_big_i8(0x12345678, 2, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_big_i8(0x12345678, 2, 0x7f) == 0x12347f78
-; run: %atomic_rmw_smax_big_i8(0x12345678, 3, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_big_i8(0x12345678, 3, 0x7f) == 0x1234567f
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 0, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 0, 0x7f) == 0x7f345678
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 1, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 1, 0x7f) == 0x127f5678
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 2, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 2, 0x7f) == 0x12347f78
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 3, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_big_i8_no_res(0x12345678, 3, 0x7f) == 0x1234567f
 
 
-function %atomic_rmw_xchg_big_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_xchg_big_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 big xchg v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 0, 0x1111) == [0x1234, 0x11115678]
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 0, 0xffff) == [0x1234, 0xffff5678]
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 2, 0x1111) == [0x5678, 0x12341111]
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 2, 0xffff) == [0x5678, 0x1234ffff]
+
+function %atomic_rmw_xchg_big_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -432,13 +850,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_xchg_big_i16(0x12345678, 0, 0x1111) == 0x11115678
-; run: %atomic_rmw_xchg_big_i16(0x12345678, 0, 0xffff) == 0xffff5678
-; run: %atomic_rmw_xchg_big_i16(0x12345678, 2, 0x1111) == 0x12341111
-; run: %atomic_rmw_xchg_big_i16(0x12345678, 2, 0xffff) == 0x1234ffff
+; run: %atomic_rmw_xchg_big_i16_no_res(0x12345678, 0, 0x1111) == 0x11115678
+; run: %atomic_rmw_xchg_big_i16_no_res(0x12345678, 0, 0xffff) == 0xffff5678
+; run: %atomic_rmw_xchg_big_i16_no_res(0x12345678, 2, 0x1111) == 0x12341111
+; run: %atomic_rmw_xchg_big_i16_no_res(0x12345678, 2, 0xffff) == 0x1234ffff
 
 
-function %atomic_rmw_xchg_big_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_xchg_big_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 big v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 big xchg v4, v2
+
+    v6 = load.i32 big v3
+    return v5, v6
+}
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 0, 0x11) == [0x12, 0x11345678]
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 0, 0xff) == [0x12, 0xff345678]
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 1, 0x11) == [0x34, 0x12115678]
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 1, 0xff) == [0x34, 0x12ff5678]
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 2, 0x11) == [0x56, 0x12341178]
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 2, 0xff) == [0x56, 0x1234ff78]
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 3, 0x11) == [0x78, 0x12345611]
+; run: %atomic_rmw_xchg_big_i8(0x12345678, 3, 0xff) == [0x78, 0x123456ff]
+
+function %atomic_rmw_xchg_big_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -451,11 +891,11 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 0, 0x11) == 0x11345678
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 0, 0xff) == 0xff345678
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 1, 0x11) == 0x12115678
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 1, 0xff) == 0x12ff5678
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 2, 0x11) == 0x12341178
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 2, 0xff) == 0x1234ff78
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 3, 0x11) == 0x12345611
-; run: %atomic_rmw_xchg_big_i8(0x12345678, 3, 0xff) == 0x123456ff
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 0, 0x11) == 0x11345678
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 0, 0xff) == 0xff345678
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 1, 0x11) == 0x12115678
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 1, 0xff) == 0x12ff5678
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 2, 0x11) == 0x12341178
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 2, 0xff) == 0x1234ff78
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 3, 0x11) == 0x12345611
+; run: %atomic_rmw_xchg_big_i8_no_res(0x12345678, 3, 0xff) == 0x123456ff

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
@@ -11,7 +11,25 @@ target riscv64 has_c has_zcb
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly
 
-function %atomic_rmw_add_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_add_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little add v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_add_little_i16(0x12345678, 2, 0x1111) == [0x1234, 0x23455678]
+; run: %atomic_rmw_add_little_i16(0x12345678, 2, 0xffff) == [0x1234, 0x12335678]
+; run: %atomic_rmw_add_little_i16(0x12345678, 0, 0x1111) == [0x5678, 0x12346789]
+; run: %atomic_rmw_add_little_i16(0x12345678, 0, 0xffff) == [0x5678, 0x12345677]
+
+function %atomic_rmw_add_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -24,12 +42,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_add_little_i16(0x12345678, 2, 0x1111) == 0x23455678
-; run: %atomic_rmw_add_little_i16(0x12345678, 2, 0xffff) == 0x12335678
-; run: %atomic_rmw_add_little_i16(0x12345678, 0, 0x1111) == 0x12346789
-; run: %atomic_rmw_add_little_i16(0x12345678, 0, 0xffff) == 0x12345677
+; run: %atomic_rmw_add_little_i16_no_res(0x12345678, 2, 0x1111) == 0x23455678
+; run: %atomic_rmw_add_little_i16_no_res(0x12345678, 2, 0xffff) == 0x12335678
+; run: %atomic_rmw_add_little_i16_no_res(0x12345678, 0, 0x1111) == 0x12346789
+; run: %atomic_rmw_add_little_i16_no_res(0x12345678, 0, 0xffff) == 0x12345677
 
-function %atomic_rmw_add_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_add_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little add v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_add_little_i8(0x12345678, 3, 0x11) == [0x12, 0x23345678]
+; run: %atomic_rmw_add_little_i8(0x12345678, 3, 0xff) == [0x12, 0x11345678]
+; run: %atomic_rmw_add_little_i8(0x12345678, 2, 0x11) == [0x34, 0x12455678]
+; run: %atomic_rmw_add_little_i8(0x12345678, 2, 0xff) == [0x34, 0x12335678]
+; run: %atomic_rmw_add_little_i8(0x12345678, 1, 0x11) == [0x56, 0x12346778]
+; run: %atomic_rmw_add_little_i8(0x12345678, 1, 0xff) == [0x56, 0x12345578]
+; run: %atomic_rmw_add_little_i8(0x12345678, 0, 0x11) == [0x78, 0x12345689]
+; run: %atomic_rmw_add_little_i8(0x12345678, 0, 0xff) == [0x78, 0x12345677]
+
+function %atomic_rmw_add_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -42,16 +82,34 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_add_little_i8(0x12345678, 3, 0x11) == 0x23345678
-; run: %atomic_rmw_add_little_i8(0x12345678, 3, 0xff) == 0x11345678
-; run: %atomic_rmw_add_little_i8(0x12345678, 2, 0x11) == 0x12455678
-; run: %atomic_rmw_add_little_i8(0x12345678, 2, 0xff) == 0x12335678
-; run: %atomic_rmw_add_little_i8(0x12345678, 1, 0x11) == 0x12346778
-; run: %atomic_rmw_add_little_i8(0x12345678, 1, 0xff) == 0x12345578
-; run: %atomic_rmw_add_little_i8(0x12345678, 0, 0x11) == 0x12345689
-; run: %atomic_rmw_add_little_i8(0x12345678, 0, 0xff) == 0x12345677
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 3, 0x11) == 0x23345678
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 3, 0xff) == 0x11345678
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 2, 0x11) == 0x12455678
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 2, 0xff) == 0x12335678
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 1, 0x11) == 0x12346778
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 1, 0xff) == 0x12345578
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 0, 0x11) == 0x12345689
+; run: %atomic_rmw_add_little_i8_no_res(0x12345678, 0, 0xff) == 0x12345677
 
-function %atomic_rmw_sub_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_sub_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little sub v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_sub_little_i16(0x12345678, 2, 0x1111) == [0x1234, 0x01235678]
+; run: %atomic_rmw_sub_little_i16(0x12345678, 2, 0xffff) == [0x1234, 0x12355678]
+; run: %atomic_rmw_sub_little_i16(0x12345678, 0, 0x1111) == [0x5678, 0x12344567]
+; run: %atomic_rmw_sub_little_i16(0x12345678, 0, 0xffff) == [0x5678, 0x12345679]
+
+function %atomic_rmw_sub_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -64,12 +122,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_sub_little_i16(0x12345678, 2, 0x1111) == 0x01235678
-; run: %atomic_rmw_sub_little_i16(0x12345678, 2, 0xffff) == 0x12355678
-; run: %atomic_rmw_sub_little_i16(0x12345678, 0, 0x1111) == 0x12344567
-; run: %atomic_rmw_sub_little_i16(0x12345678, 0, 0xffff) == 0x12345679
+; run: %atomic_rmw_sub_little_i16_no_res(0x12345678, 2, 0x1111) == 0x01235678
+; run: %atomic_rmw_sub_little_i16_no_res(0x12345678, 2, 0xffff) == 0x12355678
+; run: %atomic_rmw_sub_little_i16_no_res(0x12345678, 0, 0x1111) == 0x12344567
+; run: %atomic_rmw_sub_little_i16_no_res(0x12345678, 0, 0xffff) == 0x12345679
 
-function %atomic_rmw_sub_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_sub_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little sub v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_sub_little_i8(0x12345678, 3, 0x11) == [0x12, 0x01345678]
+; run: %atomic_rmw_sub_little_i8(0x12345678, 3, 0xff) == [0x12, 0x13345678]
+; run: %atomic_rmw_sub_little_i8(0x12345678, 2, 0x11) == [0x34, 0x12235678]
+; run: %atomic_rmw_sub_little_i8(0x12345678, 2, 0xff) == [0x34, 0x12355678]
+; run: %atomic_rmw_sub_little_i8(0x12345678, 1, 0x11) == [0x56, 0x12344578]
+; run: %atomic_rmw_sub_little_i8(0x12345678, 1, 0xff) == [0x56, 0x12345778]
+; run: %atomic_rmw_sub_little_i8(0x12345678, 0, 0x11) == [0x78, 0x12345667]
+; run: %atomic_rmw_sub_little_i8(0x12345678, 0, 0xff) == [0x78, 0x12345679]
+
+function %atomic_rmw_sub_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -82,16 +162,34 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_sub_little_i8(0x12345678, 3, 0x11) == 0x01345678
-; run: %atomic_rmw_sub_little_i8(0x12345678, 3, 0xff) == 0x13345678
-; run: %atomic_rmw_sub_little_i8(0x12345678, 2, 0x11) == 0x12235678
-; run: %atomic_rmw_sub_little_i8(0x12345678, 2, 0xff) == 0x12355678
-; run: %atomic_rmw_sub_little_i8(0x12345678, 1, 0x11) == 0x12344578
-; run: %atomic_rmw_sub_little_i8(0x12345678, 1, 0xff) == 0x12345778
-; run: %atomic_rmw_sub_little_i8(0x12345678, 0, 0x11) == 0x12345667
-; run: %atomic_rmw_sub_little_i8(0x12345678, 0, 0xff) == 0x12345679
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 3, 0x11) == 0x01345678
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 3, 0xff) == 0x13345678
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 2, 0x11) == 0x12235678
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 2, 0xff) == 0x12355678
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 1, 0x11) == 0x12344578
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 1, 0xff) == 0x12345778
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 0, 0x11) == 0x12345667
+; run: %atomic_rmw_sub_little_i8_no_res(0x12345678, 0, 0xff) == 0x12345679
 
-function %atomic_rmw_and_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_and_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little and v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_and_little_i16(0x12345678, 2, 0xf000) == [0x1234, 0x10005678]
+; run: %atomic_rmw_and_little_i16(0x12345678, 2, 0x000f) == [0x1234, 0x00045678]
+; run: %atomic_rmw_and_little_i16(0x12345678, 0, 0xf000) == [0x5678, 0x12345000]
+; run: %atomic_rmw_and_little_i16(0x12345678, 0, 0x000f) == [0x5678, 0x12340008]
+
+function %atomic_rmw_and_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -104,12 +202,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_and_little_i16(0x12345678, 2, 0xf000) == 0x10005678
-; run: %atomic_rmw_and_little_i16(0x12345678, 2, 0x000f) == 0x00045678
-; run: %atomic_rmw_and_little_i16(0x12345678, 0, 0xf000) == 0x12345000
-; run: %atomic_rmw_and_little_i16(0x12345678, 0, 0x000f) == 0x12340008
+; run: %atomic_rmw_and_little_i16_no_res(0x12345678, 2, 0xf000) == 0x10005678
+; run: %atomic_rmw_and_little_i16_no_res(0x12345678, 2, 0x000f) == 0x00045678
+; run: %atomic_rmw_and_little_i16_no_res(0x12345678, 0, 0xf000) == 0x12345000
+; run: %atomic_rmw_and_little_i16_no_res(0x12345678, 0, 0x000f) == 0x12340008
 
-function %atomic_rmw_and_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_and_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little and v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_and_little_i8(0x12345678, 3, 0xf0) == [0x12, 0x10345678]
+; run: %atomic_rmw_and_little_i8(0x12345678, 3, 0x0f) == [0x12, 0x02345678]
+; run: %atomic_rmw_and_little_i8(0x12345678, 2, 0xf0) == [0x34, 0x12305678]
+; run: %atomic_rmw_and_little_i8(0x12345678, 2, 0x0f) == [0x34, 0x12045678]
+; run: %atomic_rmw_and_little_i8(0x12345678, 1, 0xf0) == [0x56, 0x12345078]
+; run: %atomic_rmw_and_little_i8(0x12345678, 1, 0x0f) == [0x56, 0x12340678]
+; run: %atomic_rmw_and_little_i8(0x12345678, 0, 0xf0) == [0x78, 0x12345670]
+; run: %atomic_rmw_and_little_i8(0x12345678, 0, 0x0f) == [0x78, 0x12345608]
+
+function %atomic_rmw_and_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -122,17 +242,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_and_little_i8(0x12345678, 3, 0xf0) == 0x10345678
-; run: %atomic_rmw_and_little_i8(0x12345678, 3, 0x0f) == 0x02345678
-; run: %atomic_rmw_and_little_i8(0x12345678, 2, 0xf0) == 0x12305678
-; run: %atomic_rmw_and_little_i8(0x12345678, 2, 0x0f) == 0x12045678
-; run: %atomic_rmw_and_little_i8(0x12345678, 1, 0xf0) == 0x12345078
-; run: %atomic_rmw_and_little_i8(0x12345678, 1, 0x0f) == 0x12340678
-; run: %atomic_rmw_and_little_i8(0x12345678, 0, 0xf0) == 0x12345670
-; run: %atomic_rmw_and_little_i8(0x12345678, 0, 0x0f) == 0x12345608
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 3, 0xf0) == 0x10345678
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 3, 0x0f) == 0x02345678
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 2, 0xf0) == 0x12305678
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 2, 0x0f) == 0x12045678
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 1, 0xf0) == 0x12345078
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 1, 0x0f) == 0x12340678
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 0, 0xf0) == 0x12345670
+; run: %atomic_rmw_and_little_i8_no_res(0x12345678, 0, 0x0f) == 0x12345608
 
 
-function %atomic_rmw_or_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_or_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little or v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_or_little_i16(0x12345678, 2, 0xf000) == [0x1234, 0xf2345678]
+; run: %atomic_rmw_or_little_i16(0x12345678, 2, 0x000f) == [0x1234, 0x123f5678]
+; run: %atomic_rmw_or_little_i16(0x12345678, 0, 0xf000) == [0x5678, 0x1234f678]
+; run: %atomic_rmw_or_little_i16(0x12345678, 0, 0x000f) == [0x5678, 0x1234567f]
+
+function %atomic_rmw_or_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -145,12 +283,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_or_little_i16(0x12345678, 2, 0xf000) == 0xf2345678
-; run: %atomic_rmw_or_little_i16(0x12345678, 2, 0x000f) == 0x123f5678
-; run: %atomic_rmw_or_little_i16(0x12345678, 0, 0xf000) == 0x1234f678
-; run: %atomic_rmw_or_little_i16(0x12345678, 0, 0x000f) == 0x1234567f
+; run: %atomic_rmw_or_little_i16_no_res(0x12345678, 2, 0xf000) == 0xf2345678
+; run: %atomic_rmw_or_little_i16_no_res(0x12345678, 2, 0x000f) == 0x123f5678
+; run: %atomic_rmw_or_little_i16_no_res(0x12345678, 0, 0xf000) == 0x1234f678
+; run: %atomic_rmw_or_little_i16_no_res(0x12345678, 0, 0x000f) == 0x1234567f
 
-function %atomic_rmw_or_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_or_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little or v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_or_little_i8(0x12345678, 3, 0xf0) == [0x12, 0xf2345678]
+; run: %atomic_rmw_or_little_i8(0x12345678, 3, 0x0f) == [0x12, 0x1f345678]
+; run: %atomic_rmw_or_little_i8(0x12345678, 2, 0xf0) == [0x34, 0x12f45678]
+; run: %atomic_rmw_or_little_i8(0x12345678, 2, 0x0f) == [0x34, 0x123f5678]
+; run: %atomic_rmw_or_little_i8(0x12345678, 1, 0xf0) == [0x56, 0x1234f678]
+; run: %atomic_rmw_or_little_i8(0x12345678, 1, 0x0f) == [0x56, 0x12345f78]
+; run: %atomic_rmw_or_little_i8(0x12345678, 0, 0xf0) == [0x78, 0x123456f8]
+; run: %atomic_rmw_or_little_i8(0x12345678, 0, 0x0f) == [0x78, 0x1234567f]
+
+function %atomic_rmw_or_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -163,16 +323,34 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_or_little_i8(0x12345678, 3, 0xf0) == 0xf2345678
-; run: %atomic_rmw_or_little_i8(0x12345678, 3, 0x0f) == 0x1f345678
-; run: %atomic_rmw_or_little_i8(0x12345678, 2, 0xf0) == 0x12f45678
-; run: %atomic_rmw_or_little_i8(0x12345678, 2, 0x0f) == 0x123f5678
-; run: %atomic_rmw_or_little_i8(0x12345678, 1, 0xf0) == 0x1234f678
-; run: %atomic_rmw_or_little_i8(0x12345678, 1, 0x0f) == 0x12345f78
-; run: %atomic_rmw_or_little_i8(0x12345678, 0, 0xf0) == 0x123456f8
-; run: %atomic_rmw_or_little_i8(0x12345678, 0, 0x0f) == 0x1234567f
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 3, 0xf0) == 0xf2345678
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 3, 0x0f) == 0x1f345678
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 2, 0xf0) == 0x12f45678
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 2, 0x0f) == 0x123f5678
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 1, 0xf0) == 0x1234f678
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 1, 0x0f) == 0x12345f78
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 0, 0xf0) == 0x123456f8
+; run: %atomic_rmw_or_little_i8_no_res(0x12345678, 0, 0x0f) == 0x1234567f
 
-function %atomic_rmw_xor_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_xor_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little xor v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_xor_little_i16(0x12345678, 2, 0xf000) == [0x1234, 0xe2345678]
+; run: %atomic_rmw_xor_little_i16(0x12345678, 2, 0x000f) == [0x1234, 0x123b5678]
+; run: %atomic_rmw_xor_little_i16(0x12345678, 0, 0xf000) == [0x5678, 0x1234a678]
+; run: %atomic_rmw_xor_little_i16(0x12345678, 0, 0x000f) == [0x5678, 0x12345677]
+
+function %atomic_rmw_xor_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -185,12 +363,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_xor_little_i16(0x12345678, 2, 0xf000) == 0xe2345678
-; run: %atomic_rmw_xor_little_i16(0x12345678, 2, 0x000f) == 0x123b5678
-; run: %atomic_rmw_xor_little_i16(0x12345678, 0, 0xf000) == 0x1234a678
-; run: %atomic_rmw_xor_little_i16(0x12345678, 0, 0x000f) == 0x12345677
+; run: %atomic_rmw_xor_little_i16_no_res(0x12345678, 2, 0xf000) == 0xe2345678
+; run: %atomic_rmw_xor_little_i16_no_res(0x12345678, 2, 0x000f) == 0x123b5678
+; run: %atomic_rmw_xor_little_i16_no_res(0x12345678, 0, 0xf000) == 0x1234a678
+; run: %atomic_rmw_xor_little_i16_no_res(0x12345678, 0, 0x000f) == 0x12345677
 
-function %atomic_rmw_xor_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_xor_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little xor v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_xor_little_i8(0x12345678, 3, 0xf0) == [0x12, 0xe2345678]
+; run: %atomic_rmw_xor_little_i8(0x12345678, 3, 0x0f) == [0x12, 0x1d345678]
+; run: %atomic_rmw_xor_little_i8(0x12345678, 2, 0xf0) == [0x34, 0x12c45678]
+; run: %atomic_rmw_xor_little_i8(0x12345678, 2, 0x0f) == [0x34, 0x123b5678]
+; run: %atomic_rmw_xor_little_i8(0x12345678, 1, 0xf0) == [0x56, 0x1234a678]
+; run: %atomic_rmw_xor_little_i8(0x12345678, 1, 0x0f) == [0x56, 0x12345978]
+; run: %atomic_rmw_xor_little_i8(0x12345678, 0, 0xf0) == [0x78, 0x12345688]
+; run: %atomic_rmw_xor_little_i8(0x12345678, 0, 0x0f) == [0x78, 0x12345677]
+
+function %atomic_rmw_xor_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -203,17 +403,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_xor_little_i8(0x12345678, 3, 0xf0) == 0xe2345678
-; run: %atomic_rmw_xor_little_i8(0x12345678, 3, 0x0f) == 0x1d345678
-; run: %atomic_rmw_xor_little_i8(0x12345678, 2, 0xf0) == 0x12c45678
-; run: %atomic_rmw_xor_little_i8(0x12345678, 2, 0x0f) == 0x123b5678
-; run: %atomic_rmw_xor_little_i8(0x12345678, 1, 0xf0) == 0x1234a678
-; run: %atomic_rmw_xor_little_i8(0x12345678, 1, 0x0f) == 0x12345978
-; run: %atomic_rmw_xor_little_i8(0x12345678, 0, 0xf0) == 0x12345688
-; run: %atomic_rmw_xor_little_i8(0x12345678, 0, 0x0f) == 0x12345677
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 3, 0xf0) == 0xe2345678
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 3, 0x0f) == 0x1d345678
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 2, 0xf0) == 0x12c45678
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 2, 0x0f) == 0x123b5678
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 1, 0xf0) == 0x1234a678
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 1, 0x0f) == 0x12345978
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 0, 0xf0) == 0x12345688
+; run: %atomic_rmw_xor_little_i8_no_res(0x12345678, 0, 0x0f) == 0x12345677
 
 
-function %atomic_rmw_nand_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_nand_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little nand v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_nand_little_i16(0x12345678, 2, 0xf000) == [0x1234, 0xefff5678]
+; run: %atomic_rmw_nand_little_i16(0x12345678, 2, 0x000f) == [0x1234, 0xfffb5678]
+; run: %atomic_rmw_nand_little_i16(0x12345678, 0, 0xf000) == [0x5678, 0x1234afff]
+; run: %atomic_rmw_nand_little_i16(0x12345678, 0, 0x000f) == [0x5678, 0x1234fff7]
+
+function %atomic_rmw_nand_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -226,12 +444,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_nand_little_i16(0x12345678, 2, 0xf000) == 0xefff5678
-; run: %atomic_rmw_nand_little_i16(0x12345678, 2, 0x000f) == 0xfffb5678
-; run: %atomic_rmw_nand_little_i16(0x12345678, 0, 0xf000) == 0x1234afff
-; run: %atomic_rmw_nand_little_i16(0x12345678, 0, 0x000f) == 0x1234fff7
+; run: %atomic_rmw_nand_little_i16_no_res(0x12345678, 2, 0xf000) == 0xefff5678
+; run: %atomic_rmw_nand_little_i16_no_res(0x12345678, 2, 0x000f) == 0xfffb5678
+; run: %atomic_rmw_nand_little_i16_no_res(0x12345678, 0, 0xf000) == 0x1234afff
+; run: %atomic_rmw_nand_little_i16_no_res(0x12345678, 0, 0x000f) == 0x1234fff7
 
-function %atomic_rmw_nand_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_nand_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little nand v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_nand_little_i8(0x12345678, 3, 0xf0) == [0x12, 0xef345678]
+; run: %atomic_rmw_nand_little_i8(0x12345678, 3, 0x0f) == [0x12, 0xfd345678]
+; run: %atomic_rmw_nand_little_i8(0x12345678, 2, 0xf0) == [0x34, 0x12cf5678]
+; run: %atomic_rmw_nand_little_i8(0x12345678, 2, 0x0f) == [0x34, 0x12fb5678]
+; run: %atomic_rmw_nand_little_i8(0x12345678, 1, 0xf0) == [0x56, 0x1234af78]
+; run: %atomic_rmw_nand_little_i8(0x12345678, 1, 0x0f) == [0x56, 0x1234f978]
+; run: %atomic_rmw_nand_little_i8(0x12345678, 0, 0xf0) == [0x78, 0x1234568f]
+; run: %atomic_rmw_nand_little_i8(0x12345678, 0, 0x0f) == [0x78, 0x123456f7]
+
+function %atomic_rmw_nand_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -244,17 +484,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_nand_little_i8(0x12345678, 3, 0xf0) == 0xef345678
-; run: %atomic_rmw_nand_little_i8(0x12345678, 3, 0x0f) == 0xfd345678
-; run: %atomic_rmw_nand_little_i8(0x12345678, 2, 0xf0) == 0x12cf5678
-; run: %atomic_rmw_nand_little_i8(0x12345678, 2, 0x0f) == 0x12fb5678
-; run: %atomic_rmw_nand_little_i8(0x12345678, 1, 0xf0) == 0x1234af78
-; run: %atomic_rmw_nand_little_i8(0x12345678, 1, 0x0f) == 0x1234f978
-; run: %atomic_rmw_nand_little_i8(0x12345678, 0, 0xf0) == 0x1234568f
-; run: %atomic_rmw_nand_little_i8(0x12345678, 0, 0x0f) == 0x123456f7
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 3, 0xf0) == 0xef345678
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 3, 0x0f) == 0xfd345678
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 2, 0xf0) == 0x12cf5678
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 2, 0x0f) == 0x12fb5678
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 1, 0xf0) == 0x1234af78
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 1, 0x0f) == 0x1234f978
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 0, 0xf0) == 0x1234568f
+; run: %atomic_rmw_nand_little_i8_no_res(0x12345678, 0, 0x0f) == 0x123456f7
 
 
-function %atomic_rmw_umin_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_umin_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little umin v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_umin_little_i16(0x12345678, 2, 0x1111) == [0x1234, 0x11115678]
+; run: %atomic_rmw_umin_little_i16(0x12345678, 2, 0xffff) == [0x1234, 0x12345678]
+; run: %atomic_rmw_umin_little_i16(0x12345678, 0, 0x1111) == [0x5678, 0x12341111]
+; run: %atomic_rmw_umin_little_i16(0x12345678, 0, 0xffff) == [0x5678, 0x12345678]
+
+function %atomic_rmw_umin_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -267,12 +525,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_umin_little_i16(0x12345678, 2, 0x1111) == 0x11115678
-; run: %atomic_rmw_umin_little_i16(0x12345678, 2, 0xffff) == 0x12345678
-; run: %atomic_rmw_umin_little_i16(0x12345678, 0, 0x1111) == 0x12341111
-; run: %atomic_rmw_umin_little_i16(0x12345678, 0, 0xffff) == 0x12345678
+; run: %atomic_rmw_umin_little_i16_no_res(0x12345678, 2, 0x1111) == 0x11115678
+; run: %atomic_rmw_umin_little_i16_no_res(0x12345678, 2, 0xffff) == 0x12345678
+; run: %atomic_rmw_umin_little_i16_no_res(0x12345678, 0, 0x1111) == 0x12341111
+; run: %atomic_rmw_umin_little_i16_no_res(0x12345678, 0, 0xffff) == 0x12345678
 
-function %atomic_rmw_umin_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_umin_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little umin v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_umin_little_i8(0x12345678, 3, 0x11) == [0x12, 0x11345678]
+; run: %atomic_rmw_umin_little_i8(0x12345678, 3, 0xff) == [0x12, 0x12345678]
+; run: %atomic_rmw_umin_little_i8(0x12345678, 2, 0x11) == [0x34, 0x12115678]
+; run: %atomic_rmw_umin_little_i8(0x12345678, 2, 0xff) == [0x34, 0x12345678]
+; run: %atomic_rmw_umin_little_i8(0x12345678, 1, 0x11) == [0x56, 0x12341178]
+; run: %atomic_rmw_umin_little_i8(0x12345678, 1, 0xff) == [0x56, 0x12345678]
+; run: %atomic_rmw_umin_little_i8(0x12345678, 0, 0x11) == [0x78, 0x12345611]
+; run: %atomic_rmw_umin_little_i8(0x12345678, 0, 0xff) == [0x78, 0x12345678]
+
+function %atomic_rmw_umin_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -285,17 +565,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_umin_little_i8(0x12345678, 3, 0x11) == 0x11345678
-; run: %atomic_rmw_umin_little_i8(0x12345678, 3, 0xff) == 0x12345678
-; run: %atomic_rmw_umin_little_i8(0x12345678, 2, 0x11) == 0x12115678
-; run: %atomic_rmw_umin_little_i8(0x12345678, 2, 0xff) == 0x12345678
-; run: %atomic_rmw_umin_little_i8(0x12345678, 1, 0x11) == 0x12341178
-; run: %atomic_rmw_umin_little_i8(0x12345678, 1, 0xff) == 0x12345678
-; run: %atomic_rmw_umin_little_i8(0x12345678, 0, 0x11) == 0x12345611
-; run: %atomic_rmw_umin_little_i8(0x12345678, 0, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 3, 0x11) == 0x11345678
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 3, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 2, 0x11) == 0x12115678
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 2, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 1, 0x11) == 0x12341178
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 1, 0xff) == 0x12345678
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 0, 0x11) == 0x12345611
+; run: %atomic_rmw_umin_little_i8_no_res(0x12345678, 0, 0xff) == 0x12345678
 
 
-function %atomic_rmw_umax_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_umax_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little umax v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_umax_little_i16(0x12345678, 2, 0x1111) == [0x1234, 0x12345678]
+; run: %atomic_rmw_umax_little_i16(0x12345678, 2, 0xffff) == [0x1234, 0xffff5678]
+; run: %atomic_rmw_umax_little_i16(0x12345678, 0, 0x1111) == [0x5678, 0x12345678]
+; run: %atomic_rmw_umax_little_i16(0x12345678, 0, 0xffff) == [0x5678, 0x1234ffff]
+
+function %atomic_rmw_umax_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -308,12 +606,34 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_umax_little_i16(0x12345678, 2, 0x1111) == 0x12345678
-; run: %atomic_rmw_umax_little_i16(0x12345678, 2, 0xffff) == 0xffff5678
-; run: %atomic_rmw_umax_little_i16(0x12345678, 0, 0x1111) == 0x12345678
-; run: %atomic_rmw_umax_little_i16(0x12345678, 0, 0xffff) == 0x1234ffff
+; run: %atomic_rmw_umax_little_i16_no_res(0x12345678, 2, 0x1111) == 0x12345678
+; run: %atomic_rmw_umax_little_i16_no_res(0x12345678, 2, 0xffff) == 0xffff5678
+; run: %atomic_rmw_umax_little_i16_no_res(0x12345678, 0, 0x1111) == 0x12345678
+; run: %atomic_rmw_umax_little_i16_no_res(0x12345678, 0, 0xffff) == 0x1234ffff
 
-function %atomic_rmw_umax_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_umax_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little umax v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_umax_little_i8(0x12345678, 3, 0x11) == [0x12, 0x12345678]
+; run: %atomic_rmw_umax_little_i8(0x12345678, 3, 0xff) == [0x12, 0xff345678]
+; run: %atomic_rmw_umax_little_i8(0x12345678, 2, 0x11) == [0x34, 0x12345678]
+; run: %atomic_rmw_umax_little_i8(0x12345678, 2, 0xff) == [0x34, 0x12ff5678]
+; run: %atomic_rmw_umax_little_i8(0x12345678, 1, 0x11) == [0x56, 0x12345678]
+; run: %atomic_rmw_umax_little_i8(0x12345678, 1, 0xff) == [0x56, 0x1234ff78]
+; run: %atomic_rmw_umax_little_i8(0x12345678, 0, 0x11) == [0x78, 0x12345678]
+; run: %atomic_rmw_umax_little_i8(0x12345678, 0, 0xff) == [0x78, 0x123456ff]
+
+function %atomic_rmw_umax_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -326,17 +646,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_umax_little_i8(0x12345678, 3, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_little_i8(0x12345678, 3, 0xff) == 0xff345678
-; run: %atomic_rmw_umax_little_i8(0x12345678, 2, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_little_i8(0x12345678, 2, 0xff) == 0x12ff5678
-; run: %atomic_rmw_umax_little_i8(0x12345678, 1, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_little_i8(0x12345678, 1, 0xff) == 0x1234ff78
-; run: %atomic_rmw_umax_little_i8(0x12345678, 0, 0x11) == 0x12345678
-; run: %atomic_rmw_umax_little_i8(0x12345678, 0, 0xff) == 0x123456ff
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 3, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 3, 0xff) == 0xff345678
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 2, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 2, 0xff) == 0x12ff5678
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 1, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 1, 0xff) == 0x1234ff78
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 0, 0x11) == 0x12345678
+; run: %atomic_rmw_umax_little_i8_no_res(0x12345678, 0, 0xff) == 0x123456ff
 
 
-function %atomic_rmw_smin_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_smin_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little smin v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_smin_little_i16(0x12345678, 2, 0x1111) == [0x1234, 0x11115678]
+; run: %atomic_rmw_smin_little_i16(0x12345678, 2, 0xffff) == [0x1234, 0xffff5678]
+; run: %atomic_rmw_smin_little_i16(0x12345678, 0, 0x1111) == [0x5678, 0x12341111]
+; run: %atomic_rmw_smin_little_i16(0x12345678, 0, 0xffff) == [0x5678, 0x1234ffff]
+
+function %atomic_rmw_smin_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -349,13 +687,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_smin_little_i16(0x12345678, 2, 0x1111) == 0x11115678
-; run: %atomic_rmw_smin_little_i16(0x12345678, 2, 0xffff) == 0xffff5678
-; run: %atomic_rmw_smin_little_i16(0x12345678, 0, 0x1111) == 0x12341111
-; run: %atomic_rmw_smin_little_i16(0x12345678, 0, 0xffff) == 0x1234ffff
+; run: %atomic_rmw_smin_little_i16_no_res(0x12345678, 2, 0x1111) == 0x11115678
+; run: %atomic_rmw_smin_little_i16_no_res(0x12345678, 2, 0xffff) == 0xffff5678
+; run: %atomic_rmw_smin_little_i16_no_res(0x12345678, 0, 0x1111) == 0x12341111
+; run: %atomic_rmw_smin_little_i16_no_res(0x12345678, 0, 0xffff) == 0x1234ffff
 
 
-function %atomic_rmw_smin_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_smin_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little smin v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_smin_little_i8(0x12345678, 3, 0x11) == [0x12, 0x11345678]
+; run: %atomic_rmw_smin_little_i8(0x12345678, 3, 0xff) == [0x12, 0xff345678]
+; run: %atomic_rmw_smin_little_i8(0x12345678, 2, 0x11) == [0x34, 0x12115678]
+; run: %atomic_rmw_smin_little_i8(0x12345678, 2, 0xff) == [0x34, 0x12ff5678]
+; run: %atomic_rmw_smin_little_i8(0x12345678, 1, 0x11) == [0x56, 0x12341178]
+; run: %atomic_rmw_smin_little_i8(0x12345678, 1, 0xff) == [0x56, 0x1234ff78]
+; run: %atomic_rmw_smin_little_i8(0x12345678, 0, 0x11) == [0x78, 0x12345611]
+; run: %atomic_rmw_smin_little_i8(0x12345678, 0, 0xff) == [0x78, 0x123456ff]
+
+function %atomic_rmw_smin_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -368,17 +728,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_smin_little_i8(0x12345678, 3, 0x11) == 0x11345678
-; run: %atomic_rmw_smin_little_i8(0x12345678, 3, 0xff) == 0xff345678
-; run: %atomic_rmw_smin_little_i8(0x12345678, 2, 0x11) == 0x12115678
-; run: %atomic_rmw_smin_little_i8(0x12345678, 2, 0xff) == 0x12ff5678
-; run: %atomic_rmw_smin_little_i8(0x12345678, 1, 0x11) == 0x12341178
-; run: %atomic_rmw_smin_little_i8(0x12345678, 1, 0xff) == 0x1234ff78
-; run: %atomic_rmw_smin_little_i8(0x12345678, 0, 0x11) == 0x12345611
-; run: %atomic_rmw_smin_little_i8(0x12345678, 0, 0xff) == 0x123456ff
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 3, 0x11) == 0x11345678
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 3, 0xff) == 0xff345678
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 2, 0x11) == 0x12115678
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 2, 0xff) == 0x12ff5678
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 1, 0x11) == 0x12341178
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 1, 0xff) == 0x1234ff78
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 0, 0x11) == 0x12345611
+; run: %atomic_rmw_smin_little_i8_no_res(0x12345678, 0, 0xff) == 0x123456ff
 
 
-function %atomic_rmw_smax_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_smax_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little smax v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_smax_little_i16(0x12345678, 2, 0xffff) == [0x1234, 0x12345678]
+; run: %atomic_rmw_smax_little_i16(0x12345678, 2, 0x7fff) == [0x1234, 0x7fff5678]
+; run: %atomic_rmw_smax_little_i16(0x12345678, 0, 0xffff) == [0x5678, 0x12345678]
+; run: %atomic_rmw_smax_little_i16(0x12345678, 0, 0x7fff) == [0x5678, 0x12347fff]
+
+function %atomic_rmw_smax_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -391,13 +769,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_smax_little_i16(0x12345678, 2, 0xffff) == 0x12345678
-; run: %atomic_rmw_smax_little_i16(0x12345678, 2, 0x7fff) == 0x7fff5678
-; run: %atomic_rmw_smax_little_i16(0x12345678, 0, 0xffff) == 0x12345678
-; run: %atomic_rmw_smax_little_i16(0x12345678, 0, 0x7fff) == 0x12347fff
+; run: %atomic_rmw_smax_little_i16_no_res(0x12345678, 2, 0xffff) == 0x12345678
+; run: %atomic_rmw_smax_little_i16_no_res(0x12345678, 2, 0x7fff) == 0x7fff5678
+; run: %atomic_rmw_smax_little_i16_no_res(0x12345678, 0, 0xffff) == 0x12345678
+; run: %atomic_rmw_smax_little_i16_no_res(0x12345678, 0, 0x7fff) == 0x12347fff
 
 
-function %atomic_rmw_smax_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_smax_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little smax v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_smax_little_i8(0x12345678, 3, 0xff) == [0x12, 0x12345678]
+; run: %atomic_rmw_smax_little_i8(0x12345678, 3, 0x7f) == [0x12, 0x7f345678]
+; run: %atomic_rmw_smax_little_i8(0x12345678, 2, 0xff) == [0x34, 0x12345678]
+; run: %atomic_rmw_smax_little_i8(0x12345678, 2, 0x7f) == [0x34, 0x127f5678]
+; run: %atomic_rmw_smax_little_i8(0x12345678, 1, 0xff) == [0x56, 0x12345678]
+; run: %atomic_rmw_smax_little_i8(0x12345678, 1, 0x7f) == [0x56, 0x12347f78]
+; run: %atomic_rmw_smax_little_i8(0x12345678, 0, 0xff) == [0x78, 0x12345678]
+; run: %atomic_rmw_smax_little_i8(0x12345678, 0, 0x7f) == [0x78, 0x1234567f]
+
+function %atomic_rmw_smax_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -410,17 +810,35 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_smax_little_i8(0x12345678, 3, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_little_i8(0x12345678, 3, 0x7f) == 0x7f345678
-; run: %atomic_rmw_smax_little_i8(0x12345678, 2, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_little_i8(0x12345678, 2, 0x7f) == 0x127f5678
-; run: %atomic_rmw_smax_little_i8(0x12345678, 1, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_little_i8(0x12345678, 1, 0x7f) == 0x12347f78
-; run: %atomic_rmw_smax_little_i8(0x12345678, 0, 0xff) == 0x12345678
-; run: %atomic_rmw_smax_little_i8(0x12345678, 0, 0x7f) == 0x1234567f
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 3, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 3, 0x7f) == 0x7f345678
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 2, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 2, 0x7f) == 0x127f5678
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 1, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 1, 0x7f) == 0x12347f78
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 0, 0xff) == 0x12345678
+; run: %atomic_rmw_smax_little_i8_no_res(0x12345678, 0, 0x7f) == 0x1234567f
 
 
-function %atomic_rmw_xchg_little_i16(i32, i64, i16) -> i32 {
+function %atomic_rmw_xchg_little_i16(i32, i64, i16) -> i16, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i16):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i16 little xchg v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_xchg_little_i16(0x12345678, 2, 0x1111) == [0x1234, 0x11115678]
+; run: %atomic_rmw_xchg_little_i16(0x12345678, 2, 0xffff) == [0x1234, 0xffff5678]
+; run: %atomic_rmw_xchg_little_i16(0x12345678, 0, 0x1111) == [0x5678, 0x12341111]
+; run: %atomic_rmw_xchg_little_i16(0x12345678, 0, 0xffff) == [0x5678, 0x1234ffff]
+
+function %atomic_rmw_xchg_little_i16_no_res(i32, i64, i16) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i16):
@@ -433,13 +851,35 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 2, 0x1111) == 0x11115678
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 2, 0xffff) == 0xffff5678
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 0, 0x1111) == 0x12341111
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 0, 0xffff) == 0x1234ffff
+; run: %atomic_rmw_xchg_little_i16_no_res(0x12345678, 2, 0x1111) == 0x11115678
+; run: %atomic_rmw_xchg_little_i16_no_res(0x12345678, 2, 0xffff) == 0xffff5678
+; run: %atomic_rmw_xchg_little_i16_no_res(0x12345678, 0, 0x1111) == 0x12341111
+; run: %atomic_rmw_xchg_little_i16_no_res(0x12345678, 0, 0xffff) == 0x1234ffff
 
 
-function %atomic_rmw_xchg_little_i8(i32, i64, i8) -> i32 {
+function %atomic_rmw_xchg_little_i8(i32, i64, i8) -> i8, i32 {
+    ss0 = explicit_slot 4
+
+block0(v0: i32, v1: i64, v2: i8):
+    v3 = stack_addr.i64 ss0
+    store.i32 little v0, v3
+
+    v4 = iadd.i64 v3, v1
+    v5 = atomic_rmw.i8 little xchg v4, v2
+
+    v6 = load.i32 little v3
+    return v5, v6
+}
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 3, 0x11) == [0x12, 0x11345678]
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 3, 0xff) == [0x12, 0xff345678]
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 2, 0x11) == [0x34, 0x12115678]
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 2, 0xff) == [0x34, 0x12ff5678]
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 1, 0x11) == [0x56, 0x12341178]
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 1, 0xff) == [0x56, 0x1234ff78]
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 0, 0x11) == [0x78, 0x12345611]
+; run: %atomic_rmw_xchg_little_i8(0x12345678, 0, 0xff) == [0x78, 0x123456ff]
+
+function %atomic_rmw_xchg_little_i8_no_res(i32, i64, i8) -> i32 {
     ss0 = explicit_slot 4
 
 block0(v0: i32, v1: i64, v2: i8):
@@ -452,11 +892,11 @@ block0(v0: i32, v1: i64, v2: i8):
     v6 = load.i32 little v3
     return v6
 }
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 3, 0x11) == 0x11345678
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 3, 0xff) == 0xff345678
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 2, 0x11) == 0x12115678
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 2, 0xff) == 0x12ff5678
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 1, 0x11) == 0x12341178
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 1, 0xff) == 0x1234ff78
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 0, 0x11) == 0x12345611
-; run: %atomic_rmw_xchg_little_i8(0x12345678, 0, 0xff) == 0x123456ff
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 3, 0x11) == 0x11345678
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 3, 0xff) == 0xff345678
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 2, 0x11) == 0x12115678
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 2, 0xff) == 0x12ff5678
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 1, 0x11) == 0x12341178
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 1, 0xff) == 0x1234ff78
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 0, 0x11) == 0x12345611
+; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 0, 0xff) == 0x123456ff


### PR DESCRIPTION
`xchg` and `lock xadd` can be used in all cases for `Xchg`, `Add` and `Sub`, while various `lock`-prefixed arithmetic instructions can be used for `Add`, `Sub`, `And`, `Or` and `Xor` if the result value of `atomic_rmw` (the old value) isn't used.

Closes #2153