### PR TITLE
Bump MSRV to 1.80

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -28,7 +28,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2024-10-22" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2024-10-02" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -9,15 +9,7 @@ inputs:
   msrv_range:
     description: 'Versions later-than-latest-Rust the MSRV supports'
     required: false
-    # Note that this is currently set to 3 as the MSRV is 1.78 and current
-    # stable is 1.81. Currently MSRV cannot be updated as it would break the
-    # build on OSS-Fuzz which hasn't updated its Rust compiler in quite some time.
-    #
-    # Updating OSS-Fuzz is being done in
-    # https://github.com/google/oss-fuzz/pull/12365 but it's taking some time,
-    # so for now this'll get bumped instead of MSRV while we wait for the update
-    # to happen.
-    default: '3'
+    default: '2'
 
 runs:
   using: composite
@@ -36,7 +28,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2024-10-01" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2024-10-22" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.78.0"
+rust-version = "1.80.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.


### PR DESCRIPTION
This commit updates the minimum Rust version required to compile Wasmtime to 1.80.0 from the previous 1.78.0.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
