### PR TITLE
Leverage Rust 1.79, 1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,6 @@ dependencies = [
  "arbitrary",
  "cranelift",
  "cranelift-native",
- "once_cell",
  "target-lexicon",
 ]
 
@@ -3589,7 +3588,6 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "log",
- "once_cell",
  "rustix",
  "system-interface",
  "tempfile",
@@ -3739,7 +3737,6 @@ name = "wasm-spec-interpreter"
 version = "0.0.0"
 dependencies = [
  "ocaml-interop",
- "once_cell",
  "wat",
 ]
 
@@ -3925,7 +3922,6 @@ dependencies = [
  "env_logger 0.11.5",
  "futures",
  "log",
- "once_cell",
  "tokio",
  "tracing",
  "wasmtime",
@@ -3951,7 +3947,6 @@ dependencies = [
  "directories-next",
  "filetime",
  "log",
- "once_cell",
  "postcard",
  "pretty_env_logger",
  "rustix",
@@ -3996,7 +3991,6 @@ dependencies = [
  "memchr",
  "num_cpus",
  "object",
- "once_cell",
  "pulley-interpreter",
  "rayon",
  "rustix",
@@ -4183,7 +4177,6 @@ dependencies = [
  "env_logger 0.11.5",
  "libfuzzer-sys",
  "log",
- "once_cell",
  "proc-macro2",
  "pulley-interpreter-fuzz",
  "quote",
@@ -4228,7 +4221,6 @@ name = "wasmtime-jit-debug"
 version = "27.0.0"
 dependencies = [
  "object",
- "once_cell",
  "rustix",
  "wasmtime-versioned-export-macros",
 ]
@@ -4283,7 +4275,6 @@ dependencies = [
  "futures",
  "io-extras",
  "io-lifetimes",
- "once_cell",
  "rustix",
  "system-interface",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ clap = { workspace = true }
 clap_complete = { workspace = true, optional = true }
 anyhow = { workspace = true, features = ['std'] }
 target-lexicon = { workspace = true }
-once_cell = { workspace = true }
 listenfd = { version = "1.0.0", optional = true }
 wat = { workspace = true, optional = true }
 serde = { workspace = true }
@@ -299,7 +298,6 @@ clap = { version = "4.5.17", default-features = false, features = ["std", "deriv
 clap_complete = "4.4.7"
 hashbrown = { version = "0.14", default-features = false }
 capstone = "0.12.0"
-once_cell = { version = "1.12.0", default-features = false }
 smallvec = { version = "1.6.1", features = ["union"] }
 tracing = "0.1.26"
 bitflags = "2.0"

--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use once_cell::unsync::Lazy;
+use std::cell::LazyCell;
 use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
@@ -35,7 +35,7 @@ fn bench_sequential(c: &mut Criterion, path: &Path) {
             benchmark_name(&strategy),
             path.file_name().unwrap().to_str().unwrap(),
         );
-        let state = Lazy::new(|| {
+        let state = LazyCell::new(|| {
             let mut config = Config::default();
             config.allocation_strategy(strategy.clone());
 
@@ -70,7 +70,7 @@ fn bench_parallel(c: &mut Criterion, path: &Path) {
     let mut group = c.benchmark_group("parallel");
 
     for strategy in strategies() {
-        let state = Lazy::new(|| {
+        let state = LazyCell::new(|| {
             let mut config = Config::default();
             config.allocation_strategy(strategy.clone());
 
@@ -153,7 +153,7 @@ fn bench_deserialize_module(c: &mut Criterion, path: &Path) {
 
     let name = path.file_name().unwrap().to_str().unwrap();
     let tmpfile = tempfile::NamedTempFile::new().unwrap();
-    let state = Lazy::new(|| {
+    let state = LazyCell::new(|| {
         let engine = Engine::default();
         let module = Module::from_file(&engine, path).expect("failed to load WASI example module");
         let bytes = module.serialize().unwrap();

--- a/cranelift/fuzzgen/Cargo.toml
+++ b/cranelift/fuzzgen/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 cranelift = { workspace = true }
 cranelift-native = { workspace = true }
 
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 arbitrary = { workspace = true }
-once_cell = { workspace = true }
 target-lexicon = { workspace = true, features = ["std"] }

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -19,10 +19,10 @@ use cranelift::prelude::{
     EntityRef, ExtFuncData, FloatCC, InstBuilder, IntCC, JumpTableData, MemFlags, StackSlotData,
     StackSlotKind,
 };
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use target_lexicon::{Architecture, Triple};
 
 type BlockSignature = Vec<Type>;
@@ -789,7 +789,7 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
 
 type OpcodeSignature = (Opcode, Vec<Type>, Vec<Type>);
 
-static OPCODE_SIGNATURES: Lazy<Vec<OpcodeSignature>> = Lazy::new(|| {
+static OPCODE_SIGNATURES: LazyLock<Vec<OpcodeSignature>> = LazyLock::new(|| {
     let types = &[
         I8, I16, I32, I64, I128, // Scalar Integers
         F32, F64, // Scalar Floats

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -22,7 +22,6 @@ doctest = false
 [dependencies]
 env_logger = { workspace = true, optional = true }
 anyhow = { workspace = true }
-once_cell = { workspace = true }
 wasmtime = { workspace = true, features = ['runtime', 'gc', 'std'] }
 wasmtime-c-api-macros = { workspace = true }
 log = { workspace = true }

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -1,6 +1,6 @@
 use crate::{wasm_frame_vec_t, wasm_instance_t, wasm_name_t, wasm_store_t};
 use anyhow::{anyhow, Error};
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 use wasmtime::{Trap, WasmBacktrace};
 
 #[repr(C)]

--- a/crates/c-api/src/types/export.rs
+++ b/crates/c-api/src/types/export.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_externtype_t, wasm_name_t, CExternType};
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 
 #[repr(C)]
 #[derive(Clone)]

--- a/crates/c-api/src/types/func.rs
+++ b/crates/c-api/src/types/func.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_externtype_t, wasm_valtype_t, wasm_valtype_vec_t, CExternType};
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 use std::{
     mem,
     sync::{Arc, Mutex},

--- a/crates/c-api/src/types/global.rs
+++ b/crates/c-api/src/types/global.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_externtype_t, wasm_valtype_t, CExternType};
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 use wasmtime::GlobalType;
 
 pub type wasm_mutability_t = u8;

--- a/crates/c-api/src/types/import.rs
+++ b/crates/c-api/src/types/import.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_externtype_t, wasm_name_t, CExternType};
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 
 #[repr(C)]
 #[derive(Clone)]

--- a/crates/c-api/src/types/memory.rs
+++ b/crates/c-api/src/types/memory.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_externtype_t, wasm_limits_t, CExternType};
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 use std::convert::TryFrom;
 use wasmtime::MemoryType;
 

--- a/crates/c-api/src/types/table.rs
+++ b/crates/c-api/src/types/table.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_externtype_t, wasm_limits_t, wasm_valtype_t, CExternType};
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 use wasmtime::{TableType, ValType};
 
 #[repr(transparent)]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -35,6 +35,5 @@ rustix = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
 filetime = "0.2.7"
-once_cell = { workspace = true }
 pretty_env_logger = { workspace = true }
 tempfile = "3"

--- a/crates/cache/src/worker/tests/system_time_stub.rs
+++ b/crates/cache/src/worker/tests/system_time_stub.rs
@@ -1,7 +1,7 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::time::{Duration, SystemTime, SystemTimeError};
 
-pub static NOW: Lazy<SystemTime> = Lazy::new(SystemTime::now);
+pub static NOW: LazyLock<SystemTime> = LazyLock::new(SystemTime::now);
 
 #[derive(PartialOrd, PartialEq, Ord, Eq)]
 pub struct SystemTimeStub(SystemTime);

--- a/crates/fuzzing/wasm-spec-interpreter/Cargo.toml
+++ b/crates/fuzzing/wasm-spec-interpreter/Cargo.toml
@@ -17,10 +17,9 @@ workspace = true
 # `build-libinterpret` feature set by this crate's parent).
 [dependencies]
 ocaml-interop = { version = "0.8", optional = true }
-once_cell = { workspace = true, optional = true }
 
 [dev-dependencies]
 wat = { workspace = true }
 
 [features]
-build-libinterpret = ["ocaml-interop", "once_cell"]
+build-libinterpret = ["ocaml-interop"]

--- a/crates/fuzzing/wasm-spec-interpreter/src/with_library.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/src/with_library.rs
@@ -34,10 +34,9 @@
 
 use crate::{SpecExport, SpecInstance, SpecValue};
 use ocaml_interop::{BoxRoot, OCamlRuntime, ToOCaml};
-use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
-static INTERPRET: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static INTERPRET: Mutex<()> = Mutex::new(());
 
 /// Instantiate the WebAssembly module in the spec interpreter.
 pub fn instantiate(module: &[u8]) -> Result<SpecInstance, String> {

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-once_cell = { workspace = true, optional = true }
 object = { workspace = true, optional = true }
 wasmtime-versioned-export-macros = { workspace = true }
 
@@ -23,5 +22,5 @@ wasmtime-versioned-export-macros = { workspace = true }
 rustix = { workspace = true, features = ["mm", "param", "time"], optional = true }
 
 [features]
-gdb_jit_int = ["once_cell"]
+gdb_jit_int = []
 perf_jitdump = ["rustix", "object"]

--- a/crates/jit-debug/src/gdb_jit_int.rs
+++ b/crates/jit-debug/src/gdb_jit_int.rs
@@ -2,7 +2,6 @@
 //! the __jit_debug_register_code() and __jit_debug_descriptor to register
 //! or unregister generated object images with debuggers.
 
-use once_cell::sync::Lazy;
 use std::pin::Pin;
 use std::ptr;
 use std::sync::Mutex;
@@ -40,7 +39,7 @@ extern "C" {
 ///
 /// The GDB_REGISTRATION lock is needed for GdbJitImageRegistration to protect
 /// access to the __jit_debug_descriptor within this process.
-static GDB_REGISTRATION: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(Default::default()));
+static GDB_REGISTRATION: Mutex<()> = Mutex::new(());
 
 /// Registration for JIT image
 pub struct GdbJitImageRegistration {

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -43,7 +43,6 @@ libc = { workspace = true, optional = true }
 rustix = { workspace = true, features = ["fs", "event"] }
 
 [target.'cfg(windows)'.dependencies]
-once_cell = { workspace = true }
 io-extras = { workspace = true }
 rustix = { workspace = true, features = ["net"] }
 

--- a/crates/wasi-common/src/sync/sched/windows.rs
+++ b/crates/wasi-common/src/sync/sched/windows.rs
@@ -10,9 +10,8 @@
 
 use crate::sched::subscription::{RwEventFlags, Subscription};
 use crate::{file::WasiFile, sched::Poll, Error, ErrorExt};
-use once_cell::sync::Lazy;
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -144,7 +143,7 @@ struct StdinPoll {
     notify_rx: Receiver<PollState>,
 }
 
-static STDIN_POLL: Lazy<Mutex<StdinPoll>> = Lazy::new(StdinPoll::new);
+static STDIN_POLL: LazyLock<Mutex<StdinPoll>> = LazyLock::new(StdinPoll::new);
 
 impl StdinPoll {
     pub fn new() -> Mutex<Self> {

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -35,7 +35,6 @@ async-trait = { workspace = true }
 system-interface = { workspace = true}
 futures = { workspace = true }
 url = { workspace = true }
-once_cell = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "sync", "io-std", "io-util", "rt", "rt-multi-thread", "net", "macros", "fs"] }

--- a/crates/wasi/src/runtime.rs
+++ b/crates/wasi/src/runtime.rs
@@ -21,16 +21,16 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::LazyLock;
 use std::task::{Context, Poll};
 
-pub(crate) static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> =
-    once_cell::sync::Lazy::new(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_time()
-            .enable_io()
-            .build()
-            .unwrap()
-    });
+pub(crate) static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_time()
+        .enable_io()
+        .build()
+        .unwrap()
+});
 
 /// Exactly like a [`tokio::task::JoinHandle`], except that it aborts the task when
 /// the handle is dropped.

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -46,7 +46,7 @@ sptr = { workspace = true }
 postcard = { workspace = true }
 indexmap = { workspace = true }
 paste = "1.0.3"
-once_cell = { workspace = true }
+once_cell = { version = "1.12.0", optional = true }
 rayon = { version = "1.0", optional = true }
 object = { workspace = true }
 async-trait = { workspace = true, optional = true }
@@ -267,7 +267,7 @@ std = [
   'wasmtime-component-macro?/std',
   'wasmtime-environ/std',
   'object/std',
-  'once_cell/std',
+  'once_cell',
 ]
 
 # Enables support for the `Store::call_hook` API which enables injecting custom

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -67,7 +67,7 @@ impl Mmap {
 
     #[inline]
     pub fn len(&self) -> usize {
-        unsafe { (*self.memory.as_ptr()).len() }
+        self.memory.as_ptr().len()
     }
 
     pub unsafe fn make_executable(
@@ -102,7 +102,7 @@ impl Drop for Mmap {
     fn drop(&mut self) {
         unsafe {
             let ptr = self.memory.as_ptr().cast();
-            let len = (*self.memory.as_ptr()).len();
+            let len = self.memory.as_ptr().len();
             if len == 0 {
                 return;
             }

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -68,7 +68,7 @@ impl Mmap {
     }
 
     pub fn len(&self) -> usize {
-        unsafe { (*self.memory.as_ptr()).len() }
+        self.memory.as_ptr().len()
     }
 
     pub unsafe fn make_executable(

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -104,7 +104,7 @@ impl Mmap {
 
     #[inline]
     pub fn len(&self) -> usize {
-        unsafe { (*self.memory.as_ptr()).len() }
+        self.memory.as_ptr().len()
     }
 
     pub unsafe fn make_executable(
@@ -149,7 +149,7 @@ impl Drop for Mmap {
     fn drop(&mut self) {
         unsafe {
             let ptr = self.memory.as_ptr().cast();
-            let len = (*self.memory.as_ptr()).len();
+            let len = self.memory.as_ptr().len();
             if len == 0 {
                 return;
             }

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -164,7 +164,7 @@ impl Mmap {
 
     #[inline]
     pub fn len(&self) -> usize {
-        unsafe { (*self.memory.as_ptr()).len() }
+        self.memory.as_ptr().len()
     }
 
     pub unsafe fn make_executable(

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,6 @@ cargo-fuzz = true
 [dependencies]
 anyhow = { workspace = true }
 env_logger = { workspace = true }
-once_cell = { workspace = true }
 cranelift-codegen = { workspace = true, features = ["incremental-cache", "x86", "arm64", "s390x", "riscv64"] }
 cranelift-reader = { workspace = true }
 cranelift-filetests = { workspace = true }

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -10,11 +10,11 @@ use libfuzzer_sys::arbitrary;
 use libfuzzer_sys::arbitrary::Arbitrary;
 use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::sync::LazyLock;
 
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::{LibCall, TrapCode};
@@ -320,7 +320,7 @@ fn build_interpreter(testcase: &TestCase) -> Interpreter {
     interpreter
 }
 
-static STATISTICS: Lazy<Statistics> = Lazy::new(Statistics::default);
+static STATISTICS: LazyLock<Statistics> = LazyLock::new(Statistics::default);
 
 fn run_test_inputs(testcase: &TestCase, run: impl Fn(&[DataValue]) -> RunResult) {
     for args in &testcase.inputs {

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -2,15 +2,13 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use once_cell::sync::Lazy;
 use std::fs;
 use std::path::PathBuf;
 use wasmtime::{CodeBuilder, CodeHint, Engine};
 use wasmtime_cli_flags::CommonOptions;
 
-static AFTER_HELP: Lazy<String> = Lazy::new(|| {
-    format!(
-        "By default, no CPU features or presets will be enabled for the compilation.\n\
+const AFTER_HELP: &str =
+    "By default, no CPU features or presets will be enabled for the compilation.\n\
         \n\
         Usage examples:\n\
         \n\
@@ -24,15 +22,13 @@ static AFTER_HELP: Lazy<String> = Lazy::new(|| {
         \n\
         Compiling for a specific platform (Linux) and CPU preset (Skylake):\n\
         \n  \
-        wasmtime compile --target x86_64-unknown-linux -Ccranelift-skylake foo.wasm\n",
-    )
-});
+        wasmtime compile --target x86_64-unknown-linux -Ccranelift-skylake foo.wasm\n";
 
 /// Compiles a WebAssembly module.
 #[derive(Parser, PartialEq)]
 #[command(
     version,
-    after_help = AFTER_HELP.as_str()
+    after_help = AFTER_HELP,
 )]
 pub struct CompileCommand {
     #[command(flatten)]

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -1,9 +1,8 @@
 use anyhow::{bail, Context};
 use bstr::ByteSlice;
 use libtest_mimic::{Arguments, FormatSetting, Trial};
-use once_cell::sync::Lazy;
 use std::path::Path;
-use std::sync::{Condvar, Mutex};
+use std::sync::{Condvar, LazyLock, Mutex};
 use wasmtime::{
     Config, Engine, InstanceAllocationStrategy, MpkEnabled, PoolingAllocationConfig, Store,
     Strategy,
@@ -444,7 +443,7 @@ fn feature_found_src(bytes: &[u8], name: &str) -> bool {
 fn lock_pooling() -> impl Drop {
     const MAX_CONCURRENT_POOLING: u32 = 4;
 
-    static ACTIVE: Lazy<MyState> = Lazy::new(MyState::default);
+    static ACTIVE: LazyLock<MyState> = LazyLock::new(MyState::default);
 
     #[derive(Default)]
     struct MyState {


### PR DESCRIPTION
This commit is a follow-up to #9496 to leverage various APIs that the workspace now has access to. For example most dependencies on the `once_cell` crate are now removed in favor of the types stabilized in the standard library: `LazyLock` and `LazyCell`. One dependency remains in the `wasmtime` crate due to the `get_or_try_init` not being stable yet.

Some additional helper methods on raw pointer slices are also available for removing a few minor `unsafe` blocks.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
