### PR TITLE
Implement wide-arithmetic for Winch

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -487,7 +487,6 @@ impl WasmtimeConfig {
             config.threads_enabled = false;
             config.tail_call_enabled = false;
             config.reference_types_enabled = false;
-            config.wide_arithmetic_enabled = false;
 
             // Tuning  the following engine options is currently not supported
             // by Winch.

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -174,8 +174,6 @@ fn should_fail(test: &Path, strategy: Strategy) -> bool {
             "spec_testsuite/simd_store32_lane.wast",
             "spec_testsuite/simd_store64_lane.wast",
             "spec_testsuite/simd_store8_lane.wast",
-            // wide arithmetic
-            "misc_testsuite/wide-arithmetic.wast",
         ];
 
         if unsupported.iter().any(|part| test.ends_with(part)) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -5,8 +5,8 @@ use crate::{
     isa::reg::{writable, Reg, WritableReg},
     masm::{
         CalleeKind, DivKind, ExtendKind, FloatCmpKind, Imm as I, IntCmpKind,
-        MacroAssembler as Masm, OperandSize, RegImm, RemKind, RoundingMode, SPOffset, ShiftKind,
-        StackSlot, TrapCode, TruncKind,
+        MacroAssembler as Masm, MulWideKind, OperandSize, RegImm, RemKind, RoundingMode, SPOffset,
+        ShiftKind, StackSlot, TrapCode, TruncKind,
     },
 };
 use cranelift_codegen::{
@@ -672,6 +672,37 @@ impl Masm for MacroAssembler {
 
     fn current_code_offset(&self) -> CodeOffset {
         self.asm.buffer().cur_offset()
+    }
+
+    fn add128(
+        &mut self,
+        dst_lo: WritableReg,
+        dst_hi: WritableReg,
+        lhs_lo: Reg,
+        lhs_hi: Reg,
+        rhs_lo: Reg,
+        rhs_hi: Reg,
+    ) {
+        let _ = (dst_lo, dst_hi, lhs_lo, lhs_hi, rhs_lo, rhs_hi);
+        todo!()
+    }
+
+    fn sub128(
+        &mut self,
+        dst_lo: WritableReg,
+        dst_hi: WritableReg,
+        lhs_lo: Reg,
+        lhs_hi: Reg,
+        rhs_lo: Reg,
+        rhs_hi: Reg,
+    ) {
+        let _ = (dst_lo, dst_hi, lhs_lo, lhs_hi, rhs_lo, rhs_hi);
+        todo!()
+    }
+
+    fn mul_wide(&mut self, context: &mut CodeGenContext, kind: MulWideKind) {
+        let _ = (context, kind);
+        todo!()
     }
 }
 

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -2,7 +2,9 @@
 
 use crate::{
     isa::reg::Reg,
-    masm::{DivKind, ExtendKind, IntCmpKind, OperandSize, RemKind, RoundingMode, ShiftKind},
+    masm::{
+        DivKind, ExtendKind, IntCmpKind, MulWideKind, OperandSize, RemKind, RoundingMode, ShiftKind,
+    },
 };
 use cranelift_codegen::{
     ir::{
@@ -1361,6 +1363,45 @@ impl Assembler {
             addr,
             dst: dst.map(Into::into),
             size: size.into(),
+        });
+    }
+
+    pub fn adc_rr(&mut self, src: Reg, dst: WritableReg, size: OperandSize) {
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::Adc,
+            src1: dst.to_reg().into(),
+            src2: src.into(),
+            dst: dst.map(Into::into),
+        });
+    }
+
+    pub fn sbb_rr(&mut self, src: Reg, dst: WritableReg, size: OperandSize) {
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::Sbb,
+            src1: dst.to_reg().into(),
+            src2: src.into(),
+            dst: dst.map(Into::into),
+        });
+    }
+
+    pub fn mul_wide(
+        &mut self,
+        dst_lo: WritableReg,
+        dst_hi: WritableReg,
+        lhs: Reg,
+        rhs: Reg,
+        kind: MulWideKind,
+        size: OperandSize,
+    ) {
+        self.emit(Inst::Mul {
+            signed: kind == MulWideKind::Signed,
+            size: size.into(),
+            src1: lhs.into(),
+            src2: rhs.into(),
+            dst_lo: dst_lo.to_reg().into(),
+            dst_hi: dst_hi.to_reg().into(),
         });
     }
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -27,6 +27,12 @@ pub(crate) enum RemKind {
     Unsigned,
 }
 
+#[derive(Eq, PartialEq)]
+pub(crate) enum MulWideKind {
+    Signed,
+    Unsigned,
+}
+
 /// The direction to perform the memory move.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum MemMoveDirection {
@@ -1019,4 +1025,33 @@ pub(crate) trait MacroAssembler {
 
     /// The current offset, in bytes from the beginning of the function.
     fn current_code_offset(&self) -> CodeOffset;
+
+    /// Performs a 128-bit addition
+    fn add128(
+        &mut self,
+        dst_lo: WritableReg,
+        dst_hi: WritableReg,
+        lhs_lo: Reg,
+        lhs_hi: Reg,
+        rhs_lo: Reg,
+        rhs_hi: Reg,
+    );
+
+    /// Performs a 128-bit subtraction
+    fn sub128(
+        &mut self,
+        dst_lo: WritableReg,
+        dst_hi: WritableReg,
+        lhs_lo: Reg,
+        lhs_hi: Reg,
+        rhs_lo: Reg,
+        rhs_hi: Reg,
+    );
+
+    /// Performs a widening multiplication from two 64-bit operands into a
+    /// 128-bit result.
+    ///
+    /// Note that some platforms require special handling of registers in this
+    /// instruction (e.g. x64) so full access to `CodeGenContext` is provided.
+    fn mul_wide(&mut self, context: &mut CodeGenContext, kind: MulWideKind);
 }


### PR DESCRIPTION
This commit implements the wide-arithmetic proposal for Winch on x64. This is mostly for me to get my feet wet doing things in Winch. The proposal itself is relatively modest with just four new instructions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
