### PR TITLE
Update nightly in CI

### DIFF
--- a/.github/actions/install-ninja/action.yml
+++ b/.github/actions/install-ninja/action.yml
@@ -1,0 +1,18 @@
+name: 'Install ninja'
+description: 'Install ninja'
+
+runs:
+  using: composite
+  steps:
+    - name: Install ninja (macOS)
+      run: brew install ninja
+      if: runner.os == 'macOS'
+      shell: bash
+    - name: Install ninja (Windows)
+      run: choco install ninja
+      if: runner.os == 'Windows'
+      shell: bash
+    - name: Install ninja (Linux)
+      run: sudo apt-get update && sudo apt-get install -y ninja-build
+      if: runner.os == 'Linux'
+      shell: bash

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -28,7 +28,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2024-10-02" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2024-10-22" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1088,6 +1088,7 @@ jobs:
       with:
         submodules: true
 
+    - uses: ./.github/actions/install-ninja
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
@@ -1107,13 +1108,6 @@ jobs:
       if: contains(matrix.target, 'android')
       with:
         target: ${{ matrix.target }}
-
-    - name: Install ninja (macOS)
-      run: brew install ninja
-      if: runner.os == 'macOS'
-    - name: Install ninja (Windows)
-      run: choco install ninja
-      if: runner.os == 'Windows'
 
     - run: $CENTOS ./ci/build-release-artifacts.sh "${{ matrix.build }}" "${{ matrix.target }}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1108,6 +1108,13 @@ jobs:
       with:
         target: ${{ matrix.target }}
 
+    - name: Install ninja (macOS)
+      run: brew install ninja
+      if: runner.os == 'macOS'
+    - name: Install ninja (Windows)
+      run: choco install ninja
+      if: runner.os == 'Windows'
+
     - run: $CENTOS ./ci/build-release-artifacts.sh "${{ matrix.build }}" "${{ matrix.target }}"
 
     # Assemble release artifacts appropriate for this platform, then upload them

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -45,6 +45,7 @@ cargo build --release $flags --target $target -p wasmtime-cli $bin_flags --featu
 mkdir -p target/c-api-build
 cd target/c-api-build
 cmake \
+  -G Ninja \
   ../../crates/c-api \
   $cmake_flags \
   -DCMAKE_BUILD_TYPE=Release \

--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates curl make git
+RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates curl make git ninja-build
 RUN git config --global --add safe.directory '*'
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from

--- a/ci/docker/riscv64gc-linux/Dockerfile
+++ b/ci/docker/riscv64gc-linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-RUN apt-get update -y && apt-get install -y gcc gcc-riscv64-linux-gnu ca-certificates cmake git
+RUN apt-get update -y && apt-get install -y gcc gcc-riscv64-linux-gnu ca-certificates cmake git ninja-build
 RUN git config --global --add safe.directory '*'
 
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc

--- a/ci/docker/s390x-linux/Dockerfile
+++ b/ci/docker/s390x-linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certificates curl make git
+RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certificates curl make git ninja-build
 RUN git config --global --add safe.directory '*'
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,4 +1,9 @@
 FROM almalinux:8
 
-RUN dnf install -y git gcc make cmake git
+RUN dnf install -y git gcc make cmake git unzip
 RUN git config --global --add safe.directory '*'
+
+WORKDIR /usr/local/bin
+RUN curl -LO https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+RUN unzip ./ninja-linux
+WORKDIR /

--- a/ci/docker/x86_64-musl/Dockerfile
+++ b/ci/docker/x86_64-musl/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add libgcc
 # Use something glibc-based for the actual compile because the Rust toolchain
 # we're using is glibc-based in CI.
 FROM ubuntu:24.04
-RUN apt-get update -y && apt-get install -y cmake musl-tools git
+RUN apt-get update -y && apt-get install -y cmake musl-tools git ninja-build
 COPY --from=libgcc_s_src /usr/lib/libgcc_s.so.1 /usr/lib/x86_64-linux-musl
 RUN git config --global --add safe.directory '*'
 


### PR DESCRIPTION
This commit updates nightly again in CI after failing to do so in #9496. This fixes an issue in our release CI where CMake was misconfigured when cross-compiling and creating `aarch64-pc-windows-msvc` artifacts.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
