### PR TITLE
wasi-sockets: Allow TCP connect from a Bound state.

### DIFF
--- a/crates/wasi/src/tcp.rs
+++ b/crates/wasi/src/tcp.rs
@@ -238,7 +238,7 @@ impl TcpSocket {
 
     pub fn start_connect(&mut self, remote_address: SocketAddr) -> SocketResult<()> {
         match self.tcp_state {
-            TcpState::Default(..) => {}
+            TcpState::Default(..) | TcpState::Bound(..) => {}
 
             TcpState::Connecting(..) | TcpState::ConnectReady(..) => {
                 return Err(ErrorCode::ConcurrencyConflict.into())
@@ -251,7 +251,7 @@ impl TcpSocket {
         network::util::validate_remote_address(&remote_address)?;
         network::util::validate_address_family(&remote_address, &self.family)?;
 
-        let TcpState::Default(tokio_socket) =
+        let (TcpState::Default(tokio_socket) | TcpState::Bound(tokio_socket)) =
             std::mem::replace(&mut self.tcp_state, TcpState::Closed)
         else {
             unreachable!();


### PR DESCRIPTION
Typically, `bind` is only used on listener sockets. But it is perfectly fine to `bind` client sockets too.
Wasmtime was unnecessarily restrictive here.

Fixes https://github.com/WebAssembly/wasi-libc/issues/540 encountered by @pavelsavara while trying to get the dotnet testsuite to run.