### PR TITLE
x64: simplify `SyntheticAmode::finalize`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -199,7 +199,7 @@ pub(crate) fn emit(
                 }
 
                 RegMemImm::Mem { addr } => {
-                    let amode = addr.finalize(state, sink);
+                    let amode = addr.finalize(state.frame_layout(), sink);
                     // Here we revert to the "normal" G-E ordering.
                     emit_std_reg_mem(sink, prefix, opcode_m, 1, reg_g, &amode, rex, 0);
                 }
@@ -259,7 +259,7 @@ pub(crate) fn emit(
             lock,
         } => {
             let src2 = src2.to_reg();
-            let src1_dst = src1_dst.finalize(state, sink).clone();
+            let src1_dst = src1_dst.finalize(state.frame_layout(), sink).clone();
 
             let opcode = match op {
                 AluRmiROpcode::Add => 0x01,
@@ -308,7 +308,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let w = match size {
@@ -367,7 +369,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, num_opcodes, dst, src, rex_flags);
                 }
                 RegMem::Mem { addr: src } => {
-                    let amode = src.finalize(state, sink).clone();
+                    let amode = src.finalize(state.frame_layout(), sink).clone();
                     emit_std_reg_mem(sink, prefix, opcode, num_opcodes, dst, &amode, rex_flags, 0);
                 }
             }
@@ -379,7 +381,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (opcode, opcode_ext) = match op {
@@ -410,7 +414,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let opcode = match op {
@@ -531,7 +537,7 @@ pub(crate) fn emit(
                     )
                 }
                 RegMem::Mem { addr: src } => {
-                    let amode = src.finalize(state, sink);
+                    let amode = src.finalize(state.frame_layout(), sink);
                     emit_std_enc_mem(
                         sink,
                         prefix,
@@ -577,7 +583,7 @@ pub(crate) fn emit(
                     emit_std_enc_enc(sink, prefix, 0xF7, 1, subopcode, src, rex_flags)
                 }
                 RegMem::Mem { addr: src } => {
-                    let amode = src.finalize(state, sink);
+                    let amode = src.finalize(state.frame_layout(), sink);
                     emit_std_enc_mem(sink, prefix, 0xF7, 1, subopcode, &amode, rex_flags, 0);
                 }
             }
@@ -617,7 +623,7 @@ pub(crate) fn emit(
                     emit_std_enc_enc(sink, prefix, 0xF6, 1, subopcode, src, rex_flags)
                 }
                 RegMem::Mem { addr } => {
-                    let amode = addr.finalize(state, sink);
+                    let amode = addr.finalize(state.frame_layout(), sink);
                     emit_std_enc_mem(sink, prefix, 0xF6, 1, subopcode, &amode, rex_flags, 0);
                 }
             }
@@ -641,7 +647,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr } => {
-                    let amode = addr.finalize(state, sink);
+                    let amode = addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, 0x0FAF, 2, dst, &amode, rex, 0);
                 }
             }
@@ -679,7 +685,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr } => {
-                    let amode = addr.finalize(state, sink);
+                    let amode = addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, opcode, 1, dst, &amode, rex, imm_size);
                 }
             }
@@ -701,7 +707,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let dst_hi = dst_hi.to_real_reg().unwrap().hw_enc();
@@ -881,7 +889,7 @@ pub(crate) fn emit(
         }
 
         Inst::MovImmM { size, simm32, dst } => {
-            let dst = &dst.finalize(state, sink).clone();
+            let dst = &dst.finalize(state.frame_layout(), sink).clone();
             let default_rex = RexFlags::clear_w();
             let default_opcode = 0xC7;
             let bytes = size.to_bytes();
@@ -993,7 +1001,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr: src } => {
-                    let src = &src.finalize(state, sink).clone();
+                    let src = &src.finalize(state.frame_layout(), sink).clone();
 
                     emit_std_reg_mem(
                         sink,
@@ -1011,7 +1019,7 @@ pub(crate) fn emit(
 
         Inst::Mov64MR { src, dst } => {
             let dst = dst.to_reg().to_reg();
-            let src = &src.finalize(state, sink).clone();
+            let src = &src.finalize(state.frame_layout(), sink).clone();
 
             emit_std_reg_mem(
                 sink,
@@ -1027,7 +1035,7 @@ pub(crate) fn emit(
 
         Inst::LoadEffectiveAddress { addr, dst, size } => {
             let dst = dst.to_reg().to_reg();
-            let amode = addr.finalize(state, sink).clone();
+            let amode = addr.finalize(state.frame_layout(), sink).clone();
 
             // If this `lea` can actually get encoded as an `add` then do that
             // instead. Currently all candidate `iadd`s become an `lea`
@@ -1151,7 +1159,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr: src } => {
-                    let src = &src.finalize(state, sink).clone();
+                    let src = &src.finalize(state.frame_layout(), sink).clone();
 
                     emit_std_reg_mem(
                         sink,
@@ -1169,7 +1177,7 @@ pub(crate) fn emit(
 
         Inst::MovRM { size, src, dst } => {
             let src = src.to_reg();
-            let dst = &dst.finalize(state, sink).clone();
+            let dst = &dst.finalize(state.frame_layout(), sink).clone();
 
             let prefix = match size {
                 OperandSize::Size16 => LegacyPrefixes::_66,
@@ -1297,7 +1305,7 @@ pub(crate) fn emit(
                         emit_std_reg_reg(sink, prefix, opcode_bytes, 2, dst, reg, rex);
                     }
                     RegMemImm::Mem { addr } => {
-                        let addr = &addr.finalize(state, sink).clone();
+                        let addr = &addr.finalize(state.frame_layout(), sink).clone();
                         emit_std_reg_mem(sink, prefix, opcode_bytes, 2, dst, addr, rex, 0);
                     }
                     RegMemImm::Imm { .. } => unreachable!(),
@@ -1344,7 +1352,7 @@ pub(crate) fn emit(
                 }
 
                 RegMemImm::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink).clone();
+                    let addr = &addr.finalize(state.frame_layout(), sink).clone();
                     // Whereas here we revert to the "normal" G-E ordering for CMP.
                     let opcode = match (*size, is_cmp) {
                         (OperandSize::Size8, true) => 0x3A,
@@ -1439,7 +1447,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, 2, dst, reg, rex_flags);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink).clone();
+                    let addr = &addr.finalize(state.frame_layout(), sink).clone();
                     emit_std_reg_mem(sink, prefix, opcode, 2, dst, addr, rex_flags, 0);
                 }
             }
@@ -1495,7 +1503,7 @@ pub(crate) fn emit(
                 }
 
                 RegMemImm::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_enc_mem(
                         sink,
                         LegacyPrefixes::None,
@@ -1707,7 +1715,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_enc_mem(
                         sink,
                         LegacyPrefixes::None,
@@ -1946,7 +1954,7 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_enc_mem(
                         sink,
                         LegacyPrefixes::None,
@@ -2131,7 +2139,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, num_opcodes, reg_g, reg_e, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, opcode, num_opcodes, reg_g, addr, rex, 0);
                 }
             };
@@ -2157,7 +2165,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, len, dst, reg, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     // N.B.: bytes_at_end == 1, because of the `imm` byte below.
                     emit_std_reg_mem(sink, prefix, opcode, len, dst, addr, rex, 1);
                 }
@@ -2171,7 +2179,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (prefix, map, w, opcode) = match op {
@@ -2198,7 +2208,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (opcode, opcode_ext, w) = match op {
@@ -2365,7 +2377,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, length, reg_g, reg_e, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, opcode, length, reg_g, addr, rex, 0);
                 }
             }
@@ -2398,7 +2410,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, length, reg_g, reg_e, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, opcode, length, reg_g, addr, rex, 0);
                 }
             }
@@ -2463,7 +2475,9 @@ pub(crate) fn emit(
                 RegMemImm::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMemImm::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMemImm::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (prefix, map, opcode) = match op {
@@ -2609,7 +2623,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (w, prefix, map, opcode) = match op {
@@ -2648,7 +2664,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (w, map, opcode) = match op {
@@ -2687,7 +2705,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (w, map, opcode) = match op {
@@ -2754,7 +2774,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
             let mask = mask.to_reg();
 
@@ -2783,7 +2805,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (prefix, map, opcode) = match op {
@@ -2847,7 +2871,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (prefix, map, opcode) = match op {
@@ -2883,7 +2909,7 @@ pub(crate) fn emit(
 
         Inst::XmmMovRMVex { op, src, dst } => {
             let src = src.to_reg();
-            let dst = dst.clone().finalize(state, sink);
+            let dst = dst.clone().finalize(state.frame_layout(), sink);
 
             let (prefix, map, opcode) = match op {
                 AvxOpcode::Vmovdqu => (LegacyPrefixes::_F3, OpcodeMap::_0F, 0x7F),
@@ -2905,7 +2931,7 @@ pub(crate) fn emit(
 
         Inst::XmmMovRMImmVex { op, src, dst, imm } => {
             let src = src.to_reg();
-            let dst = dst.clone().finalize(state, sink);
+            let dst = dst.clone().finalize(state.frame_layout(), sink);
 
             let (w, prefix, map, opcode) = match op {
                 AvxOpcode::Vpextrb => (false, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x14),
@@ -3000,7 +3026,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (prefix, map, opcode) = match op {
@@ -3029,7 +3057,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (prefix, map, opcode) = match op {
@@ -3071,7 +3101,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
             let dst = dst.to_reg().to_reg();
             if let Some(src1) = reused_src {
@@ -3236,7 +3268,7 @@ pub(crate) fn emit(
                     }
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     assert!(
                         !regs_swapped,
                         "No existing way to encode a mem argument in the ModRM r/m field."
@@ -3267,7 +3299,7 @@ pub(crate) fn emit(
                 SseOpcode::Movupd => (LegacyPrefixes::_66, 0x0F11),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
-            let dst = &dst.finalize(state, sink);
+            let dst = &dst.finalize(state.frame_layout(), sink);
             emit_std_reg_mem(sink, prefix, opcode, 2, src, dst, RexFlags::clear_w(), 0);
         }
 
@@ -3287,7 +3319,7 @@ pub(crate) fn emit(
             } else {
                 RexFlags::clear_w()
             };
-            let dst = &dst.finalize(state, sink);
+            let dst = &dst.finalize(state.frame_layout(), sink);
             emit_std_reg_mem(sink, prefix, opcode, 3, src, dst, rex, 1);
             sink.put1(*imm);
         }
@@ -3359,7 +3391,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, 2, reg_g, reg_e, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, opcode, 2, reg_g, addr, rex, 0);
                 }
             }
@@ -3382,7 +3414,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, len, src1, reg, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, opcode, len, src1, addr, rex, 0);
                 }
             }
@@ -3411,7 +3443,7 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, 2, dst, src2, rex);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state, sink);
+                    let addr = &addr.finalize(state.frame_layout(), sink);
                     emit_std_reg_mem(sink, prefix, opcode, 2, dst, addr, rex, 0);
                 }
             }
@@ -3430,7 +3462,9 @@ pub(crate) fn emit(
                 RegMem::Reg { reg } => {
                     RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
                 }
-                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+                RegMem::Mem { addr } => {
+                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
+                }
             };
 
             let (prefix, map, opcode) = match op {
@@ -4037,7 +4071,7 @@ pub(crate) fn emit(
                 _ => unreachable!(),
             };
             let rex = RexFlags::from((OperandSize::from_ty(*ty), replacement));
-            let amode = mem.finalize(state, sink);
+            let amode = mem.finalize(state.frame_layout(), sink);
             emit_std_reg_mem(sink, prefix, opcodes, 2, replacement, &amode, rex, 0);
         }
 
@@ -4058,7 +4092,7 @@ pub(crate) fn emit(
             debug_assert_eq!(dst_old_low.to_reg(), regs::rax());
             debug_assert_eq!(dst_old_high.to_reg(), regs::rdx());
 
-            let amode = mem.finalize(state, sink);
+            let amode = mem.finalize(state.frame_layout(), sink);
             // lock cmpxchg16b (mem)
             // Note that 0xF0 is the Lock prefix.
             emit_std_enc_mem(
@@ -4089,7 +4123,7 @@ pub(crate) fn emit(
                 OperandSize::Size64 => (LegacyPrefixes::_F0, 0x0FC1),
             };
             let rex = RexFlags::from((*size, *operand));
-            let amode = mem.finalize(state, sink);
+            let amode = mem.finalize(state.frame_layout(), sink);
             emit_std_reg_mem(sink, prefix, opcodes, 2, *operand, &amode, rex, 0);
         }
 
@@ -4108,7 +4142,7 @@ pub(crate) fn emit(
                 OperandSize::Size64 => (LegacyPrefixes::None, 0x87),
             };
             let rex = RexFlags::from((*size, *operand));
-            let amode = mem.finalize(state, sink);
+            let amode = mem.finalize(state.frame_layout(), sink);
             emit_std_reg_mem(sink, prefix, opcodes, 1, *operand, &amode, rex, 0);
         }
 
@@ -4124,7 +4158,7 @@ pub(crate) fn emit(
             let temp = *temp;
             let dst_old = *dst_old;
             debug_assert_eq!(dst_old.to_reg(), regs::rax());
-            let mem = mem.finalize(state, sink).clone();
+            let mem = mem.finalize(state.frame_layout(), sink).clone();
 
             // Emit this:
             //    mov{zbq,zwq,zlq,q}     (%r_address), %rax    // rax = old value
@@ -4231,7 +4265,7 @@ pub(crate) fn emit(
             debug_assert_eq!(temp_high.to_reg(), regs::rcx());
             debug_assert_eq!(dst_old_low.to_reg(), regs::rax());
             debug_assert_eq!(dst_old_high.to_reg(), regs::rdx());
-            let mem = mem.finalize(state, sink).clone();
+            let mem = mem.finalize(state.frame_layout(), sink).clone();
 
             let again_label = sink.get_label();
 
@@ -4352,7 +4386,7 @@ pub(crate) fn emit(
             debug_assert_eq!(operand_high, regs::rcx());
             debug_assert_eq!(dst_old_low.to_reg(), regs::rax());
             debug_assert_eq!(dst_old_high.to_reg(), regs::rdx());
-            let mem = mem.finalize(state, sink).clone();
+            let mem = mem.finalize(state.frame_layout(), sink).clone();
 
             let again_label = sink.get_label();
 


### PR DESCRIPTION
There is no need for a `SyntheticAmode` to request mutable access to the entire `EmitState`; it only needs a read-only `FrameLayout`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
