### PR TITLE
x64: use `ByteSink` more liberally in the `rex` module

### DIFF
--- a/cranelift/codegen/src/isa/x64/encoding/rex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/rex.rs
@@ -155,31 +155,6 @@ impl RexFlags {
             sink.put1(rex);
         }
     }
-
-    /// Emit a four-operand instruction.
-    pub fn emit_mem_op<BS: ByteSink + ?Sized>(&self, sink: &mut BS, enc_g: u8, mem_e: &Amode) {
-        match *mem_e {
-            Amode::ImmReg { base, .. } => {
-                let enc_e = int_reg_enc(base);
-                self.emit_two_op(sink, enc_g, enc_e);
-            }
-
-            Amode::ImmRegRegShift {
-                base: reg_base,
-                index: reg_index,
-                ..
-            } => {
-                let enc_base = int_reg_enc(*reg_base);
-                let enc_index = int_reg_enc(*reg_index);
-                self.emit_three_op(sink, enc_g, enc_index, enc_base);
-            }
-
-            Amode::RipRelative { .. } => {
-                // note REX.B = 0.
-                self.emit_two_op(sink, enc_g, 0);
-            }
-        }
-    }
 }
 
 /// Generate the proper Rex flags for the given operand size.


### PR DESCRIPTION
In looking at adding auto-generated assembler code to Cranelift, I've noticed that we pass `MachBuffer` down when it is not always necessary. The `ByteSink` trait (which `MachBuffer` implements) is a simplified view to `put*` bytes into the buffer and it is a bit simpler to use when testing since it is also implemented by `Vec<u8>`. This change propagates the trait to the `rex` module.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
