### PR TITLE
Gate support for implicit return area pointers behind an option

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -209,6 +209,25 @@ pub(crate) fn define() -> SettingGroup {
     );
 
     settings.add_bool(
+        "enable_multi_ret_implicit_sret",
+        "Enable support for sret arg introduction when there are too many ret vals.",
+        r#"
+            When there are more returns than available return registers, the
+            return value has to be returned through the introduction of a
+            return area pointer. Normally this return area pointer has to be
+            introduced as `ArgumentPurpose::StructReturn` parameter, but for
+            back compat reasons Cranelift also supports implicitly introducing
+            this parameter and writing the return values through it.
+
+            **This option violates the ABI of all targets and the used ABI should
+            not be assumed to remain the same between Cranelift versions.**
+
+            This option is **deprecated** and will be removed in the future.
+        "#,
+        false,
+    );
+
+    settings.add_bool(
         "unwind_info",
         "Generate unwind information.",
         r#"

--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -216,13 +216,23 @@ pub(crate) fn define() -> SettingGroup {
             return value has to be returned through the introduction of a
             return area pointer. Normally this return area pointer has to be
             introduced as `ArgumentPurpose::StructReturn` parameter, but for
-            back compat reasons Cranelift also supports implicitly introducing
-            this parameter and writing the return values through it.
+            backward compatibility reasons Cranelift also supports implicitly
+            introducing this parameter and writing the return values through it.
 
-            **This option violates the ABI of all targets and the used ABI should
-            not be assumed to remain the same between Cranelift versions.**
+            **This option currently does not conform to platform ABIs and the
+            used ABI should not be assumed to remain the same between Cranelift
+            versions.**
 
             This option is **deprecated** and will be removed in the future.
+
+            Because of the above issues, and complexities of native ABI support
+            for the concept in general, Cranelift's support for multiple return
+            values may also be removed in the future (#9510). For the most
+            robust solution, it is recommended to build a convention on top of
+            Cranelift's primitives for passing multiple return values, for
+            example by allocating a stackslot in the caller, passing it as an
+            explicit StructReturn argument, storing return values in the callee,
+            and loading results in the caller.
         "#,
         false,
     );

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -334,7 +334,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
                 return Err(crate::CodegenError::Unsupported(
                     "Too many return values to fit in registers. \
-                    Use a StructReturn argument instead"
+                    Use a StructReturn argument instead. (#9510)"
                         .to_owned(),
                 ));
             }

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -117,7 +117,7 @@ where
                     if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
                         return Err(crate::CodegenError::Unsupported(
                             "Too many return values to fit in registers. \
-                            Use a StructReturn argument instead"
+                            Use a StructReturn argument instead. (#9510)"
                                 .to_owned(),
                         ));
                     }

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -12,6 +12,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::marker::PhantomData;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
+use std::borrow::ToOwned;
 use std::sync::OnceLock;
 
 /// Support for the Pulley ABI from the callee side (within a function body).
@@ -52,7 +53,7 @@ where
 
     fn compute_arg_locs(
         call_conv: isa::CallConv,
-        _flags: &settings::Flags,
+        flags: &settings::Flags,
         params: &[ir::AbiParam],
         args_or_rets: ArgsOrRets,
         add_ret_area_ptr: bool,
@@ -113,6 +114,14 @@ where
                         extension: param.extension,
                     });
                 } else {
+                    if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
+                        return Err(crate::CodegenError::Unsupported(
+                            "Too many return values to fit in registers. \
+                            Use a StructReturn argument instead"
+                                .to_owned(),
+                        ));
+                    }
+
                     // Compute size and 16-byte stack alignment happens
                     // separately after all args.
                     let size = reg_ty.bits() / 8;

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -158,7 +158,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                     if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
                         return Err(crate::CodegenError::Unsupported(
                             "Too many return values to fit in registers. \
-                            Use a StructReturn argument instead"
+                            Use a StructReturn argument instead. (#9510)"
                                 .to_owned(),
                         ));
                     }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -20,6 +20,7 @@ use alloc::vec::Vec;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 
 use smallvec::{smallvec, SmallVec};
+use std::borrow::ToOwned;
 use std::sync::OnceLock;
 
 /// Support for the Riscv64 ABI from the callee side (within a function body).
@@ -88,7 +89,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
 
     fn compute_arg_locs(
         call_conv: isa::CallConv,
-        _flags: &settings::Flags,
+        flags: &settings::Flags,
         params: &[ir::AbiParam],
         args_or_rets: ArgsOrRets,
         add_ret_area_ptr: bool,
@@ -154,6 +155,14 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                         extension: param.extension,
                     });
                 } else {
+                    if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
+                        return Err(crate::CodegenError::Unsupported(
+                            "Too many return values to fit in registers. \
+                            Use a StructReturn argument instead"
+                                .to_owned(),
+                        ));
+                    }
+
                     // Compute size and 16-byte stack alignment happens
                     // separately after all args.
                     let size = reg_ty.bits() / 8;

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -388,7 +388,7 @@ impl ABIMachineSpec for S390xMachineDeps {
                 if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
                     return Err(crate::CodegenError::Unsupported(
                         "Too many return values to fit in registers. \
-                        Use a StructReturn argument instead"
+                        Use a StructReturn argument instead. (#9510)"
                             .to_owned(),
                     ));
                 }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -341,7 +341,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                     if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
                         return Err(crate::CodegenError::Unsupported(
                             "Too many return values to fit in registers. \
-                            Use a StructReturn argument instead"
+                            Use a StructReturn argument instead. (#9510)"
                                 .to_owned(),
                         ));
                     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -15,6 +15,7 @@ use alloc::vec::Vec;
 use args::*;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
+use std::borrow::ToOwned;
 use std::sync::OnceLock;
 
 /// Support for the x64 ABI from the callee side (within a function body).
@@ -337,6 +338,14 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                         extension: param.extension,
                     });
                 } else {
+                    if args_or_rets == ArgsOrRets::Rets && !flags.enable_multi_ret_implicit_sret() {
+                        return Err(crate::CodegenError::Unsupported(
+                            "Too many return values to fit in registers. \
+                            Use a StructReturn argument instead"
+                                .to_owned(),
+                        ));
+                    }
+
                     let size = reg_ty.bytes();
                     let size = if call_conv == CallConv::Winch
                         && args_or_rets == ArgsOrRets::Rets

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -862,6 +862,9 @@ impl SigSet {
             /* extra ret-area ptr = */ false,
             ArgsAccumulator::new(&mut self.abi_args),
         )?;
+        if !flags.enable_multi_ret_implicit_sret() {
+            assert_eq!(sized_stack_ret_space, 0);
+        }
         let rets_end = u32::try_from(self.abi_args.len()).unwrap();
 
         // To avoid overflow issues, limit the return size to something reasonable.

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -470,14 +470,6 @@ macro_rules! isle_lower_prelude_methods {
             }
         }
 
-        fn abi_sized_stack_arg_space(&mut self, abi: Sig) -> i64 {
-            self.lower_ctx.sigs()[abi].sized_stack_arg_space()
-        }
-
-        fn abi_sized_stack_ret_space(&mut self, abi: Sig) -> i64 {
-            self.lower_ctx.sigs()[abi].sized_stack_ret_space()
-        }
-
         fn abi_arg_only_slot(&mut self, arg: &ABIArg) -> Option<ABIArgSlot> {
             match arg {
                 &ABIArg::Slots { ref slots, .. } => {

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -314,7 +314,7 @@
 
 ;; Extract a constant `i32` from a value defined by an `iconst`.
 ;; The value is sign extended to 32 bits.
-(spec (i32_from_iconst arg) 
+(spec (i32_from_iconst arg)
       (provide (= arg (extract 31 0 (sign_ext 64 result))))
       (require (= result (sign_ext (widthof result) arg))))
 (decl i32_from_iconst (i32) Value)
@@ -1043,14 +1043,6 @@
 ;; Succeeds if no implicit return-value area pointer is required.
 (decl abi_no_ret_arg () Sig)
 (extern extractor abi_no_ret_arg abi_no_ret_arg)
-
-;; Size of the argument area.
-(decl abi_sized_stack_arg_space (Sig) i64)
-(extern constructor abi_sized_stack_arg_space abi_sized_stack_arg_space)
-
-;; Size of the return-value area.
-(decl abi_sized_stack_ret_space (Sig) i64)
-(extern constructor abi_sized_stack_ret_space abi_sized_stack_ret_space)
 
 ;; Incoming return area pointer (must be present).
 (decl abi_unwrap_ret_area_ptr () Reg)

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -529,6 +529,7 @@ enable_pinned_reg = false
 enable_atomics = true
 enable_safepoints = false
 enable_llvm_abi_extensions = false
+enable_multi_ret_implicit_sret = false
 unwind_info = true
 preserve_frame_pointers = false
 machine_code_cfg_info = false

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -2,6 +2,7 @@ test compile precise-output
 set unwind_info=false
 set enable_probestack=false
 set enable_llvm_abi_extensions
+set enable_multi_ret_implicit_sret
 target aarch64
 
 function %f1(i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/aarch64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tail-call-conv.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target aarch64
 
 ;; Test the `tail` calling convention with non-tail calls and stack arguments.

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target pulley32
 
 function %colocated_args_i64_rets_i64() -> i64 {

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target pulley64
 
 function %colocated_args_i64_rets_i64() -> i64 {

--- a/cranelift/filetests/filetests/isa/riscv64/bitcast-scalar-vector.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitcast-scalar-vector.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64
 

--- a/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target riscv64gc has_v has_zbkb has_zba has_zbb has_zbc has_zbs
 
 

--- a/cranelift/filetests/filetests/isa/riscv64/issue8847.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue8847.clif
@@ -4,6 +4,7 @@ test compile
 set bb_padding_log2_minus_one=4
 set enable_alias_analysis=false
 set enable_llvm_abi_extensions=true
+set enable_multi_ret_implicit_sret
 set machine_code_cfg_info=true
 set enable_jump_tables=false
 set enable_heap_access_spectre_mitigation=false

--- a/cranelift/filetests/filetests/isa/riscv64/issue8866.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue8866.clif
@@ -4,6 +4,7 @@ test compile
 set bb_padding_log2_minus_one=4
 set enable_alias_analysis=false
 set enable_llvm_abi_extensions=true
+set enable_multi_ret_implicit_sret
 set machine_code_cfg_info=true
 set enable_jump_tables=false
 set enable_heap_access_spectre_mitigation=false

--- a/cranelift/filetests/filetests/isa/riscv64/nan-canonicalization-has_v.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/nan-canonicalization-has_v.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set enable_nan_canonicalization=true
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/nan-canonicalization.clif
@@ -1,5 +1,6 @@
 test compile precise-output
-set enable_nan_canonicalization=true 
+set enable_multi_ret_implicit_sret
+set enable_nan_canonicalization=true
 target riscv64
 
 function %f1(f64, f64) -> f64 {

--- a/cranelift/filetests/filetests/isa/riscv64/simd-abi-large-spill.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-abi-large-spill.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64gc has_v has_zvl4096b
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-abi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-abi.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 
 ;; Tests both ABI and Regalloc spill/reload.

--- a/cranelift/filetests/filetests/isa/riscv64/simd-avg_round.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-avg_round.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bitselect.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bnot.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bnot.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ceil.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ceil.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fabs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fabs.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fadd.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-eq.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-eq.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ge.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-gt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-gt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-le.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-le.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-lt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-lt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ne.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ne.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-one.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-one.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ord.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ord.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ueq.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uge.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ugt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ule.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ule.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ult.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ult.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uno.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uno.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcopysign.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-sint.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-sint.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-uint.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-uint.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-sint-sat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-sint-sat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-uint-sat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-uint-sat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fdiv.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-floor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-floor.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fma.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fma.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fmax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fmax.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fmin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fmin.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fmul.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fmul.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fneg.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fneg.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fsub.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fsub.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fvdemote.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fvdemote.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fvpromote-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fvpromote-low.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iabs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iabs.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-big.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-big.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v has_zvl2048b
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-small.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-mix.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-mix.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-mix.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-mix.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd_pairwise.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd_pairwise.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-eq.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ne.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sle.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ule.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ineg.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ineg.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ishl-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ishl-const.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ishl.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ishl.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-load-extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-load-extend.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-load-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-load-splat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-loads.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-loads.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-nearest.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-nearest.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-scalartovector.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-select.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-select.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-shuffle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-shuffle.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-snarrow.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sqmulroundsat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sqrt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sqrt.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sshr-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sshr-const.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sshr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sshr.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-stores.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-stores.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-swiden_high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-swiden_high.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-swiden_low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-swiden_low.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-swizzle.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-trunc.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-trunc.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-unarrow.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ushr-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ushr-const.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ushr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ushr.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uunarrow.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_high.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_low.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-valltrue.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vanytrue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vanytrue.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vconst-64bit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vconst-64bit.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vconst.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vconst.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vhighbits.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vstate.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vstate.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target riscv64
 
 ;; Test the `tail` calling convention with non-tail calls and stack arguments.

--- a/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/user_stack_maps.clif
@@ -1,5 +1,6 @@
 test compile precise-output
 set unwind_info=false
+set enable_multi_ret_implicit_sret
 set enable_probestack=false
 target riscv64
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_zca
 

--- a/cranelift/filetests/filetests/isa/riscv64/zfa.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zfa.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set unwind_info=false
 target riscv64 has_zfa
 

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %iadd_i128(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitcast.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 ;; Bitcast between integral types is a no-op.

--- a/cranelift/filetests/filetests/isa/s390x/bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %bitrev_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise.clif
@@ -1,5 +1,5 @@
-
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 ; FIXME: add immediate operand versions

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/s390x/concat-split.clif
+++ b/cranelift/filetests/filetests/isa/s390x/concat-split.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %iconcat_i64(i64, i64) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/conversions.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %uextend_i64_i128(i64) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/i128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/i128.clif
@@ -1,5 +1,6 @@
 test compile precise-output
 set opt_level=speed
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %mul_uextend_i64(i64, i64) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/minmax.clif
+++ b/cranelift/filetests/filetests/isa/s390x/minmax.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %umax_i128(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %f1() -> i64, i64, i64, i64 {

--- a/cranelift/filetests/filetests/isa/s390x/return-call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/return-call.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 set preserve_frame_pointers=true
 target s390x
 

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %rotr_i128_vr(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi-128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi-128.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %caller_be_to_be(i128) -> i128 {

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x arch13
 
 function %uload8x8_big(i64) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/s390x/vecmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %uload8x8_big(i64) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1,5 +1,6 @@
 test compile precise-output
 set enable_llvm_abi_extensions=true
+set enable_multi_ret_implicit_sret
 target x86_64
 
 function %f0(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/isa/x64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target x86_64
 
 function %f0(i64 vmctx) -> i64, i64, i64, i64 {

--- a/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
@@ -1,5 +1,6 @@
 test compile precise-output
 set enable_llvm_abi_extensions
+set enable_multi_ret_implicit_sret
 set preserve_frame_pointers
 target x86_64
 

--- a/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
@@ -1,5 +1,6 @@
 test compile precise-output
 set unwind_info=false
+set enable_multi_ret_implicit_sret
 set enable_probestack=false
 target x86_64
 

--- a/cranelift/filetests/filetests/isa/x64/winch.clif
+++ b/cranelift/filetests/filetests/isa/x64/winch.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set enable_multi_ret_implicit_sret
 target x86_64
 
 function %f1() winch {

--- a/cranelift/filetests/filetests/pcc/succeed/uextend-add-iconst.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/uextend-add-iconst.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_multi_ret_implicit_sret
 set enable_pcc=true
 set opt_level=speed
 target x86_64

--- a/cranelift/filetests/filetests/runtests/atomic-128.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-128.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 set enable_llvm_abi_extensions
+set enable_multi_ret_implicit_sret
 target x86_64 has_cmpxchg16b
 
 function %atomic_load(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/bb-padding.clif
+++ b/cranelift/filetests/filetests/runtests/bb-padding.clif
@@ -4,6 +4,7 @@ set bb_padding_log2_minus_one=21
 target aarch64
 target s390x
 target x86_64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/bitcast-same-type.clif
+++ b/cranelift/filetests/filetests/runtests/bitcast-same-type.clif
@@ -3,6 +3,7 @@ test run
 set enable_llvm_abi_extensions=true
 target aarch64
 target x86_64
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %bitcast_i8(i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/bswap.clif
+++ b/cranelift/filetests/filetests/runtests/bswap.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target x86_64
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/runtests/f128const.clif
+++ b/cranelift/filetests/filetests/runtests/f128const.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 set enable_llvm_abi_extensions
+set enable_multi_ret_implicit_sret
 target x86_64
 target aarch64
 

--- a/cranelift/filetests/filetests/runtests/f16const.clif
+++ b/cranelift/filetests/filetests/runtests/f16const.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 set enable_llvm_abi_extensions
+set enable_multi_ret_implicit_sret
 target x86_64
 target aarch64
 target aarch64 has_fp16

--- a/cranelift/filetests/filetests/runtests/f32const.clif
+++ b/cranelift/filetests/filetests/runtests/f32const.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target x86_64
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/runtests/f64const.clif
+++ b/cranelift/filetests/filetests/runtests/f64const.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target x86_64
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
@@ -2,11 +2,12 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target x86_64 has_bmi2
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %add_i128(i128, i128) -> i128 {
 block0(v0: i128,v1: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bandnot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bandnot.clif
@@ -1,8 +1,9 @@
 test run
 target aarch64
 target riscv64
-target s390x
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %band_not_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitcast.clif
@@ -3,9 +3,10 @@ test run
 set enable_llvm_abi_extensions=true
 target aarch64
 target x86_64
-target s390x
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %bitcast_i128_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bitops-count.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitops-count.clif
@@ -1,7 +1,6 @@
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target x86_64 has_lzcnt
 target x86_64 has_bmi1
@@ -10,6 +9,8 @@ target riscv64
 target riscv64 has_zbb
 target riscv64 has_zbb has_zbs
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %ctz_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitops.clif
@@ -1,10 +1,11 @@
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 
 function %bnot_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-bitrev.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitrev.clif
@@ -1,13 +1,14 @@
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_zbb
 target riscv64 has_zbkb
 target riscv64 has_zbb has_zbkb
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %reverse_bits_zero() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/runtests/i128-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitselect.clif
@@ -1,9 +1,10 @@
 test run
 set opt_level=none
 set enable_llvm_abi_extensions=true
+target x86_64
+set enable_multi_ret_implicit_sret
 target s390x
 target s390x has_mie2
-target x86_64
 
 function %bitselect_i128(i128, i128, i128) -> i128 {
 block0(v0: i128, v1: i128, v2: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bmask.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bmask.clif
@@ -5,6 +5,7 @@ target x86_64
 target aarch64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %bmask_i128_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-bnot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bnot.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
-target s390x
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %bnot_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bornot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bornot.clif
@@ -2,6 +2,7 @@ test run
 target aarch64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %bor_not_i128(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-bswap.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bswap.clif
@@ -3,10 +3,11 @@ test run
 set enable_llvm_abi_extensions
 target x86_64
 target aarch64
-target s390x
 target riscv64
 target riscv64 has_zbb
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %bswap_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bxornot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bxornot.clif
@@ -2,6 +2,7 @@ test run
 target aarch64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %bxor_not_i128(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-call.clif
+++ b/cranelift/filetests/filetests/runtests/i128-call.clif
@@ -5,9 +5,10 @@ target x86_64
 target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
-target s390x
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 
 function %callee_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-cls.clif
+++ b/cranelift/filetests/filetests/runtests/i128-cls.clif
@@ -3,6 +3,7 @@ target aarch64
 target riscv64
 target riscv64 has_zbb
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %cls_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-extend.clif
+++ b/cranelift/filetests/filetests/runtests/i128-extend.clif
@@ -2,13 +2,14 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_zba
 target riscv64 has_zbb
 target riscv64 has_zbkb
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %i128_uextend_i64(i64) -> i128 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/runtests/i128-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/i128-iabs.clif
@@ -2,8 +2,9 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %iabs_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-ineg.clif
+++ b/cranelift/filetests/filetests/runtests/i128-ineg.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %ineg_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-min-max.clif
+++ b/cranelift/filetests/filetests/runtests/i128-min-max.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
 target s390x
 
 

--- a/cranelift/filetests/filetests/runtests/i128-rotate.clif
+++ b/cranelift/filetests/filetests/runtests/i128-rotate.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %rotl(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):

--- a/cranelift/filetests/filetests/runtests/i128-select.clif
+++ b/cranelift/filetests/filetests/runtests/i128-select.clif
@@ -1,10 +1,11 @@
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %i128_select(i8, i128, i128) -> i128 {
 block0(v0: i8, v1: i128, v2: i128):

--- a/cranelift/filetests/filetests/runtests/i128-shifts.clif
+++ b/cranelift/filetests/filetests/runtests/i128-shifts.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %ishl_i128_i128(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):

--- a/cranelift/filetests/filetests/runtests/integer-minmax.clif
+++ b/cranelift/filetests/filetests/runtests/integer-minmax.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/issue-5690.clif
+++ b/cranelift/filetests/filetests/runtests/issue-5690.clif
@@ -6,6 +6,7 @@ set unwind_info=false
 set preserve_frame_pointers=true
 set machine_code_cfg_info=true
 set enable_table_access_spectre_mitigation=false
+set enable_multi_ret_implicit_sret
 target aarch64
 target x86_64
 target riscv64

--- a/cranelift/filetests/filetests/runtests/issue-6581.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6581.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 
 set enable_llvm_abi_extensions=true
+set enable_multi_ret_implicit_sret
 
 target x86_64
 target aarch64

--- a/cranelift/filetests/filetests/runtests/issue-6582.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6582.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target x86_64
 target aarch64
 target aarch64 sign_return_address

--- a/cranelift/filetests/filetests/runtests/issue-6635.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6635.clif
@@ -1,4 +1,5 @@
 test run
+set enable_multi_ret_implicit_sret
 set preserve_frame_pointers=true
 target x86_64
 target riscv64

--- a/cranelift/filetests/filetests/runtests/issue-6916.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6916.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/issue-6954.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6954.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target riscv64 has_v has_c has_zbkb has_zba has_zbb has_zbc has_zbs
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/runtests/issue5523.clif
+++ b/cranelift/filetests/filetests/runtests/issue5523.clif
@@ -4,8 +4,9 @@ set enable_llvm_abi_extensions=true
 target riscv64
 target riscv64 has_c has_zcb
 target aarch64
-target s390x
 target x86_64
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %a(i16, i128) -> i128 system_v {
 block0(v0: i16, v1: i128):

--- a/cranelift/filetests/filetests/runtests/issue5524.clif
+++ b/cranelift/filetests/filetests/runtests/issue5524.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target riscv64
 target riscv64 has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/issue5526.clif
+++ b/cranelift/filetests/filetests/runtests/issue5526.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target riscv64
 target riscv64 has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/riscv64_issue_4996.clif
+++ b/cranelift/filetests/filetests/runtests/riscv64_issue_4996.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 set enable_llvm_abi_extensions=true
+set enable_multi_ret_implicit_sret
 target riscv64
 target riscv64 has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/sadd_overflow.clif
+++ b/cranelift/filetests/filetests/runtests/sadd_overflow.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
 set enable_llvm_abi_extensions=true
-target x86_64
 target aarch64
+set enable_multi_ret_implicit_sret
+target x86_64
 
 function %saddof_i128(i128, i128) -> i128, i8 {
 block0(v0: i128,v1: i128):

--- a/cranelift/filetests/filetests/runtests/selectif-spectre-guard.clif
+++ b/cranelift/filetests/filetests/runtests/selectif-spectre-guard.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64
-target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+set enable_multi_ret_implicit_sret
+target s390x
 
 function %select_spectre_guard_i8_eq(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):

--- a/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-avg-round-small.clif
+++ b/cranelift/filetests/filetests/runtests/simd-avg-round-small.clif
@@ -1,6 +1,7 @@
 ; the interpreter does not currently support SIMD `avg_round`.
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; x86_64 and s390x do not currently support 64-bit vectors, or

--- a/cranelift/filetests/filetests/runtests/simd-avg-round.clif
+++ b/cranelift/filetests/filetests/runtests/simd-avg-round.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-band-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band-splat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 ssse3
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-band.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bitcast-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast-64bit.clif
@@ -1,4 +1,5 @@
 test run
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bitcast-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast-aarch64.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bitcast-i128.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast-i128.clif
@@ -1,4 +1,5 @@
 test run
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64
 target x86_64 has_avx
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
@@ -4,6 +4,7 @@ target s390x
 set opt_level=speed_and_size
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect.clif
@@ -3,8 +3,10 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+set enable_multi_ret_implicit_sret=false
 
 set opt_level=speed
 target aarch64

--- a/cranelift/filetests/filetests/runtests/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect.clif
@@ -13,6 +13,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bnot.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bnot.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 ssse3
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-bxor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-ceil.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ceil.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-extractlane.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fabs.clif
@@ -2,6 +2,7 @@ test run
 target aarch64
 target s390x
 target x86_64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd.clif
@@ -6,6 +6,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-eq.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ge.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-gt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-gt.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-le.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-le.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-lt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-lt.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ne.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-one.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-one.clif
@@ -1,5 +1,6 @@
 test run
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ord.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ord.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ueq.clif
@@ -1,5 +1,6 @@
 test run
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-uge.clif
@@ -2,6 +2,7 @@ test run
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ugt.clif
@@ -2,6 +2,7 @@ test run
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ule.clif
@@ -2,6 +2,7 @@ test run
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ult.clif
@@ -2,6 +2,7 @@ test run
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-uno.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-uno.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcopysign-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcopysign-64bit.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; x86_64 and s390x do not support 64-bit vectors in `fcopysign`.

--- a/cranelift/filetests/filetests/runtests/simd-fcopysign.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcopysign.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target s390x
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; x86_64 does not support SIMD fcopysign.

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-from-sint.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-from-sint.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-from-uint.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-from-uint.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target x86_64 sse42 has_avx has_avx512vl has_avx512f
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-to-sint-sat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-to-sint-sat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-to-uint-sat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-to-uint-sat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fdiv.clif
@@ -6,6 +6,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-floor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-floor.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fma-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma-64bit.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 ; x86_64 panics: `not implemented: unable to move type: f32x2`
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fma-neg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma-neg.clif
@@ -2,6 +2,7 @@ test run
 target x86_64 has_avx has_fma
 target x86_64 has_avx=false has_fma=false
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fma.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma.clif
@@ -3,6 +3,7 @@ test run
 target x86_64 has_avx has_fma
 target x86_64 has_avx=false has_fma=false
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-riscv64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-riscv64.clif
@@ -2,6 +2,7 @@
 ; If you change this file, you should most likely update
 ; simd-arithmetic-nondeterministic*.clif as well.
 test run
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fmax-fmin.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmax-fmin.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fmul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmul.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fneg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fneg.clif
@@ -6,6 +6,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fsub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fsub.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fvdemote.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fvdemote.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-fvpromote-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fvpromote-low.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iabs.clif
@@ -7,6 +7,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-small.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-small.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iaddpairwise-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iaddpairwise-64bit.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
@@ -7,6 +7,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-ifma.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ifma.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-imul-i8x16.clif
+++ b/cranelift/filetests/filetests/runtests/simd-imul-i8x16.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-imul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-imul.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-ineg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ineg.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insertlane.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-ishl.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ishl.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-isub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-lane-access.clif
+++ b/cranelift/filetests/filetests/runtests/simd-lane-access.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-logical.clif
+++ b/cranelift/filetests/filetests/runtests/simd-logical.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-make-vectors.clif
+++ b/cranelift/filetests/filetests/runtests/simd-make-vectors.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-min-max.clif
+++ b/cranelift/filetests/filetests/runtests/simd-min-max.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-nearest.clif
+++ b/cranelift/filetests/filetests/runtests/simd-nearest.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 ssse3
 target x86_64 sse42
 target x86_64 sse42 has_avx has_avx512vl has_avx512bitalg
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-saddsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-saddsat-aarch64.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-saddsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector-aarch64.clif
@@ -2,6 +2,7 @@ test run
 test interpret
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; i8 and i16 are invalid source sizes for x86_64

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-select.clif
+++ b/cranelift/filetests/filetests/runtests/simd-select.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-shuffle.clif
@@ -8,6 +8,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target x86_64 sse42 has_avx has_avx512vl has_avx512vbmi
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/simd-smulhi.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; The AArch64 and x86_64 backends only support scalar values.

--- a/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 ; x86_64 considers the case `i64x2` -> `i32x4` to be 'unreachable'
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -7,6 +7,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
 target x86_64 sse41 has_avx has_avx2
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat-aarch64.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target s390x
 ;; x86_64 hasn't implemented this for `i32x4`
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-sqrt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqrt.clif
@@ -6,6 +6,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -9,6 +9,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target x86_64 sse42 has_avx has_avx2
 target x86_64 sse42 has_avx has_avx2 has_avx512f has_avx512vl
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-ssubsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ssubsat-aarch64.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41 has_ssse3=false
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swizzle.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-trunc.clif
+++ b/cranelift/filetests/filetests/runtests/simd-trunc.clif
@@ -6,6 +6,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-uaddsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uaddsat-aarch64.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-umulhi.clif
+++ b/cranelift/filetests/filetests/runtests/simd-umulhi.clif
@@ -1,5 +1,6 @@
 test interpret
 test run
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; x86_64 only supports `i16`, `i32`, and `i64`

--- a/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 ; x86_64 considers the case `i64x2 -> i32x4` to be 'unreachable'
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-ushr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ushr.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target s390x
 target x86_64 skylake
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-usubsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-usubsat-aarch64.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-usubsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 ; x86_64 panics: `Did not match fcvt input!
 ; thread 'worker #0' panicked at 'register allocation: Analysis(EntryLiveinValues([v2V]))', cranelift/codegen/src/machinst/compile.rs:96:10`
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-valltrue-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-valltrue-64bit.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; s390x and x86_64 do not support 64-bit vectors.

--- a/cranelift/filetests/filetests/runtests/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-valltrue.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-vanytrue-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vanytrue-64bit.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; s390x and x86_64 do not support 64-bit vectors.

--- a/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-vconst-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst-64bit.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target aarch64
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 ; x86_64 and s390x do not support 64-bit vectors.

--- a/cranelift/filetests/filetests/runtests/simd-vconst-large.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst-large.clif
@@ -3,6 +3,7 @@ target s390x
 target aarch64
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-vconst.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst.clif
@@ -3,6 +3,7 @@ target s390x
 target aarch64
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-vhighbits-float.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits-float.clif
@@ -3,6 +3,7 @@ test run
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
+++ b/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/simd_compare_zero.clif
+++ b/cranelift/filetests/filetests/runtests/simd_compare_zero.clif
@@ -1,6 +1,7 @@
 test run
 target aarch64
 target s390x
+set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 

--- a/cranelift/filetests/filetests/runtests/ssub_overflow.clif
+++ b/cranelift/filetests/filetests/runtests/ssub_overflow.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
 set enable_llvm_abi_extensions=true
-target x86_64
 target aarch64
+set enable_multi_ret_implicit_sret
+target x86_64
 
 function %ssubof_i128(i128, i128) -> i128, i8 {
 block0(v0: i128,v1: i128):

--- a/cranelift/filetests/filetests/runtests/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/runtests/tail-call-conv.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 set enable_llvm_abi_extensions
+set enable_multi_ret_implicit_sret
 set preserve_frame_pointers
 target x86_64
 target aarch64

--- a/cranelift/filetests/filetests/runtests/trapnz.clif
+++ b/cranelift/filetests/filetests/runtests/trapnz.clif
@@ -4,6 +4,7 @@ set enable_llvm_abi_extensions=true
 target x86_64
 target aarch64
 target riscv64
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %trapnz(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/trapz.clif
+++ b/cranelift/filetests/filetests/runtests/trapz.clif
@@ -4,6 +4,7 @@ set enable_llvm_abi_extensions=true
 target x86_64
 target aarch64
 target riscv64
+set enable_multi_ret_implicit_sret
 target s390x
 
 function %trapz(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/uadd_overflow.clif
+++ b/cranelift/filetests/filetests/runtests/uadd_overflow.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
 set enable_llvm_abi_extensions=true
-target x86_64
 target aarch64
+set enable_multi_ret_implicit_sret
+target x86_64
 
 function %uaddof_i128(i128, i128) -> i128, i8 {
 block0(v0: i128,v1: i128):

--- a/cranelift/filetests/filetests/runtests/usub_overflow.clif
+++ b/cranelift/filetests/filetests/runtests/usub_overflow.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
 set enable_llvm_abi_extensions=true
-target x86_64
 target aarch64
+set enable_multi_ret_implicit_sret
+target x86_64
 
 function %usubof_i128(i128, i128) -> i128, i8 {
 block0(v0: i128,v1: i128):

--- a/cranelift/filetests/filetests/runtests/winch.clif
+++ b/cranelift/filetests/filetests/runtests/winch.clif
@@ -1,4 +1,5 @@
 test run
+set enable_multi_ret_implicit_sret
 target x86_64
 
 function %reverse_args(i32, i64, i32, i64) -> i64, i32, i64, i32 winch {

--- a/cranelift/filetests/filetests/wasm/multi-val-f32.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-f32.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_multi_ret_implicit_sret
 target x86_64 haswell
 target aarch64
 

--- a/cranelift/filetests/filetests/wasm/multi-val-f64.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-f64.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_multi_ret_implicit_sret
 target x86_64 haswell
 target aarch64
 

--- a/cranelift/filetests/filetests/wasm/multi-val-i32.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-i32.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_multi_ret_implicit_sret
 target x86_64 haswell
 target aarch64
 

--- a/cranelift/filetests/filetests/wasm/multi-val-i64.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-i64.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_multi_ret_implicit_sret
 target x86_64 haswell
 target aarch64
 

--- a/cranelift/filetests/filetests/wasm/multi-val-mixed.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-mixed.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_multi_ret_implicit_sret
 target aarch64
 target x86_64 haswell
 

--- a/cranelift/filetests/filetests/wasm/multi-val-tons-of-results.clif
+++ b/cranelift/filetests/filetests/wasm/multi-val-tons-of-results.clif
@@ -1,4 +1,5 @@
 test compile
+set enable_multi_ret_implicit_sret
 target x86_64 haswell
 target aarch64
 

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -239,6 +239,9 @@ where
             builder.enable("enable_llvm_abi_extensions")?;
         }
 
+        // FIXME remove once this option is permanently disabled
+        builder.enable("enable_multi_ret_implicit_sret")?;
+
         // This is the default, but we should ensure that it wasn't accidentally turned off anywhere.
         builder.enable("enable_verifier")?;
 

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -239,7 +239,7 @@ where
             builder.enable("enable_llvm_abi_extensions")?;
         }
 
-        // FIXME remove once this option is permanently disabled
+        // FIXME(#9510) remove once this option is permanently disabled
         builder.enable("enable_multi_ret_implicit_sret")?;
 
         // This is the default, but we should ensure that it wasn't accidentally turned off anywhere.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2081,6 +2081,11 @@ impl Config {
             .flags
             .insert("enable_probestack".into());
 
+        // The current wasm multivalue implementation depends on this.
+        self.compiler_config
+            .flags
+            .insert("enable_multi_ret_implicit_sret".into());
+
         if let Some(unwind_requested) = self.native_unwind_info {
             if !self
                 .compiler_config

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2082,6 +2082,7 @@ impl Config {
             .insert("enable_probestack".into());
 
         // The current wasm multivalue implementation depends on this.
+        // FIXME(#9510) handle this in wasmtime-cranelift instead.
         self.compiler_config
             .flags
             .insert("enable_multi_ret_implicit_sret".into());

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -308,6 +308,7 @@ impl Engine {
             "preserve_frame_pointers" => *value == FlagValue::Bool(true),
             "enable_probestack" => *value == FlagValue::Bool(true),
             "probestack_strategy" => *value == FlagValue::Enum("inline".into()),
+            "enable_multi_ret_implicit_sret" => *value == FlagValue::Bool(true),
 
             // Features wasmtime doesn't use should all be disabled, since
             // otherwise if they are enabled it could change the behavior of


### PR DESCRIPTION
It implements an incorrect ABI and may be removed in the future due to complexity reasons. By requiring to enable an option to use it, it becomes harder to accidentally hit the ABI issue and allows a more deprecation and eventual removal.