### PR TITLE
Refactor `WasmparserTypeConverter` to avoid needing a `Module`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1671,11 +1671,12 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
 
 impl TypeConvert for FuncEnvironment<'_> {
     fn lookup_heap_type(&self, ty: wasmparser::UnpackedIndex) -> WasmHeapType {
-        wasmtime_environ::WasmparserTypeConverter::new(self.types, self.module).lookup_heap_type(ty)
+        wasmtime_environ::WasmparserTypeConverter::new(self.types, |idx| self.module.types[idx])
+            .lookup_heap_type(ty)
     }
 
     fn lookup_type_index(&self, index: wasmparser::UnpackedIndex) -> EngineOrModuleTypeIndex {
-        wasmtime_environ::WasmparserTypeConverter::new(self.types, self.module)
+        wasmtime_environ::WasmparserTypeConverter::new(self.types, |idx| self.module.types[idx])
             .lookup_type_index(index)
     }
 }

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -277,11 +277,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
 
                     // Intern the rec group and then fill in this module's types
                     // index space.
-                    let interned = self.types.intern_rec_group(
-                        &self.result.module,
-                        validator_types,
-                        rec_group_id,
-                    )?;
+                    let interned = self.types.intern_rec_group(validator_types, rec_group_id)?;
                     let elems = self.types.rec_group_elements(interned);
                     let len = elems.len();
                     self.result.module.types.reserve(len);
@@ -868,11 +864,13 @@ and for re-adding support for interface types you can see this issue:
 
 impl TypeConvert for ModuleEnvironment<'_, '_> {
     fn lookup_heap_type(&self, index: wasmparser::UnpackedIndex) -> WasmHeapType {
-        WasmparserTypeConverter::new(&self.types, &self.result.module).lookup_heap_type(index)
+        WasmparserTypeConverter::new(&self.types, |idx| self.result.module.types[idx])
+            .lookup_heap_type(index)
     }
 
     fn lookup_type_index(&self, index: wasmparser::UnpackedIndex) -> EngineOrModuleTypeIndex {
-        WasmparserTypeConverter::new(&self.types, &self.result.module).lookup_type_index(index)
+        WasmparserTypeConverter::new(&self.types, |idx| self.result.module.types[idx])
+            .lookup_type_index(index)
     }
 }
 

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -1,6 +1,5 @@
 use crate::component::*;
 use crate::prelude::*;
-use crate::Module;
 use crate::ScopeVec;
 use crate::{
     EngineOrModuleTypeIndex, EntityIndex, ModuleEnvironment, ModuleInternedTypeIndex,
@@ -931,10 +930,7 @@ impl<'a, 'data> Translator<'a, 'data> {
     fn core_func_signature(&mut self, index: u32) -> WasmResult<ModuleInternedTypeIndex> {
         let types = self.validator.types(0).unwrap();
         let id = types.core_function_at(index);
-        let module = Module::default();
-        self.types
-            .module_types_builder()
-            .intern_type(&module, types, id)
+        self.types.module_types_builder().intern_type(types, id)
     }
 }
 

--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -1,8 +1,8 @@
 use crate::component::*;
 use crate::prelude::*;
 use crate::{
-    EngineOrModuleTypeIndex, EntityType, Module, ModuleInternedTypeIndex, ModuleTypes,
-    ModuleTypesBuilder, PrimaryMap, TypeConvert, WasmHeapType, WasmValType,
+    EngineOrModuleTypeIndex, EntityType, ModuleInternedTypeIndex, ModuleTypes, ModuleTypesBuilder,
+    PrimaryMap, TypeConvert, WasmHeapType, WasmValType,
 };
 use anyhow::{bail, Result};
 use cranelift_entity::EntityRef;
@@ -343,9 +343,8 @@ impl ComponentTypesBuilder {
         assert_eq!(types.id(), self.module_types.validator_id());
         Ok(match ty {
             Func(id) => EntityType::Function({
-                let module = Module::default();
                 self.module_types_builder_mut()
-                    .intern_type(&module, types, *id)?
+                    .intern_type(types, *id)?
                     .into()
             }),
             Table(ty) => EntityType::Table(self.convert_table_type(ty)?),

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -397,16 +397,20 @@ pub(crate) struct TypeConverter<'a, 'data: 'a> {
 
 impl TypeConvert for TypeConverter<'_, '_> {
     fn lookup_heap_type(&self, idx: wasmparser::UnpackedIndex) -> WasmHeapType {
-        wasmtime_environ::WasmparserTypeConverter::new(self.types, &self.translation.module)
-            .lookup_heap_type(idx)
+        wasmtime_environ::WasmparserTypeConverter::new(self.types, |idx| {
+            self.translation.module.types[idx]
+        })
+        .lookup_heap_type(idx)
     }
 
     fn lookup_type_index(
         &self,
         index: wasmparser::UnpackedIndex,
     ) -> wasmtime_environ::EngineOrModuleTypeIndex {
-        wasmtime_environ::WasmparserTypeConverter::new(self.types, &self.translation.module)
-            .lookup_type_index(index)
+        wasmtime_environ::WasmparserTypeConverter::new(self.types, |idx| {
+            self.translation.module.types[idx]
+        })
+        .lookup_type_index(index)
     }
 }
 


### PR DESCRIPTION
While poking around with @alexcrichton at how component core types are translated (or not, as we found), we realized that the `WasmparserTypeConverter` doesn't need an entire `Module` in order lookup type indices. In fact, we were previously passing empty `Module`s in cases where no lookups were needed. This change threads through a closure instead, which should help later with component core types when we certainly won't have a `Module`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
