### PR TITLE
bench-api: Allow using `winch` in the bench api

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -37,3 +37,4 @@ wat = { workspace = true }
 [features]
 default = ["shuffling-allocator", "wasi-nn"]
 wasi-nn = ["wasmtime-wasi-nn"]
+winch = ["wasmtime/winch"]


### PR DESCRIPTION
This commit allows building the `bench-api` crate via a `winch` cargo feature. This allows using `--engine-flags="-C compiler=winch"` for benchmarking.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
