### PR TITLE
Disable fuzzing both custom-page-sizes and threads

### DIFF
--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -56,6 +56,12 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
         // do that most of the time.
         config.disallow_traps = u.ratio(9, 10)?;
 
+        // FIXME(#9523) this `if` should ideally be deleted, requires some
+        // refactoring internally.
+        if config.custom_page_sizes_enabled && config.threads_enabled {
+            config.custom_page_sizes_enabled = false;
+        }
+
         Ok(ModuleConfig { config })
     }
 }

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -46,7 +46,7 @@ column is below.
 | [`function-references`]  | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
 | [`gc`] [^6]              | ✅      | ✅    | ❌[^7]   | ❌     | ✅  | ❌    |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
-| [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ❌    |
+| [`custom-page-sizes`]    | ❌      | ✅    | ⚠️[^8]    | ✅     | ✅  | ❌    |
 
 [^6]: There is also a [tracking
     issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for the
@@ -54,6 +54,8 @@ column is below.
 [^7]: The implementation of GC has [known performance
     issues](https://github.com/bytecodealliance/wasmtime/issues/9351) which can
     affect non-GC code when the GC proposal is enabled.
+[^8]: Using custom-page-sizes is [known to have issues when combined with shared
+    memories](https://github.com/bytecodealliance/wasmtime/issues/9523).
 
 ## Unimplemented proposals
 


### PR DESCRIPTION
This is an attempt to avoid #9523 in the fuzzers while that issue is fixed independently. Fuzzing is pretty limited right now so the hope is to let fuzzers find other issues while the refactoring here progresses.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
