### PR TITLE
Add very basic logging to the debug info transform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,6 +410,7 @@ all-arch = ["wasmtime/all-arch"]
 winch = ["wasmtime/winch"]
 pulley = ["wasmtime/pulley"]
 wmemcheck = ["wasmtime/wmemcheck"]
+trace-log = ["wasmtime/trace-log"]
 memory-protection-keys = ["wasmtime-cli-flags/memory-protection-keys"]
 
 # This feature, when enabled, will statically compile out all logging statements

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -97,8 +97,9 @@ pub mod incremental_cache;
 #[macro_export]
 macro_rules! trace {
     ($($tt:tt)*) => {
-        #[cfg(any(feature = "trace-log", debug_assertions))]
-        ::log::trace!($($tt)*);
+        if cfg!(any(feature = "trace-log", debug_assertions)) {
+            ::log::trace!($($tt)*);
+        }
     };
 }
 

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -97,9 +97,8 @@ pub mod incremental_cache;
 #[macro_export]
 macro_rules! trace {
     ($($tt:tt)*) => {
-        if cfg!(feature = "trace-log") {
-            ::log::trace!($($tt)*);
-        }
+        #[cfg(any(feature = "trace-log", debug_assertions))]
+        ::log::trace!($($tt)*);
     };
 }
 

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -37,6 +37,7 @@ itertools = "0.12"
 all-arch = ["cranelift-codegen/all-arch"]
 host-arch = ["cranelift-codegen/host-arch"]
 pulley = ["cranelift-codegen/pulley"]
+trace-log = ["cranelift-codegen/trace-log"]
 component-model = ["wasmtime-environ/component-model"]
 incremental-cache = ["cranelift-codegen/incremental-cache"]
 wmemcheck = ["wasmtime-environ/wmemcheck"]

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -1,6 +1,7 @@
 //! Debug utils for WebAssembly using Cranelift.
 
 use crate::CompiledFunctionMetadata;
+use core::fmt;
 use cranelift_codegen::isa::TargetIsa;
 use object::write::SymbolId;
 use std::collections::HashMap;
@@ -168,6 +169,26 @@ impl<'a> Compilation<'a> {
     /// `SymbolId`.
     pub fn symbol_id(&self, sym: usize) -> SymbolId {
         self.symbol_index_to_id[sym]
+    }
+}
+
+impl<'a> fmt::Debug for Compilation<'a> {
+    // Sample output: '[#0: OneModule, #1: TwoModule, #3]'.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        let mut is_first_module = true;
+        for (i, translation) in self.translations {
+            if !is_first_module {
+                write!(f, ", ")?;
+            } else {
+                is_first_module = false;
+            }
+            write!(f, "#{}", i.as_u32())?;
+            if let Some(name) = translation.debuginfo.name_section.module_name {
+                write!(f, ": {name}")?;
+            }
+        }
+        write!(f, "]")
     }
 }
 

--- a/crates/cranelift/src/debug/transform/debug_transform_logging.rs
+++ b/crates/cranelift/src/debug/transform/debug_transform_logging.rs
@@ -1,0 +1,241 @@
+use crate::debug::Reader;
+use core::fmt;
+use gimli::{write, AttributeValue, DebuggingInformationEntry, Dwarf, LittleEndian, Unit};
+
+macro_rules! dbi_log {
+    ($($tt:tt)*) => {
+        #[cfg(debug_assertions)]
+        ::log::trace!(target: "debug-info-transform", $($tt)*);
+    };
+}
+pub(crate) use dbi_log;
+
+pub struct CompileUnitSummary<'a> {
+    unit: &'a Unit<Reader<'a>, usize>,
+}
+
+impl<'a> fmt::Debug for CompileUnitSummary<'a> {
+    // Sample output: '[#0: OneModule, #1: TwoModule, #3]'.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let unit = self.unit;
+        let offs: usize = unit.header.offset().as_debug_info_offset().unwrap().0;
+        write!(f, "0x{offs:08x} [")?;
+        let comp_dir = match unit.comp_dir {
+            Some(dir) => &dir.to_string_lossy(),
+            None => "None",
+        };
+        write!(f, "\"{comp_dir}\"")?;
+        let name = match unit.name {
+            Some(name) => &name.to_string_lossy(),
+            None => "None",
+        };
+        write!(f, ", \"{name}\"]")
+    }
+}
+
+pub fn log_get_cu_summary<'a>(unit: &'a Unit<Reader<'a>, usize>) -> CompileUnitSummary<'a> {
+    CompileUnitSummary { unit }
+}
+
+struct DieDetailedSummary<'a> {
+    dwarf: &'a Dwarf<Reader<'a>>,
+    unit: &'a Unit<Reader<'a>, usize>,
+    die: &'a DebuggingInformationEntry<'a, 'a, Reader<'a>>,
+}
+
+pub fn log_begin_input_die(
+    dwarf: &Dwarf<Reader<'_>>,
+    unit: &Unit<Reader<'_>, usize>,
+    die: &DebuggingInformationEntry<Reader<'_>>,
+    depth: isize,
+) {
+    dbi_log!(
+        "=== Begin DIE at 0x{:08x} (depth = {}):\n{:?}",
+        die.offset().0,
+        depth,
+        DieDetailedSummary { dwarf, unit, die }
+    );
+}
+
+impl<'a> fmt::Debug for DieDetailedSummary<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let die = self.die;
+        let unit = self.unit;
+        let dwarf = self.dwarf;
+        write!(f, "{}\n", die.tag())?;
+
+        let mut attrs = die.attrs();
+        while let Some(attr) = attrs.next().unwrap_or(None) {
+            write!(f, "  {} (", attr.name())?;
+            let attr_value = attr.value();
+            match attr_value {
+                AttributeValue::Addr(addr) => {
+                    write!(f, "{addr:08x}")
+                }
+                AttributeValue::DebugAddrIndex(index) => {
+                    if let Some(addr) = dwarf.address(unit, index).ok() {
+                        write!(f, "{addr:08x}")
+                    } else {
+                        write!(f, "<error reading address at index: {}>", index.0)
+                    }
+                }
+                AttributeValue::Block(d) => write!(f, "{d:?}"),
+                AttributeValue::Udata(d) => write!(f, "{d}"),
+                AttributeValue::Data1(d) => write!(f, "{d}"),
+                AttributeValue::Data2(d) => write!(f, "{d}"),
+                AttributeValue::Data4(d) => write!(f, "{d}"),
+                AttributeValue::Data8(d) => write!(f, "{d}"),
+                AttributeValue::Sdata(d) => write!(f, "{d}"),
+                AttributeValue::Flag(d) => write!(f, "{d}"),
+                AttributeValue::DebugLineRef(offset) => write!(f, "0x{:08x}", offset.0),
+                AttributeValue::FileIndex(index) => write!(f, "0x{index:08x}"),
+                AttributeValue::String(_)
+                | AttributeValue::DebugStrRef(_)
+                | AttributeValue::DebugStrOffsetsIndex(_) => {
+                    if let Ok(s) = dwarf.attr_string(unit, attr_value) {
+                        write!(f, "\"{}\"", &s.to_string_lossy())
+                    } else {
+                        write!(f, "<error reading string>")
+                    }
+                }
+                AttributeValue::RangeListsRef(_) | AttributeValue::DebugRngListsIndex(_) => {
+                    let _ = dwarf.attr_ranges_offset(unit, attr_value);
+                    write!(f, "<TODO: rnglist dump>")
+                }
+                AttributeValue::LocationListsRef(_) | AttributeValue::DebugLocListsIndex(_) => {
+                    let _ = dwarf.attr_locations_offset(unit, attr_value);
+                    write!(f, "<TODO: loclist dump>")
+                }
+                AttributeValue::Exprloc(_) => {
+                    write!(f, "<TODO: exprloc dump>")
+                }
+                AttributeValue::Encoding(value) => write!(f, "{value}"),
+                AttributeValue::DecimalSign(value) => write!(f, "{value}"),
+                AttributeValue::Endianity(value) => write!(f, "{value}"),
+                AttributeValue::Accessibility(value) => write!(f, "{value}"),
+                AttributeValue::Visibility(value) => write!(f, "{value}"),
+                AttributeValue::Virtuality(value) => write!(f, "{value}"),
+                AttributeValue::Language(value) => write!(f, "{value}"),
+                AttributeValue::AddressClass(value) => write!(f, "{value}"),
+                AttributeValue::IdentifierCase(value) => write!(f, "{value}"),
+                AttributeValue::CallingConvention(value) => write!(f, "{value}"),
+                AttributeValue::Inline(value) => write!(f, "{value}"),
+                AttributeValue::Ordering(value) => write!(f, "{value}"),
+                AttributeValue::UnitRef(offset) => write!(f, "0x{:08x}", offset.0),
+                AttributeValue::DebugInfoRef(offset) => write!(f, "0x{:08x}", offset.0),
+                unexpected_attr => write!(f, "<unexpected attr: {unexpected_attr:?}>"),
+            }?;
+            write!(f, ")\n")?;
+        }
+        Ok(())
+    }
+}
+
+struct OutDieDetailedSummary<'a> {
+    die_id: write::UnitEntryId,
+    unit: &'a write::Unit,
+    strings: &'a write::StringTable,
+}
+
+impl<'a> fmt::Debug for OutDieDetailedSummary<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let die = self.unit.get(self.die_id);
+        write!(f, "{}\n", die.tag())?;
+        for attr in die.attrs() {
+            write!(f, "  {} (", attr.name())?;
+            let attr_value = attr.get();
+            match attr_value {
+                write::AttributeValue::Address(addr) => match addr {
+                    write::Address::Constant(addr_value) => write!(f, "{addr_value:08x}"),
+                    write::Address::Symbol { symbol, addend } => {
+                        write!(f, "symbol #{symbol}+{addend}")
+                    }
+                },
+                write::AttributeValue::Block(d) => {
+                    write!(f, "{:?}", Reader::new(d.as_slice(), LittleEndian))
+                }
+                write::AttributeValue::Udata(d) => write!(f, "{d}"),
+                write::AttributeValue::Data1(d) => write!(f, "{d}"),
+                write::AttributeValue::Data2(d) => write!(f, "{d}"),
+                write::AttributeValue::Data4(d) => write!(f, "{d}"),
+                write::AttributeValue::Data8(d) => write!(f, "{d}"),
+                write::AttributeValue::Sdata(d) => write!(f, "{d}"),
+                write::AttributeValue::Flag(d) => write!(f, "{d}"),
+                write::AttributeValue::LineProgramRef => write!(f, "LineProgramRef"),
+                write::AttributeValue::FileIndex(index) => match index {
+                    Some(id) => write!(f, "{id:?}"),
+                    None => write!(f, "<file index missing>"),
+                },
+                write::AttributeValue::String(s) => {
+                    write!(f, "\"{}\"", &String::from_utf8_lossy(s))
+                }
+                write::AttributeValue::StringRef(id) => {
+                    write!(f, "\"{}\"", &String::from_utf8_lossy(self.strings.get(*id)))
+                }
+                write::AttributeValue::RangeListRef(_) => {
+                    write!(f, "<TODO: out rnglist dump>")
+                }
+                write::AttributeValue::LocationListRef(_) => {
+                    write!(f, "<TODO: out loclist dump>")
+                }
+                write::AttributeValue::Exprloc(_) => {
+                    write!(f, "<TODO: out exprloc dump>")
+                }
+                write::AttributeValue::Encoding(value) => write!(f, "{value}"),
+                write::AttributeValue::DecimalSign(value) => write!(f, "{value}"),
+                write::AttributeValue::Endianity(value) => write!(f, "{value}"),
+                write::AttributeValue::Accessibility(value) => write!(f, "{value}"),
+                write::AttributeValue::Visibility(value) => write!(f, "{value}"),
+                write::AttributeValue::Virtuality(value) => write!(f, "{value}"),
+                write::AttributeValue::Language(value) => write!(f, "{value}"),
+                write::AttributeValue::AddressClass(value) => write!(f, "{value}"),
+                write::AttributeValue::IdentifierCase(value) => write!(f, "{value}"),
+                write::AttributeValue::CallingConvention(value) => write!(f, "{value}"),
+                write::AttributeValue::Inline(value) => write!(f, "{value}"),
+                write::AttributeValue::Ordering(value) => write!(f, "{value}"),
+                write::AttributeValue::UnitRef(unit_ref) => write!(f, "{unit_ref:?}>"),
+                write::AttributeValue::DebugInfoRef(reference) => match reference {
+                    write::Reference::Symbol(index) => write!(f, "symbol #{index}>"),
+                    write::Reference::Entry(unit_id, die_id) => {
+                        write!(f, "{die_id:?} in {unit_id:?}>")
+                    }
+                },
+                unexpected_attr => write!(f, "<unexpected attr: {unexpected_attr:?}>"),
+            }?;
+            write!(f, ")\n")?;
+        }
+        Ok(())
+    }
+}
+
+pub fn log_end_output_die(
+    input_die: &DebuggingInformationEntry<Reader<'_>>,
+    die_id: write::UnitEntryId,
+    unit: &write::Unit,
+    strings: &write::StringTable,
+    depth: isize,
+) {
+    dbi_log!(
+        "=== End DIE at 0x{:08x} (depth = {}):\n{:?}",
+        input_die.offset().0,
+        depth,
+        OutDieDetailedSummary {
+            die_id,
+            unit,
+            strings
+        }
+    );
+}
+
+pub fn log_end_output_die_skipped(
+    input_die: &DebuggingInformationEntry<Reader<'_>>,
+    reason: &str,
+    depth: isize,
+) {
+    dbi_log!(
+        "=== End DIE at 0x{:08x} (depth = {}):\n  Skipped as {}\n",
+        input_die.offset().0,
+        depth,
+        reason
+    );
+}

--- a/crates/cranelift/src/debug/transform/debug_transform_logging.rs
+++ b/crates/cranelift/src/debug/transform/debug_transform_logging.rs
@@ -15,7 +15,6 @@ pub struct CompileUnitSummary<'a> {
 }
 
 impl<'a> fmt::Debug for CompileUnitSummary<'a> {
-    // Sample output: '[#0: OneModule, #1: TwoModule, #3]'.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let unit = self.unit;
         let offs: usize = unit.header.offset().as_debug_info_offset().unwrap().0;

--- a/crates/cranelift/src/debug/transform/debug_transform_logging.rs
+++ b/crates/cranelift/src/debug/transform/debug_transform_logging.rs
@@ -4,7 +4,7 @@ use gimli::{write, AttributeValue, DebuggingInformationEntry, Dwarf, LittleEndia
 
 macro_rules! dbi_log {
     ($($tt:tt)*) => {
-        #[cfg(debug_assertions)]
+        #[cfg(any(feature = "trace-log", debug_assertions))]
         ::log::trace!(target: "debug-info-transform", $($tt)*);
     };
 }

--- a/crates/cranelift/src/debug/transform/debug_transform_logging.rs
+++ b/crates/cranelift/src/debug/transform/debug_transform_logging.rs
@@ -4,8 +4,9 @@ use gimli::{write, AttributeValue, DebuggingInformationEntry, Dwarf, LittleEndia
 
 macro_rules! dbi_log {
     ($($tt:tt)*) => {
-        #[cfg(any(feature = "trace-log", debug_assertions))]
-        ::log::trace!(target: "debug-info-transform", $($tt)*);
+        if cfg!(any(feature = "trace-log", debug_assertions)) {
+            ::log::trace!(target: "debug-info-transform", $($tt)*);
+        }
     };
 }
 pub(crate) use dbi_log;

--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -1,3 +1,4 @@
+use self::debug_transform_logging::dbi_log;
 use self::refs::DebugInfoRefsMap;
 use self::simulate::generate_simulated_dwarf;
 use self::unit::clone_unit;
@@ -16,6 +17,7 @@ pub use address_transform::AddressTransform;
 
 mod address_transform;
 mod attr;
+mod debug_transform_logging;
 mod expression;
 mod line_program;
 mod range_info_builder;
@@ -141,6 +143,8 @@ pub fn transform_dwarf(
     isa: &dyn TargetIsa,
     compilation: &mut Compilation<'_>,
 ) -> Result<write::Dwarf, Error> {
+    dbi_log!("Commencing DWARF transform for {:?}", compilation);
+
     let mut transforms = PrimaryMap::new();
     for (i, _) in compilation.translations.iter() {
         transforms.push(AddressTransform::new(compilation, i));
@@ -176,6 +180,8 @@ pub fn transform_dwarf(
     let mut translated = HashSet::new();
 
     for (module, translation) in compilation.translations.iter() {
+        dbi_log!("[== Transforming CUs for module #{} ==]", module.as_u32());
+
         let addr_tr = &transforms[module];
         let di = &translation.debuginfo;
         let context = DebugInputContext {

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -205,6 +205,9 @@ wmemcheck = [
   "std",
 ]
 
+# Enables detailed internal compiler logging via WASMTIME_LOG
+trace-log = ["wasmtime-cranelift?/trace-log"]
+
 # Enables support for demangling WebAssembly function names at runtime in
 # errors such as backtraces.
 demangle = ["wasmtime-environ/demangle", "std"]


### PR DESCRIPTION
The DI transform is a kind of compiler and logging is a very good way to gain insight into compilers - hence this change.

For example, this has already helped me narrow down the cause of #9512:
```
2024-10-30T23:26:56.408332Z TRACE debug-info-transform: === Begin DIE at 0x0000007a (depth = 2):
DW_TAG_subprogram
  DW_AT_linkage_name ("_ZN9SomeClass16SeparateFunctionEv")
  DW_AT_name ("SeparateFunction")
  DW_AT_decl_file (0x00000002)
  DW_AT_decl_line (20)
  DW_AT_type (0x0000008b)
  DW_AT_declaration (true)
  DW_AT_external (true)
  DW_AT_accessibility (DW_ACCESS_public)
    
2024-10-30T23:26:56.408361Z TRACE debug-info-transform: === End DIE at 0x0000007a (depth = 2):
  Skipped as unreachable
```

I also took the liberty of renaming a few variables for clarity.

<details>
<summary>Sample output</summary>

```
2024-10-30T23:26:56.398154Z TRACE debug-info-transform: Commencing DWARF transform for [#0: main.wasm, #1: wit-component:adapter:wasi_snapshot_preview1, #2: wit-component:shim, #3: wit-component:fixups]    
2024-10-30T23:26:56.405243Z TRACE debug-info-transform: [== Transforming CUs for module #0 ==]    
2024-10-30T23:26:56.405357Z TRACE debug-info-transform: Cloning CU 0x00000000 ["C:\wasi-sdk\sysroot\wasi-libc-wasm32-wasip2", "libc-bottom-half/crt\crt1-command.c"]    
2024-10-30T23:26:56.405562Z TRACE debug-info-transform: === Begin DIE at 0x0000000b (depth = 0):
DW_TAG_compile_unit
  DW_AT_producer ("clang version 18.1.2 (https://github.com/llvm/llvm-project 26a1d6601d727a96f4301d0d8647b5a42760ae0c)")
  DW_AT_language (DW_LANG_C11)
  DW_AT_name ("libc-bottom-half/crt\crt1-command.c")
  DW_AT_stmt_list (0x00000000)
  DW_AT_comp_dir ("C:\wasi-sdk\sysroot\wasi-libc-wasm32-wasip2")
  DW_AT_low_pc (00000005)
  DW_AT_high_pc (82)
    
2024-10-30T23:26:56.405789Z TRACE debug-info-transform: === End DIE at 0x0000000b (depth = 0):
DW_TAG_compile_unit
  DW_AT_ranges (<TODO: out rnglist dump>)
  DW_AT_producer ("clang version 18.1.2 (https://github.com/llvm/llvm-project 26a1d6601d727a96f4301d0d8647b5a42760ae0c)")
  DW_AT_language (DW_LANG_C11)
  DW_AT_name ("libc-bottom-half/crt\crt1-command.c")
  DW_AT_stmt_list (LineProgramRef)
  DW_AT_comp_dir ("C:\wasi-sdk\sysroot\wasi-libc-wasm32-wasip2")
    
2024-10-30T23:26:56.405832Z TRACE debug-info-transform: === Begin DIE at 0x00000026 (depth = 1):
DW_TAG_subprogram
  DW_AT_low_pc (00000005)
  DW_AT_high_pc (82)
  DW_AT_frame_base (<TODO: exprloc dump>)
  DW_AT_GNU_all_call_sites (true)
  DW_AT_name ("_start")
  DW_AT_decl_file (0x00000001)
  DW_AT_decl_line (11)
  DW_AT_prototyped (true)
  DW_AT_external (true)
    
2024-10-30T23:26:56.406070Z TRACE debug-info-transform: === End DIE at 0x00000026 (depth = 1):
DW_TAG_subprogram
  DW_AT_low_pc (symbol #1+0)
  DW_AT_high_pc (182)
  DW_AT_frame_base (<TODO: out exprloc dump>)
  DW_AT_GNU_all_call_sites (true)
  DW_AT_name ("_start")
  DW_AT_decl_file (FileId(1)>)
  DW_AT_decl_line (11)
  DW_AT_prototyped (true)
  DW_AT_external (true)
    
2024-10-30T23:26:56.406119Z TRACE debug-info-transform: === Begin DIE at 0x0000003d (depth = 2):
DW_TAG_variable
  DW_AT_name ("started")
  DW_AT_type (0x00000089)
  DW_AT_decl_file (0x00000001)
  DW_AT_decl_line (26)
  DW_AT_location (<TODO: exprloc dump>)
    
2024-10-30T23:26:56.406174Z TRACE debug-info-transform: === End DIE at 0x0000003d (depth = 2):
DW_TAG_variable
  DW_AT_name ("started")
  DW_AT_decl_file (FileId(1)>)
  DW_AT_decl_line (26)
    
2024-10-30T23:26:56.406204Z TRACE debug-info-transform: === Begin DIE at 0x00000055 (depth = 2):
DW_TAG_variable
  DW_AT_location (<TODO: loclist dump>)
  DW_AT_name ("r")
  DW_AT_decl_file (0x00000001)
  DW_AT_decl_line (43)
  DW_AT_type (0x0000008e)
    
2024-10-30T23:26:56.406359Z TRACE debug-info-transform: === End DIE at 0x00000055 (depth = 2):
DW_TAG_variable
  DW_AT_location (<TODO: out loclist dump>)
  DW_AT_name ("r")
  DW_AT_decl_file (FileId(1)>)
  DW_AT_decl_line (43)
    
2024-10-30T23:26:56.406392Z TRACE debug-info-transform: === Begin DIE at 0x00000064 (depth = 2):
DW_TAG_GNU_call_site
  DW_AT_abstract_origin (0x00000095)
  DW_AT_low_pc (00000036)
    
2024-10-30T23:26:56.406428Z TRACE debug-info-transform: === End DIE at 0x00000064 (depth = 2):
  Skipped as unreachable
    
2024-10-30T23:26:56.406456Z TRACE debug-info-transform: === Begin DIE at 0x0000006d (depth = 2):
DW_TAG_GNU_call_site
  DW_AT_abstract_origin (0x0000009c)
  DW_AT_low_pc (0000003c)
    
2024-10-30T23:26:56.406505Z TRACE debug-info-transform: === End DIE at 0x0000006d (depth = 2):
  Skipped as unreachable
    
2024-10-30T23:26:56.406541Z TRACE debug-info-transform: === Begin DIE at 0x00000076 (depth = 2):
DW_TAG_GNU_call_site
  DW_AT_abstract_origin (0x000000a7)
  DW_AT_low_pc (00000044)
    
2024-10-30T23:26:56.406588Z TRACE debug-info-transform: === End DIE at 0x00000076 (depth = 2):
  Skipped as unreachable
    
2024-10-30T23:26:56.406610Z TRACE debug-info-transform: === Begin DIE at 0x0000007f (depth = 2):
DW_TAG_GNU_call_site
  DW_AT_abstract_origin (0x000000ae)
  DW_AT_low_pc (00000055)
    
2024-10-30T23:26:56.406633Z TRACE debug-info-transform: === End DIE at 0x0000007f (depth = 2):
  Skipped as unreachable
    
2024-10-30T23:26:56.406650Z TRACE debug-info-transform: === Begin DIE at 0x00000089 (depth = 1):
DW_TAG_volatile_type
  DW_AT_type (0x0000008e)
    
2024-10-30T23:26:56.406696Z TRACE debug-info-transform: === End DIE at 0x00000089 (depth = 1):
DW_TAG_volatile_type
    
2024-10-30T23:26:56.406740Z TRACE debug-info-transform: === Begin DIE at 0x0000008e (depth = 1):
DW_TAG_base_type
  DW_AT_name ("int")
  DW_AT_encoding (DW_ATE_signed)
  DW_AT_byte_size (4)
    
2024-10-30T23:26:56.406805Z TRACE debug-info-transform: === End DIE at 0x0000008e (depth = 1):
DW_TAG_base_type
  DW_AT_name ("int")
  DW_AT_encoding (DW_ATE_signed)
  DW_AT_byte_size (4)
    
2024-10-30T23:26:56.406835Z TRACE debug-info-transform: === Begin DIE at 0x00000095 (depth = 1):
DW_TAG_subprogram
  DW_AT_name ("__wasm_call_ctors")
  DW_AT_decl_file (0x00000001)
  DW_AT_decl_line (6)
  DW_AT_prototyped (true)
  DW_AT_declaration (true)
  DW_AT_external (true)
    
2024-10-30T23:26:56.406865Z TRACE debug-info-transform: === End DIE at 0x00000095 (depth = 1):
  Skipped as unreachable
```
</details>