### PR TITLE
Merge static/dynamic guard size options

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -334,20 +334,12 @@ WASMTIME_CONFIG_PROP(void, static_memory_forced, bool)
 WASMTIME_CONFIG_PROP(void, static_memory_maximum_size, uint64_t)
 
 /**
- * \brief Configures the guard region size for "static" memory.
+ * \brief Configures the guard region size for linear memory.
  *
  * For more information see the Rust documentation at
- * https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Config.html#method.static_memory_guard_size.
+ * https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Config.html#method.memory_guard_size.
  */
-WASMTIME_CONFIG_PROP(void, static_memory_guard_size, uint64_t)
-
-/**
- * \brief Configures the guard region size for "dynamic" memory.
- *
- * For more information see the Rust documentation at
- * https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Config.html#method.dynamic_memory_guard_size.
- */
-WASMTIME_CONFIG_PROP(void, dynamic_memory_guard_size, uint64_t)
+WASMTIME_CONFIG_PROP(void, memory_guard_size, uint64_t)
 
 /**
  * \brief Configures the size, in bytes, of the extra virtual memory space

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -232,13 +232,8 @@ pub extern "C" fn wasmtime_config_static_memory_maximum_size_set(c: &mut wasm_co
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_static_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
-    c.config.static_memory_guard_size(size);
-}
-
-#[no_mangle]
-pub extern "C" fn wasmtime_config_dynamic_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
-    c.config.dynamic_memory_guard_size(size);
+pub extern "C" fn wasmtime_config_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
+    c.config.memory_guard_size(size);
 }
 
 #[no_mangle]

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -42,9 +42,6 @@ wasmtime_option_group! {
         /// Optimization level of generated code (0-2, s; default: 2)
         pub opt_level: Option<wasmtime::OptLevel>,
 
-        /// Byte size of the guard region after dynamic memories are allocated
-        pub dynamic_memory_guard_size: Option<u64>,
-
         /// Force using a "static" style for all wasm memories
         pub static_memory_forced: Option<bool>,
 
@@ -52,8 +49,8 @@ wasmtime_option_group! {
         /// relocatable instead of up-front-reserved.
         pub static_memory_maximum_size: Option<u64>,
 
-        /// Byte size of the guard region after static memories are allocated
-        pub static_memory_guard_size: Option<u64>,
+        /// Size, in bytes, of guard pages for linear memories.
+        pub memory_guard_size: Option<u64>,
 
         /// Bytes to reserve at the end of linear memory for growth for dynamic
         /// memories.
@@ -167,6 +164,12 @@ wasmtime_option_group! {
 
         /// Enable or disable the use of host signal handlers for traps.
         pub signals_based_traps: Option<bool>,
+
+        /// DEPRECATED: Use `-Cmemory-guard-size=N` instead.
+        pub dynamic_memory_guard_size: Option<u64>,
+
+        /// DEPRECATED: Use `-Cmemory-guard-size=N` instead.
+        pub static_memory_guard_size: Option<u64>,
     }
 
     enum Optimize {
@@ -636,13 +639,15 @@ impl CommonOptions {
             config.static_memory_forced(enable);
         }
 
-        if let Some(size) = self.opts.static_memory_guard_size {
-            config.static_memory_guard_size(size);
+        if let Some(size) = self
+            .opts
+            .static_memory_guard_size
+            .or(self.opts.dynamic_memory_guard_size)
+            .or(self.opts.memory_guard_size)
+        {
+            config.memory_guard_size(size);
         }
 
-        if let Some(size) = self.opts.dynamic_memory_guard_size {
-            config.dynamic_memory_guard_size(size);
-        }
         if let Some(size) = self.opts.dynamic_memory_reserved_for_growth {
             config.dynamic_memory_reserved_for_growth(size);
         }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -58,7 +58,7 @@ impl MemoryStyle {
                 Self::Static {
                     byte_reservation: tunables.static_memory_reservation,
                 },
-                tunables.static_memory_offset_guard_size,
+                tunables.memory_guard_size,
             );
         }
 
@@ -67,7 +67,7 @@ impl MemoryStyle {
             Self::Dynamic {
                 reserve: tunables.dynamic_memory_growth_reserve,
             },
-            tunables.dynamic_memory_offset_guard_size,
+            tunables.memory_guard_size,
         )
     }
 }

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -15,11 +15,8 @@ pub struct Tunables {
     /// the heap.
     pub static_memory_reservation: u64,
 
-    /// The size in bytes of the offset guard for static heaps.
-    pub static_memory_offset_guard_size: u64,
-
-    /// The size in bytes of the offset guard for dynamic heaps.
-    pub dynamic_memory_offset_guard_size: u64,
+    /// The size, in bytes, of the guard page region for linear memories.
+    pub memory_guard_size: u64,
 
     /// The size, in bytes, of reserved memory at the end of a "dynamic" memory,
     /// before the guard page, that memory can grow into. This is intended to
@@ -108,8 +105,7 @@ impl Tunables {
             // No virtual memory tricks are available on miri so make these
             // limits quite conservative.
             static_memory_reservation: 1 << 20,
-            static_memory_offset_guard_size: 0,
-            dynamic_memory_offset_guard_size: 0,
+            memory_guard_size: 0,
             dynamic_memory_growth_reserve: 0,
 
             // General options which have the same defaults regardless of
@@ -136,8 +132,7 @@ impl Tunables {
             // impacts performance severely but allows us to have more than a
             // few instances running around.
             static_memory_reservation: 10 * (1 << 20),
-            static_memory_offset_guard_size: 0x1_0000,
-            dynamic_memory_offset_guard_size: 0x1_0000,
+            memory_guard_size: 0x1_0000,
             dynamic_memory_growth_reserve: 1 << 20, // 1MB
 
             ..Tunables::default_miri()
@@ -154,13 +149,7 @@ impl Tunables {
             // Coupled with a 2 GiB address space guard it lets us translate
             // wasm offsets into x86 offsets as aggressively as we can.
             static_memory_reservation: 1 << 32,
-            static_memory_offset_guard_size: 0x8000_0000,
-
-            // Size in bytes of the offset guard for dynamic memories.
-            //
-            // Allocate a small guard to optimize common cases but without
-            // wasting too much memory.
-            dynamic_memory_offset_guard_size: 0x1_0000,
+            memory_guard_size: 0x8000_0000,
 
             // We've got lots of address space on 64-bit so use a larger
             // grow-into-this area, but on 32-bit we aren't as lucky. Miri is

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -267,8 +267,7 @@ impl Config {
             let memory_config = if pcc {
                 MemoryConfig::Normal(NormalMemoryConfig {
                     static_memory_maximum_size: Some(4 << 30), // 4 GiB
-                    static_memory_guard_size: Some(2 << 30),   // 2 GiB
-                    dynamic_memory_guard_size: Some(0),
+                    memory_guard_size: Some(2 << 30),          // 2 GiB
                     dynamic_memory_reserved_for_growth: Some(0),
                     guard_before_linear_memory: false,
                     memory_init_cow: true,
@@ -286,9 +285,8 @@ impl Config {
                 MemoryConfig::CustomUnaligned => {
                     cfg.with_host_memory(Arc::new(UnalignedMemoryCreator))
                         .static_memory_maximum_size(0)
-                        .dynamic_memory_guard_size(0)
+                        .memory_guard_size(0)
                         .dynamic_memory_reserved_for_growth(0)
-                        .static_memory_guard_size(0)
                         .guard_before_linear_memory(false)
                         .memory_init_cow(false);
                 }

--- a/crates/misc/component-test-util/src/lib.rs
+++ b/crates/misc/component-test-util/src/lib.rs
@@ -56,7 +56,7 @@ pub fn config() -> Config {
     // try to cut down on virtual memory usage by avoiding 4G reservations.
     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         config.static_memory_maximum_size(0);
-        config.dynamic_memory_guard_size(0);
+        config.memory_guard_size(0);
     }
     config
 }

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -365,8 +365,7 @@ impl Metadata<'_> {
         let Tunables {
             collector,
             static_memory_reservation,
-            static_memory_offset_guard_size,
-            dynamic_memory_offset_guard_size,
+            memory_guard_size,
             generate_native_debuginfo,
             parse_wasm_debuginfo,
             consume_fuel,
@@ -397,14 +396,9 @@ impl Metadata<'_> {
             "static memory reservation",
         )?;
         Self::check_int(
-            static_memory_offset_guard_size,
-            other.static_memory_offset_guard_size,
-            "static memory guard size",
-        )?;
-        Self::check_int(
-            dynamic_memory_offset_guard_size,
-            other.dynamic_memory_offset_guard_size,
-            "dynamic memory guard size",
+            memory_guard_size,
+            other.memory_guard_size,
+            "memory guard size",
         )?;
         Self::check_bool(
             generate_native_debuginfo,
@@ -722,11 +716,11 @@ Caused by:
         let engine = Engine::default();
         let mut metadata = Metadata::new(&engine);
 
-        metadata.tunables.static_memory_offset_guard_size = 0;
+        metadata.tunables.memory_guard_size = 0;
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),
-            Err(e) => assert_eq!(e.to_string(), "Module was compiled with a static memory guard size of '0' but '2147483648' is expected for the host"),
+            Err(e) => assert_eq!(e.to_string(), "Module was compiled with a memory guard size of '0' but '2147483648' is expected for the host"),
         }
 
         Ok(())

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -1049,8 +1049,7 @@ mod tests {
     #[test]
     fn respect_tunables() {
         let mut cfg = Config::new();
-        cfg.static_memory_maximum_size(0)
-            .dynamic_memory_guard_size(0);
+        cfg.static_memory_maximum_size(0).memory_guard_size(0);
         let mut store = Store::new(&Engine::new(&cfg).unwrap(), ());
         let ty = MemoryType::new(1, None);
         let mem = Memory::new(&mut store, ty).unwrap();

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -577,7 +577,7 @@ impl SlabConstraints {
         let expected_slot_bytes = round_usize_up_to_host_pages(expected_slot_bytes)?;
 
         let guard_bytes: usize = tunables
-            .static_memory_offset_guard_size
+            .memory_guard_size
             .try_into()
             .context("guard region is too large")?;
         let guard_bytes = round_usize_up_to_host_pages(guard_bytes)?;
@@ -608,7 +608,7 @@ struct SlabLayout {
     /// guard region after the memory to catch OOB access. On these guard
     /// regions, note that:
     /// - users can configure how aggressively (or not) to elide bounds checks
-    ///   via `Config::static_memory_guard_size` (see also:
+    ///   via `Config::memory_guard_size` (see also:
     ///   `memory_and_guard_size`)
     /// - memory protection keys can compress the size of the guard region by
     ///   placing slots from a different key (i.e., a stripe) in the guard
@@ -786,7 +786,7 @@ mod tests {
             },
             &Tunables {
                 static_memory_reservation: WASM_PAGE_SIZE as u64,
-                static_memory_offset_guard_size: 0,
+                memory_guard_size: 0,
                 ..Tunables::default_host()
             },
         )?;

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -75,10 +75,10 @@ struct Args {
     static_memory_maximum_size: Option<u64>,
 
     /// The size in bytes of the guard region to expect between static memory
-    /// slots; see [`Config::static_memory_guard_size`] for more details and the
+    /// slots; see [`Config::memory_guard_size`] for more details and the
     /// default value if unset.
     #[arg(long, value_parser = parse_byte_size)]
-    static_memory_guard_size: Option<u64>,
+    memory_guard_size: Option<u64>,
 }
 
 /// Parse a human-readable byte size--e.g., "512 MiB"--into the correct number
@@ -195,8 +195,8 @@ fn build_engine(args: &Args, num_memories: u32, enable_mpk: MpkEnabled) -> Resul
     if let Some(static_memory_maximum_size) = args.static_memory_maximum_size {
         config.static_memory_maximum_size(static_memory_maximum_size);
     }
-    if let Some(static_memory_guard_size) = args.static_memory_guard_size {
-        config.static_memory_guard_size(static_memory_guard_size);
+    if let Some(memory_guard_size) = args.memory_guard_size {
+        config.memory_guard_size(memory_guard_size);
     }
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -352,8 +352,7 @@ async fn async_with_pooling_stacks() {
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(0);
+    config.memory_guard_size(0);
     config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config).unwrap();
@@ -377,8 +376,7 @@ async fn async_host_func_with_pooling_stacks() -> Result<()> {
     let mut config = Config::new();
     config.async_support(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pooling));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(0);
+    config.memory_guard_size(0);
     config.static_memory_maximum_size(1 << 16);
 
     let mut store = Store::new(&Engine::new(&config)?, ());

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -101,8 +101,7 @@ fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
         for &guard_size in sizes.iter() {
             for &guard_before_linear_memory in [true, false].iter() {
                 config.static_memory_maximum_size(static_memory_maximum_size);
-                config.dynamic_memory_guard_size(guard_size);
-                config.static_memory_guard_size(guard_size);
+                config.memory_guard_size(guard_size);
                 config.guard_before_linear_memory(guard_before_linear_memory);
                 config.cranelift_debug_verifier(true);
                 engines.push(Engine::new(&config)?);
@@ -141,8 +140,7 @@ fn guards_present() -> Result<()> {
 
     let mut config = Config::new();
     config.static_memory_maximum_size(1 << 20);
-    config.dynamic_memory_guard_size(GUARD_SIZE);
-    config.static_memory_guard_size(GUARD_SIZE);
+    config.memory_guard_size(GUARD_SIZE);
     config.guard_before_linear_memory(true);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
@@ -193,8 +191,7 @@ fn guards_present_pooling(config: &mut Config) -> Result<()> {
         .max_memory_size(10 << 16)
         .memory_protection_keys(MpkEnabled::Disable);
     config.static_memory_maximum_size(1 << 20);
-    config.dynamic_memory_guard_size(GUARD_SIZE);
-    config.static_memory_guard_size(GUARD_SIZE);
+    config.memory_guard_size(GUARD_SIZE);
     config.guard_before_linear_memory(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     let engine = Engine::new(&config)?;
@@ -255,8 +252,7 @@ fn guards_present_pooling_mpk(config: &mut Config) -> Result<()> {
         .memory_protection_keys(MpkEnabled::Enable)
         .max_memory_protection_keys(2);
     config.static_memory_maximum_size(1 << 20);
-    config.dynamic_memory_guard_size(GUARD_SIZE);
-    config.static_memory_guard_size(GUARD_SIZE);
+    config.memory_guard_size(GUARD_SIZE);
     config.guard_before_linear_memory(true);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
     let engine = Engine::new(&config)?;

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -130,7 +130,7 @@ mod not_for_windows {
         config
             .with_host_memory(mem_creator.clone())
             .static_memory_maximum_size(0)
-            .dynamic_memory_guard_size(0);
+            .memory_guard_size(0);
         (Store::new(&Engine::new(&config).unwrap(), ()), mem_creator)
     }
 

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -6,8 +6,7 @@ fn successful_instantiation() -> Result<()> {
     let pool = crate::small_pool_config();
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(0);
+    config.memory_guard_size(0);
     config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
@@ -27,8 +26,7 @@ fn memory_limit() -> Result<()> {
     pool.max_memory_size(3 << 16);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(1 << 16);
+    config.memory_guard_size(1 << 16);
     config.static_memory_maximum_size(3 << 16);
     config.wasm_multi_memory(true);
 
@@ -201,8 +199,7 @@ fn memory_zeroed() -> Result<()> {
     pool.max_memory_size(1 << 16).table_elements(0);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(0);
+    config.memory_guard_size(0);
     config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
@@ -239,8 +236,7 @@ fn table_limit() -> Result<()> {
     pool.table_elements(TABLE_ELEMENTS);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(0);
+    config.memory_guard_size(0);
     config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
@@ -375,8 +371,7 @@ fn table_zeroed() -> Result<()> {
     let pool = crate::small_pool_config();
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(0);
+    config.memory_guard_size(0);
     config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
@@ -411,8 +406,7 @@ fn total_core_instances_limit() -> Result<()> {
     pool.total_core_instances(INSTANCE_LIMIT);
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
-    config.dynamic_memory_guard_size(0);
-    config.static_memory_guard_size(0);
+    config.memory_guard_size(0);
     config.static_memory_maximum_size(1 << 16);
 
     let engine = Engine::new(&config)?;
@@ -702,7 +696,7 @@ fn dynamic_memory_pooling_allocator() -> Result<()> {
         pool.max_memory_size(max_size as usize);
         let mut config = Config::new();
         config.static_memory_maximum_size(max_size);
-        config.dynamic_memory_guard_size(guard_size);
+        config.memory_guard_size(guard_size);
         config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
 
         let engine = Engine::new(&config)?;

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -87,8 +87,7 @@ mod pcc_memory_tests {
                             );
                             let mut cfg = Config::new();
                             cfg.static_memory_maximum_size(static_memory_maximum_size);
-                            cfg.static_memory_guard_size(guard_size);
-                            cfg.dynamic_memory_guard_size(guard_size);
+                            cfg.memory_guard_size(guard_size);
                             cfg.cranelift_pcc(true);
                             unsafe {
                                 cfg.cranelift_flag_set(

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -367,8 +367,7 @@ fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
         cfg.dynamic_memory_reserved_for_growth(0);
 
         let small_guard = 64 * 1024;
-        cfg.static_memory_guard_size(small_guard);
-        cfg.dynamic_memory_guard_size(small_guard);
+        cfg.memory_guard_size(small_guard);
     }
 
     let _pooling_lock = if config.pooling {
@@ -393,8 +392,7 @@ fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
         if multi_memory {
             cfg.static_memory_maximum_size(max_memory_size as u64);
             cfg.dynamic_memory_reserved_for_growth(0);
-            cfg.static_memory_guard_size(0);
-            cfg.dynamic_memory_guard_size(0);
+            cfg.memory_guard_size(0);
         }
 
         // The limits here are crafted such that the wast tests should pass.


### PR DESCRIPTION
This commit is the first of what will likely be a few to refactor the memory-related configuration options in Wasmtime. The end goal of these refactorings is to fix some preexisting issues and additionally make the configuration easier to understand for both users and implementors alike. First on the chopping block here is to merge the `dynamic_memory_guard_size` and `static_memory_guard_size` options into one option. AFAIK there's not a strong reason to have separate configuration options for these so it's hopefully simpler to have a single `memory_guard_size` option which applies to all linear memories equally.

I'll note that the old CLI options are preserved but are documented as deprecated. We don't currently warn on using "deprecated options" so for now the old options are just documented as deprecated and are otherwise silently accepted.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
