### PR TITLE
Remove the `wasmtime_environ::TablePlan` type

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -351,7 +351,7 @@ impl<P: PtrSize> VMOffsets<P> {
             num_imported_tables: cast_to_u32(module.num_imported_tables),
             num_imported_memories: cast_to_u32(module.num_imported_memories),
             num_imported_globals: cast_to_u32(module.num_imported_globals),
-            num_defined_tables: cast_to_u32(module.table_plans.len() - module.num_imported_tables),
+            num_defined_tables: cast_to_u32(module.num_defined_tables()),
             num_defined_memories: cast_to_u32(
                 module.memory_plans.len() - module.num_imported_memories,
             ),

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -175,6 +175,7 @@ impl Engine {
         }
     }
 
+    #[inline]
     pub(crate) fn tunables(&self) -> &Tunables {
         &self.inner.tunables
     }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -128,7 +128,7 @@ impl Table {
     }
 
     fn _ty(&self, store: &StoreOpaque) -> TableType {
-        let ty = &store[self.0].table.table;
+        let ty = &store[self.0].table;
         TableType::from_wasmtime_table(store.engine(), ty)
     }
 
@@ -405,7 +405,6 @@ impl Table {
         // Ensure that the table's type is engine-level canonicalized.
         wasmtime_export
             .table
-            .table
             .ref_type
             .canonicalize_for_runtime_usage(&mut |module_index| {
                 crate::runtime::vm::Instance::from_vmctx(wasmtime_export.vmctx, |instance| {
@@ -417,7 +416,7 @@ impl Table {
     }
 
     pub(crate) fn wasmtime_ty<'a>(&self, data: &'a StoreData) -> &'a wasmtime_environ::Table {
-        &data[self.0].table.table
+        &data[self.0].table
     }
 
     pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTableImport {

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -289,6 +289,7 @@ impl Instance {
                     store: StorePtr::new(store.traitobj()),
                     wmemcheck: store.engine().config().wmemcheck,
                     pkey: store.get_pkey(),
+                    tunables: store.engine().tunables(),
                 })?;
 
         // The instance still has lots of setup, for example

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -883,12 +883,12 @@ impl Module {
             .skip(em.num_imported_memories)
             .map(|plan| plan.memory.limits.min)
             .max();
-        let num_tables = u32::try_from(em.table_plans.len() - em.num_imported_tables).unwrap();
+        let num_tables = u32::try_from(em.num_defined_tables()).unwrap();
         let max_initial_table_size = em
-            .table_plans
+            .tables
             .values()
             .skip(em.num_imported_tables)
-            .map(|plan| plan.table.limits.min)
+            .map(|table| table.limits.min)
             .max();
         ResourcesRequired {
             num_memories,

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -602,6 +602,7 @@ impl<T> Store<T> {
                         runtime_info: &shim,
                         wmemcheck: engine.config().wmemcheck,
                         pkey: None,
+                        tunables: engine.tunables(),
                     })
                     .expect("failed to allocate default callee")
             };
@@ -1293,7 +1294,7 @@ impl StoreOpaque {
 
         let module = module.env_module();
         let memories = module.memory_plans.len() - module.num_imported_memories;
-        let tables = module.table_plans.len() - module.num_imported_tables;
+        let tables = module.num_defined_tables();
 
         bump(&mut self.instance_count, self.instance_limit, 1, "instance")?;
         bump(

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -47,6 +47,7 @@ fn create_handle(
             runtime_info,
             wmemcheck: false,
             pkey: None,
+            tunables: store.engine().tunables(),
         })?;
 
         Ok(store.add_dummy_instance(handle))

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -13,13 +13,13 @@ use alloc::sync::Arc;
 use core::ops::Range;
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, EntityIndex, HostPtr, MemoryPlan, MemoryStyle, Module,
-    VMOffsets,
+    Tunables, VMOffsets,
 };
 
 #[cfg(feature = "component-model")]
 use wasmtime_environ::{
     component::{Component, VMComponentOffsets},
-    StaticModuleIndex, Tunables,
+    StaticModuleIndex,
 };
 
 /// Create a "frankenstein" instance with a single memory.

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -19,7 +19,7 @@ use wasmtime_environ::{
 #[cfg(feature = "component-model")]
 use wasmtime_environ::{
     component::{Component, VMComponentOffsets},
-    StaticModuleIndex,
+    StaticModuleIndex, Tunables,
 };
 
 /// Create a "frankenstein" instance with a single memory.
@@ -64,6 +64,7 @@ pub fn create_memory(
         runtime_info,
         wmemcheck: false,
         pkey: None,
+        tunables: store.engine().tunables(),
     };
 
     unsafe {
@@ -234,10 +235,11 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
     unsafe fn allocate_table(
         &self,
         req: &mut InstanceAllocationRequest,
-        table_plan: &wasmtime_environ::TablePlan,
+        ty: &wasmtime_environ::Table,
+        tunables: &Tunables,
         table_index: DefinedTableIndex,
     ) -> Result<(TableAllocationIndex, Table)> {
-        self.ondemand.allocate_table(req, table_plan, table_index)
+        self.ondemand.allocate_table(req, ty, tunables, table_index)
     }
 
     unsafe fn deallocate_table(

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -8,7 +8,6 @@ pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<Instan
     let mut module = Module::new();
 
     let wasmtime_table = *table.wasmtime_table();
-    let tunables = store.engine().tunables();
 
     debug_assert!(
         wasmtime_table.ref_type.is_canonicalized_for_runtime_usage(),
@@ -16,8 +15,7 @@ pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<Instan
         wasmtime_table.ref_type
     );
 
-    let table_plan = wasmtime_environ::TablePlan::for_table(wasmtime_table, tunables);
-    let table_id = module.table_plans.push(table_plan);
+    let table_id = module.tables.push(wasmtime_table);
 
     // TODO: can this `exports.insert` get removed?
     module

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -2,7 +2,7 @@ use crate::runtime::vm::vmcontext::{
     VMContext, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
 };
 use core::ptr::NonNull;
-use wasmtime_environ::{DefinedMemoryIndex, Global, MemoryPlan, TablePlan};
+use wasmtime_environ::{DefinedMemoryIndex, Global, MemoryPlan, Table};
 
 /// The value of an export passed from one instance to another.
 pub enum Export {
@@ -49,7 +49,7 @@ pub struct ExportTable {
     /// Pointer to the containing `VMContext`.
     pub vmctx: *mut VMContext,
     /// The table declaration, used for compatibility checking.
-    pub table: TablePlan,
+    pub table: Table,
 }
 
 // See docs on send/sync for `ExportFunction` above.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
@@ -9,7 +9,7 @@ use crate::runtime::vm::table::Table;
 use crate::runtime::vm::CompiledModuleId;
 use alloc::sync::Arc;
 use wasmtime_environ::{
-    DefinedMemoryIndex, DefinedTableIndex, HostPtr, MemoryPlan, Module, TablePlan, VMOffsets,
+    DefinedMemoryIndex, DefinedTableIndex, HostPtr, MemoryPlan, Module, Tunables, VMOffsets,
 };
 
 #[cfg(feature = "gc")]
@@ -130,12 +130,14 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
     unsafe fn allocate_table(
         &self,
         request: &mut InstanceAllocationRequest,
-        table_plan: &TablePlan,
+        ty: &wasmtime_environ::Table,
+        tunables: &Tunables,
         _table_index: DefinedTableIndex,
     ) -> Result<(TableAllocationIndex, Table)> {
         let allocation_index = TableAllocationIndex::default();
         let table = Table::new_dynamic(
-            table_plan,
+            ty,
+            tunables,
             request
                 .store
                 .get()

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -60,8 +60,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 use wasmtime_environ::{
-    DefinedMemoryIndex, DefinedTableIndex, HostPtr, MemoryPlan, Module, TablePlan, Tunables,
-    VMOffsets,
+    DefinedMemoryIndex, DefinedTableIndex, HostPtr, MemoryPlan, Module, Tunables, VMOffsets,
 };
 
 #[cfg(feature = "gc")]
@@ -515,7 +514,7 @@ unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
                     self.validate_module_impl(module, &offsets)?;
                     num_core_instances += 1;
                     num_memories += module.memory_plans.len() - module.num_imported_memories;
-                    num_tables += module.table_plans.len() - module.num_imported_tables;
+                    num_tables += module.num_defined_tables();
                 }
                 LowerImport { .. }
                 | ExtractMemory(_)
@@ -628,10 +627,11 @@ unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
     unsafe fn allocate_table(
         &self,
         request: &mut InstanceAllocationRequest,
-        table_plan: &TablePlan,
+        ty: &wasmtime_environ::Table,
+        tunables: &Tunables,
         _table_index: DefinedTableIndex,
     ) -> Result<(super::TableAllocationIndex, Table)> {
-        self.with_flush_and_retry(|| self.tables.allocate(request, table_plan))
+        self.with_flush_and_retry(|| self.tables.allocate(request, ty, tunables))
     }
 
     unsafe fn deallocate_table(

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -12,7 +12,7 @@ use std::mem;
 use wasmparser::BlockType;
 use wasmtime_environ::{
     BuiltinFunctionIndex, FuncIndex, GlobalIndex, MemoryIndex, MemoryPlan, MemoryStyle,
-    ModuleTranslation, ModuleTypesBuilder, PrimaryMap, PtrSize, TableIndex, TablePlan, TypeConvert,
+    ModuleTranslation, ModuleTypesBuilder, PrimaryMap, PtrSize, Table, TableIndex, TypeConvert,
     TypeIndex, VMOffsets, WasmHeapType, WasmValType,
 };
 
@@ -311,9 +311,9 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
         }
     }
 
-    /// Get a [`TablePlan`] from a [`TableIndex`].
-    pub fn table_plan(&mut self, index: TableIndex) -> &TablePlan {
-        &self.translation.module.table_plans[index]
+    /// Get a [`Table`] from a [`TableIndex`].
+    pub fn table(&mut self, index: TableIndex) -> &Table {
+        &self.translation.module.tables[index]
     }
 
     /// Returns true if Spectre mitigations are enabled for heap bounds check.


### PR DESCRIPTION
In my quest to simplify memory configuration and how things work internally in Wasmtime one thing I've identified to accomplish is the removal of the `TablePlan` and `MemoryPlan` types. These introduce an abstraction layer between table/memory implementations and `Tunables` and personally I find it simpler to directly reference `Tunables` and use that instead. The goal of this commit is to plumb `Tunables` closer to where it's directly read by removing the "indirection" through the `*Plan` types.

The `TablePlan` and `MemoryPlan` types are pervasively used throughout Wasmtime so instead of having one large commit delete everything this is instead a piecemeal approach to incrementally get towards the goal of removal. Here just `TablePlan` is removed and `Tunables` is plumbed in a few more places. I plan to also in the future remove `TableStyle` and `MemoryStyle` in favor of directly reading `Tunables` but that's left for a future commit. For now `TableStyle` persists and its usage is a bit odd in isolation but I plan to follow this up with the removal of `TableStyle`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
