### PR TITLE
Remove the `wasmtime_environ::MemoryPlan` type

### DIFF
--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -966,8 +966,8 @@ impl<'a> Inliner<'a> {
             Some(memory) => match &self.runtime_instances[memory.instance] {
                 InstanceModule::Static(idx) => match &memory.item {
                     ExportItem::Index(i) => {
-                        let plan = &self.nested_modules[*idx].module.memory_plans[*i];
-                        match plan.memory.idx_type {
+                        let ty = &self.nested_modules[*idx].module.memories[*i];
+                        match ty.idx_type {
                             IndexType::I32 => false,
                             IndexType::I64 => true,
                         }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -338,10 +338,10 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return a new `VMOffsets` instance, for a given pointer size.
     pub fn new(ptr: P, module: &Module) -> Self {
         let num_owned_memories = module
-            .memory_plans
+            .memories
             .iter()
             .skip(module.num_imported_memories)
-            .filter(|p| !p.1.memory.shared)
+            .filter(|p| !p.1.shared)
             .count()
             .try_into()
             .unwrap();
@@ -352,9 +352,7 @@ impl<P: PtrSize> VMOffsets<P> {
             num_imported_memories: cast_to_u32(module.num_imported_memories),
             num_imported_globals: cast_to_u32(module.num_imported_globals),
             num_defined_tables: cast_to_u32(module.num_defined_tables()),
-            num_defined_memories: cast_to_u32(
-                module.memory_plans.len() - module.num_imported_memories,
-            ),
+            num_defined_memories: cast_to_u32(module.num_defined_memories()),
             num_owned_memories,
             num_defined_globals: cast_to_u32(module.globals.len() - module.num_imported_globals),
             num_escaped_funcs: cast_to_u32(module.num_escaped_funcs),

--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -112,7 +112,7 @@ impl Extern {
                 Extern::Func(Func::from_wasmtime_function(f, store))
             }
             crate::runtime::vm::Export::Memory(m) => {
-                if m.memory.memory.shared {
+                if m.memory.shared {
                     Extern::SharedMemory(SharedMemory::from_wasmtime_memory(m, store))
                 } else {
                     Extern::Memory(Memory::from_wasmtime_memory(m, store))

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -9,7 +9,6 @@ use core::fmt;
 use core::ops::Range;
 use core::slice;
 use core::time::Duration;
-use wasmtime_environ::MemoryPlan;
 
 pub use crate::runtime::vm::WaitResult;
 
@@ -294,7 +293,7 @@ impl Memory {
     /// ```
     pub fn ty(&self, store: impl AsContext) -> MemoryType {
         let store = store.as_context();
-        let ty = &store[self.0].memory.memory;
+        let ty = &store[self.0].memory;
         MemoryType::from_wasmtime_memory(&ty)
     }
 
@@ -499,7 +498,7 @@ impl Memory {
     }
 
     pub(crate) fn _page_size(&self, store: &StoreOpaque) -> u64 {
-        store[self.0].memory.memory.page_size()
+        store[self.0].memory.page_size()
     }
 
     /// Returns the log2 of this memory's page size, in bytes.
@@ -519,7 +518,7 @@ impl Memory {
     }
 
     pub(crate) fn _page_size_log2(&self, store: &StoreOpaque) -> u8 {
-        store[self.0].memory.memory.page_size_log2
+        store[self.0].memory.page_size_log2
     }
 
     /// Grows this WebAssembly memory by `delta` pages.
@@ -632,7 +631,7 @@ impl Memory {
     }
 
     pub(crate) fn wasmtime_ty<'a>(&self, store: &'a StoreData) -> &'a wasmtime_environ::Memory {
-        &store[self.0].memory.memory
+        &store[self.0].memory
     }
 
     pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMMemoryImport {
@@ -808,9 +807,9 @@ impl SharedMemory {
         debug_assert!(ty.maximum().is_some());
 
         let tunables = engine.tunables();
-        let plan = MemoryPlan::for_memory(*ty.wasmtime_memory(), tunables);
-        let page_size_log2 = plan.memory.page_size_log2;
-        let memory = crate::runtime::vm::SharedMemory::new(plan)?;
+        let ty = ty.wasmtime_memory();
+        let page_size_log2 = ty.page_size_log2;
+        let memory = crate::runtime::vm::SharedMemory::new(ty, tunables)?;
 
         Ok(Self {
             vm: memory,
@@ -1055,8 +1054,13 @@ mod tests {
         let ty = MemoryType::new(1, None);
         let mem = Memory::new(&mut store, ty).unwrap();
         let store = store.as_context();
-        assert_eq!(store[mem.0].memory.offset_guard_size, 0);
-        match &store[mem.0].memory.style {
+        let (style, offset_guard_size) = wasmtime_environ::MemoryStyle::for_memory(
+            store[mem.0].memory,
+            store.engine().tunables(),
+        );
+
+        assert_eq!(offset_guard_size, 0);
+        match style {
             wasmtime_environ::MemoryStyle::Dynamic { .. } => {}
             other => panic!("unexpected style {other:?}"),
         }

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -876,12 +876,12 @@ impl Module {
     /// ```
     pub fn resources_required(&self) -> ResourcesRequired {
         let em = self.env_module();
-        let num_memories = u32::try_from(em.memory_plans.len() - em.num_imported_memories).unwrap();
+        let num_memories = u32::try_from(em.num_defined_memories()).unwrap();
         let max_initial_memory_size = em
-            .memory_plans
+            .memories
             .values()
             .skip(em.num_imported_memories)
-            .map(|plan| plan.memory.limits.min)
+            .map(|memory| memory.limits.min)
             .max();
         let num_tables = u32::try_from(em.num_defined_tables()).unwrap();
         let max_initial_table_size = em

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1292,7 +1292,7 @@ impl StoreOpaque {
         }
 
         let module = module.env_module();
-        let memories = module.memory_plans.len() - module.num_imported_memories;
+        let memories = module.num_defined_memories();
         let tables = module.num_defined_tables();
 
         bump(&mut self.instance_count, self.instance_limit, 1, "instance")?;

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -12,8 +12,8 @@ use crate::MemoryType;
 use alloc::sync::Arc;
 use core::ops::Range;
 use wasmtime_environ::{
-    DefinedMemoryIndex, DefinedTableIndex, EntityIndex, HostPtr, MemoryPlan, MemoryStyle, Module,
-    Tunables, VMOffsets,
+    DefinedMemoryIndex, DefinedTableIndex, EntityIndex, HostPtr, MemoryStyle, Module, Tunables,
+    VMOffsets,
 };
 
 #[cfg(feature = "component-model")]
@@ -34,14 +34,10 @@ pub fn create_memory(
 ) -> Result<InstanceId> {
     let mut module = Module::new();
 
-    // Create a memory plan for the memory, though it will never be used for
-    // constructing a memory with an allocator: instead the memories are either
-    // preallocated (i.e., shared memory) or allocated manually below.
-    let plan = wasmtime_environ::MemoryPlan::for_memory(
-        *memory_ty.wasmtime_memory(),
-        store.engine().tunables(),
-    );
-    let memory_id = module.memory_plans.push(plan.clone());
+    // Create a memory, though it will never be used for constructing a memory
+    // with an allocator: instead the memories are either preallocated (i.e.,
+    // shared memory) or allocated manually below.
+    let memory_id = module.memories.push(*memory_ty.wasmtime_memory());
 
     // Since we have only associated a single memory with the "frankenstein"
     // instance, it will be exported at index 0.
@@ -126,13 +122,14 @@ pub(crate) struct MemoryCreatorProxy(pub Arc<dyn MemoryCreator>);
 impl RuntimeMemoryCreator for MemoryCreatorProxy {
     fn new_memory(
         &self,
-        plan: &MemoryPlan,
+        ty: &wasmtime_environ::Memory,
+        tunables: &Tunables,
         minimum: usize,
         maximum: Option<usize>,
         _: Option<&Arc<MemoryImage>>,
     ) -> Result<Box<dyn RuntimeLinearMemory>> {
-        let ty = MemoryType::from_wasmtime_memory(&plan.memory);
-        let reserved_size_in_bytes = match plan.style {
+        let (style, offset_guard_size) = MemoryStyle::for_memory(*ty, tunables);
+        let reserved_size_in_bytes = match style {
             MemoryStyle::Static { byte_reservation } => {
                 Some(usize::try_from(byte_reservation).unwrap())
             }
@@ -140,16 +137,16 @@ impl RuntimeMemoryCreator for MemoryCreatorProxy {
         };
         self.0
             .new_memory(
-                ty,
+                MemoryType::from_wasmtime_memory(ty),
                 minimum,
                 maximum,
                 reserved_size_in_bytes,
-                usize::try_from(plan.offset_guard_size).unwrap(),
+                usize::try_from(offset_guard_size).unwrap(),
             )
             .map(|mem| {
                 Box::new(LinearMemoryProxy {
                     mem,
-                    page_size_log2: plan.memory.page_size_log2,
+                    page_size_log2: ty.page_size_log2,
                 }) as Box<dyn RuntimeLinearMemory>
             })
             .map_err(|e| anyhow!(e))
@@ -174,7 +171,7 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
 
     fn validate_module_impl(&self, module: &Module, offsets: &VMOffsets<HostPtr>) -> Result<()> {
         anyhow::ensure!(
-            module.memory_plans.len() == 1,
+            module.memories.len() == 1,
             "`SingleMemoryInstance` allocator can only be used for modules with a single memory"
         );
         self.ondemand.validate_module_impl(module, offsets)?;
@@ -200,7 +197,8 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
     unsafe fn allocate_memory(
         &self,
         request: &mut InstanceAllocationRequest,
-        memory_plan: &MemoryPlan,
+        ty: &wasmtime_environ::Memory,
+        tunables: &Tunables,
         memory_index: DefinedMemoryIndex,
     ) -> Result<(MemoryAllocationIndex, Memory)> {
         #[cfg(debug_assertions)]
@@ -218,7 +216,7 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
             )),
             None => self
                 .ondemand
-                .allocate_memory(request, memory_plan, memory_index),
+                .allocate_memory(request, ty, tunables, memory_index),
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -11,7 +11,7 @@ static mut VMCTX_AND_MEMORY: (*mut VMContext, usize) = (std::ptr::null_mut(), 0)
 pub unsafe extern "C" fn resolve_vmctx_memory(ptr: usize) -> *const u8 {
     Instance::from_vmctx(VMCTX_AND_MEMORY.0, |handle| {
         assert!(
-            VMCTX_AND_MEMORY.1 < handle.env_module().memory_plans.len(),
+            VMCTX_AND_MEMORY.1 < handle.env_module().memories.len(),
             "memory index for debugger is out of bounds"
         );
         let index = MemoryIndex::new(VMCTX_AND_MEMORY.1);
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
     );
     Instance::from_vmctx(VMCTX_AND_MEMORY.0, |handle| {
         assert!(
-            VMCTX_AND_MEMORY.1 < handle.env_module().memory_plans.len(),
+            VMCTX_AND_MEMORY.1 < handle.env_module().memories.len(),
             "memory index for debugger is out of bounds"
         );
         let index = MemoryIndex::new(VMCTX_AND_MEMORY.1);

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -2,7 +2,7 @@ use crate::runtime::vm::vmcontext::{
     VMContext, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
 };
 use core::ptr::NonNull;
-use wasmtime_environ::{DefinedMemoryIndex, Global, MemoryPlan, Table};
+use wasmtime_environ::{DefinedMemoryIndex, Global, Memory, Table};
 
 /// The value of an export passed from one instance to another.
 pub enum Export {
@@ -70,7 +70,7 @@ pub struct ExportMemory {
     /// Pointer to the containing `VMContext`.
     pub vmctx: *mut VMContext,
     /// The memory declaration, used for compatibility checking.
-    pub memory: MemoryPlan,
+    pub memory: Memory,
     /// The index at which the memory is defined within the `vmctx`.
     pub index: DefinedMemoryIndex,
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
@@ -9,7 +9,7 @@ use crate::runtime::vm::table::Table;
 use crate::runtime::vm::CompiledModuleId;
 use alloc::sync::Arc;
 use wasmtime_environ::{
-    DefinedMemoryIndex, DefinedTableIndex, HostPtr, MemoryPlan, Module, Tunables, VMOffsets,
+    DefinedMemoryIndex, DefinedTableIndex, HostPtr, Module, Tunables, VMOffsets,
 };
 
 #[cfg(feature = "gc")]
@@ -96,7 +96,8 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
     unsafe fn allocate_memory(
         &self,
         request: &mut InstanceAllocationRequest,
-        memory_plan: &MemoryPlan,
+        ty: &wasmtime_environ::Memory,
+        tunables: &Tunables,
         memory_index: DefinedMemoryIndex,
     ) -> Result<(MemoryAllocationIndex, Memory)> {
         let creator = self
@@ -106,7 +107,8 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
         let image = request.runtime_info.memory_image(memory_index)?;
         let allocation_index = MemoryAllocationIndex::default();
         let memory = Memory::new_dynamic(
-            memory_plan,
+            ty,
+            tunables,
             creator,
             request
                 .store

--- a/crates/wasmtime/src/runtime/vm/threads/shared_memory_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/threads/shared_memory_disabled.rs
@@ -4,16 +4,16 @@ use crate::prelude::*;
 use crate::runtime::vm::{RuntimeLinearMemory, VMMemoryDefinition, VMStore, WaitResult};
 use core::ops::Range;
 use core::time::Duration;
-use wasmtime_environ::{MemoryPlan, Trap};
+use wasmtime_environ::{Trap, Tunables};
 
 #[derive(Clone)]
 pub enum SharedMemory {}
 
 impl SharedMemory {
     pub fn wrap(
-        _plan: &MemoryPlan,
+        _ty: &wasmtime_environ::Memory,
+        _tunables: &Tunables,
         _memory: Box<dyn RuntimeLinearMemory>,
-        _ty: wasmtime_environ::Memory,
     ) -> Result<Self> {
         bail!("support for shared memories was disabled at compile time");
     }

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -104,6 +104,7 @@ impl TargetIsa for Aarch64 {
             translation,
             types,
             builtins,
+            tunables,
             self,
             abi::Aarch64ABI::ptr_type(),
         );

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -114,6 +114,7 @@ impl TargetIsa for X64 {
             translation,
             types,
             builtins,
+            tunables,
             self,
             abi::X64ABI::ptr_type(),
         );


### PR DESCRIPTION
This is the equivalent of #9530 for memories. The goal of this commit is to eventually remove the abstraction layer of `MemoryPlan` and `MemoryStyle` in favor of directly reading the configuration of `Tunables`. The prediction is that it will be simpler to work directly with configured values instead of a layer of abstraction between the configuration and the runtime which needs to be evolved independently to capture how to interpret the configuration.

Like with #9530 my plan is to eventually remove the `MemoryStyle` type itself, but that'll be a larger change, so it's deferred to a future PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
