### PR TITLE
Fix custom-page-sizes + pooling-allocator + CoW

### DIFF
--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -1259,7 +1259,7 @@ fn tricky_empty_table_with_empty_virtual_memory_alloc() -> Result<()> {
 }
 
 #[test]
-fn custom_page_sizes_resuing_same_slot() -> Result<()> {
+fn custom_page_sizes_reusing_same_slot() -> Result<()> {
     let mut config = Config::new();
     config.wasm_custom_page_sizes(true);
     let mut cfg = PoolingAllocationConfig::default();

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -1259,6 +1259,7 @@ fn tricky_empty_table_with_empty_virtual_memory_alloc() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn custom_page_sizes_reusing_same_slot() -> Result<()> {
     let mut config = Config::new();
     config.wasm_custom_page_sizes(true);


### PR DESCRIPTION
This commit fixes a runtime error that happened with the pooling allocator when combined with the custom-page-sizes proposal. The bug that happened was that sizes flowing into the pooling allocator were no longer host-page-size-aligned which caused syscalls to return an error unexpectedly. This meant that situations which were supposed to work were in fact not working.

The fix in this commit is to page-align incoming sizes into the CoW-pieces of memory management. This is coupled with a few more assertions that the `accessible` field is always page-aligned, as expected.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
