### PR TITLE
Enable some Clippy conversion lints for `wasmtime-cranelift`

### DIFF
--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -17,7 +17,7 @@ rust-version.workspace = true
 workspace = true
 
 [package.metadata.docs.rs]
-# Ask Cargo to build docs with the feature `all-arch` 
+# Ask Cargo to build docs with the feature `all-arch`
 features = ["all-arch"]
 
 [dependencies]
@@ -62,7 +62,7 @@ default = ["std", "unwind", "host-arch", "timing"]
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two
 # features need to be enabled.
-std = []
+std = ["serde?/std"]
 
 # The "core" feature used to enable a hashmap workaround, but is now
 # deprecated (we (i) always use hashbrown, and (ii) don't support a

--- a/crates/cranelift/src/compiled_function.rs
+++ b/crates/cranelift/src/compiled_function.rs
@@ -111,7 +111,7 @@ impl CompiledFunction {
             .into_iter()
             .map(|&MachSrcLoc { start, end, loc }| (loc, start, (end - start)));
         let instructions = if with_instruction_addresses {
-            collect_address_maps(len as u32, srclocs)
+            collect_address_maps(len.try_into().unwrap(), srclocs)
         } else {
             Default::default()
         };
@@ -123,7 +123,7 @@ impl CompiledFunction {
             start_srcloc,
             end_srcloc,
             body_offset: 0,
-            body_len: len as u32,
+            body_len: len.try_into().unwrap(),
         };
 
         self.metadata.address_map = address_map;

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -833,8 +833,8 @@ impl FunctionCompiler<'_> {
             let offset = data.original_position();
             let len = data.bytes_remaining();
             compiled_function.set_address_map(
-                offset as u32,
-                len as u32,
+                offset.try_into().unwrap(),
+                len.try_into().unwrap(),
                 tunables.generate_address_map,
             );
         }

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -1,5 +1,10 @@
 //! Debug utils for WebAssembly using Cranelift.
 
+// FIXME: this whole crate opts-in to these two noisier-than-default lints, but
+// this module has lots of hits on this warning which aren't the easiest to
+// resolve. Ideally all warnings would be resolved here though.
+#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+
 use crate::CompiledFunctionMetadata;
 use cranelift_codegen::isa::TargetIsa;
 use object::write::SymbolId;

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -952,7 +952,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             .name_section
             .func_names
             .get(&func_index)
-            .map(|s| *s)
+            .copied()
     }
 
     /// Proof-carrying code: create a memtype describing an empty

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -3,6 +3,10 @@
 //! This crate provides an implementation of the `wasmtime_environ::Compiler`
 //! and `wasmtime_environ::CompilerBuilder` traits.
 
+// See documentation in crates/wasmtime/src/runtime.rs for why this is
+// selectively enabled here.
+#![warn(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+
 use cranelift_codegen::{
     binemit,
     cursor::FuncCursor,

--- a/crates/cranelift/src/translate/func_translator.rs
+++ b/crates/cranelift/src/translate/func_translator.rs
@@ -278,6 +278,6 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
 /// Get the current source location from a reader.
 fn cur_srcloc(reader: &BinaryReader) -> ir::SourceLoc {
     // We record source locations as byte code offsets relative to the beginning of the file.
-    // This will wrap around if byte code is larger than 4 GB.
-    ir::SourceLoc::new(reader.original_position() as u32)
+    // This will panic if bytecode is larger than 4 GB.
+    ir::SourceLoc::new(reader.original_position().try_into().unwrap())
 }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -1,6 +1,8 @@
 //! Runtime library support for Wasmtime.
 
 #![deny(missing_docs)]
+// See documentation in crates/wasmtime/src/runtime.rs for why this is
+// selectively enabled here.
 #![warn(clippy::cast_sign_loss)]
 
 use crate::prelude::*;


### PR DESCRIPTION
Similar to how `wasmtime::runtime` has a few off-by-default lints turned on for it do the same for the compilation phase of `wasmtime-cranelift`. This is intended to help weed out lossy `as` casts and instead steer users to `from` or `try_from` conversions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
