### PR TITLE
Some minor portability tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -505,9 +505,8 @@ jobs:
         CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: false
 
     # Check whether `wasmtime` cross-compiles to x86_64-unknown-freebsd
-    # TODO: We aren't building with default features since the `ittapi` crate fails to compile on freebsd.
     - run: rustup target add x86_64-unknown-freebsd
-    - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache --target x86_64-unknown-freebsd
+    - run: cargo check --target x86_64-unknown-freebsd
 
     # Re-vendor all WIT files and ensure that they're all up-to-date by ensuring
     # that there's no git changes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,6 +343,7 @@ criterion = { version = "0.5.0", default-features = false, features = ["html_rep
 rustc-hash = "2.0.0"
 libtest-mimic = "0.7.0"
 semver = { version = "1.0.17", default-features = false }
+ittapi = "0.4.0"
 
 # =============================================================================
 #

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -74,8 +74,15 @@ features = [
   "Win32_Security",
 ]
 
-[target.'cfg(all(target_arch = "x86_64", not(any(target_os = "android", target_os = "illumos"))))'.dependencies]
-ittapi = { version = "0.4.0", optional = true }
+# Allow-list the platforms that `ittapi` builds on since it's got C code that
+# doesn't compile by default on all platforms just yet. Also note that this is
+# only enabled for `x86_64` targets as well.
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
+ittapi = { workspace = true, optional = true }
+[target.'cfg(all(target_arch = "x86_64", target_os = "macos"))'.dependencies]
+ittapi = { workspace = true, optional = true }
+[target.'cfg(all(target_arch = "x86_64", target_os = "windows"))'.dependencies]
+ittapi = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 memfd = { workspace = true, optional = true }

--- a/crates/wasmtime/src/profiling_agent.rs
+++ b/crates/wasmtime/src/profiling_agent.rs
@@ -27,18 +27,17 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    // Note: VTune support is disabled on windows mingw because the ittapi crate doesn't compile
-    // there; see also https://github.com/bytecodealliance/wasmtime/pull/4003 for rationale.
+    // Note that the `#[cfg]` here should be kept in sync with the
+    // corresponding dependency directive on `ittapi` in `Cargo.toml`.
     if #[cfg(all(
-            feature = "profiling",
-            target_arch = "x86_64",
-            not(any(
-                target_os = "android",
-                target_os = "illumos",
-                all(target_os = "windows", target_env = "gnu"),
-            )),
-        ))
-    ] {
+        feature = "profiling",
+        target_arch = "x86_64",
+        any(
+            target_os = "windows",
+            target_os = "macos",
+            target_os = "linux",
+        ),
+    ))] {
         mod vtune;
         pub use vtune::new as new_vtune;
     } else {

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -93,6 +93,7 @@ For explanations of what each tier means see below.
 | Target               | `aarch64-linux-android`           | CI testing, full-time maintainer |
 | Target               | `x86_64-linux-android`            | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-linux-musl` [^4]  | CI testing, full-time maintainer |
+| Target               | `x86_64-unknown-illumos`          | CI testing, full-time maintainer |
 | Compiler Backend     | Winch on x86\_64                  | WebAssembly proposals (`simd`, `relaxed-simd`, `tail-call`, `reference-types`, `threads`)     |
 | Compiler Backend     | Winch on aarch64                  | Complete implementation     |
 | WebAssembly Proposal | [`gc`]                            | Complete implementation     |

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -94,6 +94,7 @@ For explanations of what each tier means see below.
 | Target               | `x86_64-linux-android`            | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-linux-musl` [^4]  | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-illumos`          | CI testing, full-time maintainer |
+| Target               | `x86_64-unknown-freebsd`          | CI testing, full-time maintainer |
 | Compiler Backend     | Winch on x86\_64                  | WebAssembly proposals (`simd`, `relaxed-simd`, `tail-call`, `reference-types`, `threads`)     |
 | Compiler Backend     | Winch on aarch64                  | Complete implementation     |
 | WebAssembly Proposal | [`gc`]                            | Complete implementation     |
@@ -142,7 +143,7 @@ features to figure out how best to implement them and at least move them to Tier
 3 above.
 
 * Target: ARM 32-bit
-* Target: [FreeBSD](https://github.com/bytecodealliance/wasmtime/issues/5499)
+* Target: [AArch64 FreeBSD](https://github.com/bytecodealliance/wasmtime/issues/5499)
 * Target: [NetBSD/OpenBSD](https://github.com/bytecodealliance/wasmtime/issues/6962)
 * Target: [i686 (32-bit Intel targets)](https://github.com/bytecodealliance/wasmtime/issues/1980)
 * Target: MIPS


### PR DESCRIPTION
Inspired during review of https://github.com/bytecodealliance/wasmtime/pull/9535

* Platforms supporting vtune are now opt-in instead of being opt-out
* Build all of the `wasmtime` CLI via `cargo check` for FreeBSD in CI (instead of just the `wasmtime` crate)
* List illumos/freebsd as tier 3 in our tier listings