### PR TITLE
More refactoring to remove `MemoryStyle`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2373,7 +2373,8 @@ impl<'module_environment> crate::translate::FuncEnvironment
 
         // If we have a declared maximum, we can make this a "static" heap, which is
         // allocated up front and never moved.
-        let (style, offset_guard_size) = MemoryStyle::for_memory(memory, self.tunables);
+        let style = MemoryStyle::for_memory(memory, self.tunables);
+        let offset_guard_size = self.tunables.memory_guard_size;
         let (heap_style, readonly_base, base_fact, memory_type) = match style {
             MemoryStyle::Dynamic { .. } => {
                 let heap_bound = func.create_global_value(ir::GlobalValueData::Load {

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -1254,7 +1254,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let effective_addr = if memarg.offset == 0 {
                 addr
             } else {
-                let index_type = environ.heaps()[heap].index_type;
+                let index_type = environ.heaps()[heap].index_type();
                 let offset = builder.ins().iconst(index_type, memarg.offset as i64);
                 environ.uadd_overflow_trap(builder, addr, offset, ir::TrapCode::HEAP_OUT_OF_BOUNDS)
             };
@@ -1278,7 +1278,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let effective_addr = if memarg.offset == 0 {
                 addr
             } else {
-                let index_type = environ.heaps()[heap].index_type;
+                let index_type = environ.heaps()[heap].index_type();
                 let offset = builder.ins().iconst(index_type, memarg.offset as i64);
                 environ.uadd_overflow_trap(builder, addr, offset, ir::TrapCode::HEAP_OUT_OF_BOUNDS)
             };
@@ -3222,7 +3222,9 @@ where
         // relatively odd/rare. In the future if needed we can look into
         // optimizing this more.
         Err(_) => {
-            let offset = builder.ins().iconst(heap.index_type, memarg.offset as i64);
+            let offset = builder
+                .ins()
+                .iconst(heap.index_type(), memarg.offset.signed());
             let adjusted_index = environ.uadd_overflow_trap(
                 builder,
                 index,
@@ -3251,7 +3253,7 @@ where
     let mut flags = MemFlags::new();
     flags.set_endianness(ir::Endianness::Little);
 
-    if heap.memory_type.is_some() {
+    if heap.pcc_memory_type.is_some() {
         // Proof-carrying code is enabled; check this memory access.
         flags.set_checked();
     }

--- a/crates/cranelift/src/translate/code_translator/bounds_checks.rs
+++ b/crates/cranelift/src/translate/code_translator/bounds_checks.rs
@@ -20,14 +20,14 @@
 //! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 use super::Reachability;
-use crate::translate::{FuncEnvironment, HeapData, HeapStyle};
+use crate::translate::{FuncEnvironment, HeapData};
 use cranelift_codegen::{
     cursor::{Cursor, FuncCursor},
     ir::{self, condcodes::IntCC, InstBuilder, RelSourceLoc},
     ir::{Expr, Fact},
 };
 use cranelift_frontend::FunctionBuilder;
-use wasmtime_environ::WasmResult;
+use wasmtime_environ::{MemoryStyle, WasmResult};
 use Reachability::*;
 
 /// Helper used to emit bounds checks (as necessary) and compute the native
@@ -50,12 +50,13 @@ where
     Env: FuncEnvironment + ?Sized,
 {
     let pointer_bit_width = u16::try_from(env.pointer_type().bits()).unwrap();
+    let bound_gv = heap.bound;
     let orig_index = index;
     let index = cast_index_to_pointer_ty(
         index,
-        heap.index_type,
+        heap.index_type(),
         env.pointer_type(),
-        heap.memory_type.is_some(),
+        heap.pcc_memory_type.is_some(),
         &mut builder.cursor(),
     );
     let offset_and_size = offset_plus_size(offset, access_size);
@@ -64,7 +65,7 @@ where
 
     let host_page_size_log2 = env.target_config().page_size_align_log2;
     let can_use_virtual_memory =
-        heap.page_size_log2 >= host_page_size_log2 && env.signals_based_traps();
+        heap.memory.page_size_log2 >= host_page_size_log2 && env.signals_based_traps();
     let memory_guard_size = env.tunables().memory_guard_size;
 
     let make_compare = |builder: &mut FunctionBuilder,
@@ -138,14 +139,15 @@ where
     // different bounds checks and optimizations of those bounds checks. It is
     // intentionally written in a straightforward case-matching style that will
     // hopefully make it easy to port to ISLE one day.
-    Ok(match heap.style {
+    let style = MemoryStyle::for_memory(heap.memory, env.tunables());
+    Ok(match style {
         // ====== Dynamic Memories ======
         //
         // 1. First special case for when `offset + access_size == 1`:
         //
         //            index + 1 > bound
         //        ==> index >= bound
-        HeapStyle::Dynamic { bound_gv } if offset_and_size == 1 => {
+        MemoryStyle::Dynamic { .. } if offset_and_size == 1 => {
             let bound = get_dynamic_heap_bound(builder, env, heap);
             let oob = make_compare(
                 builder,
@@ -163,7 +165,7 @@ where
                 offset,
                 access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
+                AddrPcc::dynamic(heap.pcc_memory_type, bound_gv),
                 oob,
             ))
         }
@@ -193,7 +195,7 @@ where
         //    offset immediates -- which is a common code pattern when accessing
         //    multiple fields in the same struct that is in linear memory --
         //    will all emit the same `index > bound` check, which we can GVN.
-        HeapStyle::Dynamic { bound_gv }
+        MemoryStyle::Dynamic { .. }
             if can_use_virtual_memory && offset_and_size <= memory_guard_size =>
         {
             let bound = get_dynamic_heap_bound(builder, env, heap);
@@ -213,7 +215,7 @@ where
                 offset,
                 access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
+                AddrPcc::dynamic(heap.pcc_memory_type, bound_gv),
                 oob,
             ))
         }
@@ -225,7 +227,9 @@ where
         //
         //            index + offset + access_size > bound
         //        ==> index > bound - (offset + access_size)
-        HeapStyle::Dynamic { bound_gv } if offset_and_size <= heap.min_size.into() => {
+        MemoryStyle::Dynamic { .. }
+            if offset_and_size <= heap.memory.minimum_byte_size().unwrap_or(u64::MAX) =>
+        {
             let bound = get_dynamic_heap_bound(builder, env, heap);
             let adjustment = offset_and_size as i64;
             let adjustment_value = builder.ins().iconst(env.pointer_type(), adjustment);
@@ -257,7 +261,7 @@ where
                 offset,
                 access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
+                AddrPcc::dynamic(heap.pcc_memory_type, bound_gv),
                 oob,
             ))
         }
@@ -267,7 +271,7 @@ where
         //        index + offset + access_size > bound
         //
         //    And we have to handle the overflow case in the left-hand side.
-        HeapStyle::Dynamic { bound_gv } => {
+        MemoryStyle::Dynamic { .. } => {
             let access_size_val = builder
                 .ins()
                 // Explicit cast from u64 to i64: we just want the raw
@@ -307,7 +311,7 @@ where
                 offset,
                 access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
+                AddrPcc::dynamic(heap.pcc_memory_type, bound_gv),
                 oob,
             ))
         }
@@ -320,7 +324,7 @@ where
         // 1. First special case: trap immediately if `offset + access_size >
         //    bound`, since we will end up being out-of-bounds regardless of the
         //    given `index`.
-        HeapStyle::Static { bound } if offset_and_size > bound.into() => {
+        MemoryStyle::Static { byte_reservation } if offset_and_size > byte_reservation => {
             assert!(
                 can_use_virtual_memory,
                 "static memories require the ability to use virtual memory"
@@ -368,11 +372,11 @@ where
         //    `u32::MAX`. This means that `index` is always either in bounds or
         //    within the guard page region, neither of which require emitting an
         //    explicit bounds check.
-        HeapStyle::Static { bound }
+        MemoryStyle::Static { byte_reservation }
             if can_use_virtual_memory
-                && heap.index_type == ir::types::I32
+                && heap.index_type() == ir::types::I32
                 && u64::from(u32::MAX)
-                    <= u64::from(bound) + u64::from(memory_guard_size) - offset_and_size =>
+                    <= byte_reservation + memory_guard_size - offset_and_size =>
         {
             assert!(
                 can_use_virtual_memory,
@@ -384,10 +388,7 @@ where
                 env.pointer_type(),
                 index,
                 offset,
-                AddrPcc::static32(
-                    heap.memory_type,
-                    u64::from(bound) + u64::from(memory_guard_size),
-                ),
+                AddrPcc::static32(heap.pcc_memory_type, byte_reservation + memory_guard_size),
             ))
         }
 
@@ -402,14 +403,14 @@ where
         //    Since we have to emit explicit bounds checks, we might as well be
         //    precise, not rely on the virtual memory subsystem at all, and not
         //    factor in the guard pages here.
-        HeapStyle::Static { bound } => {
+        MemoryStyle::Static { byte_reservation } => {
             assert!(
                 can_use_virtual_memory,
                 "static memories require the ability to use virtual memory"
             );
             // NB: this subtraction cannot wrap because we didn't hit the first
             // special case.
-            let adjusted_bound = u64::from(bound) - offset_and_size;
+            let adjusted_bound = byte_reservation - offset_and_size;
             let adjusted_bound_value = builder
                 .ins()
                 .iconst(env.pointer_type(), adjusted_bound as i64);
@@ -433,7 +434,7 @@ where
                 offset,
                 access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::static32(heap.memory_type, u64::from(bound)),
+                AddrPcc::static32(heap.pcc_memory_type, byte_reservation),
                 oob,
             ))
         }
@@ -449,9 +450,9 @@ fn get_dynamic_heap_bound<Env>(
 where
     Env: FuncEnvironment + ?Sized,
 {
-    let enable_pcc = heap.memory_type.is_some();
+    let enable_pcc = heap.pcc_memory_type.is_some();
 
-    let (value, gv) = match (heap.max_size, &heap.style) {
+    let (value, gv) = match heap.memory.static_heap_size() {
         // The heap has a constant size, no need to actually load the
         // bound.  TODO: this is currently disabled for PCC because we
         // can't easily prove that the GV load indeed results in a
@@ -460,22 +461,16 @@ where
         // in the GV, then re-enable this opt. (Or, alternately,
         // compile such memories with a static-bound memtype and
         // facts.)
-        (Some(max_size), HeapStyle::Dynamic { bound_gv })
-            if heap.min_size == max_size && !enable_pcc =>
-        {
-            (
-                builder.ins().iconst(env.pointer_type(), max_size as i64),
-                *bound_gv,
-            )
-        }
-
-        // Load the heap bound from its global variable.
-        (_, HeapStyle::Dynamic { bound_gv }) => (
-            builder.ins().global_value(env.pointer_type(), *bound_gv),
-            *bound_gv,
+        Some(max_size) if !enable_pcc => (
+            builder.ins().iconst(env.pointer_type(), max_size as i64),
+            heap.bound,
         ),
 
-        (_, HeapStyle::Static { .. }) => unreachable!("not a dynamic heap"),
+        // Load the heap bound from its global variable.
+        _ => (
+            builder.ins().global_value(env.pointer_type(), heap.bound),
+            heap.bound,
+        ),
     };
 
     // If proof-carrying code is enabled, apply a fact to the range to

--- a/crates/cranelift/src/translate/environ/spec.rs
+++ b/crates/cranelift/src/translate/environ/spec.rs
@@ -17,8 +17,8 @@ use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;
 use wasmparser::{Operator, WasmFeatures};
 use wasmtime_environ::{
-    DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeConvert, TypeIndex,
-    WasmHeapType, WasmRefType, WasmResult,
+    DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, Tunables, TypeConvert,
+    TypeIndex, WasmHeapType, WasmRefType, WasmResult,
 };
 
 /// The value of a WebAssembly global variable.
@@ -62,6 +62,9 @@ pub trait TargetEnvironment: TypeConvert {
     /// Returns a pair of the CLIF reference type to use and a boolean that
     /// describes whether the value should be included in GC stack maps or not.
     fn reference_type(&self, ty: WasmHeapType) -> (ir::Type, bool);
+
+    /// Returns the compilation knobs that are in effect.
+    fn tunables(&self) -> &Tunables;
 }
 
 /// A smallvec that holds the IR values for a struct's fields.

--- a/crates/cranelift/src/translate/heap.rs
+++ b/crates/cranelift/src/translate/heap.rs
@@ -71,9 +71,6 @@ pub struct HeapData {
     /// Heap accesses larger than this will always trap.
     pub max_size: Option<u64>,
 
-    /// Size in bytes of the offset-guard pages following the heap.
-    pub offset_guard_size: u64,
-
     /// Heap style, with additional style-specific info.
     pub style: HeapStyle,
 

--- a/crates/cranelift/src/translate/mod.rs
+++ b/crates/cranelift/src/translate/mod.rs
@@ -20,7 +20,7 @@ mod translation_utils;
 
 pub use self::environ::{FuncEnvironment, GlobalVariable, StructFieldsVec, TargetEnvironment};
 pub use self::func_translator::FuncTranslator;
-pub use self::heap::{Heap, HeapData, HeapStyle};
+pub use self::heap::{Heap, HeapData};
 pub use self::state::FuncTranslationState;
 pub use self::table::{TableData, TableSize};
 pub use self::translation_utils::*;

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -26,7 +26,7 @@ pub enum MemoryStyle {
 
 impl MemoryStyle {
     /// Decide on an implementation style for the given `Memory`.
-    pub fn for_memory(memory: Memory, tunables: &Tunables) -> (Self, u64) {
+    pub fn for_memory(memory: Memory, tunables: &Tunables) -> Self {
         let is_static =
             // Ideally we would compare against (an upper bound on) the target's
             // page size, but unfortunately that is a little hard to plumb
@@ -55,21 +55,15 @@ impl MemoryStyle {
             };
 
         if is_static {
-            return (
-                Self::Static {
-                    byte_reservation: tunables.memory_reservation,
-                },
-                tunables.memory_guard_size,
-            );
+            return Self::Static {
+                byte_reservation: tunables.memory_reservation,
+            };
         }
 
         // Otherwise, make it dynamic.
-        (
-            Self::Dynamic {
-                reserve: tunables.memory_reservation_for_growth,
-            },
-            tunables.memory_guard_size,
-        )
+        Self::Dynamic {
+            reserve: tunables.memory_reservation_for_growth,
+        }
     }
 }
 

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -1797,6 +1797,19 @@ impl Memory {
             IndexType::I32 => WASM32_MAX_SIZE,
         }
     }
+
+    /// Returns the static size of this heap in bytes at runtime, if available.
+    ///
+    /// This is only computable when the minimum size equals the maximum size.
+    pub fn static_heap_size(&self) -> Option<u64> {
+        let min = self.minimum_byte_size().ok()?;
+        let max = self.maximum_byte_size().ok()?;
+        if min == max {
+            Some(min)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -1053,12 +1053,12 @@ mod tests {
         let ty = MemoryType::new(1, None);
         let mem = Memory::new(&mut store, ty).unwrap();
         let store = store.as_context();
-        let (style, offset_guard_size) = wasmtime_environ::MemoryStyle::for_memory(
+        let style = wasmtime_environ::MemoryStyle::for_memory(
             store[mem.0].memory,
             store.engine().tunables(),
         );
 
-        assert_eq!(offset_guard_size, 0);
+        assert_eq!(store.engine().tunables().memory_guard_size, 0);
         match style {
             wasmtime_environ::MemoryStyle::Dynamic { .. } => {}
             other => panic!("unexpected style {other:?}"),

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -128,7 +128,7 @@ impl RuntimeMemoryCreator for MemoryCreatorProxy {
         maximum: Option<usize>,
         _: Option<&Arc<MemoryImage>>,
     ) -> Result<Box<dyn RuntimeLinearMemory>> {
-        let (style, offset_guard_size) = MemoryStyle::for_memory(*ty, tunables);
+        let style = MemoryStyle::for_memory(*ty, tunables);
         let reserved_size_in_bytes = match style {
             MemoryStyle::Static { byte_reservation } => {
                 Some(usize::try_from(byte_reservation).unwrap())
@@ -141,7 +141,7 @@ impl RuntimeMemoryCreator for MemoryCreatorProxy {
                 minimum,
                 maximum,
                 reserved_size_in_bytes,
-                usize::try_from(offset_guard_size).unwrap(),
+                usize::try_from(tunables.memory_guard_size).unwrap(),
             )
             .map(|mem| {
                 Box::new(LinearMemoryProxy {

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -450,9 +450,9 @@ impl MemoryImageSlot {
         // and/or is static), then we need to reset memory protections. Put
         // another way, the only time it is safe to not reset protections is
         // when we are using dynamic memory without any guard pages.
-        let (style, offset_guard_size) = MemoryStyle::for_memory(*ty, tunables);
+        let style = MemoryStyle::for_memory(*ty, tunables);
         if initial_size_bytes_page_aligned < self.accessible
-            && (offset_guard_size > 0 || matches!(style, MemoryStyle::Static { .. }))
+            && (tunables.memory_guard_size > 0 || matches!(style, MemoryStyle::Static { .. }))
         {
             self.set_protection(initial_size_bytes_page_aligned..self.accessible, false)?;
             self.accessible = initial_size_bytes_page_aligned;

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -338,7 +338,7 @@ impl MemoryPool {
             // satisfied by the configuration of this pooling allocator. This
             // should be returned as an error through `validate_memory_plans`
             // but double-check here to be sure.
-            let (style, _) = MemoryStyle::for_memory(*ty, tunables);
+            let style = MemoryStyle::for_memory(*ty, tunables);
             match style {
                 MemoryStyle::Static { byte_reservation } => {
                     assert!(

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -223,12 +223,12 @@ impl MmapMemory {
         mut maximum: Option<usize>,
         memory_image: Option<&Arc<MemoryImage>>,
     ) -> Result<Self> {
-        let (style, offset_guard_size) = MemoryStyle::for_memory(*ty, tunables);
+        let style = MemoryStyle::for_memory(*ty, tunables);
 
         // It's a programmer error for these two configuration values to exceed
         // the host available address space, so panic if such a configuration is
         // found (mostly an issue for hypothetical 32-bit hosts).
-        let offset_guard_bytes = usize::try_from(offset_guard_size).unwrap();
+        let offset_guard_bytes = usize::try_from(tunables.memory_guard_size).unwrap();
         let pre_guard_bytes = if tunables.guard_before_linear_memory {
             offset_guard_bytes
         } else {

--- a/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
+++ b/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
@@ -45,7 +45,7 @@ impl SharedMemory {
         if !ty.shared {
             bail!("shared memory must have a `shared` memory type");
         }
-        let (style, _) = MemoryStyle::for_memory(*ty, tunables);
+        let style = MemoryStyle::for_memory(*ty, tunables);
         if !matches!(style, MemoryStyle::Static { .. }) {
             bail!("shared memory can only be built from a static memory allocation")
         }

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -14,16 +14,17 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0021                               v5 = uextend.i64 v2
-;; @0021                               v6 = global_value.i64 gv4
+;; @0021                               v6 = global_value.i64 gv5
 ;; @0021                               v7 = iadd v6, v5
 ;; @0021                               v8 = load.i32 little heap v7
 ;; @0026                               v9 = uextend.i64 v3
-;; @0026                               v10 = global_value.i64 gv4
+;; @0026                               v10 = global_value.i64 gv5
 ;; @0026                               v11 = iadd v10, v9
 ;; @0026                               v12 = load.i32 little heap v11
 ;; @0029                               v13 = iadd v8, v12

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -22,7 +22,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -41,7 +42,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -11,12 +11,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v5 = global_value.i64 gv5
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f32 little heap v6
 ;; @0031                               jump block1(v7)

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v5 = global_value.i64 gv5
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f64 little heap v6
 ;; @0031                               jump block1(v7)

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -28,7 +28,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -54,7 +55,7 @@
 ;;                                 block2:
 ;; @0056                               v16 = iconst.i32 0
 ;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
-;; @005a                               v18 = global_value.i64 gv4
+;; @005a                               v18 = global_value.i64 gv5
 ;; @005a                               v19 = iadd v18, v17
 ;; @005a                               store.i32 little heap v11, v19
 ;; @005d                               jump block1

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -14,7 +14,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -23,7 +24,7 @@
 ;; @002b                               v4 = global_value.i64 gv3
 ;; @002b                               v5 = load.i32 notrap aligned table v4+112
 ;; @002d                               v6 = uextend.i64 v3  ; v3 = 0
-;; @002d                               v7 = global_value.i64 gv4
+;; @002d                               v7 = global_value.i64 gv5
 ;; @002d                               v8 = iadd v7, v6
 ;; @002d                               store little heap v5, v8
 ;; @0030                               jump block1

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v5 = global_value.i64 gv5
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i32 little heap v6
 ;; @0031                               jump block1(v7)

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v5 = global_value.i64 gv5
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i32 little heap v6
 ;; @0035                               jump block1(v7)

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v5 = global_value.i64 gv5
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i32 little heap v6
 ;; @0035                               jump block1(v7)

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i32 little heap v6
 ;; @0034                               jump block1(v7)

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i32 little heap v6
 ;; @0034                               jump block1(v7)

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = global_value.i64 gv4
+;; @0033                               v5 = global_value.i64 gv5
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v5 = global_value.i64 gv5
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv4
+;; @002e                               v5 = global_value.i64 gv5
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i64 little heap v6
 ;; @0031                               jump block1(v7)

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v5 = global_value.i64 gv5
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i64 little heap v6
 ;; @0035                               jump block1(v7)

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v5 = global_value.i64 gv5
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i64 little heap v6
 ;; @0035                               jump block1(v7)

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i64 little heap v6
 ;; @0034                               jump block1(v7)

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -13,12 +13,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i64 little heap v6
 ;; @0034                               jump block1(v7)

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv4
+;; @0031                               v5 = global_value.i64 gv5
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = global_value.i64 gv4
+;; @0033                               v5 = global_value.i64 gv5
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = global_value.i64 gv4
+;; @0033                               v5 = global_value.i64 gv5
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore32 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -14,12 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv4
+;; @0032                               v5 = global_value.i64 gv5
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -24,7 +24,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+112
+;;     gv4 = load.i64 notrap aligned gv3+120
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+112
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +34,7 @@
 ;;
 ;;                                 block2:
 ;; @0058                               v7 = uextend.i64 v2
-;; @0058                               v8 = global_value.i64 gv4
+;; @0058                               v8 = global_value.i64 gv5
 ;; @0058                               v9 = iadd v8, v7
 ;; @0058                               v10 = sload16.i64 little heap v9
 ;; @005c                               jump block3

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -47,7 +47,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+112
+;;     gv4 = load.i64 notrap aligned gv3+120
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+112
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +60,7 @@
 ;;
 ;;                                 block4:
 ;; @004b                               v7 = uextend.i64 v4
-;; @004b                               v8 = global_value.i64 gv4
+;; @004b                               v8 = global_value.i64 gv5
 ;; @004b                               v9 = iadd v8, v7
 ;; @004b                               v10 = sload16.i64 little heap v9
 ;; @004e                               trap user11

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -23,7 +23,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -31,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
@@ -45,7 +46,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -53,7 +55,7 @@
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = global_value.i64 gv4
+;; @0048                               v7 = global_value.i64 gv5
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = load.i32 little heap v8
 ;; @004b                               jump block1(v9)

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -23,7 +23,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -31,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -47,7 +48,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v7 = global_value.i64 gv5
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -23,7 +23,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -31,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -47,7 +48,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = global_value.i64 gv5
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -42,12 +43,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = global_value.i64 gv5
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1(v7)

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -23,7 +23,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -31,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -47,7 +48,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v7 = global_value.i64 gv5
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -23,7 +23,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -31,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -47,7 +48,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +57,7 @@
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = global_value.i64 gv5
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0048                               v7 = global_value.i64 gv4
+;; @0048                               v7 = global_value.i64 gv5
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -48,14 +49,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v7 = global_value.i64 gv5
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -48,14 +49,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = global_value.i64 gv5
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -42,12 +43,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = global_value.i64 gv5
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1(v7)

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -48,14 +49,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0049                               v7 = global_value.i64 gv4
+;; @0049                               v7 = global_value.i64 gv5
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = global_value.i64 gv5
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -48,14 +49,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = global_value.i64 gv5
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -42,12 +43,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = global_value.i64 gv5
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
 ;; @004b                               jump block1(v7)

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = global_value.i64 gv5
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = global_value.i64 gv5
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -42,12 +43,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = global_value.i64 gv5
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1(v7)

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = global_value.i64 gv5
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = global_value.i64 gv5
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -42,12 +43,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = global_value.i64 gv5
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
 ;; @004b                               jump block1(v7)

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = global_value.i64 gv5
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = global_value.i64 gv5
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -42,12 +43,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = global_value.i64 gv5
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1(v7)

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = global_value.i64 gv5
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -23,12 +23,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = global_value.i64 gv5
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -44,12 +45,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = global_value.i64 gv5
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -44,14 +45,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1(v8)

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -44,14 +45,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1(v8)

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -45,13 +46,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -45,13 +46,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -44,14 +45,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1(v8)

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -44,14 +45,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1(v8)

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -23,14 +23,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -46,14 +47,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -45,13 +46,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -45,13 +46,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = global_value.i64 gv4
+;; @0048                               v6 = global_value.i64 gv5
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = global_value.i64 gv4
+;; @0049                               v6 = global_value.i64 gv5
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -23,13 +23,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = global_value.i64 gv5
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -47,13 +48,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = global_value.i64 gv5
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -17,7 +17,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -25,12 +26,12 @@
 ;; @0021                               v3 = iconst.i32 0
 ;; @0023                               v4 = iconst.i32 0
 ;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0025                               v6 = global_value.i64 gv4
+;; @0025                               v6 = global_value.i64 gv5
 ;; @0025                               v7 = iadd v6, v5
 ;; @0025                               store little heap v4, v7  ; v4 = 0
 ;; @0028                               v8 = iconst.i32 0
 ;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
-;; @002a                               v10 = global_value.i64 gv4
+;; @002a                               v10 = global_value.i64 gv5
 ;; @002a                               v11 = iadd v10, v9
 ;; @002a                               v12 = load.i32 little heap v11
 ;; @002d                               brif v12, block2, block4
@@ -39,7 +40,7 @@
 ;; @002f                               v13 = iconst.i32 0
 ;; @0031                               v14 = iconst.i32 10
 ;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
-;; @0033                               v16 = global_value.i64 gv4
+;; @0033                               v16 = global_value.i64 gv5
 ;; @0033                               v17 = iadd v16, v15
 ;; @0033                               store little heap v14, v17  ; v14 = 10
 ;; @0036                               jump block3
@@ -48,7 +49,7 @@
 ;; @0037                               v18 = iconst.i32 0
 ;; @0039                               v19 = iconst.i32 11
 ;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
-;; @003b                               v21 = global_value.i64 gv4
+;; @003b                               v21 = global_value.i64 gv5
 ;; @003b                               v22 = iadd v21, v20
 ;; @003b                               store little heap v19, v22  ; v19 = 11
 ;; @003e                               jump block3

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -18,7 +18,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i32 uext, i32 uext) system_v
 ;;     fn0 = colocated u1:6 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -21,19 +21,20 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0036                               v3 = iconst.i32 48
 ;; @0038                               v4 = iconst.i32 0
 ;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
-;; @003a                               v6 = global_value.i64 gv4
+;; @003a                               v6 = global_value.i64 gv5
 ;; @003a                               v7 = iadd v6, v5
 ;; @003a                               v8 = load.i8x16 little heap v7
 ;; @003e                               v9 = iconst.i32 16
 ;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
-;; @0040                               v11 = global_value.i64 gv4
+;; @0040                               v11 = global_value.i64 gv5
 ;; @0040                               v12 = iadd v11, v10
 ;; @0040                               v13 = load.i8x16 little heap v12
 ;; @0046                               brif v2, block2, block4(v8, v13)
@@ -44,7 +45,7 @@
 ;; @0048                               v18 = iadd v16, v17
 ;; @004b                               v19 = iconst.i32 32
 ;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
-;; @004d                               v21 = global_value.i64 gv4
+;; @004d                               v21 = global_value.i64 gv5
 ;; @004d                               v22 = iadd v21, v20
 ;; @004d                               v23 = load.i8x16 little heap v22
 ;; @0051                               v26 = bitcast.i8x16 little v18
@@ -56,7 +57,7 @@
 ;; @0052                               v29 = isub v27, v28
 ;; @0055                               v30 = iconst.i32 0
 ;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
-;; @0057                               v32 = global_value.i64 gv4
+;; @0057                               v32 = global_value.i64 gv5
 ;; @0057                               v33 = iadd v32, v31
 ;; @0057                               v34 = load.i8x16 little heap v33
 ;; @005b                               v35 = bitcast.i8x16 little v29
@@ -67,7 +68,7 @@
 ;; @005c                               v37 = bitcast.i16x8 little v15
 ;; @005c                               v38 = imul v36, v37
 ;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
-;; @005f                               v40 = global_value.i64 gv4
+;; @005f                               v40 = global_value.i64 gv5
 ;; @005f                               v41 = iadd v40, v39
 ;; @005f                               store little heap v38, v41
 ;; @0063                               jump block1

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -89,14 +89,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @003f                               v3 = iconst.i32 0
 ;; @0045                               v4 = icmp eq v2, v2
 ;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0047                               v6 = global_value.i64 gv4
+;; @0047                               v6 = global_value.i64 gv5
 ;; @0047                               v7 = iadd v6, v5
 ;; @0047                               store little heap v4, v7
 ;; @004b                               jump block1
@@ -110,7 +111,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -119,7 +121,7 @@
 ;; @0054                               v5 = bitcast.i16x8 little v2
 ;; @0054                               v6 = icmp eq v4, v5
 ;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v8 = global_value.i64 gv4
+;; @0056                               v8 = global_value.i64 gv5
 ;; @0056                               v9 = iadd v8, v7
 ;; @0056                               store little heap v6, v9
 ;; @005a                               jump block1
@@ -133,7 +135,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -142,7 +145,7 @@
 ;; @0063                               v5 = bitcast.i32x4 little v2
 ;; @0063                               v6 = icmp eq v4, v5
 ;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0065                               v8 = global_value.i64 gv4
+;; @0065                               v8 = global_value.i64 gv5
 ;; @0065                               v9 = iadd v8, v7
 ;; @0065                               store little heap v6, v9
 ;; @0069                               jump block1
@@ -156,7 +159,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -165,7 +169,7 @@
 ;; @0072                               v5 = bitcast.i64x2 little v2
 ;; @0072                               v6 = icmp eq v4, v5
 ;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0075                               v8 = global_value.i64 gv4
+;; @0075                               v8 = global_value.i64 gv5
 ;; @0075                               v9 = iadd v8, v7
 ;; @0075                               store little heap v6, v9
 ;; @0079                               jump block1
@@ -179,14 +183,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @007c                               v3 = iconst.i32 0
 ;; @0082                               v4 = icmp ne v2, v2
 ;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0084                               v6 = global_value.i64 gv4
+;; @0084                               v6 = global_value.i64 gv5
 ;; @0084                               v7 = iadd v6, v5
 ;; @0084                               store little heap v4, v7
 ;; @0088                               jump block1
@@ -200,7 +205,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -209,7 +215,7 @@
 ;; @0091                               v5 = bitcast.i16x8 little v2
 ;; @0091                               v6 = icmp ne v4, v5
 ;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0093                               v8 = global_value.i64 gv4
+;; @0093                               v8 = global_value.i64 gv5
 ;; @0093                               v9 = iadd v8, v7
 ;; @0093                               store little heap v6, v9
 ;; @0097                               jump block1
@@ -223,7 +229,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -232,7 +239,7 @@
 ;; @00a0                               v5 = bitcast.i32x4 little v2
 ;; @00a0                               v6 = icmp ne v4, v5
 ;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00a2                               v8 = global_value.i64 gv4
+;; @00a2                               v8 = global_value.i64 gv5
 ;; @00a2                               v9 = iadd v8, v7
 ;; @00a2                               store little heap v6, v9
 ;; @00a6                               jump block1
@@ -246,7 +253,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -255,7 +263,7 @@
 ;; @00af                               v5 = bitcast.i64x2 little v2
 ;; @00af                               v6 = icmp ne v4, v5
 ;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00b2                               v8 = global_value.i64 gv4
+;; @00b2                               v8 = global_value.i64 gv5
 ;; @00b2                               v9 = iadd v8, v7
 ;; @00b2                               store little heap v6, v9
 ;; @00b6                               jump block1
@@ -269,14 +277,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @00b9                               v3 = iconst.i32 0
 ;; @00bf                               v4 = icmp slt v2, v2
 ;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00c1                               v6 = global_value.i64 gv4
+;; @00c1                               v6 = global_value.i64 gv5
 ;; @00c1                               v7 = iadd v6, v5
 ;; @00c1                               store little heap v4, v7
 ;; @00c5                               jump block1
@@ -290,7 +299,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -299,7 +309,7 @@
 ;; @00ce                               v5 = bitcast.i16x8 little v2
 ;; @00ce                               v6 = icmp slt v4, v5
 ;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00d0                               v8 = global_value.i64 gv4
+;; @00d0                               v8 = global_value.i64 gv5
 ;; @00d0                               v9 = iadd v8, v7
 ;; @00d0                               store little heap v6, v9
 ;; @00d4                               jump block1
@@ -313,7 +323,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -322,7 +333,7 @@
 ;; @00dd                               v5 = bitcast.i32x4 little v2
 ;; @00dd                               v6 = icmp slt v4, v5
 ;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00df                               v8 = global_value.i64 gv4
+;; @00df                               v8 = global_value.i64 gv5
 ;; @00df                               v9 = iadd v8, v7
 ;; @00df                               store little heap v6, v9
 ;; @00e3                               jump block1
@@ -336,7 +347,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -345,7 +357,7 @@
 ;; @00ec                               v5 = bitcast.i64x2 little v2
 ;; @00ec                               v6 = icmp slt v4, v5
 ;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00ef                               v8 = global_value.i64 gv4
+;; @00ef                               v8 = global_value.i64 gv5
 ;; @00ef                               v9 = iadd v8, v7
 ;; @00ef                               store little heap v6, v9
 ;; @00f3                               jump block1
@@ -359,14 +371,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @00f6                               v3 = iconst.i32 0
 ;; @00fc                               v4 = icmp ult v2, v2
 ;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00fe                               v6 = global_value.i64 gv4
+;; @00fe                               v6 = global_value.i64 gv5
 ;; @00fe                               v7 = iadd v6, v5
 ;; @00fe                               store little heap v4, v7
 ;; @0102                               jump block1
@@ -380,7 +393,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -389,7 +403,7 @@
 ;; @010b                               v5 = bitcast.i16x8 little v2
 ;; @010b                               v6 = icmp ult v4, v5
 ;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @010d                               v8 = global_value.i64 gv4
+;; @010d                               v8 = global_value.i64 gv5
 ;; @010d                               v9 = iadd v8, v7
 ;; @010d                               store little heap v6, v9
 ;; @0111                               jump block1
@@ -403,7 +417,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -412,7 +427,7 @@
 ;; @011a                               v5 = bitcast.i32x4 little v2
 ;; @011a                               v6 = icmp ult v4, v5
 ;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @011c                               v8 = global_value.i64 gv4
+;; @011c                               v8 = global_value.i64 gv5
 ;; @011c                               v9 = iadd v8, v7
 ;; @011c                               store little heap v6, v9
 ;; @0120                               jump block1
@@ -426,14 +441,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0123                               v3 = iconst.i32 0
 ;; @0129                               v4 = icmp sgt v2, v2
 ;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
-;; @012b                               v6 = global_value.i64 gv4
+;; @012b                               v6 = global_value.i64 gv5
 ;; @012b                               v7 = iadd v6, v5
 ;; @012b                               store little heap v4, v7
 ;; @012f                               jump block1
@@ -447,7 +463,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -456,7 +473,7 @@
 ;; @0138                               v5 = bitcast.i16x8 little v2
 ;; @0138                               v6 = icmp sgt v4, v5
 ;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @013a                               v8 = global_value.i64 gv4
+;; @013a                               v8 = global_value.i64 gv5
 ;; @013a                               v9 = iadd v8, v7
 ;; @013a                               store little heap v6, v9
 ;; @013e                               jump block1
@@ -470,7 +487,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -479,7 +497,7 @@
 ;; @0147                               v5 = bitcast.i32x4 little v2
 ;; @0147                               v6 = icmp sgt v4, v5
 ;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0149                               v8 = global_value.i64 gv4
+;; @0149                               v8 = global_value.i64 gv5
 ;; @0149                               v9 = iadd v8, v7
 ;; @0149                               store little heap v6, v9
 ;; @014d                               jump block1
@@ -493,7 +511,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -502,7 +521,7 @@
 ;; @0156                               v5 = bitcast.i64x2 little v2
 ;; @0156                               v6 = icmp sgt v4, v5
 ;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0159                               v8 = global_value.i64 gv4
+;; @0159                               v8 = global_value.i64 gv5
 ;; @0159                               v9 = iadd v8, v7
 ;; @0159                               store little heap v6, v9
 ;; @015d                               jump block1
@@ -516,14 +535,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0160                               v3 = iconst.i32 0
 ;; @0166                               v4 = icmp ugt v2, v2
 ;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0168                               v6 = global_value.i64 gv4
+;; @0168                               v6 = global_value.i64 gv5
 ;; @0168                               v7 = iadd v6, v5
 ;; @0168                               store little heap v4, v7
 ;; @016c                               jump block1
@@ -537,7 +557,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -546,7 +567,7 @@
 ;; @0175                               v5 = bitcast.i16x8 little v2
 ;; @0175                               v6 = icmp ugt v4, v5
 ;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0177                               v8 = global_value.i64 gv4
+;; @0177                               v8 = global_value.i64 gv5
 ;; @0177                               v9 = iadd v8, v7
 ;; @0177                               store little heap v6, v9
 ;; @017b                               jump block1
@@ -560,7 +581,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -569,7 +591,7 @@
 ;; @0184                               v5 = bitcast.i32x4 little v2
 ;; @0184                               v6 = icmp ugt v4, v5
 ;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0186                               v8 = global_value.i64 gv4
+;; @0186                               v8 = global_value.i64 gv5
 ;; @0186                               v9 = iadd v8, v7
 ;; @0186                               store little heap v6, v9
 ;; @018a                               jump block1
@@ -583,7 +605,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -592,7 +615,7 @@
 ;; @0193                               v5 = bitcast.f32x4 little v2
 ;; @0193                               v6 = fcmp eq v4, v5
 ;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0195                               v8 = global_value.i64 gv4
+;; @0195                               v8 = global_value.i64 gv5
 ;; @0195                               v9 = iadd v8, v7
 ;; @0195                               store little heap v6, v9
 ;; @0199                               jump block1
@@ -606,7 +629,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -615,7 +639,7 @@
 ;; @01a2                               v5 = bitcast.f64x2 little v2
 ;; @01a2                               v6 = fcmp eq v4, v5
 ;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01a4                               v8 = global_value.i64 gv4
+;; @01a4                               v8 = global_value.i64 gv5
 ;; @01a4                               v9 = iadd v8, v7
 ;; @01a4                               store little heap v6, v9
 ;; @01a8                               jump block1
@@ -629,7 +653,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -638,7 +663,7 @@
 ;; @01b1                               v5 = bitcast.f32x4 little v2
 ;; @01b1                               v6 = fcmp ne v4, v5
 ;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01b3                               v8 = global_value.i64 gv4
+;; @01b3                               v8 = global_value.i64 gv5
 ;; @01b3                               v9 = iadd v8, v7
 ;; @01b3                               store little heap v6, v9
 ;; @01b7                               jump block1
@@ -652,7 +677,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -661,7 +687,7 @@
 ;; @01c0                               v5 = bitcast.f64x2 little v2
 ;; @01c0                               v6 = fcmp ne v4, v5
 ;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01c2                               v8 = global_value.i64 gv4
+;; @01c2                               v8 = global_value.i64 gv5
 ;; @01c2                               v9 = iadd v8, v7
 ;; @01c2                               store little heap v6, v9
 ;; @01c6                               jump block1
@@ -675,7 +701,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -684,7 +711,7 @@
 ;; @01cf                               v5 = bitcast.f32x4 little v2
 ;; @01cf                               v6 = fcmp lt v4, v5
 ;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01d1                               v8 = global_value.i64 gv4
+;; @01d1                               v8 = global_value.i64 gv5
 ;; @01d1                               v9 = iadd v8, v7
 ;; @01d1                               store little heap v6, v9
 ;; @01d5                               jump block1
@@ -698,7 +725,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -707,7 +735,7 @@
 ;; @01de                               v5 = bitcast.f64x2 little v2
 ;; @01de                               v6 = fcmp lt v4, v5
 ;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01e0                               v8 = global_value.i64 gv4
+;; @01e0                               v8 = global_value.i64 gv5
 ;; @01e0                               v9 = iadd v8, v7
 ;; @01e0                               store little heap v6, v9
 ;; @01e4                               jump block1
@@ -721,7 +749,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -730,7 +759,7 @@
 ;; @01ed                               v5 = bitcast.f32x4 little v2
 ;; @01ed                               v6 = fcmp le v4, v5
 ;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01ef                               v8 = global_value.i64 gv4
+;; @01ef                               v8 = global_value.i64 gv5
 ;; @01ef                               v9 = iadd v8, v7
 ;; @01ef                               store little heap v6, v9
 ;; @01f3                               jump block1
@@ -744,7 +773,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -753,7 +783,7 @@
 ;; @01fc                               v5 = bitcast.f64x2 little v2
 ;; @01fc                               v6 = fcmp le v4, v5
 ;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01fe                               v8 = global_value.i64 gv4
+;; @01fe                               v8 = global_value.i64 gv5
 ;; @01fe                               v9 = iadd v8, v7
 ;; @01fe                               store little heap v6, v9
 ;; @0202                               jump block1
@@ -767,7 +797,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -776,7 +807,7 @@
 ;; @020b                               v5 = bitcast.f32x4 little v2
 ;; @020b                               v6 = fcmp gt v4, v5
 ;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @020d                               v8 = global_value.i64 gv4
+;; @020d                               v8 = global_value.i64 gv5
 ;; @020d                               v9 = iadd v8, v7
 ;; @020d                               store little heap v6, v9
 ;; @0211                               jump block1
@@ -790,7 +821,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -799,7 +831,7 @@
 ;; @021a                               v5 = bitcast.f64x2 little v2
 ;; @021a                               v6 = fcmp gt v4, v5
 ;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @021c                               v8 = global_value.i64 gv4
+;; @021c                               v8 = global_value.i64 gv5
 ;; @021c                               v9 = iadd v8, v7
 ;; @021c                               store little heap v6, v9
 ;; @0220                               jump block1
@@ -813,7 +845,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -822,7 +855,7 @@
 ;; @0229                               v5 = bitcast.f32x4 little v2
 ;; @0229                               v6 = fcmp ge v4, v5
 ;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
-;; @022b                               v8 = global_value.i64 gv4
+;; @022b                               v8 = global_value.i64 gv5
 ;; @022b                               v9 = iadd v8, v7
 ;; @022b                               store little heap v6, v9
 ;; @022f                               jump block1
@@ -836,7 +869,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly checked gv3+96
+;;     gv4 = load.i64 notrap aligned gv3+104
+;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -845,7 +879,7 @@
 ;; @0238                               v5 = bitcast.f64x2 little v2
 ;; @0238                               v6 = fcmp ge v4, v5
 ;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @023a                               v8 = global_value.i64 gv4
+;; @023a                               v8 = global_value.i64 gv5
 ;; @023a                               v9 = iadd v8, v7
 ;; @023a                               store little heap v6, v9
 ;; @023e                               jump block1

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -11,9 +11,9 @@ use std::collections::{
 use std::mem;
 use wasmparser::BlockType;
 use wasmtime_environ::{
-    BuiltinFunctionIndex, FuncIndex, GlobalIndex, Memory, MemoryIndex, MemoryStyle,
-    ModuleTranslation, ModuleTypesBuilder, PrimaryMap, PtrSize, Table, TableIndex, Tunables,
-    TypeConvert, TypeIndex, VMOffsets, WasmHeapType, WasmValType,
+    BuiltinFunctionIndex, FuncIndex, GlobalIndex, IndexType, Memory, MemoryIndex,
+    ModuleTranslation, ModuleTypesBuilder, PrimaryMap, PtrSize, Table, TableIndex, TypeConvert,
+    TypeIndex, VMOffsets, WasmHeapType, WasmValType,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -42,20 +42,6 @@ pub struct TableData {
     pub(crate) current_elements_size: OperandSize,
 }
 
-/// Style of the heap.
-#[derive(Debug, Copy, Clone)]
-pub enum HeapStyle {
-    /// Static heap, which has a fixed address.
-    Static {
-        /// The heap bound in bytes, not including the bytes for the offset
-        /// guard pages.
-        bound: u64,
-    },
-    /// Dynamic heap, which can be relocated to a different address when grown.
-    /// The bounds are calculated at runtime on every access.
-    Dynamic,
-}
-
 /// Heap metadata.
 ///
 /// Heaps represent a WebAssembly linear memory.
@@ -71,19 +57,17 @@ pub struct HeapData {
     /// If the WebAssembly memory is imported, this field contains the offset to locate the
     /// base of the heap.
     pub import_from: Option<u32>,
-    /// The memory type (32 or 64).
-    pub ty: WasmValType,
-    /// The style of the heap.
-    pub style: HeapStyle,
-    /// The guaranteed minimum size, in bytes.
-    pub min_size: u64,
-    /// The maximum heap size in bytes.
-    pub max_size: Option<u64>,
-    /// The log2 of this memory's page size, in bytes.
-    ///
-    /// By default the page size is 64KiB (0x10000; 2**16; 1<<16; 65536) but the
-    /// custom-page-sizes proposal allows opting into a page size of `1`.
-    pub page_size_log2: u8,
+    /// The memory type this heap is associated with.
+    pub memory: Memory,
+}
+
+impl HeapData {
+    pub fn index_type(&self) -> WasmValType {
+        match self.memory.idx_type {
+            IndexType::I32 => WasmValType::I32,
+            IndexType::I64 => WasmValType::I64,
+        }
+    }
 }
 
 /// A function callee.
@@ -114,8 +98,6 @@ pub struct FuncEnv<'a, 'translation: 'a, 'data: 'translation, P: PtrSize> {
     pub types: &'translation ModuleTypesBuilder,
     /// The built-in functions available to the JIT code.
     pub builtins: &'translation mut BuiltinFunctions,
-    /// Configurable code generation options.
-    tunables: &'translation Tunables,
     /// Track resolved table information.
     resolved_tables: HashMap<TableIndex, TableData>,
     /// Track resolved heap information.
@@ -151,7 +133,6 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
         translation: &'translation ModuleTranslation<'data>,
         types: &'translation ModuleTypesBuilder,
         builtins: &'translation mut BuiltinFunctions,
-        tunables: &'translation Tunables,
         isa: &dyn TargetIsa,
         ptr_type: WasmValType,
     ) -> Self {
@@ -159,7 +140,6 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
             vmoffsets,
             translation,
             types,
-            tunables,
             resolved_tables: HashMap::new(),
             resolved_heaps: HashMap::new(),
             resolved_callees: HashMap::new(),
@@ -292,21 +272,12 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
                     };
 
                 let memory = &self.translation.module.memories[index];
-                let (min_size, max_size) = heap_limits(memory);
-                let style = heap_style_and_offset_guard_size(memory, self.tunables);
 
                 *entry.insert(HeapData {
                     offset: base_offset,
                     import_from,
                     current_length_offset,
-                    style,
-                    ty: match memory.idx_type {
-                        wasmtime_environ::IndexType::I32 => WasmValType::I32,
-                        wasmtime_environ::IndexType::I64 => WasmValType::I64,
-                    },
-                    min_size,
-                    max_size,
-                    page_size_log2: memory.page_size_log2,
+                    memory: *memory,
                 })
             }
         }
@@ -419,26 +390,4 @@ impl<'a, 'data> TypeConverter<'a, 'data> {
     pub fn new(translation: &'a ModuleTranslation<'data>, types: &'a ModuleTypesBuilder) -> Self {
         Self { translation, types }
     }
-}
-
-fn heap_style_and_offset_guard_size(memory: &Memory, tunables: &Tunables) -> HeapStyle {
-    let style = MemoryStyle::for_memory(*memory, tunables);
-    match style {
-        MemoryStyle::Static { byte_reservation } => HeapStyle::Static {
-            bound: byte_reservation,
-        },
-
-        MemoryStyle::Dynamic { .. } => HeapStyle::Dynamic,
-    }
-}
-
-fn heap_limits(memory: &Memory) -> (u64, Option<u64>) {
-    (
-        memory.minimum_byte_size().unwrap_or_else(|_| {
-            // 2^64 as a minimum doesn't fin in a 64 bit integer.
-            // So in this case, the minimum is clamped to u64::MAX.
-            u64::MAX
-        }),
-        memory.maximum_byte_size().ok(),
-    )
 }

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -84,8 +84,6 @@ pub struct HeapData {
     /// By default the page size is 64KiB (0x10000; 2**16; 1<<16; 65536) but the
     /// custom-page-sizes proposal allows opting into a page size of `1`.
     pub page_size_log2: u8,
-    /// Size in bytes of the offset guard pages, located after the heap bounds.
-    pub offset_guard_size: u64,
 }
 
 /// A function callee.
@@ -309,7 +307,6 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
                     min_size,
                     max_size,
                     page_size_log2: memory.page_size_log2,
-                    offset_guard_size: self.tunables.memory_guard_size,
                 })
             }
         }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -8,20 +8,19 @@ use crate::{
     stack::TypedReg,
 };
 use anyhow::Result;
-use smallvec::SmallVec;
-use wasmparser::{
-    BinaryReader, FuncValidator, MemArg, Operator, ValidatorResources, VisitOperator,
-};
-use wasmtime_environ::{
-    GlobalIndex, MemoryIndex, PtrSize, TableIndex, Tunables, TypeIndex, WasmHeapType, WasmValType,
-    FUNCREF_MASK,
-};
-
 use cranelift_codegen::{
     binemit::CodeOffset,
     ir::{RelSourceLoc, SourceLoc},
 };
+use smallvec::SmallVec;
+use wasmparser::{
+    BinaryReader, FuncValidator, MemArg, Operator, ValidatorResources, VisitOperator,
+};
 use wasmtime_cranelift::{TRAP_BAD_SIGNATURE, TRAP_TABLE_OUT_OF_BOUNDS};
+use wasmtime_environ::{
+    GlobalIndex, MemoryIndex, MemoryStyle, PtrSize, TableIndex, Tunables, TypeIndex, WasmHeapType,
+    WasmValType, FUNCREF_MASK,
+};
 
 mod context;
 pub(crate) use context::*;
@@ -585,11 +584,16 @@ where
         let memory_index = MemoryIndex::from_u32(memarg.memory);
         let heap = self.env.resolve_heap(memory_index);
         let index = Index::from_typed_reg(self.context.pop_to_reg(self.masm, None));
-        let offset =
-            bounds::ensure_index_and_offset(self.masm, index, memarg.offset, heap.ty.into());
+        let offset = bounds::ensure_index_and_offset(
+            self.masm,
+            index,
+            memarg.offset,
+            heap.index_type().into(),
+        );
         let offset_with_access_size = add_offset_and_access_size(offset, access_size);
 
-        let addr = match heap.style {
+        let style = MemoryStyle::for_memory(heap.memory, self.tunables);
+        let addr = match style {
             // == Dynamic Heaps ==
 
             // Account for the general case for dynamic memories. The access is
@@ -597,7 +601,7 @@ where
             // * index + offset + access_size overflows
             //   OR
             // * index + offset + access_size > bound
-            HeapStyle::Dynamic => {
+            MemoryStyle::Dynamic { .. } => {
                 let bounds =
                     bounds::load_dynamic_heap_bounds(&mut self.context, self.masm, &heap, ptr_size);
 
@@ -621,7 +625,7 @@ where
                 self.masm.mov(
                     writable!(index_offset_and_access_size),
                     index_reg.into(),
-                    heap.ty.into(),
+                    heap.index_type().into(),
                 );
                 // Perform
                 // index = index + offset + access_size, trapping if the
@@ -675,7 +679,9 @@ where
             // optimizing the work that the compiler has to do until the
             // reachability is restored or when reaching the end of the
             // function.
-            HeapStyle::Static { bound } if offset_with_access_size > bound => {
+            MemoryStyle::Static { byte_reservation }
+                if offset_with_access_size > byte_reservation =>
+            {
                 self.emit_fuel_increment();
                 self.masm.trap(TrapCode::HEAP_OUT_OF_BOUNDS);
                 self.context.reachable = false;
@@ -708,10 +714,10 @@ where
             // * If the heap type is 32-bits, the offset is at most u32::MAX, so
             // no  adjustment is needed as part of
             // [bounds::ensure_index_and_offset].
-            HeapStyle::Static { bound }
-                if heap.ty == WasmValType::I32
+            MemoryStyle::Static { byte_reservation }
+                if heap.index_type() == WasmValType::I32
                     && u64::from(u32::MAX)
-                        <= u64::from(bound) + u64::from(self.tunables.memory_guard_size)
+                        <= byte_reservation + u64::from(self.tunables.memory_guard_size)
                             - offset_with_access_size =>
             {
                 let addr = self.context.any_gpr(self.masm);
@@ -726,8 +732,8 @@ where
             //
             // bound - (offset + access_size) cannot wrap, because we already
             // checked that (offset + access_size) > bound, above.
-            HeapStyle::Static { bound } => {
-                let bounds = Bounds::from_u64(bound);
+            MemoryStyle::Static { byte_reservation } => {
+                let bounds = Bounds::from_u64(byte_reservation);
                 let addr = bounds::load_heap_addr_checked(
                     self.masm,
                     &mut self.context,
@@ -908,14 +914,14 @@ where
             .address_at_reg(base, heap_data.current_length_offset);
         self.masm.load_ptr(size_addr, writable!(size_reg));
         // Emit a shift to get the size in pages rather than in bytes.
-        let dst = TypedReg::new(heap_data.ty, size_reg);
-        let pow = heap_data.page_size_log2;
+        let dst = TypedReg::new(heap_data.index_type(), size_reg);
+        let pow = heap_data.memory.page_size_log2;
         self.masm.shift_ir(
             writable!(dst.reg),
             pow as u64,
             dst.into(),
             ShiftKind::ShrU,
-            heap_data.ty.into(),
+            heap_data.index_type().into(),
         );
         self.context.stack.push(dst.into());
     }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -711,7 +711,7 @@ where
             HeapStyle::Static { bound }
                 if heap.ty == WasmValType::I32
                     && u64::from(u32::MAX)
-                        <= u64::from(bound) + u64::from(heap.offset_guard_size)
+                        <= u64::from(bound) + u64::from(self.tunables.memory_guard_size)
                             - offset_with_access_size =>
             {
                 let addr = self.context.any_gpr(self.masm);

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -104,7 +104,6 @@ impl TargetIsa for Aarch64 {
             translation,
             types,
             builtins,
-            tunables,
             self,
             abi::Aarch64ABI::ptr_type(),
         );

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -114,7 +114,6 @@ impl TargetIsa for X64 {
             translation,
             types,
             builtins,
-            tunables,
             self,
             abi::X64ABI::ptr_type(),
         );

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1653,7 +1653,7 @@ where
         // The memory32_grow builtin returns a pointer type, therefore we must
         // ensure that the return type is representative of the address space of
         // the heap type.
-        match (self.env.ptr_type(), heap.ty) {
+        match (self.env.ptr_type(), heap.index_type()) {
             (WasmValType::I64, WasmValType::I64) => {}
             // When the heap type is smaller than the pointer type, we adjust
             // the result of the memory32_grow builtin.


### PR DESCRIPTION
This commit has more refactoring to simplify handling of linear memories in Wasmtime. The end goal is to remove the static/dynamic distinction and simplify the internal implementation and external interface. This is along the same lines of #9528, #9532, #9531, and #9530. The goal of this PR is a series of standalone commits which work towards futher "pushing down" the usage of `MemoryStyle` down to the consumers of bounds check code. The goal here is to remove layers of abstraction and instead unify everything around the same abstraction of `Tunables` and `wasmtime_environ::Memory`. Many fields in Winch/Cranelift `HeapData` have been removed in favor of storing `Memory` directly.

This PR affects generated golden tests because previously the global value for the heap bound was not generated if the heap was a "static" heap. With the eventual removal of static/dynamic distinction it's easier to just always generate this and have it not get used most of the time. Thus while the clif output tests are changing none of the actual generated code itself should be changing.