### PR TITLE
Fix a panic on the CLI with `-Scli=n`

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -233,21 +233,19 @@ impl RunCommand {
                     if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
                         std::process::exit(exit.0);
                     }
-                    if e.is::<wasmtime::Trap>() {
-                        eprintln!("Error: {e:?}");
-                        cfg_if::cfg_if! {
-                            if #[cfg(unix)] {
-                                std::process::exit(rustix::process::EXIT_SIGNALED_SIGABRT);
-                            } else if #[cfg(windows)] {
-                                // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
-                                std::process::exit(3);
-                            }
+                }
+                if e.is::<wasmtime::Trap>() {
+                    eprintln!("Error: {e:?}");
+                    cfg_if::cfg_if! {
+                        if #[cfg(unix)] {
+                            std::process::exit(rustix::process::EXIT_SIGNALED_SIGABRT);
+                        } else if #[cfg(windows)] {
+                            // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
+                            std::process::exit(3);
                         }
                     }
-                    return Err(e);
-                } else {
-                    unreachable!("either preview1_ctx or preview2_ctx present")
                 }
+                return Err(e);
             }
         }
 


### PR DESCRIPTION
When a module trapped and `-Scli=n` was passed the CLI would panic instead of properly returning an error, and this commit fixes that.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
