### PR TITLE
Bump Wasmtime to 28.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "27.0.0"
+version = "28.0.0"
 
 [[package]]
 name = "byteorder"
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -691,14 +691,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -739,25 +739,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.114.0"
+version = "0.115.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1168,7 +1168,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "arbitrary",
  "cranelift-bitset",
@@ -3525,7 +3525,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3575,7 +3575,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3881,14 +3881,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3904,14 +3904,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4059,11 +4059,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "27.0.0"
+version = "28.0.0"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "object",
  "rustix",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "27.0.0"
+version = "28.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "27.0.0"
+version = "28.0.0"
 
 [[package]]
 name = "wast"
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4567,7 +4567,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "27.0.0"
+version = "28.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -194,60 +194,60 @@ unnecessary_cast = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=27.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "27.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=27.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=27.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=27.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=27.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=27.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=27.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=27.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=27.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=27.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=27.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "27.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=27.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "27.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "27.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "27.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "27.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=27.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=27.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=27.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=27.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=27.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=28.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "28.0.0", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=28.0.0" }
+wasmtime-cache = { path = "crates/cache", version = "=28.0.0" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=28.0.0" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=28.0.0" }
+wasmtime-winch = { path = "crates/winch", version = "=28.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=28.0.0" }
+wasmtime-explorer = { path = "crates/explorer", version = "=28.0.0" }
+wasmtime-fiber = { path = "crates/fiber", version = "=28.0.0" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=28.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=28.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "28.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=28.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "28.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "28.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "28.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "28.0.0" }
+wasmtime-component-util = { path = "crates/component-util", version = "=28.0.0" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=28.0.0" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=28.0.0" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=28.0.0" }
+wasmtime-slab = { path = "crates/slab", version = "=28.0.0" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=27.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=27.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=27.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=27.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=28.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=28.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=28.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=28.0.0", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=27.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=27.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=28.0.0" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=28.0.0" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=27.0.0" }
+pulley-interpreter = { path = 'pulley', version = "=28.0.0" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-codegen = { path = "cranelift/codegen", version = "0.114.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.114.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.114.0" }
-cranelift-native = { path = "cranelift/native", version = "0.114.0" }
-cranelift-module = { path = "cranelift/module", version = "0.114.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.114.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.114.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.115.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.115.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.115.0" }
+cranelift-native = { path = "cranelift/native", version = "0.115.0" }
+cranelift-module = { path = "cranelift/module", version = "0.115.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.115.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.115.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.114.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.114.0" }
+cranelift-object = { path = "cranelift/object", version = "0.115.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.115.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.114.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.114.0" }
-cranelift-control = { path = "cranelift/control", version = "0.114.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.114.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.115.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.115.0" }
+cranelift-control = { path = "cranelift/control", version = "0.115.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.115.0" }
 
-winch-codegen = { path = "winch/codegen", version = "=27.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=28.0.0" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 27.0.0
+## 28.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [27.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-27.0.0/RELEASES.md)
 * [26.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-26.0.0/RELEASES.md)
 * [25.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-25.0.0/RELEASES.md)
 * [24.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-24.0.0/RELEASES.md)

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.114.0"
+version = "0.115.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.114.0"
+version = "0.115.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.114.0"
+version = "0.115.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -24,7 +24,7 @@ features = ["all-arch"]
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.114.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.115.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -53,8 +53,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.114.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.114.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.115.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.115.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.114.0"
+version = "0.115.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,4 +16,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.114.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.115.0" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.114.0"
+version = "0.115.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.114.0"
+version = "0.115.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.114.0"
+version = "0.115.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.114.0"
+version = "0.115.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.114.0"
+version = "0.115.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.114.0"
+version = "0.115.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.114.0"
+version = "0.115.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.114.0"
+version = "0.115.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.114.0"
+version = "0.115.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.114.0"
+version = "0.115.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.114.0"
+version = "0.115.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.114.0"
+version = "0.115.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.114.0"
+version = "0.115.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,11 +206,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "27.0.0"
+#define WASMTIME_VERSION "28.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 27
+#define WASMTIME_VERSION_MAJOR 28
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -32,6 +36,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-bforest]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -49,6 +57,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -64,6 +76,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-codegen]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -81,6 +97,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -96,6 +116,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -113,6 +137,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-control]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -128,6 +156,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-entity]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
@@ -145,6 +177,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -160,6 +196,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
@@ -177,6 +217,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -192,6 +236,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-jit]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
@@ -209,6 +257,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-module]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -224,6 +276,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-native]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-native]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
@@ -241,6 +297,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-object]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -257,6 +317,10 @@ audited_as = "0.111.0"
 version = "0.114.0"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.115.0"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -272,6 +336,10 @@ audited_as = "0.111.0"
 [[unpublished.cranelift-serde]]
 version = "0.114.0"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-serde]]
+version = "0.115.0"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
@@ -297,6 +365,10 @@ audited_as = "0.1.1"
 version = "27.0.0"
 audited_as = "0.1.1"
 
+[[unpublished.pulley-interpreter]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -312,6 +384,10 @@ audited_as = "24.0.0"
 [[unpublished.wasi-common]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasi-common]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -329,6 +405,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -344,6 +424,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-asm-macros]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -361,6 +445,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-cache]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -376,6 +464,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-cli]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -393,6 +485,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -408,6 +504,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-component-macro]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-component-macro]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
@@ -425,6 +525,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -440,6 +544,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-cranelift]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
@@ -457,6 +565,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -472,6 +584,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-explorer]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-explorer]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
@@ -489,6 +605,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-fiber]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -505,6 +625,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -521,6 +645,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -536,6 +664,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-slab]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-slab]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
@@ -565,6 +697,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -581,6 +717,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "25.0.0"
 audited_as = "24.0.0"
@@ -592,6 +732,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
@@ -608,6 +752,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "25.0.0"
@@ -637,6 +785,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -652,6 +804,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-wast]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
@@ -669,6 +825,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-winch]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -684,6 +844,10 @@ audited_as = "24.0.0"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
@@ -701,6 +865,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wiggle]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -717,6 +885,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wiggle]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -733,6 +905,10 @@ audited_as = "24.0.0"
 version = "27.0.0"
 audited_as = "25.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "28.0.0"
+audited_as = "26.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -748,6 +924,10 @@ audited_as = "24.0.0"
 [[unpublished.wiggle-macro]]
 version = "27.0.0"
 audited_as = "25.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -772,6 +952,10 @@ audited_as = "0.23.1"
 [[unpublished.winch-codegen]]
 version = "27.0.0"
 audited_as = "0.23.1"
+
+[[unpublished.winch-codegen]]
+version = "28.0.0"
+audited_as = "26.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1071,6 +1255,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1086,6 +1276,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1107,6 +1303,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-bitset]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1122,6 +1324,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1143,6 +1351,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-meta]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-shared]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1158,6 +1372,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-shared]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-shared]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1179,6 +1399,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-control]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-entity]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1194,6 +1420,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-entity]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-entity]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1215,6 +1447,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-frontend]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-interpreter]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1230,6 +1468,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-interpreter]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-interpreter]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1251,6 +1495,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-isle]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-jit]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1266,6 +1516,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-jit]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-jit]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1287,6 +1543,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-module]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-native]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1302,6 +1564,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-native]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-native]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1323,6 +1591,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-object]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-reader]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1341,6 +1615,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1356,6 +1636,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-serde]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-serde]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1586,6 +1872,12 @@ user-name = "Nick Fitzgerald"
 [[publisher.pulley-interpreter]]
 version = "0.1.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.pulley-interpreter]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1858,6 +2150,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -2079,6 +2377,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2094,6 +2398,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2115,6 +2425,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2130,6 +2446,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2151,6 +2473,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2166,6 +2494,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2187,6 +2521,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2202,6 +2542,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2223,6 +2569,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2238,6 +2590,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2259,6 +2617,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2274,6 +2638,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2295,6 +2665,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-slab]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2310,6 +2686,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-slab]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-slab]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2331,6 +2713,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2346,6 +2734,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2361,6 +2755,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-keyvalue]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2376,6 +2776,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2397,6 +2803,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-threads]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wast]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2412,6 +2824,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wast]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wast]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2433,6 +2851,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2451,6 +2875,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2466,6 +2896,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2571,6 +3007,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2589,6 +3031,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2604,6 +3052,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2636,6 +3090,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.23.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-27.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 27.0.0 to 28.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 27.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-27.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-27.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-27.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
