### PR TITLE
Refactor how wasm features are calculated for `*.wast` tests

### DIFF
--- a/tests/misc_testsuite/component-model/adapter.wast
+++ b/tests/misc_testsuite/component-model/adapter.wast
@@ -1,3 +1,5 @@
+;;! multi_memory = true
+
 ;; basic function lifting
 (component
   (core module $m

--- a/tests/misc_testsuite/component-model/fused.wast
+++ b/tests/misc_testsuite/component-model/fused.wast
@@ -1,3 +1,6 @@
+;;! multi_memory = true
+;;! component_model_more_flags = true
+
 ;; smoke test with no arguments and no results
 (component
   (core module $m

--- a/tests/misc_testsuite/component-model/modules.wast
+++ b/tests/misc_testsuite/component-model/modules.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (component $foo
   (core module (export "a-module"))
 )

--- a/tests/misc_testsuite/component-model/strings.wast
+++ b/tests/misc_testsuite/component-model/strings.wast
@@ -1,3 +1,5 @@
+;;! multi_memory = true
+
 ;; unaligned utf16 string
 (assert_trap
   (component

--- a/tests/misc_testsuite/custom-page-sizes/custom-page-sizes-invalid.wast
+++ b/tests/misc_testsuite/custom-page-sizes/custom-page-sizes-invalid.wast
@@ -1,3 +1,6 @@
+;;! custom_page_sizes = true
+;;! multi_memory = true
+
 ;; Page size that is not a power of two.
 (assert_malformed
   (module quote "(memory 0 (pagesize 3))")

--- a/tests/misc_testsuite/custom-page-sizes/custom-page-sizes.wast
+++ b/tests/misc_testsuite/custom-page-sizes/custom-page-sizes.wast
@@ -1,3 +1,6 @@
+;;! custom_page_sizes = true
+;;! multi_memory = true
+
 ;; Check all the valid custom page sizes.
 (module (memory 1 (pagesize 1)))
 (module (memory 1 (pagesize 65536)))

--- a/tests/misc_testsuite/elem-ref-null.wast
+++ b/tests/misc_testsuite/elem-ref-null.wast
@@ -1,2 +1,4 @@
+;;! reference_types = true
+
 (module
   (elem funcref (ref.null func)))

--- a/tests/misc_testsuite/elem_drop.wast
+++ b/tests/misc_testsuite/elem_drop.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table 1 1 funcref)
   (elem (i32.const 0) funcref (ref.func 0))

--- a/tests/misc_testsuite/externref-id-function.wast
+++ b/tests/misc_testsuite/externref-id-function.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (func (export "identity") (param externref) (result externref)
     local.get 0))

--- a/tests/misc_testsuite/externref-segment.wast
+++ b/tests/misc_testsuite/externref-segment.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table 2 externref)
   (elem (i32.const 0) externref (ref.null extern))

--- a/tests/misc_testsuite/externref-table-dropped-segment-issue-8281.wast
+++ b/tests/misc_testsuite/externref-table-dropped-segment-issue-8281.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table $t 0 0 externref)
 

--- a/tests/misc_testsuite/function-references/call_indirect.wast
+++ b/tests/misc_testsuite/function-references/call_indirect.wast
@@ -1,3 +1,6 @@
+;;! gc = true
+;;! function_references = true
+
 (module
   (table $t1 2 funcref)
   (elem (table $t1) (i32.const 0) func $nop)

--- a/tests/misc_testsuite/function-references/instance.wast
+++ b/tests/misc_testsuite/function-references/instance.wast
@@ -1,3 +1,6 @@
+;;! gc = true
+;;! multi_memory = true
+
 ;; Instantiation is generative
 
 (module definition $M

--- a/tests/misc_testsuite/function-references/table_fill.wast
+++ b/tests/misc_testsuite/function-references/table_fill.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (table $t 10 externref)
 

--- a/tests/misc_testsuite/function-references/table_get.wast
+++ b/tests/misc_testsuite/function-references/table_get.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $res-i32 (func (result i32)))
   (table $t2 2 externref)

--- a/tests/misc_testsuite/function-references/table_grow.wast
+++ b/tests/misc_testsuite/function-references/table_grow.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (table $t 0 externref)
 

--- a/tests/misc_testsuite/function-references/table_set.wast
+++ b/tests/misc_testsuite/function-references/table_set.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $res-i32 (func (result i32)))
   (table $t2 1 externref)

--- a/tests/misc_testsuite/gc/anyref_that_is_i31_barriers.wast
+++ b/tests/misc_testsuite/gc/anyref_that_is_i31_barriers.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 ;; Test that our inline GC barriers detect `i31`s and don't attempt to actually
 ;; deref them or anything like that.
 

--- a/tests/misc_testsuite/gc/array-alloc-too-large.wast
+++ b/tests/misc_testsuite/gc/array-alloc-too-large.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $arr_i8 (array i8))
   (type $arr_i64 (array i64))

--- a/tests/misc_testsuite/gc/array-init-data.wast
+++ b/tests/misc_testsuite/gc/array-init-data.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $arr (array (mut i8)))
 

--- a/tests/misc_testsuite/gc/array-new-data.wast
+++ b/tests/misc_testsuite/gc/array-new-data.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $arr (array (mut i8)))
 

--- a/tests/misc_testsuite/gc/array-new-elem.wast
+++ b/tests/misc_testsuite/gc/array-new-elem.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $arr (array i31ref))
 

--- a/tests/misc_testsuite/gc/array-types.wast
+++ b/tests/misc_testsuite/gc/array-types.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type (array i8))
   (type (array i16))

--- a/tests/misc_testsuite/gc/func-refs-in-gc-heap.wast
+++ b/tests/misc_testsuite/gc/func-refs-in-gc-heap.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $f0 (func (result i32)))
 

--- a/tests/misc_testsuite/gc/i31ref-of-global-initializers.wast
+++ b/tests/misc_testsuite/gc/i31ref-of-global-initializers.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module $env
   (global (export "g1") i32 (i32.const 42))
   (global (export "g2") i32 (i32.const 99))

--- a/tests/misc_testsuite/gc/i31ref-tables.wast
+++ b/tests/misc_testsuite/gc/i31ref-tables.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module $tables_of_i31ref
   (table $table 3 10 i31ref)
   (elem (table $table) (i32.const 0) i31ref (item (ref.i31 (i32.const 999)))

--- a/tests/misc_testsuite/gc/more-rec-groups-than-types.wast
+++ b/tests/misc_testsuite/gc/more-rec-groups-than-types.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 ;; Test that we properly handle empty rec groups and when we have more rec
 ;; groups defined in the type section than actual types (and therefore the
 ;; length that the type section reports is greater than the length of the types

--- a/tests/misc_testsuite/gc/null-i31ref.wast
+++ b/tests/misc_testsuite/gc/null-i31ref.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (func (export "get_u-null") (result i32)
     (i31.get_u (ref.null i31))

--- a/tests/misc_testsuite/gc/rec-group-funcs.wast
+++ b/tests/misc_testsuite/gc/rec-group-funcs.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 ;; Test that we properly canonicalize function types across modules, at the
 ;; engine level. We rely on this canonicalization to make cross-module imports
 ;; work among other things.

--- a/tests/misc_testsuite/gc/ref-test.wast
+++ b/tests/misc_testsuite/gc/ref-test.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (func (export "nulls-to-nullable-tops") (result i32)
     (ref.test anyref (ref.null any))

--- a/tests/misc_testsuite/gc/struct-instructions.wast
+++ b/tests/misc_testsuite/gc/struct-instructions.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type $ty (struct (field (mut f32))
                     (field (mut i8))

--- a/tests/misc_testsuite/gc/struct-types.wast
+++ b/tests/misc_testsuite/gc/struct-types.wast
@@ -1,3 +1,5 @@
+;;! gc = true
+
 (module
   (type (struct))
   (type (struct (field)))

--- a/tests/misc_testsuite/linking-errors.wast
+++ b/tests/misc_testsuite/linking-errors.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module $m
   (global (export "g i32") i32 (i32.const 0))
   (global (export "g mut i32") (mut i32)  (i32.const 0))

--- a/tests/misc_testsuite/many_table_gets_lead_to_gc.wast
+++ b/tests/misc_testsuite/many_table_gets_lead_to_gc.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table $t 1 externref)
 

--- a/tests/misc_testsuite/memory64/bounds.wast
+++ b/tests/misc_testsuite/memory64/bounds.wast
@@ -1,3 +1,5 @@
+;;! memory64 = true
+
 (assert_unlinkable
   (module
     (memory i64 1)

--- a/tests/misc_testsuite/memory64/codegen.wast
+++ b/tests/misc_testsuite/memory64/codegen.wast
@@ -1,3 +1,5 @@
+;;! memory64 = true
+
 ;; make sure everything codegens correctly and has no cranelift verifier errors
 (module
   (memory i64 1)

--- a/tests/misc_testsuite/memory64/linking-errors.wast
+++ b/tests/misc_testsuite/memory64/linking-errors.wast
@@ -1,3 +1,5 @@
+;;! memory64 = true
+
 (module $m
   (memory (export "mem") 0)
 )

--- a/tests/misc_testsuite/memory64/linking.wast
+++ b/tests/misc_testsuite/memory64/linking.wast
@@ -1,3 +1,5 @@
+;;! memory64 = true
+
 (module $export32 (memory (export "m") 1))
 (module $export64 (memory (export "m") i64 1))
 

--- a/tests/misc_testsuite/memory64/more-than-4gb.wast
+++ b/tests/misc_testsuite/memory64/more-than-4gb.wast
@@ -1,3 +1,5 @@
+;;! memory64 = true
+
 ;; try to create as few 4gb memories as we can to reduce the memory consumption
 ;; of this test, so create one up front here and use it below.
 (module $memory

--- a/tests/misc_testsuite/memory64/multi-memory.wast
+++ b/tests/misc_testsuite/memory64/multi-memory.wast
@@ -1,3 +1,6 @@
+;;! memory64 = true
+;;! multi_memory = true
+
 ;; 64 => 64
 (module
   (memory $a i64 1)

--- a/tests/misc_testsuite/memory64/offsets.wast
+++ b/tests/misc_testsuite/memory64/offsets.wast
@@ -1,3 +1,5 @@
+;;! memory64 = true
+
 (module
   (memory i64 1)
   (func (export "load1") (result i32)

--- a/tests/misc_testsuite/memory64/simd.wast
+++ b/tests/misc_testsuite/memory64/simd.wast
@@ -1,3 +1,5 @@
+;;! memory64 = true
+
 ;; make sure everything codegens correctly and has no cranelift verifier errors
 (module
   (memory i64 1)

--- a/tests/misc_testsuite/memory64/threads.wast
+++ b/tests/misc_testsuite/memory64/threads.wast
@@ -1,3 +1,6 @@
+;;! memory64 = true
+;;! threads = true
+
 ;; make sure everything codegens correctly and has no cranelift verifier errors
 (module
   (memory i64 1)

--- a/tests/misc_testsuite/multi-memory/simple.wast
+++ b/tests/misc_testsuite/multi-memory/simple.wast
@@ -1,3 +1,5 @@
+;;! multi_memory = true
+
 (module
   (memory $m1 1)
   (memory $m2 1)

--- a/tests/misc_testsuite/mutable_externref_globals.wast
+++ b/tests/misc_testsuite/mutable_externref_globals.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 ;; This test contains the changes in
 ;; https://github.com/WebAssembly/reference-types/pull/104, and can be deleted
 ;; once that merges and we update our upstream tests.

--- a/tests/misc_testsuite/no-mixup-stack-maps.wast
+++ b/tests/misc_testsuite/no-mixup-stack-maps.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (global $g (mut externref) (ref.null extern))
 

--- a/tests/misc_testsuite/no-panic.wast
+++ b/tests/misc_testsuite/no-panic.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (func $test (param i32) (result externref)
         i32.const 0

--- a/tests/misc_testsuite/simd/canonicalize-nan.wast
+++ b/tests/misc_testsuite/simd/canonicalize-nan.wast
@@ -1,3 +1,5 @@
+;;! nan_canonicalization = true
+
 ;; This *.wast test should be run with `cranelift_nan_canonicalization` set to
 ;; `true` in `wast.rs`
 

--- a/tests/misc_testsuite/simple_ref_is_null.wast
+++ b/tests/misc_testsuite/simple_ref_is_null.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (func (export "func_is_null") (param funcref) (result i32)
     (ref.is_null (local.get 0))

--- a/tests/misc_testsuite/table_copy_on_imported_tables.wast
+++ b/tests/misc_testsuite/table_copy_on_imported_tables.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module $m
   (func $f (param i32 i32 i32 i32 i32 i32) (result i32) (local.get 0))
   (func $g (param i32 i32 i32 i32 i32 i32) (result i32) (local.get 1))

--- a/tests/misc_testsuite/table_grow_with_funcref.wast
+++ b/tests/misc_testsuite/table_grow_with_funcref.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table $t 0 funcref)
   (func (export "size") (result i32)

--- a/tests/misc_testsuite/tail-call/loop-across-modules.wast
+++ b/tests/misc_testsuite/tail-call/loop-across-modules.wast
@@ -1,3 +1,6 @@
+;;! tail_call = true
+;;! reference_types = true
+
 ;; Do the following loop: `A.f` indirect tail calls through the table, which is
 ;; populated by `B.start` to contain `B.g`, which in turn tail calls `A.f` and
 ;; the loop begins again.

--- a/tests/misc_testsuite/threads/LB.wast
+++ b/tests/misc_testsuite/threads/LB.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module $Mem
   (memory (export "shared") 1 1 shared)
 )

--- a/tests/misc_testsuite/threads/LB_atomic.wast
+++ b/tests/misc_testsuite/threads/LB_atomic.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module $Mem
   (memory (export "shared") 1 1 shared)
 )

--- a/tests/misc_testsuite/threads/MP.wast
+++ b/tests/misc_testsuite/threads/MP.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module $Mem
   (memory (export "shared") 1 1 shared)
 )

--- a/tests/misc_testsuite/threads/MP_atomic.wast
+++ b/tests/misc_testsuite/threads/MP_atomic.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module $Mem
   (memory (export "shared") 1 1 shared)
 )

--- a/tests/misc_testsuite/threads/MP_wait.wast
+++ b/tests/misc_testsuite/threads/MP_wait.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module $Mem
   (memory (export "shared") 1 1 shared)
 )

--- a/tests/misc_testsuite/threads/SB.wast
+++ b/tests/misc_testsuite/threads/SB.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module $Mem
   (memory (export "shared") 1 1 shared)
 )

--- a/tests/misc_testsuite/threads/SB_atomic.wast
+++ b/tests/misc_testsuite/threads/SB_atomic.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module $Mem
   (memory (export "shared") 1 1 shared)
 )

--- a/tests/misc_testsuite/threads/atomics_notify.wast
+++ b/tests/misc_testsuite/threads/atomics_notify.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 ;; From https://github.com/bytecodealliance/wasmtime/pull/5255
 ;;
 

--- a/tests/misc_testsuite/threads/atomics_wait_address.wast
+++ b/tests/misc_testsuite/threads/atomics_wait_address.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 ;; From https://bugzilla.mozilla.org/show_bug.cgi?id=1684861.
 ;;
 

--- a/tests/misc_testsuite/threads/load-store-alignment.wast
+++ b/tests/misc_testsuite/threads/load-store-alignment.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 (module
   ;; NB this should use a shared memory when it's supported
   (memory 1)

--- a/tests/misc_testsuite/threads/wait_notify.wast
+++ b/tests/misc_testsuite/threads/wait_notify.wast
@@ -1,3 +1,5 @@
+;;! threads = true
+
 ;; test that looping notify eventually unblocks a parallel waiting thread
 (module $Mem
   (memory (export "shared") 1 1 shared)

--- a/tests/misc_testsuite/wide-arithmetic.wast
+++ b/tests/misc_testsuite/wide-arithmetic.wast
@@ -1,3 +1,5 @@
+;;! wide_arithmetic = true
+
 (module
   (func (export "i64.add128") (param i64 i64 i64 i64) (result i64 i64)
     local.get 0

--- a/tests/misc_testsuite/winch/table_fill.wast
+++ b/tests/misc_testsuite/winch/table_fill.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (type $t0 (func))
   (func $f1 (type $t0))

--- a/tests/misc_testsuite/winch/table_get.wast
+++ b/tests/misc_testsuite/winch/table_get.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table $t3 3 funcref)
   (elem (table $t3) (i32.const 1) func $dummy)

--- a/tests/misc_testsuite/winch/table_grow.wast
+++ b/tests/misc_testsuite/winch/table_grow.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table $t1 0 funcref)
 

--- a/tests/misc_testsuite/winch/table_set.wast
+++ b/tests/misc_testsuite/winch/table_set.wast
@@ -1,3 +1,5 @@
+;;! reference_types = true
+
 (module
   (table $t3 2 funcref)
   (elem (table $t3) (i32.const 1) func $dummy)

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,20 @@
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+
+/// Parse test configuration from the specified test, comments starting with
+/// `;;!`.
+pub fn parse_test_config<T>(wat: &str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    // The test config source is the leading lines of the WAT file that are
+    // prefixed with `;;!`.
+    let config_lines: Vec<_> = wat
+        .lines()
+        .take_while(|l| l.starts_with(";;!"))
+        .map(|l| &l[3..])
+        .collect();
+    let config_text = config_lines.join("\n");
+
+    toml::from_str(&config_text).context("failed to parse the test configuration")
+}

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context};
-use bstr::ByteSlice;
 use libtest_mimic::{Arguments, FormatSetting, Trial};
+use serde_derive::Deserialize;
 use std::path::Path;
 use std::sync::{Condvar, LazyLock, Mutex};
 use wasmtime::{
@@ -9,6 +9,8 @@ use wasmtime::{
 };
 use wasmtime_environ::Memory;
 use wasmtime_wast::{SpectestConfig, WastContext};
+
+mod support;
 
 fn main() {
     env_logger::init();
@@ -92,14 +94,25 @@ fn add_tests(trials: &mut Vec<Trial>, path: &Path) {
     }
 }
 
-fn should_fail(test: &Path, strategy: Strategy) -> bool {
+fn should_fail(test: &Path, wast_config: &WastConfig, test_config: &TestConfig) -> bool {
     // Winch only supports x86_64 at this time.
-    if strategy == Strategy::Winch && !cfg!(target_arch = "x86_64") {
+    if wast_config.strategy == Strategy::Winch && !cfg!(target_arch = "x86_64") {
         return true;
     }
 
     // Disable spec tests for proposals that Winch does not implement yet.
-    if strategy == Strategy::Winch {
+    if wast_config.strategy == Strategy::Winch {
+        // A few proposals that winch has no support for.
+        if test_config.gc == Some(true)
+            || test_config.threads == Some(true)
+            || test_config.tail_call == Some(true)
+            || test_config.function_references == Some(true)
+            || test_config.gc == Some(true)
+            || test_config.relaxed_simd == Some(true)
+        {
+            return true;
+        }
+
         let unsupported = [
             // externref/reference-types related
             "component-model/modules.wast",
@@ -209,27 +222,6 @@ fn should_fail(test: &Path, strategy: Strategy) -> bool {
         if unsupported.iter().any(|part| test.ends_with(part)) {
             return true;
         }
-
-        // A few proposals that winch has no support for.
-        let unsupported_proposals = [
-            "function-references",
-            "gc",
-            "tail-call",
-            "relaxed-simd",
-            "threads",
-            // Winch technically supports memory64 but the upstream tests have
-            // gc/function-references/exceptions/etc all merged in now so Winch
-            // can no longer run those tests without panicking.
-            "memory64",
-        ];
-        if let Some(parent) = test.parent() {
-            if unsupported_proposals
-                .iter()
-                .any(|part| parent.ends_with(part))
-            {
-                return true;
-            }
-        }
     }
 
     for part in test.iter() {
@@ -258,48 +250,181 @@ fn should_fail(test: &Path, strategy: Strategy) -> bool {
         }
     }
 
+    // Some tests are known to fail with the pooling allocator
+    if wast_config.pooling {
+        let unsupported = [
+            // allocates too much memory for the pooling configuration here
+            "misc_testsuite/memory64/more-than-4gb.wast",
+            // shared memories + pooling allocator aren't supported yet
+            "misc_testsuite/memory-combos.wast",
+            "misc_testsuite/threads/LB.wast",
+            "misc_testsuite/threads/LB_atomic.wast",
+            "misc_testsuite/threads/MP.wast",
+            "misc_testsuite/threads/MP_atomic.wast",
+            "misc_testsuite/threads/MP_wait.wast",
+            "misc_testsuite/threads/SB.wast",
+            "misc_testsuite/threads/SB_atomic.wast",
+            "misc_testsuite/threads/atomics_notify.wast",
+            "misc_testsuite/threads/atomics_wait_address.wast",
+            "misc_testsuite/threads/wait_notify.wast",
+            "spec_testsuite/proposals/threads/atomic.wast",
+            "spec_testsuite/proposals/threads/exports.wast",
+            "spec_testsuite/proposals/threads/memory.wast",
+        ];
+
+        if unsupported.iter().any(|part| test.ends_with(part)) {
+            return true;
+        }
+    }
+
     false
 }
 
+/// Configuration where the main function will generate a combinatorial
+/// matrix of these top-level configurations to run the entire test suite with
+/// that configuration.
 struct WastConfig {
     strategy: Strategy,
     pooling: bool,
     collector: Collector,
 }
 
+/// Per-test configuration which is written down in the test file itself for
+/// `misc_testsuite/**/*.wast` or in `spec_test_config` below for spec tests.
+#[derive(Debug, PartialEq, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TestConfig {
+    memory64: Option<bool>,
+    custom_page_sizes: Option<bool>,
+    multi_memory: Option<bool>,
+    threads: Option<bool>,
+    gc: Option<bool>,
+    function_references: Option<bool>,
+    relaxed_simd: Option<bool>,
+    reference_types: Option<bool>,
+    tail_call: Option<bool>,
+    extended_const: Option<bool>,
+    wide_arithmetic: Option<bool>,
+    hogs_memory: Option<bool>,
+    nan_canonicalization: Option<bool>,
+    component_model_more_flags: Option<bool>,
+}
+
+fn spec_test_config(wast: &Path) -> TestConfig {
+    let mut ret = TestConfig::default();
+
+    match wast.strip_prefix("proposals") {
+        // This lists the features require to run the various spec tests suites
+        // in their `proposals` folder.
+        Ok(rest) => {
+            let proposal = rest.iter().next().unwrap().to_str().unwrap();
+            match proposal {
+                "multi-memory" => {
+                    ret.multi_memory = Some(true);
+                    ret.reference_types = Some(true);
+                }
+                "wide-arithmetic" => {
+                    ret.wide_arithmetic = Some(true);
+                }
+                "threads" => {
+                    ret.threads = Some(true);
+                }
+                "tail-call" => {
+                    ret.tail_call = Some(true);
+                    ret.reference_types = Some(true);
+                }
+                "relaxed-simd" => {
+                    ret.relaxed_simd = Some(true);
+                }
+                "memory64" => {
+                    ret.memory64 = Some(true);
+                    ret.tail_call = Some(true);
+                    ret.gc = Some(true);
+                    ret.extended_const = Some(true);
+                    ret.multi_memory = Some(true);
+                    ret.relaxed_simd = Some(true);
+                }
+                "extended-const" => {
+                    ret.extended_const = Some(true);
+                    ret.reference_types = Some(true);
+                }
+                "custom-page-sizes" => {
+                    ret.custom_page_sizes = Some(true);
+                    ret.multi_memory = Some(true);
+                }
+                "exception-handling" => {
+                    ret.reference_types = Some(true);
+                }
+                "gc" => {
+                    ret.gc = Some(true);
+                    ret.tail_call = Some(true);
+                }
+                "function-references" => {
+                    ret.function_references = Some(true);
+                    ret.tail_call = Some(true);
+                }
+                "annotations" => {}
+                _ => panic!("unsuported proposal {proposal:?}"),
+            }
+        }
+
+        // This lists the features required to run the top-level of spec tests
+        // outside of the `proposals` directory.
+        Err(_) => {
+            ret.reference_types = Some(true);
+        }
+    }
+    ret
+}
+
 // Each of the tests included from `wast_testsuite_tests` will call this
 // function which actually executes the `wast` test suite given the `strategy`
 // to compile it.
 fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
-    let should_fail = should_fail(wast, config.strategy);
-    let wast_bytes =
-        std::fs::read(wast).with_context(|| format!("failed to read `{}`", wast.display()))?;
+    let wast_contents = std::fs::read_to_string(wast)
+        .with_context(|| format!("failed to read `{}`", wast.display()))?;
+
+    // If this is a spec test then the configuration for it is loaded via
+    // `spec_test_config`, but otherwise it's required to be listed in the top
+    // of the file as we control the contents of the file.
+    let test_config = match wast.strip_prefix("tests/spec_testsuite") {
+        Ok(test) => spec_test_config(test),
+        Err(_) => support::parse_test_config(&wast_contents)?,
+    };
+    let should_fail = should_fail(wast, &config, &test_config);
 
     let wast = Path::new(wast);
 
-    let misc = feature_found(wast, "misc_testsuite");
-    let memory64 = feature_found(wast, "memory64");
-    let custom_page_sizes = feature_found(wast, "custom-page-sizes");
-    let multi_memory = feature_found(wast, "multi-memory")
-        || feature_found(wast, "component-model")
-        || custom_page_sizes
-        || memory64
-        || misc;
-    let threads = feature_found(wast, "threads");
-    let gc = feature_found(wast, "gc") || memory64;
-    let function_references = gc || memory64 || feature_found(wast, "function-references");
-    let reference_types = !(threads && feature_found(wast, "proposals"));
-    let relaxed_simd = feature_found(wast, "relaxed-simd") || memory64;
-    let tail_call = function_references || feature_found(wast, "tail-call");
-    let use_shared_memory = feature_found_src(&wast_bytes, "shared_memory")
-        || feature_found_src(&wast_bytes, "shared)");
-    let extended_const = feature_found(wast, "extended-const") || memory64;
-    let wide_arithmetic = feature_found(wast, "wide-arithmetic");
+    // Note that all of these proposals/features are currently default-off to
+    // ensure that we annotate all tests accurately with what features they
+    // need, even in the future when features are stabilized.
+    let memory64 = test_config.memory64.unwrap_or(false);
+    let custom_page_sizes = test_config.custom_page_sizes.unwrap_or(false);
+    let multi_memory = test_config.multi_memory.unwrap_or(false);
+    let threads = test_config.threads.unwrap_or(false);
+    let gc = test_config.gc.unwrap_or(false);
+    let tail_call = test_config.tail_call.unwrap_or(false);
+    let extended_const = test_config.extended_const.unwrap_or(false);
+    let wide_arithmetic = test_config.wide_arithmetic.unwrap_or(false);
+    let test_hogs_memory = test_config.hogs_memory.unwrap_or(false);
+    let component_model_more_flags = test_config.component_model_more_flags.unwrap_or(false);
+    let nan_canonicalization = test_config.nan_canonicalization.unwrap_or(false);
+    let relaxed_simd = test_config.relaxed_simd.unwrap_or(false);
 
-    if config.pooling && use_shared_memory {
-        log::warn!("skipping pooling test with shared memory");
-        return Ok(());
-    }
+    // Some proposals in wasm depend on previous proposals. For example the gc
+    // proposal depends on function-references which depends on reference-types.
+    // To avoid needing to enable all of them at once implicitly enable
+    // downstream proposals once the end proposal is enabled (e.g. when enabling
+    // gc that also enables function-references and reference-types).
+    let function_references = test_config
+        .function_references
+        .or(test_config.gc)
+        .unwrap_or(false);
+    let reference_types = test_config
+        .reference_types
+        .or(test_config.function_references)
+        .or(test_config.gc)
+        .unwrap_or(false);
 
     let is_cranelift = match config.strategy {
         Strategy::Cranelift => true,
@@ -318,21 +443,14 @@ fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
         .wasm_custom_page_sizes(custom_page_sizes)
         .wasm_extended_const(extended_const)
         .wasm_wide_arithmetic(wide_arithmetic)
+        .wasm_component_model_more_flags(component_model_more_flags)
         .strategy(config.strategy)
-        .collector(config.collector);
+        .collector(config.collector)
+        .cranelift_nan_canonicalization(nan_canonicalization);
 
     if is_cranelift {
         cfg.cranelift_debug_verifier(true);
     }
-
-    let component_model = feature_found(wast, "component-model");
-    cfg.wasm_component_model(component_model)
-        .wasm_component_model_more_flags(component_model);
-
-    if feature_found(wast, "canonicalize-nan") && is_cranelift {
-        cfg.cranelift_nan_canonicalization(true);
-    }
-    let test_allocates_lots_of_memory = wast.ends_with("more-than-4gb.wast");
 
     // By default we'll allocate huge chunks (6gb) of the address space for each
     // linear memory. This is typically fine but when we emulate tests with QEMU
@@ -352,18 +470,14 @@ fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
 
         // If the test allocates a lot of memory, that's considered "hogging"
         // memory, so skip it.
-        if test_allocates_lots_of_memory {
+        if test_hogs_memory {
             return Ok(());
         }
 
         // Don't use 4gb address space reservations when not hogging memory, and
         // also don't reserve lots of memory after dynamic memories for growth
         // (makes growth slower).
-        if use_shared_memory {
-            cfg.memory_reservation(2 * u64::from(Memory::DEFAULT_PAGE_SIZE));
-        } else {
-            cfg.memory_reservation(0);
-        }
+        cfg.memory_reservation(2 * u64::from(Memory::DEFAULT_PAGE_SIZE));
         cfg.memory_reservation_for_growth(0);
 
         let small_guard = 64 * 1024;
@@ -374,7 +488,7 @@ fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
         // Some memory64 tests take more than 4gb of resident memory to test,
         // but we don't want to configure the pooling allocator to allow that
         // (that's a ton of memory to reserve), so we skip those tests.
-        if test_allocates_lots_of_memory {
+        if test_hogs_memory {
             return Ok(());
         }
 
@@ -436,11 +550,11 @@ fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
             let store = Store::new(&engine, ());
             let mut wast_context = WastContext::new(store);
             wast_context.register_spectest(&SpectestConfig {
-                use_shared_memory,
+                use_shared_memory: true,
                 suppress_prints: true,
             })?;
             wast_context
-                .run_buffer(wast.to_str().unwrap(), &wast_bytes)
+                .run_buffer(wast.to_str().unwrap(), wast_contents.as_bytes())
                 .with_context(|| format!("failed to run spec test with {desc} engine"))
         });
 
@@ -454,17 +568,6 @@ fn run_wast(wast: &Path, config: WastConfig) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn feature_found(path: &Path, name: &str) -> bool {
-    path.iter().any(|part| match part.to_str() {
-        Some(s) => s.contains(name),
-        None => false,
-    })
-}
-
-fn feature_found_src(bytes: &[u8], name: &str) -> bool {
-    bytes.contains_str(name)
 }
 
 // The pooling tests make about 6TB of address space reservation which means


### PR DESCRIPTION
This commit refactors the `tests/wast.rs` test suite which runs all of the upstream spec tests as `*.wast` files as well as our own `misc_testsuite` which has its own suite of `*.wast` files. Previously the set of wasm features active for each test was a sort of random mishmash and convoluted set of conditionals which was updated and edited over time as upstream proposal test suites evolved. This was then mirrored into our own conventions for `misc_testsuite` as well. Overall though this has a number of downsides I'm trying to fix here:

* The calculation of what features are enabled is quite complicated and effectively a random mishmash of `||` conditionals with hierarchies that don't make any sense beyond "this is just required to get things to pass".

* There is no means of per-test configuration. For example `canonicalize-nans.wast` had hardcoded logic in `tests/wast.rs` that it needed a different setting turned on in `Config`.

* There was no easy means to write tests for Wasmtime which take a union of a number of proposals together without having lots of sub-folders that may not make sense.

* Tests that require a particular proposal had to have duplicate logic for Winch as it doesn't support the full suite of features of all proposals that Cranelift does.

The new system implemented in this commit takes a leaf out of the `disas` tests. There is a new `TestConfig` structure in the `tests/wast.rs` harness which is decoded from each test (leading `;;!` comments) which enables specifying, in each test, what's required. This encompasses many wasm proposals but additionally captures other behavior like nan-canonicalization. This means that all test files in `misc_testsuite/**/*.wast` are now manually annotated with what wasm features they require and what's needed to run. This makes per-test configuration much easier, per-config-setting much easier, and blanket ignore-by-proposal for Winch much easier as well.

For spec tests we can't modify the contents of the upstream `*.wast` files. To handle this they're handled specially where `TestConfig` is manually created and manipulated for each spec proposal and the main test suite itself. This enables per-proposal configuration that doesn't leak into any others and makes it more obvious what proposals are doing what.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
