### PR TITLE
Release Wasmtime 26.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "26.0.0"
+version = "26.0.1"
 
 [[package]]
 name = "byteorder"
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -631,14 +631,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "arbitrary",
  "serde",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -679,25 +679,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.113.0"
+version = "0.113.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1093,7 +1093,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "arbitrary",
  "cranelift-bitset",
@@ -3255,7 +3255,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3305,7 +3305,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3600,14 +3600,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3623,14 +3623,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3781,11 +3781,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "26.0.0"
+version = "26.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "object",
  "once_cell",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "26.0.0"
+version = "26.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "26.0.0"
+version = "26.0.1"
 
 [[package]]
 name = "wast"
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4291,7 +4291,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "26.0.0"
+version = "26.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "26.0.0"
+version = "26.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -192,60 +192,60 @@ unnecessary_cast = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=26.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "26.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=26.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=26.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=26.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=26.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=26.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=26.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=26.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=26.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=26.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=26.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "26.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=26.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "26.0.0" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "26.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "26.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "26.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=26.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=26.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=26.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=26.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=26.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=26.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "26.0.1", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=26.0.1" }
+wasmtime-cache = { path = "crates/cache", version = "=26.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=26.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=26.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=26.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=26.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=26.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=26.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=26.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=26.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "26.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=26.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "26.0.1" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "26.0.1" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "26.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "26.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=26.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=26.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=26.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=26.0.1" }
+wasmtime-slab = { path = "crates/slab", version = "=26.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=26.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=26.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=26.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=26.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=26.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=26.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=26.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=26.0.1", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=26.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=26.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=26.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=26.0.1" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=26.0.0" }
+pulley-interpreter = { path = 'pulley', version = "=26.0.1" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-codegen = { path = "cranelift/codegen", version = "0.113.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.113.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.113.0" }
-cranelift-native = { path = "cranelift/native", version = "0.113.0" }
-cranelift-module = { path = "cranelift/module", version = "0.113.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.113.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.113.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.113.1", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.113.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.113.1" }
+cranelift-native = { path = "cranelift/native", version = "0.113.1" }
+cranelift-module = { path = "cranelift/module", version = "0.113.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.113.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.113.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.113.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.113.0" }
+cranelift-object = { path = "cranelift/object", version = "0.113.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.113.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.113.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.113.0" }
-cranelift-control = { path = "cranelift/control", version = "0.113.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.113.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.113.1" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.113.1" }
+cranelift-control = { path = "cranelift/control", version = "0.113.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.113.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=26.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=26.0.1" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+## 26.0.1
+
+Released 2024-11-05.
+
+### Fixed
+
+* Update to cap-std 3.4.1, for #9559, which fixes a wasi-filesystem sandbox
+  escape on Windows.
+  [CVE-2024-51745](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-c2f5-jxjv-2hh8).
+
+--------------------------------------------------------------------------------
+
 ## 26.0.0
 
 Released 2024-10-22.

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.113.0"
+version = "0.113.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.113.0"
+version = "0.113.1"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.113.0"
+version = "0.113.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -20,7 +20,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.113.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.113.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -49,8 +49,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.113.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.113.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.113.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.113.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.113.0"
+version = "0.113.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,4 +16,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.113.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.113.1" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.113.0"
+version = "0.113.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.113.0"
+version = "0.113.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.113.0"
+version = "0.113.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.113.0"
+version = "0.113.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.113.0"
+version = "0.113.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.113.0"
+version = "0.113.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.113.0"
+version = "0.113.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.113.0"
+version = "0.113.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.113.0"
+version = "0.113.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.113.0"
+version = "0.113.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.113.0"
+version = "0.113.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.113.0"
+version = "0.113.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.113.0"
+version = "0.113.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "26.0.0"
+#define WASMTIME_VERSION "26.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -24,6 +28,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-bforest]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -37,6 +45,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -48,6 +60,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-codegen]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -61,6 +77,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -72,6 +92,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -85,6 +109,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-control]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -96,6 +124,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-entity]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
@@ -109,6 +141,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -120,6 +156,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
@@ -133,6 +173,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -144,6 +188,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-jit]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
@@ -157,6 +205,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-module]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -168,6 +220,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-native]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-native]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
@@ -181,6 +237,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-object]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -193,6 +253,10 @@ audited_as = "0.110.1"
 version = "0.113.0"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.113.1"
+audited_as = "0.113.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -204,6 +268,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-serde]]
 version = "0.113.0"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-serde]]
+version = "0.113.1"
+audited_as = "0.113.0"
 
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
@@ -225,6 +293,10 @@ audited_as = "0.1.1"
 version = "26.0.0"
 audited_as = "0.1.1"
 
+[[unpublished.pulley-interpreter]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -236,6 +308,10 @@ audited_as = "23.0.1"
 [[unpublished.wasi-common]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasi-common]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -249,6 +325,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -260,6 +340,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -273,6 +357,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -284,6 +372,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-cli]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -297,6 +389,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -308,6 +404,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
@@ -321,6 +421,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -332,6 +436,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
@@ -345,6 +453,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-environ]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -356,6 +468,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-explorer]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-explorer]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
@@ -369,6 +485,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-fiber]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -380,6 +500,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
@@ -393,6 +517,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -404,6 +532,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-slab]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-slab]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
@@ -429,6 +561,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -440,6 +576,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "25.0.0"
@@ -449,6 +589,10 @@ audited_as = "24.0.0"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -460,6 +604,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "25.0.0"
@@ -469,6 +617,10 @@ audited_as = "24.0.0"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wasi-runtime-config]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -480,6 +632,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
@@ -493,6 +649,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -504,6 +664,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-winch]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
@@ -517,6 +681,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -528,6 +696,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wiggle]]
 version = "24.0.0"
@@ -541,6 +713,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wiggle]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -553,6 +729,10 @@ audited_as = "23.0.1"
 version = "26.0.0"
 audited_as = "24.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "26.0.1"
+audited_as = "26.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -564,6 +744,10 @@ audited_as = "23.0.1"
 [[unpublished.wiggle-macro]]
 version = "26.0.0"
 audited_as = "24.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -584,6 +768,10 @@ audited_as = "0.22.0"
 [[unpublished.winch-codegen]]
 version = "26.0.0"
 audited_as = "0.23.1"
+
+[[unpublished.winch-codegen]]
+version = "26.0.1"
+audited_as = "26.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -877,6 +1065,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -886,6 +1080,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -901,6 +1101,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-bitset]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -910,6 +1116,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -925,6 +1137,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-meta]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-shared]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -934,6 +1152,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-shared]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-shared]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -949,6 +1173,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-control]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-entity]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -958,6 +1188,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-entity]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-entity]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -973,6 +1209,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-frontend]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-interpreter]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -982,6 +1224,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-interpreter]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-interpreter]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -997,6 +1245,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-isle]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-jit]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1006,6 +1260,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-jit]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-jit]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1021,6 +1281,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-module]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-native]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1030,6 +1296,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-native]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-native]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1045,6 +1317,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-object]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-reader]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1057,6 +1335,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.113.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1066,6 +1350,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-serde]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-serde]]
+version = "0.113.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1289,6 +1579,12 @@ user-name = "Nick Fitzgerald"
 [[publisher.pulley-interpreter]]
 version = "0.1.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.pulley-interpreter]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1555,6 +1851,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1722,6 +2024,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1731,6 +2039,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1746,6 +2060,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1755,6 +2075,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1770,6 +2096,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1779,6 +2111,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1794,6 +2132,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1803,6 +2147,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1818,6 +2168,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1827,6 +2183,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1842,6 +2204,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1851,6 +2219,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1866,6 +2240,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-slab]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1875,6 +2255,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-slab]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-slab]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1890,6 +2276,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1899,6 +2291,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1908,6 +2306,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-keyvalue]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1917,6 +2321,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1926,6 +2336,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-runtime-config]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1935,6 +2351,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1950,6 +2372,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1959,6 +2387,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-winch]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1974,6 +2408,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1983,6 +2423,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2058,6 +2504,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2070,6 +2522,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "26.0.0"
+when = "2024-10-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2079,6 +2537,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2111,6 +2575,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.23.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "26.0.0"
+when = "2024-10-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 26.0.1, requested by @sunfishcode.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-26.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
