### PR TITLE
Release Wasmtime 25.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "25.0.2"
+version = "25.0.3"
 
 [[package]]
 name = "byteorder"
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -576,14 +576,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "arbitrary",
  "serde",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -624,25 +624,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.112.2"
+version = "0.112.3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-codegen",
  "env_logger",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.112.2"
+version = "0.112.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1055,7 +1055,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arbitrary",
  "cranelift-bitset",
@@ -3146,7 +3146,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "wasmparser 0.217.0",
@@ -3196,7 +3196,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3529,14 +3529,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3552,14 +3552,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3708,11 +3708,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "25.0.2"
+version = "25.0.3"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "object",
  "once_cell",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "25.0.2"
+version = "25.0.3"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "log",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "log",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "25.0.2"
+version = "25.0.3"
 
 [[package]]
 name = "wast"
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "25.0.2"
+version = "25.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4219,7 +4219,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "25.0.2"
+version = "25.0.3"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -184,62 +184,62 @@ manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=25.0.2" }
-wasmtime = { path = "crates/wasmtime", version = "25.0.2", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=25.0.2" }
-wasmtime-cache = { path = "crates/cache", version = "=25.0.2" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=25.0.2" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=25.0.2" }
-wasmtime-winch = { path = "crates/winch", version = "=25.0.2" }
-wasmtime-environ = { path = "crates/environ", version = "=25.0.2" }
-wasmtime-explorer = { path = "crates/explorer", version = "=25.0.2" }
-wasmtime-fiber = { path = "crates/fiber", version = "=25.0.2" }
-wasmtime-types = { path = "crates/types", version = "25.0.2" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=25.0.2" }
-wasmtime-wast = { path = "crates/wast", version = "=25.0.2" }
-wasmtime-wasi = { path = "crates/wasi", version = "25.0.2", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=25.0.2", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "25.0.2" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "25.0.2" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "25.0.2" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "25.0.2" }
-wasmtime-component-util = { path = "crates/component-util", version = "=25.0.2" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=25.0.2" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=25.0.2" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=25.0.2" }
-wasmtime-slab = { path = "crates/slab", version = "=25.0.2" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=25.0.3" }
+wasmtime = { path = "crates/wasmtime", version = "25.0.3", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=25.0.3" }
+wasmtime-cache = { path = "crates/cache", version = "=25.0.3" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=25.0.3" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=25.0.3" }
+wasmtime-winch = { path = "crates/winch", version = "=25.0.3" }
+wasmtime-environ = { path = "crates/environ", version = "=25.0.3" }
+wasmtime-explorer = { path = "crates/explorer", version = "=25.0.3" }
+wasmtime-fiber = { path = "crates/fiber", version = "=25.0.3" }
+wasmtime-types = { path = "crates/types", version = "25.0.3" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=25.0.3" }
+wasmtime-wast = { path = "crates/wast", version = "=25.0.3" }
+wasmtime-wasi = { path = "crates/wasi", version = "25.0.3", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=25.0.3", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "25.0.3" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "25.0.3" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "25.0.3" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "25.0.3" }
+wasmtime-component-util = { path = "crates/component-util", version = "=25.0.3" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=25.0.3" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=25.0.3" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=25.0.3" }
+wasmtime-slab = { path = "crates/slab", version = "=25.0.3" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=25.0.2", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=25.0.2" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=25.0.2" }
-wasi-common = { path = "crates/wasi-common", version = "=25.0.2", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=25.0.3", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=25.0.3" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=25.0.3" }
+wasi-common = { path = "crates/wasi-common", version = "=25.0.3", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=25.0.2" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=25.0.2" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=25.0.3" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=25.0.3" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=0.1.2" }
+pulley-interpreter = { path = 'pulley', version = "=0.1.3" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.112.2" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.112.2", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.112.2" }
-cranelift-entity = { path = "cranelift/entity", version = "0.112.2" }
-cranelift-native = { path = "cranelift/native", version = "0.112.2" }
-cranelift-module = { path = "cranelift/module", version = "0.112.2" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.112.2" }
-cranelift-reader = { path = "cranelift/reader", version = "0.112.2" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.112.3" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.112.3", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.112.3" }
+cranelift-entity = { path = "cranelift/entity", version = "0.112.3" }
+cranelift-native = { path = "cranelift/native", version = "0.112.3" }
+cranelift-module = { path = "cranelift/module", version = "0.112.3" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.112.3" }
+cranelift-reader = { path = "cranelift/reader", version = "0.112.3" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.112.2" }
-cranelift-jit = { path = "cranelift/jit", version = "0.112.2" }
+cranelift-object = { path = "cranelift/object", version = "0.112.3" }
+cranelift-jit = { path = "cranelift/jit", version = "0.112.3" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.112.2" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.112.2" }
-cranelift-control = { path = "cranelift/control", version = "0.112.2" }
-cranelift = { path = "cranelift/umbrella", version = "0.112.2" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.112.3" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.112.3" }
+cranelift-control = { path = "cranelift/control", version = "0.112.3" }
+cranelift = { path = "cranelift/umbrella", version = "0.112.3" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.23.2" }
+winch-codegen = { path = "winch/codegen", version = "=0.23.3" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+## 25.0.3
+
+Released 2024-11-05.
+
+### Fixed
+
+* Update to cap-std 3.4.1, for #9559, which fixes a wasi-filesystem sandbox
+  escape on Windows.
+  [CVE-2024-51745](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-c2f5-jxjv-2hh8).
+
+--------------------------------------------------------------------------------
+
 ## 25.0.2
 
 Released 2024-10-09.

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.112.2"
+version = "0.112.3"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.112.2"
+version = "0.112.3"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.112.2"
+version = "0.112.3"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -20,7 +20,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.112.2" }
+cranelift-codegen-shared = { path = "./shared", version = "0.112.3" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -49,8 +49,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.112.2" }
-cranelift-isle = { path = "../isle/isle", version = "=0.112.2" }
+cranelift-codegen-meta = { path = "meta", version = "0.112.3" }
+cranelift-isle = { path = "../isle/isle", version = "=0.112.3" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.112.2"
+version = "0.112.3"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,4 +16,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.112.2" }
+cranelift-codegen-shared = { path = "../shared", version = "0.112.3" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.112.2"
+version = "0.112.3"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.112.2"
+version = "0.112.3"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.112.2"
+version = "0.112.3"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.112.2"
+version = "0.112.3"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.112.2"
+version = "0.112.3"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.112.2"
+version = "0.112.3"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.112.2"
+version = "0.112.3"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.112.2"
+version = "0.112.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.112.2"
+version = "0.112.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.112.2"
+version = "0.112.3"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.112.2"
+version = "0.112.3"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.112.2"
+version = "0.112.3"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.112.2"
+version = "0.112.3"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.112.2"
+version = "0.112.3"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "25.0.2"
+#define WASMTIME_VERSION "25.0.3"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 2
+#define WASMTIME_VERSION_PATCH 3
 
 #ifdef __cplusplus
 extern "C" {

--- a/pulley/Cargo.toml
+++ b/pulley/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "pulley-interpreter"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/pulley"
-version = "0.1.2"
+version = "0.1.3"
 
 [lints]
 workspace = true

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -32,6 +36,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-bforest]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -49,6 +57,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -64,6 +76,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-codegen]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -81,6 +97,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -96,6 +116,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -113,6 +137,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-control]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -128,6 +156,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-entity]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
@@ -145,6 +177,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -160,6 +196,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
@@ -177,6 +217,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -192,6 +236,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-jit]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
@@ -209,6 +257,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-module]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -224,6 +276,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-native]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-native]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
@@ -241,6 +297,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-object]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -257,6 +317,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -273,6 +337,10 @@ audited_as = "0.112.0"
 version = "0.112.2"
 audited_as = "0.112.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.112.3"
+audited_as = "0.112.2"
+
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -288,6 +356,10 @@ audited_as = "0.112.0"
 [[unpublished.cranelift-wasm]]
 version = "0.112.2"
 audited_as = "0.112.1"
+
+[[unpublished.cranelift-wasm]]
+version = "0.112.3"
+audited_as = "0.112.2"
 
 [[unpublished.pulley-interpreter]]
 version = "0.1.0"
@@ -301,6 +373,10 @@ audited_as = "0.1.0"
 version = "0.1.2"
 audited_as = "0.1.1"
 
+[[unpublished.pulley-interpreter]]
+version = "0.1.3"
+audited_as = "0.1.2"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -316,6 +392,10 @@ audited_as = "25.0.0"
 [[unpublished.wasi-common]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasi-common]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -333,6 +413,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -348,6 +432,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-asm-macros]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -365,6 +453,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-cache]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -380,6 +472,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-cli]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -397,6 +493,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -412,6 +512,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-component-macro]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-component-macro]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
@@ -429,6 +533,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -444,6 +552,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-cranelift]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
@@ -461,6 +573,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -476,6 +592,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-explorer]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-explorer]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
@@ -493,6 +613,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-fiber]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -508,6 +632,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-jit-debug]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
@@ -525,6 +653,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -540,6 +672,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-slab]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-slab]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
@@ -557,6 +693,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-types]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-wasi]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -573,6 +713,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -588,6 +732,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-wasi-http]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "25.0.0"
@@ -601,6 +749,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -616,6 +768,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "25.0.0"
@@ -629,6 +785,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wasi-runtime-config]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -644,6 +804,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-wasi-threads]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
@@ -661,6 +825,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -676,6 +844,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-winch]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-winch]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
@@ -693,6 +865,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -708,6 +884,10 @@ audited_as = "25.0.0"
 [[unpublished.wasmtime-wmemcheck]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wiggle]]
 version = "24.0.0"
@@ -725,6 +905,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wiggle]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -741,6 +925,10 @@ audited_as = "25.0.0"
 version = "25.0.2"
 audited_as = "25.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "25.0.3"
+audited_as = "25.0.2"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -756,6 +944,10 @@ audited_as = "25.0.0"
 [[unpublished.wiggle-macro]]
 version = "25.0.2"
 audited_as = "25.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "25.0.3"
+audited_as = "25.0.2"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -776,6 +968,10 @@ audited_as = "0.23.0"
 [[unpublished.winch-codegen]]
 version = "0.23.2"
 audited_as = "0.23.1"
+
+[[unpublished.winch-codegen]]
+version = "0.23.3"
+audited_as = "0.23.2"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1012,6 +1208,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1027,6 +1229,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1048,6 +1256,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-bitset]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1063,6 +1277,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1084,6 +1304,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-meta]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-shared]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1099,6 +1325,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-shared]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-shared]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1120,6 +1352,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-control]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-entity]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1135,6 +1373,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-entity]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-entity]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1156,6 +1400,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-frontend]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-interpreter]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1171,6 +1421,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-interpreter]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-interpreter]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1192,6 +1448,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-isle]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-jit]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1207,6 +1469,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-jit]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-jit]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1228,6 +1496,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-module]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-native]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1243,6 +1517,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-native]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-native]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1264,6 +1544,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-object]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-reader]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1279,6 +1565,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-reader]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-reader]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1300,6 +1592,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.112.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1315,6 +1613,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.112.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.112.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1776,6 +2080,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1925,6 +2235,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1940,6 +2256,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1961,6 +2283,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1976,6 +2304,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1997,6 +2331,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2012,6 +2352,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2033,6 +2379,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2048,6 +2400,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2069,6 +2427,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2084,6 +2448,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2105,6 +2475,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2120,6 +2496,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2141,6 +2523,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-slab]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2156,6 +2544,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-slab]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-slab]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2177,6 +2571,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2195,6 +2595,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2210,6 +2616,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2231,6 +2643,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-keyvalue]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2246,6 +2664,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2267,6 +2691,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-runtime-config]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2282,6 +2712,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2303,6 +2739,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2318,6 +2760,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-winch]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2339,6 +2787,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2354,6 +2808,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2423,6 +2883,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2441,6 +2907,12 @@ when = "2024-09-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "25.0.2"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2456,6 +2928,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "25.0.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "25.0.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2488,6 +2966,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.23.1"
 when = "2024-09-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.23.2"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.23.2"
+version = "0.23.3"
 edition.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 25.0.3, requested by @sunfishcode.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-25.0.3/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
