### PR TITLE
Release Wasmtime 24.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "24.0.1"
+version = "24.0.2"
 
 [[package]]
 name = "byteorder"
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -569,14 +569,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -615,25 +615,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.1"
+version = "0.111.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-codegen",
  "env_logger",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.1"
+version = "0.111.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1045,7 +1045,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3089,7 +3089,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3139,7 +3139,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3433,14 +3433,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3456,14 +3456,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3612,11 +3612,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.1"
+version = "24.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "object",
  "once_cell",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.1"
+version = "24.0.2"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "24.0.1"
+version = "24.0.2"
 
 [[package]]
 name = "wast"
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "24.0.1"
+version = "24.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4121,7 +4121,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "24.0.1"
+version = "24.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -183,60 +183,60 @@ manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.1" }
-wasmtime = { path = "crates/wasmtime", version = "24.0.1", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.1" }
-wasmtime-cache = { path = "crates/cache", version = "=24.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=24.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=24.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=24.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=24.0.1" }
-wasmtime-types = { path = "crates/types", version = "24.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=24.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "24.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.1" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.1" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=24.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.1" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.1" }
-wasmtime-slab = { path = "crates/slab", version = "=24.0.1" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "24.0.2", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.2" }
+wasmtime-cache = { path = "crates/cache", version = "=24.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=24.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=24.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=24.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=24.0.2" }
+wasmtime-types = { path = "crates/types", version = "24.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=24.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "24.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.2" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.2" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=24.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.2" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.2" }
+wasmtime-slab = { path = "crates/slab", version = "=24.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=24.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=24.0.1", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=24.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=24.0.2", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.2" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.111.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.111.1", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.111.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.111.1" }
-cranelift-native = { path = "cranelift/native", version = "0.111.1" }
-cranelift-module = { path = "cranelift/module", version = "0.111.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.111.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.111.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.111.2", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.111.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.111.2" }
+cranelift-native = { path = "cranelift/native", version = "0.111.2" }
+cranelift-module = { path = "cranelift/module", version = "0.111.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.111.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.111.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.111.1" }
+cranelift-object = { path = "cranelift/object", version = "0.111.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.111.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.111.1" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.111.1" }
-cranelift-control = { path = "cranelift/control", version = "0.111.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.111.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.111.2" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.111.2" }
+cranelift-control = { path = "cranelift/control", version = "0.111.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.111.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.22.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.22.2" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+## 24.0.2
+
+Released 2024-11-05.
+
+### Fixed
+
+* Update to cap-std 3.4.1, for #9559, which fixes a wasi-filesystem sandbox
+  escape on Windows.
+  [CVE-2024-51745](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-c2f5-jxjv-2hh8).
+
+--------------------------------------------------------------------------------
+
 ## 24.0.1
 
 Released 2024-10-09.

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.111.1"
+version = "0.111.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.111.1"
+version = "0.111.2"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.111.1"
+version = "0.111.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.111.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.111.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.111.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.111.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.111.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.111.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.111.1"
+version = "0.111.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.111.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.111.2" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.111.1"
+version = "0.111.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.111.1"
+version = "0.111.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.111.1"
+version = "0.111.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.111.1"
+version = "0.111.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.111.1"
+version = "0.111.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.111.1"
+version = "0.111.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.111.1"
+version = "0.111.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.111.1"
+version = "0.111.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.111.1"
+version = "0.111.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.111.1"
+version = "0.111.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.111.1"
+version = "0.111.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.111.1"
+version = "0.111.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.111.1"
+version = "0.111.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.111.1"
+version = "0.111.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "24.0.1"
+#define WASMTIME_VERSION "24.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -16,6 +20,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-bforest]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -25,6 +33,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -32,6 +44,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-codegen]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -41,6 +57,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -48,6 +68,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -57,6 +81,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-control]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -64,6 +92,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-entity]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
@@ -73,6 +105,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -80,6 +116,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
@@ -89,6 +129,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -96,6 +140,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-jit]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
@@ -105,6 +153,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-module]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -112,6 +164,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-native]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-native]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
@@ -121,6 +177,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-object]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -128,6 +188,10 @@ audited_as = "0.110.1"
 [[unpublished.cranelift-reader]]
 version = "0.111.1"
 audited_as = "0.111.0"
+
+[[unpublished.cranelift-reader]]
+version = "0.111.2"
+audited_as = "0.111.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
@@ -137,6 +201,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -145,6 +213,10 @@ audited_as = "0.110.1"
 version = "0.111.1"
 audited_as = "0.111.0"
 
+[[unpublished.cranelift-wasm]]
+version = "0.111.2"
+audited_as = "0.111.1"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -152,6 +224,10 @@ audited_as = "23.0.1"
 [[unpublished.wasi-common]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasi-common]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -161,6 +237,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -168,6 +248,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -177,6 +261,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -184,6 +272,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-cli]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -193,6 +285,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -200,6 +296,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
@@ -209,6 +309,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -216,6 +320,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
@@ -225,6 +333,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-environ]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -232,6 +344,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-explorer]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-explorer]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
@@ -241,6 +357,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-fiber]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -248,6 +368,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
@@ -257,6 +381,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -264,6 +392,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-slab]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-slab]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
@@ -273,6 +405,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-types]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -281,6 +417,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -288,11 +428,19 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -300,11 +448,19 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wasi-runtime-config]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -312,6 +468,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
@@ -321,6 +481,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -328,6 +492,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-winch]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
@@ -337,6 +505,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -344,6 +516,10 @@ audited_as = "23.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wiggle]]
 version = "24.0.0"
@@ -353,6 +529,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wiggle]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -361,6 +541,10 @@ audited_as = "23.0.1"
 version = "24.0.1"
 audited_as = "24.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "24.0.2"
+audited_as = "24.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -368,6 +552,10 @@ audited_as = "23.0.1"
 [[unpublished.wiggle-macro]]
 version = "24.0.1"
 audited_as = "24.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "24.0.2"
+audited_as = "24.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -380,6 +568,10 @@ audited_as = "0.21.1"
 [[unpublished.winch-codegen]]
 version = "0.22.1"
 audited_as = "0.22.0"
+
+[[unpublished.winch-codegen]]
+version = "0.22.2"
+audited_as = "0.22.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -610,6 +802,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -619,6 +817,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -634,6 +838,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-bitset]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -643,6 +853,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -658,6 +874,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-meta]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-shared]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -667,6 +889,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-shared]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-shared]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -682,6 +910,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-control]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-entity]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -691,6 +925,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-entity]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-entity]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -706,6 +946,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-frontend]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-interpreter]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -715,6 +961,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-interpreter]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-interpreter]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -730,6 +982,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-isle]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-jit]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -739,6 +997,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-jit]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-jit]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -754,6 +1018,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-module]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-native]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -763,6 +1033,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-native]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-native]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -778,6 +1054,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-object]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-reader]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -787,6 +1069,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-reader]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-reader]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -802,6 +1090,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.111.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -811,6 +1105,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.111.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.111.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1210,6 +1510,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1305,6 +1611,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1314,6 +1626,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1329,6 +1647,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1338,6 +1662,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1353,6 +1683,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1362,6 +1698,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1377,6 +1719,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1386,6 +1734,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1401,6 +1755,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1410,6 +1770,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1425,6 +1791,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1434,6 +1806,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1449,6 +1827,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-slab]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1458,6 +1842,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-slab]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-slab]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1473,6 +1863,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1485,6 +1881,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1494,6 +1896,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1503,6 +1911,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-keyvalue]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1512,6 +1926,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1521,6 +1941,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-runtime-config]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1530,6 +1956,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1545,6 +1977,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1554,6 +1992,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-winch]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1569,6 +2013,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1578,6 +2028,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1617,6 +2073,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1629,6 +2091,12 @@ when = "2024-08-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "24.0.1"
+when = "2024-10-09"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1638,6 +2106,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "24.0.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "24.0.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1664,6 +2138,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.22.0"
 when = "2024-08-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.22.1"
+when = "2024-10-09"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.22.1"
+version = "0.22.2"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 24.0.2, requested by @sunfishcode.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-24.0.2/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
