### PR TITLE
Refactor `vm::Instance` for better `Store` safety

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -300,7 +300,7 @@ unsafe fn call_host_and_handle_result<T>(
     let instance = (*cx).instance();
     let types = (*instance).component_types();
     let raw_store = (*instance).store();
-    let mut store = StoreContextMut::from_raw(raw_store);
+    let mut store = StoreContextMut(&mut *raw_store.cast());
 
     let res = crate::runtime::vm::catch_unwind_and_longjmp(|| {
         store.0.call_hook(CallHook::CallingHost)?;

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use crate::runtime::vm::{self as runtime};
 use crate::store::{AutoAssertNoGc, StoreData, StoreOpaque, Stored};
 use crate::trampoline::generate_table_export;
+use crate::vm::ExportTable;
 use crate::{AnyRef, AsContext, AsContextMut, ExternRef, Func, HeapType, Ref, TableType};
 use core::iter;
 use core::ptr::NonNull;
@@ -138,9 +139,11 @@ impl Table {
         lazy_init_range: impl Iterator<Item = u64>,
     ) -> *mut runtime::Table {
         unsafe {
-            let export = &store[self.0];
-            crate::runtime::vm::Instance::from_vmctx(export.vmctx, |handle| {
-                let idx = handle.table_index(&*export.definition);
+            let ExportTable {
+                vmctx, definition, ..
+            } = store[self.0];
+            crate::runtime::vm::Instance::from_vmctx(vmctx, |handle| {
+                let idx = handle.table_index(&*definition);
                 handle.get_defined_table_with_lazy_init(idx, lazy_init_range)
             })
         }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2049,19 +2049,22 @@ impl<T> Caller<'_, T> {
         R: 'static,
     {
         debug_assert!(!caller.is_null());
-        crate::runtime::vm::Instance::from_vmctx(caller, |instance| {
-            let store = StoreContextMut::from_raw(instance.store());
-            let gc_lifo_scope = store.0.gc_roots().enter_lifo_scope();
+        crate::runtime::vm::InstanceAndStore::from_vmctx(caller, |pair| {
+            let (gc_lifo_scope, ret) = {
+                let (instance, store) = pair.unpack_context_mut::<T>();
+                let gc_lifo_scope = store.0.gc_roots().enter_lifo_scope();
 
-            let ret = f(Caller {
-                store,
-                caller: &instance,
-            });
+                let ret = f(Caller {
+                    store,
+                    caller: &instance,
+                });
+
+                (gc_lifo_scope, ret)
+            };
 
             // Safe to recreate a mutable borrow of the store because `ret`
             // cannot be borrowing from the store.
-            let store = StoreContextMut::<T>::from_raw(instance.store());
-            store.0.exit_gc_lifo_scope(gc_lifo_scope);
+            pair.store_mut().exit_gc_lifo_scope(gc_lifo_scope);
 
             ret
         })

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -340,13 +340,11 @@ impl Instance {
         // items from this instance into other instances should be ok when
         // those items are loaded and run we'll have all the metadata to
         // look at them.
-        instance_handle.initialize(
-            compiled_module.module(),
-            store
-                .engine()
-                .features()
-                .contains(WasmFeatures::BULK_MEMORY),
-        )?;
+        let bulk_memory = store
+            .engine()
+            .features()
+            .contains(WasmFeatures::BULK_MEMORY);
+        instance_handle.initialize(store, compiled_module.module(), bulk_memory)?;
 
         Ok((instance, compiled_module.module().start_func))
     }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2661,7 +2661,7 @@ unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
     }
 
     #[cfg(not(feature = "gc"))]
-    fn gc(&mut self, root: Option<VMGcRef>) -> Result<Option<VMGcRef>> {
+    fn maybe_async_gc(&mut self, root: Option<VMGcRef>) -> Result<Option<VMGcRef>> {
         Ok(root)
     }
 

--- a/crates/wasmtime/src/runtime/store/context.rs
+++ b/crates/wasmtime/src/runtime/store/context.rs
@@ -18,26 +18,6 @@ pub struct StoreContext<'a, T>(pub(crate) &'a StoreInner<T>);
 #[repr(transparent)]
 pub struct StoreContextMut<'a, T>(pub(crate) &'a mut StoreInner<T>);
 
-impl<'a, T> StoreContextMut<'a, T> {
-    /// One of the unsafe lynchpins of Wasmtime.
-    ///
-    /// This method is called from one location, `Caller::with`, and is where we
-    /// load the raw unsafe trait object pointer from a `*mut VMContext` and
-    /// then cast it back to a `StoreContextMut`. This is naturally unsafe due
-    /// to the raw pointer usage, but it's also unsafe because `T` here needs to
-    /// line up with the `T` used to define the trait object itself.
-    ///
-    /// This should generally be achieved with various trait bounds throughout
-    /// Wasmtime that might give access to the `Caller<'_, T>` type.
-    /// Unfortunately there's not a ton of debug asserts we can add here, so we
-    /// rely on testing to largely help show that this is correctly used.
-    pub(crate) unsafe fn from_raw(
-        store: *mut dyn crate::runtime::vm::VMStore,
-    ) -> StoreContextMut<'a, T> {
-        StoreContextMut(&mut *(store as *mut StoreInner<T>))
-    }
-}
-
 /// A trait used to get shared access to a [`Store`] in Wasmtime.
 ///
 /// This trait is used as a bound on the first argument of many methods within

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -162,7 +162,7 @@ pub unsafe trait VMStore {
     fn component_calls(&mut self) -> &mut component::CallContexts;
 }
 
-impl Deref for dyn VMStore {
+impl Deref for dyn VMStore + '_ {
     type Target = StoreOpaque;
 
     fn deref(&self) -> &Self::Target {
@@ -170,7 +170,7 @@ impl Deref for dyn VMStore {
     }
 }
 
-impl DerefMut for dyn VMStore {
+impl DerefMut for dyn VMStore + '_ {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.store_opaque_mut()
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -57,8 +57,8 @@ pub use crate::runtime::vm::gc::*;
 pub use crate::runtime::vm::imports::Imports;
 pub use crate::runtime::vm::instance::{
     GcHeapAllocationIndex, Instance, InstanceAllocationRequest, InstanceAllocator,
-    InstanceAllocatorImpl, InstanceHandle, MemoryAllocationIndex, OnDemandInstanceAllocator,
-    StorePtr, TableAllocationIndex,
+    InstanceAllocatorImpl, InstanceAndStore, InstanceHandle, MemoryAllocationIndex,
+    OnDemandInstanceAllocator, StorePtr, TableAllocationIndex,
 };
 #[cfg(feature = "pooling-allocator")]
 pub use crate::runtime::vm::instance::{
@@ -155,7 +155,7 @@ pub unsafe trait VMStore {
     ///
     /// If the async GC was cancelled, returns an error. This should be raised
     /// as a trap to clean up Wasm execution.
-    fn gc(&mut self, root: Option<VMGcRef>) -> Result<Option<VMGcRef>>;
+    fn maybe_async_gc(&mut self, root: Option<VMGcRef>) -> Result<Option<VMGcRef>>;
 
     /// Metadata required for resources for the component model.
     #[cfg(feature = "component-model")]

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -179,6 +179,8 @@ impl ConstExprEvaluator {
         // store's lifetime.
         #[cfg(feature = "gc")]
         let mut store = crate::OpaqueRootScope::new(store);
+        #[cfg(not(feature = "gc"))]
+        let mut store = store;
 
         // We cannot allow GC during const evaluation because the stack of
         // `ValRaw`s are not rooted. If we had a GC reference on our stack, and

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -125,17 +125,10 @@ impl InstanceAndStore {
         f(&mut *ptr)
     }
 
-    /// Get the underlying `dyn VMStore` trait object for this
-    /// `InstanceAndStore`.
-    #[inline]
-    pub(crate) fn store_mut(&mut self) -> &mut (dyn VMStore + 'static) {
-        unsafe { &mut *self.store_ptr() }
-    }
-
     /// Unpacks this `InstanceAndStore` into its underlying `Instance` and `dyn
     /// VMStore`.
     #[inline]
-    pub(crate) fn unpack_mut(&mut self) -> (&mut Instance, &mut (dyn VMStore + 'static)) {
+    pub(crate) fn unpack_mut(&mut self) -> (&mut Instance, &mut dyn VMStore) {
         unsafe {
             let store = &mut *self.store_ptr();
             (&mut self.instance, store)
@@ -168,7 +161,7 @@ impl InstanceAndStore {
     /// functions are shared amongst threads and don't all share the same
     /// store).
     #[inline]
-    fn store_ptr(&self) -> *mut (dyn VMStore + 'static) {
+    fn store_ptr(&self) -> *mut dyn VMStore {
         let ptr = unsafe {
             *self
                 .instance

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -57,7 +57,7 @@
 use crate::prelude::*;
 use crate::runtime::vm::table::{Table, TableElementType};
 use crate::runtime::vm::vmcontext::VMFuncRef;
-use crate::runtime::vm::{Instance, TrapReason, VMGcRef};
+use crate::runtime::vm::{Instance, TrapReason, VMGcRef, VMStore};
 #[cfg(feature = "threads")]
 use core::time::Duration;
 use wasmtime_environ::Unsigned;
@@ -86,7 +86,7 @@ pub mod raw {
     // between doc comments and `cfg`s.
     #![allow(unused_doc_comments, unused_attributes)]
 
-    use crate::runtime::vm::{Instance, TrapReason, VMContext};
+    use crate::runtime::vm::{InstanceAndStore, TrapReason, VMContext};
 
     macro_rules! libcall {
         (
@@ -110,9 +110,10 @@ pub mod raw {
                     $(#[cfg($attr)])?
                     {
                         let ret = crate::runtime::vm::traphandlers::catch_unwind_and_longjmp(|| {
-                            Instance::from_vmctx(vmctx, |instance| {
+                            InstanceAndStore::from_vmctx(vmctx, |pair| {
                                 {
-                                    super::$name(instance, $($pname),*)
+                                    let (instance, store) = pair.unpack_mut();
+                                    super::$name(store, instance, $($pname),*)
                                 }
                             })
                         });
@@ -192,26 +193,27 @@ pub mod raw {
 }
 
 fn memory32_grow(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     delta: u64,
     memory_index: u32,
 ) -> Result<*mut u8, TrapReason> {
     let memory_index = MemoryIndex::from_u32(memory_index);
-    let result =
-        match instance
-            .memory_grow(memory_index, delta)
-            .map_err(|error| TrapReason::User {
-                error,
-                needs_backtrace: true,
-            })? {
-            Some(size_in_bytes) => size_in_bytes / instance.memory_page_size(memory_index),
-            None => usize::max_value(),
-        };
+    let result = match instance
+        .memory_grow(store, memory_index, delta)
+        .map_err(|error| TrapReason::User {
+            error,
+            needs_backtrace: true,
+        })? {
+        Some(size_in_bytes) => size_in_bytes / instance.memory_page_size(memory_index),
+        None => usize::max_value(),
+    };
     Ok(result as *mut _)
 }
 
 /// Implementation of `table.grow` for `funcref` tables.
 unsafe fn table_grow_func_ref(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     table_index: u32,
     delta: u64,
@@ -224,7 +226,7 @@ unsafe fn table_grow_func_ref(
         TableElementType::GcRef => unreachable!(),
     };
 
-    let result = match instance.table_grow(table_index, delta, element)? {
+    let result = match instance.table_grow(store, table_index, delta, element)? {
         Some(r) => r,
         None => usize::MAX,
     };
@@ -234,6 +236,7 @@ unsafe fn table_grow_func_ref(
 /// Implementation of `table.grow` for GC-reference tables.
 #[cfg(feature = "gc")]
 unsafe fn table_grow_gc_ref(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     table_index: u32,
     delta: u64,
@@ -244,11 +247,16 @@ unsafe fn table_grow_gc_ref(
     let element = match instance.table_element_type(table_index) {
         TableElementType::Func => unreachable!(),
         TableElementType::GcRef => VMGcRef::from_raw_u32(init_value)
-            .map(|r| (*instance.store()).unwrap_gc_store_mut().clone_gc_ref(&r))
+            .map(|r| {
+                store
+                    .store_opaque_mut()
+                    .unwrap_gc_store_mut()
+                    .clone_gc_ref(&r)
+            })
             .into(),
     };
 
-    let result = match instance.table_grow(table_index, delta, element)? {
+    let result = match instance.table_grow(store, table_index, delta, element)? {
         Some(r) => r,
         None => usize::MAX,
     };
@@ -257,6 +265,7 @@ unsafe fn table_grow_gc_ref(
 
 /// Implementation of `table.fill` for `funcref`s.
 unsafe fn table_fill_func_ref(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     table_index: u32,
     dst: u64,
@@ -269,12 +278,7 @@ unsafe fn table_fill_func_ref(
         TableElementType::Func => {
             let val = val.cast::<VMFuncRef>();
             table
-                .fill(
-                    (*instance.store()).optional_gc_store_mut()?,
-                    dst,
-                    val.into(),
-                    len,
-                )
+                .fill(store.optional_gc_store_mut()?, dst, val.into(), len)
                 .err2anyhow()?;
             Ok(())
         }
@@ -284,6 +288,7 @@ unsafe fn table_fill_func_ref(
 
 #[cfg(feature = "gc")]
 unsafe fn table_fill_gc_ref(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     table_index: u32,
     dst: u64,
@@ -295,7 +300,7 @@ unsafe fn table_fill_gc_ref(
     match table.element_type() {
         TableElementType::Func => unreachable!(),
         TableElementType::GcRef => {
-            let gc_store = (*instance.store()).gc_store_mut()?;
+            let gc_store = store.store_opaque_mut().unwrap_gc_store_mut();
             let gc_ref = VMGcRef::from_raw_u32(val);
             let gc_ref = gc_ref.map(|r| gc_store.clone_gc_ref(&r));
             table
@@ -308,6 +313,7 @@ unsafe fn table_fill_gc_ref(
 
 // Implementation of `table.copy`.
 unsafe fn table_copy(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     dst_table_index: u32,
     src_table_index: u32,
@@ -317,17 +323,19 @@ unsafe fn table_copy(
 ) -> Result<()> {
     let dst_table_index = TableIndex::from_u32(dst_table_index);
     let src_table_index = TableIndex::from_u32(src_table_index);
+    let store = store.store_opaque_mut();
     let dst_table = instance.get_table(dst_table_index);
     // Lazy-initialize the whole range in the source table first.
     let src_range = src..(src.checked_add(len).unwrap_or(u64::MAX));
     let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);
-    let gc_store = (*instance.store()).optional_gc_store_mut()?;
+    let gc_store = store.optional_gc_store_mut()?;
     Table::copy(gc_store, dst_table, src_table, dst, src, len).err2anyhow()?;
     Ok(())
 }
 
 // Implementation of `table.init`.
 fn table_init(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     table_index: u32,
     elem_index: u32,
@@ -337,17 +345,25 @@ fn table_init(
 ) -> Result<(), Trap> {
     let table_index = TableIndex::from_u32(table_index);
     let elem_index = ElemIndex::from_u32(elem_index);
-    instance.table_init(table_index, elem_index, dst, src, len)
+    instance.table_init(
+        store.store_opaque_mut(),
+        table_index,
+        elem_index,
+        dst,
+        src,
+        len,
+    )
 }
 
 // Implementation of `elem.drop`.
-fn elem_drop(instance: &mut Instance, elem_index: u32) {
+fn elem_drop(_store: &mut (dyn VMStore + 'static), instance: &mut Instance, elem_index: u32) {
     let elem_index = ElemIndex::from_u32(elem_index);
     instance.elem_drop(elem_index)
 }
 
 // Implementation of `memory.copy`.
 fn memory_copy(
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     dst_index: u32,
     dst: u64,
@@ -362,6 +378,7 @@ fn memory_copy(
 
 // Implementation of `memory.fill` for locally defined memories.
 fn memory_fill(
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     memory_index: u32,
     dst: u64,
@@ -375,6 +392,7 @@ fn memory_fill(
 
 // Implementation of `memory.init`.
 fn memory_init(
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     memory_index: u32,
     data_index: u32,
@@ -388,7 +406,11 @@ fn memory_init(
 }
 
 // Implementation of `ref.func`.
-fn ref_func(instance: &mut Instance, func_index: u32) -> *mut u8 {
+fn ref_func(
+    _store: &mut (dyn VMStore + 'static),
+    instance: &mut Instance,
+    func_index: u32,
+) -> *mut u8 {
     instance
         .get_func_ref(FuncIndex::from_u32(func_index))
         .expect("ref_func: funcref should always be available for given func index")
@@ -396,13 +418,14 @@ fn ref_func(instance: &mut Instance, func_index: u32) -> *mut u8 {
 }
 
 // Implementation of `data.drop`.
-fn data_drop(instance: &mut Instance, data_index: u32) {
+fn data_drop(_store: &mut (dyn VMStore + 'static), instance: &mut Instance, data_index: u32) {
     let data_index = DataIndex::from_u32(data_index);
     instance.data_drop(data_index)
 }
 
 // Returns a table entry after lazily initializing it.
 unsafe fn table_get_lazy_init_func_ref(
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     table_index: u32,
     index: u64,
@@ -418,10 +441,11 @@ unsafe fn table_get_lazy_init_func_ref(
 
 /// Drop a GC reference.
 #[cfg(feature = "gc-drc")]
-unsafe fn drop_gc_ref(instance: &mut Instance, gc_ref: u32) {
+unsafe fn drop_gc_ref(store: &mut (dyn VMStore + 'static), _instance: &mut Instance, gc_ref: u32) {
     log::trace!("libcalls::drop_gc_ref({gc_ref:#x})");
     let gc_ref = VMGcRef::from_raw_u32(gc_ref).expect("non-null VMGcRef");
-    (*instance.store())
+    store
+        .store_opaque_mut()
         .unwrap_gc_store_mut()
         .drop_gc_ref(gc_ref);
 }
@@ -429,9 +453,18 @@ unsafe fn drop_gc_ref(instance: &mut Instance, gc_ref: u32) {
 /// Do a GC, keeping `gc_ref` rooted and returning the updated `gc_ref`
 /// reference.
 #[cfg(feature = "gc-drc")]
-unsafe fn gc(instance: &mut Instance, gc_ref: u32) -> Result<u32> {
+unsafe fn gc(
+    store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    gc_ref: u32,
+) -> Result<u32> {
     let gc_ref = VMGcRef::from_raw_u32(gc_ref);
-    let gc_ref = gc_ref.map(|r| (*instance.store()).unwrap_gc_store_mut().clone_gc_ref(&r));
+    let gc_ref = gc_ref.map(|r| {
+        store
+            .store_opaque_mut()
+            .unwrap_gc_store_mut()
+            .clone_gc_ref(&r)
+    });
 
     if let Some(gc_ref) = &gc_ref {
         // It is possible that we are GC'ing because the DRC's activation
@@ -441,16 +474,17 @@ unsafe fn gc(instance: &mut Instance, gc_ref: u32) -> Result<u32> {
         // time of a GC. So make sure to "expose" this GC reference to Wasm (aka
         // insert it into the DRC's activation table) before we do the actual
         // GC.
-        let gc_store = (*instance.store()).unwrap_gc_store_mut();
+        let gc_store = store.store_opaque_mut().unwrap_gc_store_mut();
         let gc_ref = gc_store.clone_gc_ref(gc_ref);
         gc_store.expose_gc_ref_to_wasm(gc_ref);
     }
 
-    match (*instance.store()).gc(gc_ref)? {
+    match store.maybe_async_gc(gc_ref)? {
         None => Ok(0),
         Some(r) => {
             let raw = r.as_raw_u32();
-            (*instance.store())
+            store
+                .store_opaque_mut()
                 .unwrap_gc_store_mut()
                 .expose_gc_ref_to_wasm(r);
             Ok(raw)
@@ -463,6 +497,7 @@ unsafe fn gc(instance: &mut Instance, gc_ref: u32) -> Result<u32> {
 /// The Wasm code is responsible for initializing the object.
 #[cfg(feature = "gc-drc")]
 unsafe fn gc_alloc_raw(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     kind: u32,
     module_interned_type_index: u32,
@@ -492,17 +527,18 @@ unsafe fn gc_alloc_raw(
     let align = usize::try_from(align).unwrap();
     let layout = Layout::from_size_align(size, align).unwrap();
 
-    let gc_ref = match (*instance.store())
+    let gc_ref = match store
+        .store_opaque_mut()
         .unwrap_gc_store_mut()
         .alloc_raw(header, layout)?
     {
         Some(r) => r,
         None => {
             // If the allocation failed, do a GC to hopefully clean up space.
-            (*instance.store()).gc(None)?;
+            store.maybe_async_gc(None)?;
 
             // And then try again.
-            (*instance.store())
+            store
                 .unwrap_gc_store_mut()
                 .alloc_raw(header, layout)?
                 .ok_or_else(|| GcHeapOutOfMemory::new(()))
@@ -517,11 +553,15 @@ unsafe fn gc_alloc_raw(
 //
 // This libcall may not GC.
 #[cfg(feature = "gc")]
-unsafe fn intern_func_ref_for_gc_heap(instance: &mut Instance, func_ref: *mut u8) -> Result<u32> {
+unsafe fn intern_func_ref_for_gc_heap(
+    store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    func_ref: *mut u8,
+) -> Result<u32> {
     use crate::{store::AutoAssertNoGc, vm::SendSyncPtr};
     use core::ptr::NonNull;
 
-    let mut store = AutoAssertNoGc::new((*instance.store()).store_opaque_mut());
+    let mut store = AutoAssertNoGc::new(store.store_opaque_mut());
 
     let func_ref = func_ref.cast::<VMFuncRef>();
     let func_ref = NonNull::new(func_ref).map(SendSyncPtr::new);
@@ -536,6 +576,7 @@ unsafe fn intern_func_ref_for_gc_heap(instance: &mut Instance, func_ref: *mut u8
 // This libcall may not GC.
 #[cfg(feature = "gc")]
 unsafe fn get_interned_func_ref(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     func_ref_id: u32,
     module_interned_type_index: u32,
@@ -544,7 +585,7 @@ unsafe fn get_interned_func_ref(
     use crate::store::AutoAssertNoGc;
     use wasmtime_environ::{packed_option::ReservedValue, ModuleInternedTypeIndex};
 
-    let store = AutoAssertNoGc::new((*instance.store()).store_opaque_mut());
+    let store = AutoAssertNoGc::new(store.store_opaque_mut());
 
     let func_ref_id = FuncRefTableId::from_raw(func_ref_id);
     let module_interned_type_index = ModuleInternedTypeIndex::from_bits(module_interned_type_index);
@@ -569,6 +610,7 @@ unsafe fn get_interned_func_ref(
 /// Implementation of the `array.new_data` instruction.
 #[cfg(feature = "gc")]
 unsafe fn array_new_data(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     array_type_index: u32,
     data_index: u32,
@@ -585,7 +627,7 @@ unsafe fn array_new_data(
     // of the array).
     let data_range = instance.wasm_data_range(data_index);
     let shared_ty = instance.engine_type_index(array_type_index);
-    let array_ty = ArrayType::from_shared_type_index((*instance.store()).engine(), shared_ty);
+    let array_ty = ArrayType::from_shared_type_index(store.store_opaque_mut().engine(), shared_ty);
     let one_elem_size = array_ty
         .element_type()
         .data_byte_size()
@@ -604,13 +646,15 @@ unsafe fn array_new_data(
         .ok_or_else(|| Trap::MemoryOutOfBounds.into_anyhow())?;
 
     // Allocate the (uninitialized) array.
-    let gc_layout = (*instance.store())
+    let gc_layout = store
+        .store_opaque_mut()
         .engine()
         .signatures()
         .layout(shared_ty)
         .expect("array types have GC layouts");
     let array_layout = gc_layout.unwrap_array();
-    let array_ref = match (*instance.store())
+    let array_ref = match store
+        .store_opaque_mut()
         .unwrap_gc_store_mut()
         .alloc_uninit_array(shared_ty, len, &array_layout)?
     {
@@ -618,8 +662,9 @@ unsafe fn array_new_data(
         None => {
             // Collect garbage to hopefully free up space, then try the
             // allocation again.
-            (*instance.store()).gc(None)?;
-            (*instance.store())
+            store.maybe_async_gc(None)?;
+            store
+                .store_opaque_mut()
                 .unwrap_gc_store_mut()
                 .alloc_uninit_array(shared_ty, u32::try_from(byte_len).unwrap(), &array_layout)?
                 .ok_or_else(|| GcHeapOutOfMemory::new(()).into_anyhow())?
@@ -627,14 +672,16 @@ unsafe fn array_new_data(
     };
 
     // Copy the data into the array, initializing it.
-    (*instance.store())
+    store
+        .store_opaque_mut()
         .unwrap_gc_store_mut()
         .gc_object_data(array_ref.as_gc_ref())
         .copy_from_slice(array_layout.base_size, data);
 
     // Return the array to Wasm!
     let raw = array_ref.as_gc_ref().as_raw_u32();
-    (*instance.store())
+    store
+        .store_opaque_mut()
         .unwrap_gc_store_mut()
         .expose_gc_ref_to_wasm(array_ref.into());
     Ok(raw)
@@ -643,6 +690,7 @@ unsafe fn array_new_data(
 /// Implementation of the `array.init_data` instruction.
 #[cfg(feature = "gc")]
 unsafe fn array_init_data(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     array_type_index: u32,
     array: u32,
@@ -664,7 +712,7 @@ unsafe fn array_init_data(
     // Null check the array.
     let gc_ref = VMGcRef::from_raw_u32(array).ok_or_else(|| Trap::NullReference.into_anyhow())?;
     let array = gc_ref
-        .into_arrayref(&*(*instance.store()).unwrap_gc_store().gc_heap)
+        .into_arrayref(&*store.unwrap_gc_store().gc_heap)
         .expect("gc ref should be an array");
 
     let dst = usize::try_from(dst).map_err(|_| Trap::MemoryOutOfBounds.into_anyhow())?;
@@ -672,7 +720,7 @@ unsafe fn array_init_data(
     let len = usize::try_from(len).map_err(|_| Trap::MemoryOutOfBounds.into_anyhow())?;
 
     // Bounds check the array.
-    let array_len = array.len((*instance.store()).store_opaque());
+    let array_len = array.len(store.store_opaque());
     let array_len = usize::try_from(array_len).map_err(|_| Trap::ArrayOutOfBounds.into_anyhow())?;
     if dst
         .checked_add(len)
@@ -684,7 +732,7 @@ unsafe fn array_init_data(
 
     // Calculate the byte length from the array length.
     let shared_ty = instance.engine_type_index(array_type_index);
-    let array_ty = ArrayType::from_shared_type_index((*instance.store()).engine(), shared_ty);
+    let array_ty = ArrayType::from_shared_type_index(store.engine(), shared_ty);
     let one_elem_size = array_ty
         .element_type()
         .data_byte_size()
@@ -708,7 +756,7 @@ unsafe fn array_init_data(
         .checked_mul(one_elem_size)
         .unwrap();
 
-    let array_layout = (*instance.store())
+    let array_layout = store
         .engine()
         .signatures()
         .layout(shared_ty)
@@ -717,7 +765,7 @@ unsafe fn array_init_data(
 
     let obj_offset = array_layout.base_size.checked_add(dst_offset).unwrap();
 
-    (*instance.store())
+    store
         .unwrap_gc_store_mut()
         .gc_object_data(array.as_gc_ref())
         .copy_from_slice(obj_offset, data);
@@ -727,6 +775,7 @@ unsafe fn array_init_data(
 
 #[cfg(feature = "gc")]
 unsafe fn array_new_elem(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     array_type_index: u32,
     elem_index: u32,
@@ -736,7 +785,7 @@ unsafe fn array_new_elem(
     use crate::{
         store::AutoAssertNoGc,
         vm::const_expr::{ConstEvalContext, ConstExprEvaluator},
-        ArrayRef, ArrayRefPre, ArrayType, Func, GcHeapOutOfMemory, RootedGcRefImpl, Val,
+        ArrayRef, ArrayRefPre, ArrayType, Func, GcHeapOutOfMemory, RootSet, RootedGcRefImpl, Val,
     };
     use wasmtime_environ::{ModuleInternedTypeIndex, TableSegmentElements};
 
@@ -751,15 +800,11 @@ unsafe fn array_new_elem(
     let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds.into_anyhow())?;
 
     let shared_ty = instance.engine_type_index(array_type_index);
-    let array_ty = ArrayType::from_shared_type_index((*instance.store()).engine(), shared_ty);
+    let array_ty = ArrayType::from_shared_type_index(store.engine(), shared_ty);
     let elem_ty = array_ty.element_type();
-    let pre = ArrayRefPre::_new((*instance.store()).store_opaque_mut(), array_ty);
+    let pre = ArrayRefPre::_new(store, array_ty);
 
-    // NB: Don't use `OpaqueRootScope` here because we need to borrow the store
-    // through `instance` during const evaluation, which is within the same
-    // region that the `OpaqueRootScope` would otherwise span while borrowing
-    // the same store, resulting in double borrows.
-    instance.with_gc_lifo_scope(|instance| {
+    RootSet::with_lifo_scope(store, |store| {
         // Turn the elements into `Val`s.
         let mut vals = Vec::with_capacity(usize::try_from(elements.len()).unwrap());
         match elements {
@@ -772,10 +817,7 @@ unsafe fn array_new_elem(
                         .map(|f| {
                             let raw_func_ref =
                                 instance.get_func_ref(*f).unwrap_or(core::ptr::null_mut());
-                            let func = Func::from_vm_func_ref(
-                                (*instance.store()).store_opaque_mut(),
-                                raw_func_ref,
-                            );
+                            let func = Func::from_vm_func_ref(store, raw_func_ref);
                             Val::FuncRef(func)
                         }),
                 );
@@ -791,28 +833,26 @@ unsafe fn array_new_elem(
 
                 vals.extend(xs.iter().map(|x| unsafe {
                     let raw = const_evaluator
-                        .eval(&mut const_context, x)
+                        .eval(store, &mut const_context, x)
                         .expect("const expr should be valid");
-                    let mut store =
-                        AutoAssertNoGc::new((*const_context.instance.store()).store_opaque_mut());
+                    let mut store = AutoAssertNoGc::new(store);
                     Val::_from_raw(&mut store, raw, elem_ty.unwrap_val_type())
                 }));
             }
         }
 
-        let array = match ArrayRef::_new_fixed((*instance.store()).store_opaque_mut(), &pre, &vals)
-        {
+        let array = match ArrayRef::_new_fixed(store, &pre, &vals) {
             Ok(a) => a,
             Err(e) if e.is::<GcHeapOutOfMemory<()>>() => {
                 // Collect garbage to hopefully free up space, then try the
                 // allocation again.
-                (*instance.store()).gc(None)?;
-                ArrayRef::_new_fixed((*instance.store()).store_opaque_mut(), &pre, &vals)?
+                store.maybe_async_gc(None)?;
+                ArrayRef::_new_fixed(store, &pre, &vals)?
             }
             Err(e) => return Err(e),
         };
 
-        let mut store = AutoAssertNoGc::new((*instance.store()).store_opaque_mut());
+        let mut store = AutoAssertNoGc::new(store);
         let gc_ref = array.try_clone_gc_ref(&mut store)?;
         let raw = gc_ref.as_raw_u32();
         store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref);
@@ -822,6 +862,7 @@ unsafe fn array_new_elem(
 
 #[cfg(feature = "gc")]
 unsafe fn array_init_elem(
+    store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     array_type_index: u32,
     array: u32,
@@ -833,103 +874,90 @@ unsafe fn array_init_elem(
     use crate::{
         store::AutoAssertNoGc,
         vm::const_expr::{ConstEvalContext, ConstExprEvaluator},
-        ArrayRef, Func, Val,
+        ArrayRef, Func, OpaqueRootScope, Val,
     };
     use wasmtime_environ::{ModuleInternedTypeIndex, TableSegmentElements};
 
-    // NB: Don't use `OpaqueRootScope` here because we need to borrow the store
-    // through `instance` during const evaluation, which is within the same
-    // region that the `OpaqueRootScope` would otherwise span while borrowing
-    // the same store, resulting in double borrows.
-    instance.with_gc_lifo_scope(|instance| {
-        // Convert the indices into their typed forms.
-        let _array_type_index = ModuleInternedTypeIndex::from_u32(array_type_index);
-        let elem_index = ElemIndex::from_u32(elem_index);
+    let mut store = OpaqueRootScope::new(store.store_opaque_mut());
 
-        log::trace!(
+    // Convert the indices into their typed forms.
+    let _array_type_index = ModuleInternedTypeIndex::from_u32(array_type_index);
+    let elem_index = ElemIndex::from_u32(elem_index);
+
+    log::trace!(
             "array.init_elem(array={array:#x}, dst={dst}, elem_index={elem_index:?}, src={src}, len={len})",
         );
 
-        // Convert the raw GC ref into a `Rooted<ArrayRef>`.
-        let array =
-            VMGcRef::from_raw_u32(array).ok_or_else(|| Trap::NullReference.into_anyhow())?;
-        let array = (*instance.store()).unwrap_gc_store_mut().clone_gc_ref(&array);
-        let array = {
-            let mut no_gc = AutoAssertNoGc::new((*instance.store()).store_opaque_mut());
-            ArrayRef::from_cloned_gc_ref(&mut no_gc, array)
-        };
+    // Convert the raw GC ref into a `Rooted<ArrayRef>`.
+    let array = VMGcRef::from_raw_u32(array).ok_or_else(|| Trap::NullReference.into_anyhow())?;
+    let array = store.unwrap_gc_store_mut().clone_gc_ref(&array);
+    let array = {
+        let mut no_gc = AutoAssertNoGc::new(&mut store);
+        ArrayRef::from_cloned_gc_ref(&mut no_gc, array)
+    };
 
-        // Bounds check the destination within the array.
-        let array_len = array._len((*instance.store()).store_opaque())?;
-        log::trace!("array_len = {array_len}");
-        if dst
-            .checked_add(len)
-            .ok_or_else(|| Trap::ArrayOutOfBounds.into_anyhow())?
-            > array_len
-        {
-            return Err(Trap::ArrayOutOfBounds.into_anyhow());
-        }
+    // Bounds check the destination within the array.
+    let array_len = array._len(&store)?;
+    log::trace!("array_len = {array_len}");
+    if dst
+        .checked_add(len)
+        .ok_or_else(|| Trap::ArrayOutOfBounds.into_anyhow())?
+        > array_len
+    {
+        return Err(Trap::ArrayOutOfBounds.into_anyhow());
+    }
 
-        // Get the passive element segment.
-        let mut storage = None;
-        let elements = instance.passive_element_segment(&mut storage, elem_index);
+    // Get the passive element segment.
+    let mut storage = None;
+    let elements = instance.passive_element_segment(&mut storage, elem_index);
 
-        // Convert array offsets into `usize`s.
-        let src = usize::try_from(src).map_err(|_| Trap::TableOutOfBounds.into_anyhow())?;
-        let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds.into_anyhow())?;
+    // Convert array offsets into `usize`s.
+    let src = usize::try_from(src).map_err(|_| Trap::TableOutOfBounds.into_anyhow())?;
+    let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds.into_anyhow())?;
 
-        // Turn the elements into `Val`s.
-        let vals = match elements {
-            TableSegmentElements::Functions(fs) => fs
-                .get(src..)
+    // Turn the elements into `Val`s.
+    let vals = match elements {
+        TableSegmentElements::Functions(fs) => fs
+            .get(src..)
+            .and_then(|s| s.get(..len))
+            .ok_or_else(|| Trap::TableOutOfBounds.into_anyhow())?
+            .iter()
+            .map(|f| {
+                let raw_func_ref = instance.get_func_ref(*f).unwrap_or(core::ptr::null_mut());
+                let func = Func::from_vm_func_ref(&mut store, raw_func_ref);
+                Val::FuncRef(func)
+            })
+            .collect::<Vec<_>>(),
+        TableSegmentElements::Expressions(xs) => {
+            let elem_ty = array._ty(&store)?.element_type();
+            let elem_ty = elem_ty.unwrap_val_type();
+
+            let mut const_context = ConstEvalContext::new(instance);
+            let mut const_evaluator = ConstExprEvaluator::default();
+
+            xs.get(src..)
                 .and_then(|s| s.get(..len))
                 .ok_or_else(|| Trap::TableOutOfBounds.into_anyhow())?
                 .iter()
-                .map(|f| {
-                    let raw_func_ref = instance.get_func_ref(*f).unwrap_or(core::ptr::null_mut());
-                    let func = Func::from_vm_func_ref(
-                        (*instance.store()).store_opaque_mut(),
-                        raw_func_ref,
-                    );
-                    Val::FuncRef(func)
+                .map(|x| unsafe {
+                    let raw = const_evaluator
+                        .eval(&mut store, &mut const_context, x)
+                        .expect("const expr should be valid");
+                    let mut store = AutoAssertNoGc::new(&mut store);
+                    Val::_from_raw(&mut store, raw, elem_ty)
                 })
-                .collect::<Vec<_>>(),
-            TableSegmentElements::Expressions(xs) => {
-                let elem_ty = array
-                    ._ty((*instance.store()).store_opaque())?
-                    .element_type();
-                let elem_ty = elem_ty.unwrap_val_type();
-
-                let mut const_context = ConstEvalContext::new(instance);
-                let mut const_evaluator = ConstExprEvaluator::default();
-
-                xs.get(src..)
-                    .and_then(|s| s.get(..len))
-                    .ok_or_else(|| Trap::TableOutOfBounds.into_anyhow())?
-                    .iter()
-                    .map(|x| unsafe {
-                        let raw = const_evaluator
-                            .eval(&mut const_context, x)
-                            .expect("const expr should be valid");
-                        let mut store = AutoAssertNoGc::new(
-                            (*const_context.instance.store()).store_opaque_mut(),
-                        );
-                        Val::_from_raw(&mut store, raw, elem_ty)
-                    })
-                    .collect::<Vec<_>>()
-            }
-        };
-
-        // Copy the values into the array.
-        let store = (*instance.store()).store_opaque_mut();
-        for (i, val) in vals.into_iter().enumerate() {
-            let i = u32::try_from(i).unwrap();
-            let j = dst.checked_add(i).unwrap();
-            array._set(store, j, val)?;
+                .collect::<Vec<_>>()
         }
+    };
 
-        Ok(())
-    })
+    // Copy the values into the array.
+    for (i, val) in vals.into_iter().enumerate() {
+        let i = u32::try_from(i).unwrap();
+        let j = dst.checked_add(i).unwrap();
+        array._set(&mut store, j, val)?;
+    }
+
+    Ok(())
 }
 
 // TODO: Specialize this libcall for only non-GC array elements, so we never
@@ -938,7 +966,8 @@ unsafe fn array_init_elem(
 // `memcpy`-style APIs to do the actual copies here.
 #[cfg(feature = "gc")]
 unsafe fn array_copy(
-    instance: &mut Instance,
+    store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
     dst_array: u32,
     dst: u32,
     src_array: u32,
@@ -951,8 +980,7 @@ unsafe fn array_copy(
             "array.copy(dst_array={dst_array:#x}, dst_index={dst}, src_array={src_array:#x}, src_index={src}, len={len})",
         );
 
-    let store = (*instance.store()).store_opaque_mut();
-    let mut store = OpaqueRootScope::new(store);
+    let mut store = OpaqueRootScope::new(store.store_opaque_mut());
     let mut store = AutoAssertNoGc::new(&mut store);
 
     // Convert the raw GC refs into `Rooted<ArrayRef>`s.
@@ -1009,7 +1037,8 @@ unsafe fn array_copy(
 
 #[cfg(feature = "gc")]
 unsafe fn is_subtype(
-    instance: &mut Instance,
+    store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
     actual_engine_type: u32,
     expected_engine_type: u32,
 ) -> bool {
@@ -1018,7 +1047,7 @@ unsafe fn is_subtype(
     let actual = VMSharedTypeIndex::from_u32(actual_engine_type);
     let expected = VMSharedTypeIndex::from_u32(expected_engine_type);
 
-    let is_subtype: bool = (*instance.store())
+    let is_subtype: bool = store
         .engine()
         .signatures()
         .is_subtype(actual, expected)
@@ -1031,6 +1060,7 @@ unsafe fn is_subtype(
 // Implementation of `memory.atomic.notify` for locally defined memories.
 #[cfg(feature = "threads")]
 fn memory_atomic_notify(
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     memory_index: u32,
     addr_index: u64,
@@ -1045,6 +1075,7 @@ fn memory_atomic_notify(
 // Implementation of `memory.atomic.wait32` for locally defined memories.
 #[cfg(feature = "threads")]
 fn memory_atomic_wait32(
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     memory_index: u32,
     addr_index: u64,
@@ -1061,6 +1092,7 @@ fn memory_atomic_wait32(
 // Implementation of `memory.atomic.wait64` for locally defined memories.
 #[cfg(feature = "threads")]
 fn memory_atomic_wait64(
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     memory_index: u32,
     addr_index: u64,
@@ -1075,18 +1107,23 @@ fn memory_atomic_wait64(
 }
 
 // Hook for when an instance runs out of fuel.
-unsafe fn out_of_gas(instance: &mut Instance) -> Result<()> {
-    (*instance.store()).out_of_gas()
+fn out_of_gas(store: &mut (dyn VMStore + 'static), _instance: &mut Instance) -> Result<()> {
+    store.out_of_gas()
 }
 
 // Hook for when an instance observes that the epoch has changed.
-unsafe fn new_epoch(instance: &mut Instance) -> Result<u64> {
-    (*instance.store()).new_epoch()
+fn new_epoch(store: &mut (dyn VMStore + 'static), _instance: &mut Instance) -> Result<u64> {
+    store.new_epoch()
 }
 
 // Hook for validating malloc using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-unsafe fn check_malloc(instance: &mut Instance, addr: u32, len: u32) -> Result<u32> {
+unsafe fn check_malloc(
+    store: &mut (dyn VMStore + 'static),
+    instance: &mut Instance,
+    addr: u32,
+    len: u32,
+) -> Result<u32> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.malloc(addr as usize, len as usize);
         wmemcheck_state.memcheck_on();
@@ -1110,7 +1147,11 @@ unsafe fn check_malloc(instance: &mut Instance, addr: u32, len: u32) -> Result<u
 
 // Hook for validating free using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-unsafe fn check_free(instance: &mut Instance, addr: u32) -> Result<u32> {
+unsafe fn check_free(
+    store: &mut (dyn VMStore + 'static),
+    instance: &mut Instance,
+    addr: u32,
+) -> Result<u32> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.free(addr as usize);
         wmemcheck_state.memcheck_on();
@@ -1131,7 +1172,13 @@ unsafe fn check_free(instance: &mut Instance, addr: u32) -> Result<u32> {
 
 // Hook for validating load using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-fn check_load(instance: &mut Instance, num_bytes: u32, addr: u32, offset: u32) -> Result<u32> {
+fn check_load(
+    store: &mut (dyn VMStore + 'static),
+    instance: &mut Instance,
+    num_bytes: u32,
+    addr: u32,
+    offset: u32,
+) -> Result<u32> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.read(addr as usize + offset as usize, num_bytes as usize);
         match result {
@@ -1154,7 +1201,13 @@ fn check_load(instance: &mut Instance, num_bytes: u32, addr: u32, offset: u32) -
 
 // Hook for validating store using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-fn check_store(instance: &mut Instance, num_bytes: u32, addr: u32, offset: u32) -> Result<u32> {
+fn check_store(
+    store: &mut (dyn VMStore + 'static),
+    instance: &mut Instance,
+    num_bytes: u32,
+    addr: u32,
+    offset: u32,
+) -> Result<u32> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.write(addr as usize + offset as usize, num_bytes as usize);
         match result {
@@ -1193,7 +1246,11 @@ fn free_start(instance: &mut Instance) {
 
 // Hook for tracking wasm stack updates using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-fn update_stack_pointer(_instance: &mut Instance, _value: u32) {
+fn update_stack_pointer(
+    _store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    _value: u32,
+) {
     // TODO: stack-tracing has yet to be finalized. All memory below
     // the address of the top of the stack is marked as valid for
     // loads and stores.
@@ -1204,7 +1261,7 @@ fn update_stack_pointer(_instance: &mut Instance, _value: u32) {
 
 // Hook updating wmemcheck_state memory state vector every time memory.grow is called.
 #[cfg(feature = "wmemcheck")]
-fn update_mem_size(instance: &mut Instance, num_pages: u32) {
+fn update_mem_size(store: &mut (dyn VMStore + 'static), instance: &mut Instance, num_pages: u32) {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         const KIB: usize = 1024;
         let num_bytes = num_pages as usize * 64 * KIB;
@@ -1212,13 +1269,21 @@ fn update_mem_size(instance: &mut Instance, num_pages: u32) {
     }
 }
 
-fn trap(_instance: &mut Instance, code: u8) -> Result<(), TrapReason> {
+fn trap(
+    _store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    code: u8,
+) -> Result<(), TrapReason> {
     Err(TrapReason::Wasm(
         wasmtime_environ::Trap::from_u8(code).unwrap(),
     ))
 }
 
-fn f64_to_i64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
+fn f64_to_i64(
+    _store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    val: f64,
+) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }
@@ -1230,7 +1295,11 @@ fn f64_to_i64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     return Ok((val as i64).unsigned());
 }
 
-fn f64_to_u64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
+fn f64_to_u64(
+    _store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    val: f64,
+) -> Result<u64, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }
@@ -1242,7 +1311,11 @@ fn f64_to_u64(_instance: &mut Instance, val: f64) -> Result<u64, TrapReason> {
     return Ok(val as u64);
 }
 
-fn f64_to_i32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
+fn f64_to_i32(
+    _store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    val: f64,
+) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }
@@ -1254,7 +1327,11 @@ fn f64_to_i32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
     return Ok((val as i32).unsigned());
 }
 
-fn f64_to_u32(_instance: &mut Instance, val: f64) -> Result<u32, TrapReason> {
+fn f64_to_u32(
+    _store: &mut (dyn VMStore + 'static),
+    _instance: &mut Instance,
+    val: f64,
+) -> Result<u32, TrapReason> {
     if val.is_nan() {
         return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
     }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1119,7 +1119,7 @@ fn new_epoch(store: &mut (dyn VMStore + 'static), _instance: &mut Instance) -> R
 // Hook for validating malloc using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 unsafe fn check_malloc(
-    store: &mut (dyn VMStore + 'static),
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     addr: u32,
     len: u32,
@@ -1148,7 +1148,7 @@ unsafe fn check_malloc(
 // Hook for validating free using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 unsafe fn check_free(
-    store: &mut (dyn VMStore + 'static),
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     addr: u32,
 ) -> Result<u32> {
@@ -1173,7 +1173,7 @@ unsafe fn check_free(
 // Hook for validating load using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 fn check_load(
-    store: &mut (dyn VMStore + 'static),
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     num_bytes: u32,
     addr: u32,
@@ -1202,7 +1202,7 @@ fn check_load(
 // Hook for validating store using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 fn check_store(
-    store: &mut (dyn VMStore + 'static),
+    _store: &mut (dyn VMStore + 'static),
     instance: &mut Instance,
     num_bytes: u32,
     addr: u32,
@@ -1230,7 +1230,7 @@ fn check_store(
 
 // Hook for turning wmemcheck load/store validation off when entering a malloc function.
 #[cfg(feature = "wmemcheck")]
-fn malloc_start(instance: &mut Instance) {
+fn malloc_start(_store: &mut (dyn VMStore + 'static), instance: &mut Instance) {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         wmemcheck_state.memcheck_off();
     }
@@ -1238,7 +1238,7 @@ fn malloc_start(instance: &mut Instance) {
 
 // Hook for turning wmemcheck load/store validation off when entering a free function.
 #[cfg(feature = "wmemcheck")]
-fn free_start(instance: &mut Instance) {
+fn free_start(_store: &mut (dyn VMStore + 'static), instance: &mut Instance) {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         wmemcheck_state.memcheck_off();
     }
@@ -1261,7 +1261,7 @@ fn update_stack_pointer(
 
 // Hook updating wmemcheck_state memory state vector every time memory.grow is called.
 #[cfg(feature = "wmemcheck")]
-fn update_mem_size(store: &mut (dyn VMStore + 'static), instance: &mut Instance, num_pages: u32) {
+fn update_mem_size(_store: &mut (dyn VMStore + 'static), instance: &mut Instance, num_pages: u32) {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         const KIB: usize = 1024;
         let num_bytes = num_pages as usize * 64 * KIB;


### PR DESCRIPTION
At various times, for example in libcalls, we need to go from a raw `vmctx` pointer that Wasm gave us to both an `&mut Instance` and an `&mut Store{Opaque,Context}`. This is a pretty fundamental unsafe aspect of implementing a language runtimne in Rust, but we can tighten things up a bit and make them a little safer than they currently are. This commit is such an attempt and is notably tackling the issue of creating multiple store borrows after we have an instance borrow.

This commit makes the following changes:

* `Instance` doesn't expose a method to get the raw `*mut dyn VMStore` pointer or otherwise create a store borrow.

* You cannot construct an `Instance` directly from a `vmctx` pointer.

* There is now an `InstanceAndStore` type that represents unique access to both an `Instance` and a `Store`.

* You can (with `unsafe`) create an `InstanceAndStore` from a raw `vmctx` pointer. This generally only happens inside a couple "bottlenecks", not all throughout the codebase, like the shared plumbing code for libcalls.

* The `InstanceAndStore` can be unpacked into a mutable borrow of an `Instance` and a mutable borrow of a `Store`. This unpacking takes holds a mutable borrow of the original `InstanceAndStore`, so double borrows of the store are no longer a concern, so long as you don't use `unsafe` to create new `InstanceAndStore`s for the same `vmctx`.

* All `Instance` methods and functions that previously would unsafely turn the `Instance`'s internal store pointer into a store borrow to perform some action now take a store argument, and this store is threaded around as necessary.

Altogether, I feel that we've ended up with an architecture that is a safety improvement over where we were previously, and will help us properly avoid Rust UB.

For what its worth, I do not think this is the end state. I foresee at least two additional follow ups that I unfortunately do not currently have time for:

1. Create `ComponentInstanceAndStore`, which is the same thing that this commit did but for components. I started on this but ran out of fuel while trying to update macros for all the component shims and transcoders.

2. Stop dealing with `&mut vm::Table`s and `&mut vm::Global`s and all that in the runtime. Instead just deal with indices, similar to how things are structured in the host API level. This refactoring was not previously possible due to (1) the `wasmtime` versus `wasmtime-runtime` crate split and (2) the lack of `StoreOpaque`s threaded through the VM internals. The first blocker was addressed a few months ago, this commit removes the second blocker. This will still be a pretty large refactoring though, but I think ultimately will be worth it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
