### PR TITLE
Update memory configuration during fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/memory.rs
+++ b/crates/fuzzing/src/generators/memory.rs
@@ -145,13 +145,18 @@ pub struct NormalMemoryConfig {
 
 impl<'a> Arbitrary<'a> for NormalMemoryConfig {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        // This attempts to limit memory and guard sizes to 32-bit ranges so
-        // we don't exhaust a 64-bit address space easily.
         Ok(Self {
-            memory_reservation: <Option<u32> as Arbitrary>::arbitrary(u)?.map(Into::into),
-            memory_guard_size: <Option<u32> as Arbitrary>::arbitrary(u)?.map(Into::into),
-            memory_reservation_for_growth: <Option<u32> as Arbitrary>::arbitrary(u)?
-                .map(Into::into),
+            // Allow up to 8GiB reservations of the virtual address space for
+            // the initial memory reservation.
+            memory_reservation: interesting_virtual_memory_size(u, 33)?,
+
+            // Allow up to 4GiB guard page reservations to be made.
+            memory_guard_size: interesting_virtual_memory_size(u, 32)?,
+
+            // Allow up up to 1GiB extra memory to grow into for dynamic
+            // memories.
+            memory_reservation_for_growth: interesting_virtual_memory_size(u, 30)?,
+
             guard_before_linear_memory: u.arbitrary()?,
             cranelift_enable_heap_access_spectre_mitigations: u.arbitrary()?,
             memory_init_cow: u.arbitrary()?,
@@ -159,13 +164,47 @@ impl<'a> Arbitrary<'a> for NormalMemoryConfig {
     }
 }
 
+/// Helper function to generate "interesting numbers" for virtual memory
+/// configuration options that `Config` supports.
+fn interesting_virtual_memory_size(
+    u: &mut Unstructured<'_>,
+    max_log2: u32,
+) -> arbitrary::Result<Option<u64>> {
+    // Most of the time return "none" meaning "use the default settings".
+    if u.ratio(3, 4)? {
+        return Ok(None);
+    }
+
+    // Otherwise do a split between various strategies.
+    #[derive(Arbitrary)]
+    enum Interesting {
+        Zero,
+        PowerOfTwo,
+        Arbitrary,
+    }
+
+    let size = match u.arbitrary()? {
+        Interesting::Zero => 0,
+        Interesting::PowerOfTwo => 1 << u.int_in_range(0..=max_log2)?,
+        Interesting::Arbitrary => u.int_in_range(0..=1 << max_log2)?,
+    };
+    Ok(Some(size))
+}
+
 impl NormalMemoryConfig {
     /// Apply this memory configuration to the given `wasmtime::Config`.
     pub fn apply_to(&self, config: &mut wasmtime::Config) {
+        if let Some(n) = self.memory_reservation {
+            config.memory_reservation(n);
+        }
+        if let Some(n) = self.memory_guard_size {
+            config.memory_guard_size(n);
+        }
+        if let Some(n) = self.memory_reservation_for_growth {
+            config.memory_reservation_for_growth(n);
+        }
+
         config
-            .memory_reservation(self.memory_reservation.unwrap_or(0))
-            .memory_guard_size(self.memory_guard_size.unwrap_or(0))
-            .memory_reservation_for_growth(self.memory_reservation_for_growth.unwrap_or(0))
             .guard_before_linear_memory(self.guard_before_linear_memory)
             .memory_init_cow(self.memory_init_cow);
 


### PR DESCRIPTION
This commit updates how the `NormalMemoryConfig` works during fuzzing. Previously this was either 0 or an arbitrary 32-bit number. This ended up not not handling cases such as 4GiB exactly which is 1 larger than the 32-bit range. Additionally 33+-bit numbers were never tested. This intends to expand our fuzz coverage here by most of the time using the default settings of `Config` and then otherwise selecting amongst an "interesting" set of numbers such as 0, powers of two, etc.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
