### PR TITLE
Add `Module::deserialize_open_file`

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -11,7 +11,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use object::write::{Object, StandardSegment};
 use object::SectionKind;
 #[cfg(feature = "std")]
-use std::path::Path;
+use std::{fs::File, path::Path};
 use wasmparser::WasmFeatures;
 use wasmtime_environ::obj;
 use wasmtime_environ::{FlagValue, ObjectKind, Tunables};
@@ -693,13 +693,12 @@ impl Engine {
     #[cfg(feature = "std")]
     pub(crate) fn load_code_file(
         &self,
-        path: &Path,
+        file: File,
         expected: ObjectKind,
     ) -> Result<Arc<crate::CodeMemory>> {
         self.load_code(
-            crate::runtime::vm::MmapVec::from_file(path).with_context(|| {
-                format!("failed to create file mapping for: {}", path.display())
-            })?,
+            crate::runtime::vm::MmapVec::from_file(file)
+                .with_context(|| "Failed to create file mapping".to_string())?,
             expected,
         )
     }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -3,6 +3,8 @@ use crate::component::types;
 use crate::component::InstanceExportLookup;
 use crate::prelude::*;
 use crate::runtime::vm::component::ComponentRuntimeInfo;
+#[cfg(feature = "std")]
+use crate::runtime::vm::open_file_for_mmap;
 use crate::runtime::vm::{
     CompiledModuleId, VMArrayCallFunction, VMFuncRef, VMFunctionBody, VMWasmCallFunction,
 };
@@ -228,7 +230,10 @@ impl Component {
     /// [`Module::deserialize_file`]: crate::Module::deserialize_file
     #[cfg(feature = "std")]
     pub unsafe fn deserialize_file(engine: &Engine, path: impl AsRef<Path>) -> Result<Component> {
-        let code = engine.load_code_file(path.as_ref(), ObjectKind::Component)?;
+        let file = open_file_for_mmap(path.as_ref())?;
+        let code = engine
+            .load_code_file(file, ObjectKind::Component)
+            .with_context(|| format!("failed to load code for: {}", path.as_ref().display()))?;
         Component::from_parts(engine, code, None)
     }
 

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -444,6 +444,13 @@ impl Module {
     ///
     /// [`deserialize_file`]: Module::deserialize_file
     ///
+    /// Note that the corresponding will be mapped as private writeable
+    /// (copy-on-write) and executable. For `windows` this means the file needs
+    /// to be opened with at least `FILE_GENERIC_READ | FILE_GENERIC_EXECUTE`
+    /// [`access_mode`].
+    ///
+    /// [`access_mode`]: https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.access_mode
+    ///
     /// # Unsafety
     ///
     /// All of the reasons that [`deserialize_file`] is `unsafe` applies to this

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+#[cfg(feature = "std")]
+use crate::runtime::vm::open_file_for_mmap;
 use crate::runtime::vm::{CompiledModuleId, MmapVec, ModuleMemoryImages, VMWasmCallFunction};
 use crate::sync::OnceLock;
 use crate::{
@@ -15,7 +17,7 @@ use core::fmt;
 use core::ops::Range;
 use core::ptr::NonNull;
 #[cfg(feature = "std")]
-use std::path::Path;
+use std::{fs::File, path::Path};
 use wasmparser::{Parser, ValidPayload, Validator};
 use wasmtime_environ::{
     CompiledModuleInfo, EntityIndex, HostPtr, ModuleTypes, ObjectKind, TypeTrace, VMOffsets,
@@ -343,7 +345,8 @@ impl Module {
     /// state of the file.
     #[cfg(all(feature = "std", any(feature = "cranelift", feature = "winch")))]
     pub unsafe fn from_trusted_file(engine: &Engine, file: impl AsRef<Path>) -> Result<Module> {
-        let mmap = MmapVec::from_file(file.as_ref())?;
+        let open_file = open_file_for_mmap(file.as_ref())?;
+        let mmap = MmapVec::from_file(open_file)?;
         if &mmap[0..4] == b"\x7fELF" {
             let code = engine.load_code(mmap, ObjectKind::Module)?;
             return Module::from_parts(engine, code, None);
@@ -426,7 +429,28 @@ impl Module {
     /// state of the file.
     #[cfg(feature = "std")]
     pub unsafe fn deserialize_file(engine: &Engine, path: impl AsRef<Path>) -> Result<Module> {
-        let code = engine.load_code_file(path.as_ref(), ObjectKind::Module)?;
+        let file = open_file_for_mmap(path.as_ref())?;
+        Self::deserialize_open_file(engine, file)
+            .with_context(|| format!("failed deserialization for: {}", path.as_ref().display()))
+    }
+
+    /// Same as [`deserialize_file`], except that it takes an open `File`
+    /// instead of a path.
+    ///
+    /// This method is provided because it can be used instead of
+    /// [`deserialize_file`] in situations where `wasmtime` is running with
+    /// limited file system permissions. In that case a process
+    /// with file system access can pass already opened files to `wasmtime`.
+    ///
+    /// [`deserialize_file`]: Module::deserialize_file
+    ///
+    /// # Unsafety
+    ///
+    /// All of the reasons that [`deserialize_file`] is `unsafe` applies to this
+    /// function as well.
+    #[cfg(feature = "std")]
+    pub unsafe fn deserialize_open_file(engine: &Engine, file: File) -> Result<Module> {
+        let code = engine.load_code_file(file, ObjectKind::Module)?;
         Module::from_parts(engine, code, None)
     }
 

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -70,6 +70,8 @@ pub use crate::runtime::vm::mmap::Mmap;
 pub use crate::runtime::vm::mmap_vec::MmapVec;
 pub use crate::runtime::vm::mpk::MpkEnabled;
 pub use crate::runtime::vm::store_box::*;
+#[cfg(feature = "std")]
+pub use crate::runtime::vm::sys::mmap::open_file_for_mmap;
 pub use crate::runtime::vm::sys::unwind::UnwindRegistration;
 pub use crate::runtime::vm::table::{Table, TableElement};
 pub use crate::runtime::vm::traphandlers::*;

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -5,7 +5,7 @@ use crate::runtime::vm::sys::mmap;
 use crate::{prelude::*, vm::usize_is_multiple_of_host_page_size};
 use core::ops::Range;
 #[cfg(feature = "std")]
-use std::{fs::File, path::Path, sync::Arc};
+use std::{fs::File, sync::Arc};
 
 /// A simple struct consisting of a page-aligned pointer to page-aligned
 /// and initially-zeroed memory and a length.
@@ -34,8 +34,8 @@ impl Mmap {
     /// The memory mapping and the length of the file within the mapping are
     /// returned.
     #[cfg(feature = "std")]
-    pub fn from_file(path: &Path) -> Result<Self> {
-        let (sys, file) = mmap::Mmap::from_file(path)?;
+    pub fn from_file(file: File) -> Result<Self> {
+        let sys = mmap::Mmap::from_file(&file)?;
         Ok(Mmap {
             sys,
             file: Some(Arc::new(file)),

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -34,11 +34,11 @@ impl Mmap {
     /// The memory mapping and the length of the file within the mapping are
     /// returned.
     #[cfg(feature = "std")]
-    pub fn from_file(file: File) -> Result<Self> {
+    pub fn from_file(file: Arc<File>) -> Result<Self> {
         let sys = mmap::Mmap::from_file(&file)?;
         Ok(Mmap {
             sys,
-            file: Some(Arc::new(file)),
+            file: Some(file),
         })
     }
 

--- a/crates/wasmtime/src/runtime/vm/mmap_vec.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap_vec.rs
@@ -63,7 +63,7 @@ impl MmapVec {
     pub fn from_file(file: File) -> Result<MmapVec> {
         let file = Arc::new(file);
         let mmap = Mmap::from_file(Arc::clone(&file))
-            .with_context(move || format!("failed to create mmap for file {:?}", file))?;
+            .with_context(move || format!("failed to create mmap for file {file:?}"))?;
         let len = mmap.len();
         Ok(MmapVec::new(mmap, len))
     }

--- a/crates/wasmtime/src/runtime/vm/mmap_vec.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap_vec.rs
@@ -61,11 +61,9 @@ impl MmapVec {
     /// fully mapped into memory.
     #[cfg(feature = "std")]
     pub fn from_file(file: File) -> Result<MmapVec> {
-        use std::os::fd::AsRawFd;
-        let fd = file.as_raw_fd();
-
-        let mmap = Mmap::from_file(file)
-            .with_context(|| format!("failed to create mmap for file descriptor: {fd}"))?;
+        let file = Arc::new(file);
+        let mmap = Mmap::from_file(Arc::clone(&file))
+            .with_context(move || format!("failed to create mmap for file {:?}", file))?;
         let len = mmap.len();
         Ok(MmapVec::new(mmap, len))
     }

--- a/crates/wasmtime/src/runtime/vm/mmap_vec.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap_vec.rs
@@ -3,7 +3,7 @@ use crate::runtime::vm::Mmap;
 use alloc::sync::Arc;
 use core::ops::{Deref, DerefMut, Range};
 #[cfg(feature = "std")]
-use std::{fs::File, path::Path};
+use std::fs::File;
 
 /// A type akin to `Vec<u8>`, but backed by `mmap` and able to be split.
 ///
@@ -54,17 +54,18 @@ impl MmapVec {
         Ok(result)
     }
 
-    /// Creates a new `MmapVec` which is the `path` specified mmap'd into
-    /// memory.
+    /// Creates a new `MmapVec` which is the given `File` mmap'd into memory.
     ///
-    /// This function will attempt to open the file located at `path` and will
-    /// then use that file to learn about its size and map the full contents
-    /// into memory. This will return an error if the file doesn't exist or if
-    /// it's too large to be fully mapped into memory.
+    /// This function will determine the file's size and map the full contents
+    /// into memory. This will return an error if the file is too large to be
+    /// fully mapped into memory.
     #[cfg(feature = "std")]
-    pub fn from_file(path: &Path) -> Result<MmapVec> {
-        let mmap = Mmap::from_file(path)
-            .with_context(|| format!("failed to create mmap for file: {}", path.display()))?;
+    pub fn from_file(file: File) -> Result<MmapVec> {
+        use std::os::fd::AsRawFd;
+        let fd = file.as_raw_fd();
+
+        let mmap = Mmap::from_file(file)
+            .with_context(|| format!("failed to create mmap for file descriptor: {fd}"))?;
         let len = mmap.len();
         Ok(MmapVec::new(mmap, len))
     }

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -7,6 +7,11 @@ use core::ptr::{self, NonNull};
 #[cfg(feature = "std")]
 use std::{fs::File, path::Path};
 
+#[cfg(feature = "std")]
+pub fn open_file_for_mmap(_path: &Path) -> Result<File> {
+    anyhow::bail!("not supported on this platform");
+}
+
 #[derive(Debug)]
 pub struct Mmap {
     memory: SendSyncPtr<[u8]>,
@@ -38,7 +43,7 @@ impl Mmap {
     }
 
     #[cfg(feature = "std")]
-    pub fn from_file(_path: &Path) -> Result<(Self, File)> {
+    pub fn from_file(_file: &File) -> Result<Self> {
         anyhow::bail!("not supported on this platform");
     }
 

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -13,6 +13,10 @@ use std::ops::Range;
 use std::path::Path;
 use std::ptr::NonNull;
 
+pub fn open_file_for_mmap(_path: &Path) -> Result<File> {
+    bail!("not supported on miri");
+}
+
 #[derive(Debug)]
 pub struct Mmap {
     memory: SendSyncPtr<[u8]>,
@@ -46,7 +50,7 @@ impl Mmap {
         Ok(Mmap { memory })
     }
 
-    pub fn from_file(_path: &Path) -> Result<(Self, File)> {
+    pub fn from_file(_file: &File) -> Result<Self> {
         bail!("not supported on miri");
     }
 

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -17,13 +17,13 @@ use windows_sys::Win32::System::Memory::*;
 /// while also disallowing other processes modifying the file
 /// and having those modifications show up in our address space.
 pub fn open_file_for_mmap(path: &Path) -> Result<File> {
-    let file = OpenOptions::new()
+    OpenOptions::new()
         .read(true)
         .access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE)
         .share_mode(FILE_SHARE_READ)
         .open(path)
         .err2anyhow()
-        .context("failed to open file")?;
+        .context("failed to open file")
 }
 
 #[derive(Debug)]
@@ -135,7 +135,7 @@ impl Mmap {
                     .context("failed change pages to `PAGE_READONLY`");
             }
 
-            Ok((ret, file))
+            Ok(ret)
         }
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use std::net::TcpListener;
-use std::{path::Path, time::Duration};
+use std::{fs::File, path::Path, time::Duration};
 use wasmtime::{Engine, Module, Precompiled, StoreLimits, StoreLimitsBuilder};
 use wasmtime_cli_flags::{opt::WasmtimeOptionValue, CommonOptions};
 use wasmtime_wasi::bindings::LinkOptions;
@@ -160,6 +160,7 @@ impl RunCommon {
             Some("-") => "/dev/stdin".as_ref(),
             _ => path,
         };
+        let file = File::open(path)?;
 
         // First attempt to load the module as an mmap. If this succeeds then
         // detection can be done with the contents of the mmap and if a
@@ -179,7 +180,7 @@ impl RunCommon {
         // which isn't ready to happen at this time). It's hoped though that
         // opening a file twice isn't too bad in the grand scheme of things with
         // respect to the CLI.
-        match wasmtime::_internal::MmapVec::from_file(path) {
+        match wasmtime::_internal::MmapVec::from_file(file) {
             Ok(map) => self.load_module_contents(
                 engine,
                 path,

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -104,7 +104,7 @@ fn test_deserialize_from_file() -> Result<()> {
         let func = instance.get_typed_func::<(), i32>(&mut store, "run")?;
         assert_eq!(func.call(&mut store, ())?, 42);
 
-        // Try an alreeady opened file as well.
+        // Try an already opened file as well.
         let mut open_options = OpenOptions::new();
         open_options.read(true);
         #[cfg(target_os = "windows")]

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -103,6 +103,14 @@ fn test_deserialize_from_file() -> Result<()> {
         let instance = Instance::new(&mut store, &module, &[])?;
         let func = instance.get_typed_func::<(), i32>(&mut store, "run")?;
         assert_eq!(func.call(&mut store, ())?, 42);
+
+        // Try an alreeady opened file as well.
+        let file = fs::File::open(&path)?;
+        let module = unsafe { Module::deserialize_open_file(store.engine(), file)? };
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let func = instance.get_typed_func::<(), i32>(&mut store, "run")?;
+        assert_eq!(func.call(&mut store, ())?, 42);
+
         Ok(())
     }
 }

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -110,6 +110,7 @@ fn test_deserialize_from_file() -> Result<()> {
         #[cfg(target_os = "windows")]
         {
             use std::os::windows::prelude::*;
+            use windows_sys::Win32::Storage::FileSystem::*;
             open_options.access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE);
         }
 

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -109,7 +109,7 @@ fn test_deserialize_from_file() -> Result<()> {
         open_options.read(true);
         #[cfg(target_os = "windows")]
         {
-            use std::os::windows::OpenOptionsExt;
+            use std::os::windows::fs::OpenOptionsExt;
             open_options.access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE);
         }
 

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -1,5 +1,5 @@
 use anyhow::bail;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use wasmtime::*;
 
 fn serialize(engine: &Engine, wat: &str) -> Result<Vec<u8>> {
@@ -105,7 +105,15 @@ fn test_deserialize_from_file() -> Result<()> {
         assert_eq!(func.call(&mut store, ())?, 42);
 
         // Try an alreeady opened file as well.
-        let file = fs::File::open(&path)?;
+        let mut open_options = OpenOptions::new();
+        open_options.read(true);
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::OpenOptionsExt;
+            open_options.access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE);
+        }
+
+        let file = open_options.open(&path)?;
         let module = unsafe { Module::deserialize_open_file(store.engine(), file)? };
         let instance = Instance::new(&mut store, &module, &[])?;
         let func = instance.get_typed_func::<(), i32>(&mut store, "run")?;

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -109,7 +109,7 @@ fn test_deserialize_from_file() -> Result<()> {
         open_options.read(true);
         #[cfg(target_os = "windows")]
         {
-            use std::os::windows::fs::OpenOptionsExt;
+            use std::os::windows::prelude::*;
             open_options.access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE);
         }
 


### PR DESCRIPTION
Add an API to deserialize a `Module` from an already opened file. This can be useful in situations where `wasmtime` is running in a sandboxed environment with limited access to the file system. Then another process can handle opening the files and passing them to `wasmtime`.