### PR TITLE
x64: Improve lowering for conditional traps

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1864,13 +1864,20 @@
       (side_effect (x64_ud2 code)))
 
 ;;;; Rules for `trapz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule (lower (trapz val code))
-      (side_effect (trap_if_val (ZeroCond.Zero) val code)))
+
+(rule 0 (lower (trapz val code))
+        (side_effect (trap_if_val (ZeroCond.Zero) val code)))
+
+(rule 1 (lower (trapz (icmp cc a b) code))
+        (side_effect (trap_if_icmp (emit_cmp (intcc_complement cc) a b) code)))
 
 ;;;; Rules for `trapnz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (trapnz val code))
-      (side_effect (trap_if_val (ZeroCond.NonZero) val code)))
+(rule 0 (lower (trapnz val code))
+        (side_effect (trap_if_val (ZeroCond.NonZero) val code)))
+
+(rule 1 (lower (trapnz (icmp cc a b) code))
+        (side_effect (trap_if_icmp (emit_cmp cc a b) code)))
 
 ;;;; Rules for `uadd_overflow_trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -63,7 +63,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -92,7 +92,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -121,7 +121,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -150,7 +150,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -163,3 +163,62 @@ block0(v0: i128):
 ;   popq %rbp
 ;   retq
 ;   ud2 ; trap: user1
+
+function %trapz_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  trapz v2, user1
+  return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   cmpq    %rsi, %rdi
+;   jnz #trap=user1
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   cmpq %rsi, %rdi
+;   jne 0x12
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+
+function %trapnz_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  trapnz v2, user1
+  return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   cmpq    %rsi, %rdi
+;   jz #trap=user1
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   cmpq %rsi, %rdi
+;   je 0x12
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+

--- a/tests/disas/epoch-interruption-x86.wat
+++ b/tests/disas/epoch-interruption-x86.wat
@@ -28,12 +28,12 @@
 ;;       jae     0x64
 ;;       jmp     0x46
 ;;   57: movq    %r13, %rdi
-;;       callq   0xf3
+;;       callq   0xec
 ;;       jmp     0x46
 ;;   64: movq    0x10(%r12), %rax
 ;;       cmpq    %rax, %rdi
 ;;       jb      0x46
 ;;   72: movq    %r13, %rdi
-;;       callq   0xf3
+;;       callq   0xec
 ;;       jmp     0x46
 ;;   7f: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       movl    %edx, %r11d
-;;       subq    $4, %r9
-;;       cmpq    %r9, %r11
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x2c
-;;   1f: movq    0x60(%rdi), %rax
-;;       movl    %ecx, (%rax, %r11)
+;;       movq    0x68(%rdi), %r8
+;;       movl    %edx, %r10d
+;;       subq    $4, %r8
+;;       cmpq    %r8, %r10
+;;       ja      0x25
+;;   18: movq    0x60(%rdi), %rsi
+;;       movl    %ecx, (%rsi, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2c: ud2
+;;   25: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       movl    %edx, %r11d
-;;       subq    $4, %r9
-;;       cmpq    %r9, %r11
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x6c
-;;   5f: movq    0x60(%rdi), %rax
-;;       movl    (%rax, %r11), %eax
+;;       movq    0x68(%rdi), %r8
+;;       movl    %edx, %r10d
+;;       subq    $4, %r8
+;;       cmpq    %r8, %r10
+;;       ja      0x65
+;;   58: movq    0x60(%rdi), %rsi
+;;       movl    (%rsi, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       movl    %edx, %r11d
-;;       subq    $0x1004, %r9
-;;       cmpq    %r9, %r11
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x33
-;;   22: movq    0x60(%rdi), %rax
-;;       movl    %ecx, 0x1000(%rax, %r11)
+;;       movq    0x68(%rdi), %r8
+;;       movl    %edx, %r10d
+;;       subq    $0x1004, %r8
+;;       cmpq    %r8, %r10
+;;       ja      0x2c
+;;   1b: movq    0x60(%rdi), %rsi
+;;       movl    %ecx, 0x1000(%rsi, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   33: ud2
+;;   2c: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       movl    %edx, %r11d
-;;       subq    $0x1004, %r9
-;;       cmpq    %r9, %r11
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x73
-;;   62: movq    0x60(%rdi), %rax
-;;       movl    0x1000(%rax, %r11), %eax
+;;       movq    0x68(%rdi), %r8
+;;       movl    %edx, %r10d
+;;       subq    $0x1004, %r8
+;;       cmpq    %r8, %r10
+;;       ja      0x6c
+;;   5b: movq    0x60(%rdi), %rsi
+;;       movl    0x1000(%rsi, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   73: ud2
+;;   6c: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -22,42 +22,36 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
-;;       movq    %r8, %r11
-;;       addq    0x2f(%rip), %r11
-;;       jb      0x39
-;;   17: cmpq    0x68(%rdi), %r11
-;;       seta    %al
-;;       testb   %al, %al
-;;       jne     0x3b
-;;   27: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edx
-;;       movl    %ecx, (%r8, %rdx)
+;;       movq    %r8, %r10
+;;       addq    0x27(%rip), %r10
+;;       jb      0x33
+;;   17: cmpq    0x68(%rdi), %r10
+;;       ja      0x35
+;;   21: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %edi
+;;       movl    %ecx, (%r8, %rdi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   39: ud2
-;;   3b: ud2
-;;   3d: addb    %al, (%rax)
-;;   3f: addb    %al, (%rax, %rax)
+;;   33: ud2
+;;   35: ud2
+;;   37: addb    %al, (%rax, %rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
-;;       movq    %r8, %r11
-;;       addq    0x2f(%rip), %r11
-;;       jb      0x99
-;;   77: cmpq    0x68(%rdi), %r11
-;;       seta    %al
-;;       testb   %al, %al
-;;       jne     0x9b
-;;   87: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %ecx
-;;       movl    (%r8, %rcx), %eax
+;;       movq    %r8, %r10
+;;       addq    0x27(%rip), %r10
+;;       jb      0x73
+;;   57: cmpq    0x68(%rdi), %r10
+;;       ja      0x75
+;;   61: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %edi
+;;       movl    (%r8, %rdi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   99: ud2
-;;   9b: ud2
-;;   9d: addb    %al, (%rax)
-;;   9f: addb    %al, (%rax, %rax)
+;;   73: ud2
+;;   75: ud2
+;;   77: addb    %al, (%rax, %rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       setae   %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x25
-;;   18: movq    0x60(%rdi), %rsi
-;;       movb    %cl, (%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       jae     0x1e
+;;   11: movq    0x60(%rdi), %r10
+;;       movb    %cl, (%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
+;;   1e: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       setae   %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x66
-;;   58: movq    0x60(%rdi), %rsi
-;;       movzbq  (%rsi, %r9), %rax
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       jae     0x3f
+;;   31: movq    0x60(%rdi), %r10
+;;       movzbq  (%r10, %r8), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   3f: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       movl    %edx, %r11d
-;;       subq    $0x1001, %r9
-;;       cmpq    %r9, %r11
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x33
-;;   22: movq    0x60(%rdi), %rax
-;;       movb    %cl, 0x1000(%rax, %r11)
+;;       movq    0x68(%rdi), %r8
+;;       movl    %edx, %r10d
+;;       subq    $0x1001, %r8
+;;       cmpq    %r8, %r10
+;;       ja      0x2c
+;;   1b: movq    0x60(%rdi), %rsi
+;;       movb    %cl, 0x1000(%rsi, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   33: ud2
+;;   2c: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       movl    %edx, %r11d
-;;       subq    $0x1001, %r9
-;;       cmpq    %r9, %r11
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x74
-;;   62: movq    0x60(%rdi), %rax
-;;       movzbq  0x1000(%rax, %r11), %rax
+;;       movq    0x68(%rdi), %r8
+;;       movl    %edx, %r10d
+;;       subq    $0x1001, %r8
+;;       cmpq    %r8, %r10
+;;       ja      0x6d
+;;   5b: movq    0x60(%rdi), %rsi
+;;       movzbq  0x1000(%rsi, %r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   74: ud2
+;;   6d: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -22,45 +22,39 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
-;;       movq    %r8, %r11
-;;       addq    0x2f(%rip), %r11
-;;       jb      0x39
-;;   17: cmpq    0x68(%rdi), %r11
-;;       seta    %al
-;;       testb   %al, %al
-;;       jne     0x3b
-;;   27: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edx
-;;       movb    %cl, (%r8, %rdx)
+;;       movq    %r8, %r10
+;;       addq    0x27(%rip), %r10
+;;       jb      0x33
+;;   17: cmpq    0x68(%rdi), %r10
+;;       ja      0x35
+;;   21: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %edi
+;;       movb    %cl, (%r8, %rdi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   39: ud2
-;;   3b: ud2
+;;   33: ud2
+;;   35: ud2
+;;   37: addb    %al, (%rcx)
+;;   39: addb    %bh, %bh
+;;   3b: incl    (%rax)
 ;;   3d: addb    %al, (%rax)
-;;   3f: addb    %al, (%rcx)
-;;   41: addb    %bh, %bh
-;;   43: incl    (%rax)
-;;   45: addb    %al, (%rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
-;;       movq    %r8, %r11
-;;       addq    0x2f(%rip), %r11
-;;       jb      0x9a
-;;   77: cmpq    0x68(%rdi), %r11
-;;       seta    %al
-;;       testb   %al, %al
-;;       jne     0x9c
-;;   87: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %ecx
-;;       movzbq  (%r8, %rcx), %rax
+;;       movq    %r8, %r10
+;;       addq    0x27(%rip), %r10
+;;       jb      0x74
+;;   57: cmpq    0x68(%rdi), %r10
+;;       ja      0x76
+;;   61: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %edi
+;;       movzbq  (%r8, %rdi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   9a: ud2
-;;   9c: ud2
-;;   9e: addb    %al, (%rax)
-;;   a0: addl    %eax, (%rax)
+;;   74: ud2
+;;   76: ud2
+;;   78: addl    %eax, (%rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x25
-;;   18: movq    0x60(%rdi), %rsi
-;;       movl    %ecx, (%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       ja      0x1e
+;;   11: movq    0x60(%rdi), %r10
+;;       movl    %ecx, (%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
+;;   1e: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x65
-;;   58: movq    0x60(%rdi), %rsi
-;;       movl    (%rsi, %r9), %eax
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       ja      0x3e
+;;   31: movq    0x60(%rdi), %r10
+;;       movl    (%r10, %r8), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
+;;   3e: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x29
-;;   18: movq    0x60(%rdi), %rsi
-;;       movl    %ecx, 0x1000(%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       ja      0x22
+;;   11: movq    0x60(%rdi), %r10
+;;       movl    %ecx, 0x1000(%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
+;;   22: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x69
-;;   58: movq    0x60(%rdi), %rsi
-;;       movl    0x1000(%rsi, %r9), %eax
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       ja      0x62
+;;   51: movq    0x60(%rdi), %r10
+;;       movl    0x1000(%r10, %r8), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
+;;   62: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -23,29 +23,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    0x68(%rdi), %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x2a
-;;   18: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movl    %ecx, (%r8, %rdi)
+;;       ja      0x24
+;;   11: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movl    %ecx, (%r8, %r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2a: ud2
+;;   24: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    0x68(%rdi), %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x6a
-;;   58: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movl    (%r8, %rdi), %eax
+;;       ja      0x64
+;;   51: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movl    (%r8, %r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6a: ud2
+;;   64: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       setae   %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x25
-;;   18: movq    0x60(%rdi), %rsi
-;;       movb    %cl, (%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       jae     0x1e
+;;   11: movq    0x60(%rdi), %r10
+;;       movb    %cl, (%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
+;;   1e: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       setae   %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x66
-;;   58: movq    0x60(%rdi), %rsi
-;;       movzbq  (%rsi, %r9), %rax
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       jae     0x3f
+;;   31: movq    0x60(%rdi), %r10
+;;       movzbq  (%r10, %r8), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   3f: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x29
-;;   18: movq    0x60(%rdi), %rsi
-;;       movb    %cl, 0x1000(%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       ja      0x22
+;;   11: movq    0x60(%rdi), %r10
+;;       movb    %cl, 0x1000(%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
+;;   22: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x68(%rdi), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x6a
-;;   58: movq    0x60(%rdi), %rsi
-;;       movzbq  0x1000(%rsi, %r9), %rax
+;;       movl    %edx, %r8d
+;;       cmpq    0x68(%rdi), %r8
+;;       ja      0x63
+;;   51: movq    0x60(%rdi), %r10
+;;       movzbq  0x1000(%r10, %r8), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6a: ud2
+;;   63: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -23,29 +23,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    0x68(%rdi), %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x2a
-;;   18: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movb    %cl, (%r8, %rdi)
+;;       ja      0x24
+;;   11: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movb    %cl, (%r8, %r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2a: ud2
+;;   24: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    0x68(%rdi), %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x6b
-;;   58: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movzbq  (%r8, %rdi), %rax
+;;       ja      0x65
+;;   51: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movzbq  (%r8, %r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6b: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       subq    $4, %r9
-;;       cmpq    %r9, %rdx
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x28
-;;   1c: movq    0x60(%rdi), %rdi
-;;       movl    %ecx, (%rdi, %rdx)
+;;       movq    0x68(%rdi), %r8
+;;       subq    $4, %r8
+;;       cmpq    %r8, %rdx
+;;       ja      0x22
+;;   15: movq    0x60(%rdi), %r11
+;;       movl    %ecx, (%r11, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   28: ud2
+;;   22: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       subq    $4, %r9
-;;       cmpq    %r9, %rdx
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x68
-;;   5c: movq    0x60(%rdi), %rdi
-;;       movl    (%rdi, %rdx), %eax
+;;       movq    0x68(%rdi), %r8
+;;       subq    $4, %r8
+;;       cmpq    %r8, %rdx
+;;       ja      0x62
+;;   55: movq    0x60(%rdi), %r11
+;;       movl    (%r11, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: ud2
+;;   62: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       subq    $0x1004, %r9
-;;       cmpq    %r9, %rdx
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x2f
-;;   1f: movq    0x60(%rdi), %rdi
-;;       movl    %ecx, 0x1000(%rdi, %rdx)
+;;       movq    0x68(%rdi), %r8
+;;       subq    $0x1004, %r8
+;;       cmpq    %r8, %rdx
+;;       ja      0x29
+;;   18: movq    0x60(%rdi), %r11
+;;       movl    %ecx, 0x1000(%r11, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2f: ud2
+;;   29: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       subq    $0x1004, %r9
-;;       cmpq    %r9, %rdx
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x6f
-;;   5f: movq    0x60(%rdi), %rdi
-;;       movl    0x1000(%rdi, %rdx), %eax
+;;       movq    0x68(%rdi), %r8
+;;       subq    $0x1004, %r8
+;;       cmpq    %r8, %rdx
+;;       ja      0x69
+;;   58: movq    0x60(%rdi), %r11
+;;       movl    0x1000(%r11, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6f: ud2
+;;   69: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,45 +21,39 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %r10
-;;       addq    0x32(%rip), %r10
-;;       jb      0x36
-;;   14: cmpq    0x68(%rdi), %r10
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x38
-;;   25: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %eax
-;;       movl    %ecx, (%rdx, %rax)
+;;       movq    %rdx, %r9
+;;       addq    0x2a(%rip), %r9
+;;       jb      0x2f
+;;   14: cmpq    0x68(%rdi), %r9
+;;       ja      0x31
+;;   1e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %esi
+;;       movl    %ecx, (%rdx, %rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   36: ud2
-;;   38: ud2
-;;   3a: addb    %al, (%rax)
-;;   3c: addb    %al, (%rax)
-;;   3e: addb    %al, (%rax)
-;;   40: addb    $0, %al
+;;   2f: ud2
+;;   31: ud2
+;;   33: addb    %al, (%rax)
+;;   35: addb    %al, (%rax)
+;;   37: addb    %al, (%rax, %rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %r10
-;;       addq    0x32(%rip), %r10
-;;       jb      0x96
-;;   74: cmpq    0x68(%rdi), %r10
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x98
-;;   85: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %eax
-;;       movl    (%rdx, %rax), %eax
+;;       movq    %rdx, %r9
+;;       addq    0x2a(%rip), %r9
+;;       jb      0x6f
+;;   54: cmpq    0x68(%rdi), %r9
+;;       ja      0x71
+;;   5e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %esi
+;;       movl    (%rdx, %rsi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   96: ud2
-;;   98: ud2
-;;   9a: addb    %al, (%rax)
-;;   9c: addb    %al, (%rax)
-;;   9e: addb    %al, (%rax)
-;;   a0: addb    $0, %al
+;;   6f: ud2
+;;   71: ud2
+;;   73: addb    %al, (%rax)
+;;   75: addb    %al, (%rax)
+;;   77: addb    %al, (%rax, %rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -22,26 +22,22 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       setae   %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x22
-;;   15: movq    0x60(%rdi), %r11
-;;       movb    %cl, (%r11, %rdx)
+;;       jae     0x1b
+;;    e: movq    0x60(%rdi), %r9
+;;       movb    %cl, (%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   22: ud2
+;;   1b: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       setae   %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x63
-;;   55: movq    0x60(%rdi), %r11
-;;       movzbq  (%r11, %rdx), %rax
+;;       jae     0x3c
+;;   2e: movq    0x60(%rdi), %r9
+;;       movzbq  (%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   63: ud2
+;;   3c: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       subq    $0x1001, %r9
-;;       cmpq    %r9, %rdx
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x2f
-;;   1f: movq    0x60(%rdi), %rdi
-;;       movb    %cl, 0x1000(%rdi, %rdx)
+;;       movq    0x68(%rdi), %r8
+;;       subq    $0x1001, %r8
+;;       cmpq    %r8, %rdx
+;;       ja      0x29
+;;   18: movq    0x60(%rdi), %r11
+;;       movb    %cl, 0x1000(%r11, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2f: ud2
+;;   29: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x68(%rdi), %r9
-;;       subq    $0x1001, %r9
-;;       cmpq    %r9, %rdx
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x71
-;;   5f: movq    0x60(%rdi), %rdi
-;;       movzbq  0x1000(%rdi, %rdx), %rax
+;;       movq    0x68(%rdi), %r8
+;;       subq    $0x1001, %r8
+;;       cmpq    %r8, %rdx
+;;       ja      0x6a
+;;   58: movq    0x60(%rdi), %r11
+;;       movzbq  0x1000(%r11, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   71: ud2
+;;   6a: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,44 +21,44 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %r10
-;;       addq    0x32(%rip), %r10
-;;       jb      0x36
-;;   14: cmpq    0x68(%rdi), %r10
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x38
-;;   25: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %eax
-;;       movb    %cl, (%rdx, %rax)
+;;       movq    %rdx, %r9
+;;       addq    0x2a(%rip), %r9
+;;       jb      0x2f
+;;   14: cmpq    0x68(%rdi), %r9
+;;       ja      0x31
+;;   1e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %esi
+;;       movb    %cl, (%rdx, %rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   36: ud2
-;;   38: ud2
-;;   3a: addb    %al, (%rax)
-;;   3c: addb    %al, (%rax)
-;;   3e: addb    %al, (%rax)
-;;   40: addl    %eax, (%rax)
+;;   2f: ud2
+;;   31: ud2
+;;   33: addb    %al, (%rax)
+;;   35: addb    %al, (%rax)
+;;   37: addb    %al, (%rcx)
+;;   39: addb    %bh, %bh
+;;   3b: incl    (%rax)
+;;   3d: addb    %al, (%rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %r10
-;;       addq    0x32(%rip), %r10
-;;       jb      0x98
-;;   74: cmpq    0x68(%rdi), %r10
-;;       seta    %sil
-;;       testb   %sil, %sil
-;;       jne     0x9a
-;;   85: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %eax
-;;       movzbq  (%rdx, %rax), %rax
+;;       movq    %rdx, %r9
+;;       addq    0x2a(%rip), %r9
+;;       jb      0x71
+;;   54: cmpq    0x68(%rdi), %r9
+;;       ja      0x73
+;;   5e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %esi
+;;       movzbq  (%rdx, %rsi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   98: ud2
-;;   9a: ud2
-;;   9c: addb    %al, (%rax)
-;;   9e: addb    %al, (%rax)
-;;   a0: addl    %eax, (%rax)
+;;   71: ud2
+;;   73: ud2
+;;   75: addb    %al, (%rax)
+;;   77: addb    %al, (%rcx)
+;;   79: addb    %bh, %bh
+;;   7b: incl    (%rax)
+;;   7d: addb    %al, (%rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -22,26 +22,22 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x22
-;;   15: movq    0x60(%rdi), %r11
-;;       movl    %ecx, (%r11, %rdx)
+;;       ja      0x1b
+;;    e: movq    0x60(%rdi), %r9
+;;       movl    %ecx, (%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   22: ud2
+;;   1b: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x62
-;;   55: movq    0x60(%rdi), %r11
-;;       movl    (%r11, %rdx), %eax
+;;       ja      0x3b
+;;   2e: movq    0x60(%rdi), %r9
+;;       movl    (%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   62: ud2
+;;   3b: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -22,26 +22,22 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x26
-;;   15: movq    0x60(%rdi), %r11
-;;       movl    %ecx, 0x1000(%r11, %rdx)
+;;       ja      0x1f
+;;    e: movq    0x60(%rdi), %r9
+;;       movl    %ecx, 0x1000(%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   26: ud2
+;;   1f: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x66
-;;   55: movq    0x60(%rdi), %r11
-;;       movl    0x1000(%r11, %rdx), %eax
+;;       ja      0x5f
+;;   4e: movq    0x60(%rdi), %r9
+;;       movl    0x1000(%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   5f: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -22,28 +22,24 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x26
-;;   15: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movl    %ecx, (%rdx, %rsi)
+;;       ja      0x21
+;;    e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movl    %ecx, (%rdx, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   26: ud2
+;;   21: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x66
-;;   55: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movl    (%rdx, %rsi), %eax
+;;       ja      0x61
+;;   4e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movl    (%rdx, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   61: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -22,26 +22,22 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       setae   %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x22
-;;   15: movq    0x60(%rdi), %r11
-;;       movb    %cl, (%r11, %rdx)
+;;       jae     0x1b
+;;    e: movq    0x60(%rdi), %r9
+;;       movb    %cl, (%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   22: ud2
+;;   1b: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       setae   %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x63
-;;   55: movq    0x60(%rdi), %r11
-;;       movzbq  (%r11, %rdx), %rax
+;;       jae     0x3c
+;;   2e: movq    0x60(%rdi), %r9
+;;       movzbq  (%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   63: ud2
+;;   3c: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -22,26 +22,22 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x26
-;;   15: movq    0x60(%rdi), %r11
-;;       movb    %cl, 0x1000(%r11, %rdx)
+;;       ja      0x1f
+;;    e: movq    0x60(%rdi), %r9
+;;       movb    %cl, 0x1000(%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   26: ud2
+;;   1f: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x67
-;;   55: movq    0x60(%rdi), %r11
-;;       movzbq  0x1000(%r11, %rdx), %rax
+;;       ja      0x60
+;;   4e: movq    0x60(%rdi), %r9
+;;       movzbq  0x1000(%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   67: ud2
+;;   60: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -22,28 +22,24 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x26
-;;   15: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movb    %cl, (%rdx, %rsi)
+;;       ja      0x21
+;;    e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movb    %cl, (%rdx, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   26: ud2
+;;   21: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x68(%rdi), %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x68
-;;   55: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movzbq  (%rdx, %rsi), %rax
+;;       ja      0x62
+;;   4e: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movzbq  (%rdx, %r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: ud2
+;;   62: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,37 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x22(%rip), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x28
-;;   1b: movq    0x60(%rdi), %rsi
-;;       movl    %ecx, (%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x1a(%rip), %r8
+;;       ja      0x21
+;;   14: movq    0x60(%rdi), %r10
+;;       movl    %ecx, (%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   28: ud2
-;;   2a: addb    %al, (%rax)
-;;   2c: addb    %al, (%rax)
-;;   2e: addb    %al, (%rax)
-;;   30: cld
+;;   21: ud2
+;;   23: addb    %al, (%rax)
+;;   25: addb    %al, (%rax)
+;;   27: addb    %bh, %ah
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x22(%rip), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x68
-;;   5b: movq    0x60(%rdi), %rsi
-;;       movl    (%rsi, %r9), %eax
+;;       movl    %edx, %r8d
+;;       cmpq    0x1a(%rip), %r8
+;;       ja      0x61
+;;   54: movq    0x60(%rdi), %r10
+;;       movl    (%r10, %r8), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: ud2
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
-;;   70: cld
+;;   61: ud2
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %ah

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,35 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x22(%rip), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x2c
-;;   1b: movq    0x60(%rdi), %rsi
-;;       movl    %ecx, 0x1000(%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x1a(%rip), %r8
+;;       ja      0x25
+;;   14: movq    0x60(%rdi), %r10
+;;       movl    %ecx, 0x1000(%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2c: ud2
-;;   2e: addb    %al, (%rax)
-;;   30: cld
-;;   31: outl    %eax, %dx
+;;   25: ud2
+;;   27: addb    %bh, %ah
+;;   29: outl    %eax, %dx
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x22(%rip), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x6c
-;;   5b: movq    0x60(%rdi), %rsi
-;;       movl    0x1000(%rsi, %r9), %eax
+;;       movl    %edx, %r8d
+;;       cmpq    0x1a(%rip), %r8
+;;       ja      0x65
+;;   54: movq    0x60(%rdi), %r10
+;;       movl    0x1000(%r10, %r8), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
-;;   6e: addb    %al, (%rax)
-;;   70: cld
-;;   71: outl    %eax, %dx
+;;   65: ud2
+;;   67: addb    %bh, %ah
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -23,29 +23,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    $0xfffc, %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x2d
-;;   1b: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movl    %ecx, (%r8, %rdi)
+;;       ja      0x27
+;;   14: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movl    %ecx, (%r8, %r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2d: ud2
+;;   27: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    $0xfffc, %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x6d
-;;   5b: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movl    (%r8, %rdi), %eax
+;;       ja      0x67
+;;   54: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movl    (%r8, %r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6d: ud2
+;;   67: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,32 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x22(%rip), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x2c
-;;   1b: movq    0x60(%rdi), %rsi
-;;       movb    %cl, 0x1000(%rsi, %r9)
+;;       movl    %edx, %r8d
+;;       cmpq    0x1a(%rip), %r8
+;;       ja      0x25
+;;   14: movq    0x60(%rdi), %r10
+;;       movb    %cl, 0x1000(%r10, %r8)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2c: ud2
-;;   2e: addb    %al, (%rax)
+;;   25: ud2
+;;   27: addb    %bh, %bh
+;;   29: outl    %eax, %dx
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r9d
-;;       cmpq    0x22(%rip), %r9
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x6d
-;;   5b: movq    0x60(%rdi), %rsi
-;;       movzbq  0x1000(%rsi, %r9), %rax
+;;       movl    %edx, %r8d
+;;       cmpq    0x1a(%rip), %r8
+;;       ja      0x66
+;;   54: movq    0x60(%rdi), %r10
+;;       movzbq  0x1000(%r10, %r8), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6d: ud2
-;;   6f: addb    %bh, %bh
-;;   71: outl    %eax, %dx
+;;   66: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -23,29 +23,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    $0xffff, %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x2d
-;;   1b: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movb    %cl, (%r8, %rdi)
+;;       ja      0x27
+;;   14: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movb    %cl, (%r8, %r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   2d: ud2
+;;   27: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r8d
 ;;       cmpq    $0xffff, %r8
-;;       seta    %r11b
-;;       testb   %r11b, %r11b
-;;       jne     0x6e
-;;   5b: addq    0x60(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       movzbq  (%r8, %rdi), %rax
+;;       ja      0x68
+;;   54: addq    0x60(%rdi), %r8
+;;       movl    $0xffff0000, %r11d
+;;       movzbq  (%r8, %r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   68: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x25
-;;   18: movq    0x60(%rdi), %r11
-;;       movl    %ecx, (%r11, %rdx)
+;;       cmpq    0x15(%rip), %rdx
+;;       ja      0x1e
+;;   11: movq    0x60(%rdi), %r9
+;;       movl    %ecx, (%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
-;;   27: addb    %bh, %ah
+;;   1e: ud2
+;;   20: cld
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x65
-;;   58: movq    0x60(%rdi), %r11
-;;       movl    (%r11, %rdx), %eax
+;;       cmpq    0x15(%rip), %rdx
+;;       ja      0x5e
+;;   51: movq    0x60(%rdi), %r9
+;;       movl    (%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
-;;   67: addb    %bh, %ah
+;;   5e: ud2
+;;   60: cld

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,35 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x29
-;;   18: movq    0x60(%rdi), %r11
-;;       movl    %ecx, 0x1000(%r11, %rdx)
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x22
+;;   11: movq    0x60(%rdi), %r9
+;;       movl    %ecx, 0x1000(%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
-;;   2b: addb    %al, (%rax)
-;;   2d: addb    %al, (%rax)
-;;   2f: addb    %bh, %ah
-;;   31: outl    %eax, %dx
+;;   22: ud2
+;;   24: addb    %al, (%rax)
+;;   26: addb    %al, (%rax)
+;;   28: cld
+;;   29: outl    %eax, %dx
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x69
-;;   58: movq    0x60(%rdi), %r11
-;;       movl    0x1000(%r11, %rdx), %eax
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x62
+;;   51: movq    0x60(%rdi), %r9
+;;       movl    0x1000(%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
-;;   6b: addb    %al, (%rax)
-;;   6d: addb    %al, (%rax)
-;;   6f: addb    %bh, %ah
-;;   71: outl    %eax, %dx
+;;   62: ud2
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)
+;;   68: cld
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -22,28 +22,24 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xfffc, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x29
-;;   18: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movl    %ecx, (%rdx, %rsi)
+;;       ja      0x24
+;;   11: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movl    %ecx, (%rdx, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
+;;   24: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xfffc, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x69
-;;   58: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movl    (%rdx, %rsi), %eax
+;;       ja      0x64
+;;   51: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movl    (%rdx, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
+;;   64: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,28 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x25
-;;   18: movq    0x60(%rdi), %r11
-;;       movb    %cl, (%r11, %rdx)
+;;       cmpq    0x15(%rip), %rdx
+;;       ja      0x1e
+;;   11: movq    0x60(%rdi), %r9
+;;       movb    %cl, (%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
-;;   27: addb    %bh, %bh
+;;   1e: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x66
-;;   58: movq    0x60(%rdi), %r11
-;;       movzbq  (%r11, %rdx), %rax
+;;       ja      0x5f
+;;   51: movq    0x60(%rdi), %r9
+;;       movzbq  (%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   5f: ud2
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,33 +21,28 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x29
-;;   18: movq    0x60(%rdi), %r11
-;;       movb    %cl, 0x1000(%r11, %rdx)
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x22
+;;   11: movq    0x60(%rdi), %r9
+;;       movb    %cl, 0x1000(%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
-;;   2b: addb    %al, (%rax)
-;;   2d: addb    %al, (%rax)
-;;   2f: addb    %bh, %bh
-;;   31: outl    %eax, %dx
+;;   22: ud2
+;;   24: addb    %al, (%rax)
+;;   26: addb    %al, (%rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x6a
-;;   58: movq    0x60(%rdi), %r11
-;;       movzbq  0x1000(%r11, %rdx), %rax
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x63
+;;   51: movq    0x60(%rdi), %r9
+;;       movzbq  0x1000(%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6a: ud2
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   63: ud2
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -22,28 +22,24 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xffff, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x29
-;;   18: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movb    %cl, (%rdx, %rsi)
+;;       ja      0x24
+;;   11: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movb    %cl, (%rdx, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
+;;   24: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xffff, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x6b
-;;   58: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movzbq  (%rdx, %rsi), %rax
+;;       ja      0x65
+;;   51: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movzbq  (%rdx, %r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6b: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x25
-;;   18: movq    0x60(%rdi), %r11
-;;       movl    %ecx, (%r11, %rdx)
+;;       cmpq    0x15(%rip), %rdx
+;;       ja      0x1e
+;;   11: movq    0x60(%rdi), %r9
+;;       movl    %ecx, (%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
-;;   27: addb    %bh, %ah
+;;   1e: ud2
+;;   20: cld
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x65
-;;   58: movq    0x60(%rdi), %r11
-;;       movl    (%r11, %rdx), %eax
+;;       cmpq    0x15(%rip), %rdx
+;;       ja      0x5e
+;;   51: movq    0x60(%rdi), %r9
+;;       movl    (%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
-;;   67: addb    %bh, %ah
+;;   5e: ud2
+;;   60: cld

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,35 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x29
-;;   18: movq    0x60(%rdi), %r11
-;;       movl    %ecx, 0x1000(%r11, %rdx)
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x22
+;;   11: movq    0x60(%rdi), %r9
+;;       movl    %ecx, 0x1000(%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
-;;   2b: addb    %al, (%rax)
-;;   2d: addb    %al, (%rax)
-;;   2f: addb    %bh, %ah
-;;   31: outl    %eax, %dx
+;;   22: ud2
+;;   24: addb    %al, (%rax)
+;;   26: addb    %al, (%rax)
+;;   28: cld
+;;   29: outl    %eax, %dx
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x69
-;;   58: movq    0x60(%rdi), %r11
-;;       movl    0x1000(%r11, %rdx), %eax
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x62
+;;   51: movq    0x60(%rdi), %r9
+;;       movl    0x1000(%r9, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
-;;   6b: addb    %al, (%rax)
-;;   6d: addb    %al, (%rax)
-;;   6f: addb    %bh, %ah
-;;   71: outl    %eax, %dx
+;;   62: ud2
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)
+;;   68: cld
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -22,28 +22,24 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xfffc, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x29
-;;   18: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movl    %ecx, (%rdx, %rsi)
+;;       ja      0x24
+;;   11: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movl    %ecx, (%rdx, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
+;;   24: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xfffc, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x69
-;;   58: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movl    (%rdx, %rsi), %eax
+;;       ja      0x64
+;;   51: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movl    (%rdx, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
+;;   64: ud2

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,28 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x25
-;;   18: movq    0x60(%rdi), %r11
-;;       movb    %cl, (%r11, %rdx)
+;;       cmpq    0x15(%rip), %rdx
+;;       ja      0x1e
+;;   11: movq    0x60(%rdi), %r9
+;;       movb    %cl, (%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
-;;   27: addb    %bh, %bh
+;;   1e: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    0x1d(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x66
-;;   58: movq    0x60(%rdi), %r11
-;;       movzbq  (%r11, %rdx), %rax
+;;       ja      0x5f
+;;   51: movq    0x60(%rdi), %r9
+;;       movzbq  (%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   5f: ud2
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,33 +21,28 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x29
-;;   18: movq    0x60(%rdi), %r11
-;;       movb    %cl, 0x1000(%r11, %rdx)
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x22
+;;   11: movq    0x60(%rdi), %r9
+;;       movb    %cl, 0x1000(%r9, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
-;;   2b: addb    %al, (%rax)
-;;   2d: addb    %al, (%rax)
-;;   2f: addb    %bh, %bh
-;;   31: outl    %eax, %dx
+;;   22: ud2
+;;   24: addb    %al, (%rax)
+;;   26: addb    %al, (%rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       cmpq    0x25(%rip), %rdx
-;;       seta    %r9b
-;;       testb   %r9b, %r9b
-;;       jne     0x6a
-;;   58: movq    0x60(%rdi), %r11
-;;       movzbq  0x1000(%r11, %rdx), %rax
+;;       cmpq    0x1d(%rip), %rdx
+;;       ja      0x63
+;;   51: movq    0x60(%rdi), %r9
+;;       movzbq  0x1000(%r9, %rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6a: ud2
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   63: ud2
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %bh
+;;   69: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -22,28 +22,24 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xffff, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x29
-;;   18: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movb    %cl, (%rdx, %rsi)
+;;       ja      0x24
+;;   11: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movb    %cl, (%rdx, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   29: ud2
+;;   24: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       cmpq    $0xffff, %rdx
-;;       seta    %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0x6b
-;;   58: addq    0x60(%rdi), %rdx
-;;       movl    $0xffff0000, %esi
-;;       movzbq  (%rdx, %rsi), %rax
+;;       ja      0x65
+;;   51: addq    0x60(%rdi), %rdx
+;;       movl    $0xffff0000, %r10d
+;;       movzbq  (%rdx, %r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6b: ud2
+;;   65: ud2

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -76,7 +76,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x304
+;;       callq   0x2ed
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
@@ -128,7 +128,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x304
+;;       callq   0x2ed
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x20(%rsp), %r14

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -72,7 +72,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x32e
+;;       callq   0x307
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14

--- a/tests/disas/winch/x64/load/grow_load.wat
+++ b/tests/disas/winch/x64/load/grow_load.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
 ;;       movl    $0, %edx
-;;       callq   0x2e9
+;;       callq   0x2c6
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x58(%rsp), %r14

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -113,7 +113,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x4f4
+;;       callq   0x4cf
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
@@ -133,7 +133,7 @@
 ;;       movl    0xc(%rsp), %edx
 ;;       movq    4(%rsp), %rcx
 ;;       movl    (%rsp), %r8d
-;;       callq   0x53b
+;;       callq   0x510
 ;;       addq    $0x10, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       addq    $0x30, %rsp

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x2fb
+;;       callq   0x2da
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/grow.wat
+++ b/tests/disas/winch/x64/table/grow.wat
@@ -30,7 +30,7 @@
 ;;       movl    $0, %esi
 ;;       movl    $0xa, %edx
 ;;       movq    8(%rsp), %rcx
-;;       callq   0x180
+;;       callq   0x16b
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x937
+;;       callq   0x8c4
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x980
+;;       callq   0x906
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x937
+;;       callq   0x8c4
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x980
+;;       callq   0x906
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9c5
+;;       callq   0x945
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9c5
+;;       callq   0x945
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9c5
+;;       callq   0x945
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x9c5
+;;       callq   0x945
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9c5
+;;       callq   0x945
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -243,7 +243,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0xa0e
+;;       callq   0x987
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -109,7 +109,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x4c0
+;;       callq   0x495
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14


### PR DESCRIPTION
This commit improves the lowering rules on x64 for conditional traps (e.g. `trapz` and `trapnz`) to include a special-case with `icmp` which enables removing some extra instructions by materializing a comparison result into a register.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
