### PR TITLE
Make source links relative to OUT_DIR

### DIFF
--- a/cranelift/codegen/meta/src/srcgen.rs
+++ b/cranelift/codegen/meta/src/srcgen.rs
@@ -94,7 +94,6 @@ impl Formatter {
         directory: &std::path::Path,
     ) -> Result<(), error::Error> {
         let path = directory.join(&filename);
-        eprintln!("Writing generated file: {}", path.display());
         let mut f = fs::File::create(path)?;
 
         for l in self.lines.iter().map(|l| l.as_bytes()) {

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -127,7 +127,7 @@ impl<'a> Codegen<'a> {
             "// Generated automatically from the instruction-selection DSL code in:",
         )
         .unwrap();
-        for file in &self.files.file_names {
+        for file in &self.files.file_names_relative() {
             writeln!(code, "// - {file}").unwrap();
         }
 

--- a/cranelift/isle/isle/src/files.rs
+++ b/cranelift/isle/isle/src/files.rs
@@ -100,12 +100,33 @@ impl Files {
         self.file_names.get(file).map(|x| x.as_str())
     }
 
+    /// Same as `file_name` but try to make the file relative to the project root. Otherwise,
+    /// return the original file name (if found).
+    pub fn file_name_relative(&self, file: usize) -> Option<&str> {
+        self.file_name(file).map(|f| relative(f))
+    }
+
+    /// Try to make file names relative to the project root. Otherwise, return the original file
+    /// names.
+    pub fn file_names_relative(&self) -> Vec<&str> {
+        self.file_names.iter().map(|f| relative(f)).collect()
+    }
+
     pub fn file_text(&self, file: usize) -> Option<&str> {
         self.file_texts.get(file).map(|x| x.as_str())
     }
 
     pub fn file_line_map(&self, file: usize) -> Option<&LineMap> {
         self.file_line_maps.get(file)
+    }
+}
+
+/// If OUT_DIR is set, strips it from the file name.
+/// Otherwise returns the original file name.
+pub fn relative(file_name: &str) -> &str {
+    match std::env::var("OUT_DIR") {
+        Err(_) => file_name,
+        Ok(root) => file_name.strip_prefix(&root).unwrap_or(file_name).into(),
     }
 }
 

--- a/cranelift/isle/isle/src/lexer.rs
+++ b/cranelift/isle/isle/src/lexer.rs
@@ -39,7 +39,7 @@ impl Pos {
     pub fn pretty_print_line(&self, files: &Files) -> String {
         format!(
             "{} line {}",
-            files.file_name(self.file).unwrap(),
+            files.file_name_relative(self.file).unwrap(),
             files.file_line_map(self.file).unwrap().line(self.offset)
         )
     }


### PR DESCRIPTION
Fixes #9553

When generating code, `cranelift-isle` records the path to the source files. These paths were sometimes absolute, meaning it kept a trace of the system it was run on.

These changes here add helper functions in `Files` to try and strip the value of `$OUT_DIR` (if set) from the file names.

This also removes a log line (which included the full path of files) from `cranelift-codegen-meta`.