### PR TITLE
Remove the use of `MemoryStyle` in Winch

### DIFF
--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -116,6 +116,8 @@ pub struct FuncEnv<'a, 'translation: 'a, 'data: 'translation, P: PtrSize> {
     heap_access_spectre_mitigation: bool,
     /// Whether or not to enable Spectre mitigation on table element accesses.
     table_access_spectre_mitigation: bool,
+    /// Size of pages on the compilation target.
+    pub page_size_log2: u8,
     name_map: PrimaryMap<UserExternalNameRef, UserExternalName>,
     name_intern: HashMap<UserExternalName, UserExternalNameRef>,
 }
@@ -148,6 +150,7 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
             ptr_type,
             heap_access_spectre_mitigation: isa.flags().enable_heap_access_spectre_mitigation(),
             table_access_spectre_mitigation: isa.flags().enable_table_access_spectre_mitigation(),
+            page_size_log2: isa.page_size_align_log2(),
             builtins,
             name_map: Default::default(),
             name_intern: Default::default(),

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -154,4 +154,21 @@ impl TargetIsa for Aarch64 {
         // TODO: should fill this in with an actual implementation
         Ok(None)
     }
+
+    fn page_size_align_log2(&self) -> u8 {
+        use target_lexicon::*;
+        match self.triple().operating_system {
+            OperatingSystem::MacOSX { .. }
+            | OperatingSystem::Darwin
+            | OperatingSystem::Ios
+            | OperatingSystem::Tvos => {
+                debug_assert_eq!(1 << 14, 0x4000);
+                14
+            }
+            _ => {
+                debug_assert_eq!(1 << 16, 0x10000);
+                16
+            }
+        }
+    }
 }

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -210,6 +210,12 @@ pub trait TargetIsa: Send + Sync {
         let width = self.triple().pointer_width().unwrap();
         width.bytes()
     }
+
+    /// The log2 of the target's page size and alignment.
+    ///
+    /// Note that this may be an upper-bound that is larger than necessary for
+    /// some platforms since it may depend on runtime configuration.
+    fn page_size_align_log2(&self) -> u8;
 }
 
 impl Debug for &dyn TargetIsa {

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -167,4 +167,8 @@ impl TargetIsa for X64 {
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {
         Some(cranelift_codegen::isa::x64::create_cie())
     }
+
+    fn page_size_align_log2(&self) -> u8 {
+        12
+    }
 }


### PR DESCRIPTION
This applies a similar change as #9576 but to Winch. Similar to the previous PR one case needed some reshuffling, but otherwise all current behavior is maintained and this should otherwise be a refactoring.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
