### PR TITLE
Use blocks instead of instructions in DominatorTree

### DIFF
--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -512,7 +512,7 @@ impl<'a> EgraphPass<'a> {
     ) -> Self {
         let num_values = func.dfg.num_values();
         let mut domtree = DominatorTreePreorder::new();
-        domtree.compute(raw_domtree, &func.layout);
+        domtree.compute(raw_domtree);
         Self {
             func,
             domtree,


### PR DESCRIPTION
Since all branching instructions are terminators now, it makes sense to use blocks in `DominatorTree` as a unit of granularity. This makes interfaces a bit cleaner and allows to avoid `idom(..).inst_block(..).expect(..)` chain in a couple of places.

This is an independent part of work on adding new dominator tree computation algorithm.
Discussed in [zulip](https://bytecodealliance.zulipchat.com/#narrow/channel/217117-cranelift/topic/Dominator.20trees).
