### PR TITLE
Fix typo from #9545

### DIFF
--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -236,7 +236,7 @@ pub extern "C" fn wasmtime_config_memory_guard_size_set(c: &mut wasm_config_t, s
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_memory_reservation_reserved_for_growth_set(
+pub extern "C" fn wasmtime_config_memory_reservation_for_growth_set(
     c: &mut wasm_config_t,
     size: u64,
 ) {


### PR DESCRIPTION
While trying to update wasmtime-py to use the latest dev version, I noticed what I think is just a typo causing a mismatch between the [c header file](https://github.com/bytecodealliance/wasmtime/blob/f406347a6e8af835f52bfb6868a64f01be2ee533/crates/c-api/include/wasmtime/config.h#L353):

> WASMTIME_CONFIG_PROP(void, memory_reservation_for_growth, uint64_t)

which expands to `wasmtime_config_memory_reservation_for_growth_set` and this line (which still has "reserved"). I think just a typo from #9545. 
