### PR TITLE
Use enum for directory/file permissions to make generated bindings easier to use

### DIFF
--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -166,7 +166,7 @@ WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t *config);
 /**
  * \brief The permissions granted for a directory when preopening it.
  */
-enum wasi_dir_perms_enum {
+enum wasi_dir_perms_flags {
   /**
    * \brief This directory can be read, for example its entries can be iterated
    */
@@ -181,14 +181,14 @@ enum wasi_dir_perms_enum {
 
 /**
  * \brief The permissions granted for directories when preopening them,
- * which is a bitmask with flag values from enum #wasi_dir_perms_enum.
+ * which is a bitmask with flag values from wasi_dir_perms_flags.
  */
 typedef size_t wasi_dir_perms;
 
 /**
  * \brief The permissions granted for files when preopening a directory.
  */
-enum wasi_file_perms_enum {
+enum wasi_file_perms_flags {
   /**
    * \brief Files can be read.
    */
@@ -202,7 +202,7 @@ enum wasi_file_perms_enum {
 
 /**
  * \brief The max permissions granted a file within a preopened directory,
- * which is a bitmask with flag values from enum #wasi_file_perms_enum.
+ * which is a bitmask with flag values from wasi_file_perms_flags.
  */
 typedef size_t wasi_file_perms;
 

--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -164,26 +164,47 @@ WASI_API_EXTERN bool wasi_config_set_stderr_file(wasi_config_t *config,
 WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t *config);
 
 /**
- * \brief This directory can be read, for example its entries can be iterated
- * over and files can be opened.
+ * \brief The permissions granted for a directory when preopening it.
  */
-#define WASMTIME_WASI_DIR_PERMS_READ 1
+enum wasi_dir_perms_enum {
+  /**
+   * \brief This directory can be read, for example its entries can be iterated
+   */
+  WASMTIME_WASI_DIR_PERMS_READ = 1,
+
+  /**
+   * \brief This directory can be written to, for example new files can be
+   * created within it.
+   */
+  WASMTIME_WASI_DIR_PERMS_WRITE = 2,
+};
 
 /**
- * \brief This directory can be mutated, for example by creating new files
- * within it.
+ * \brief The permissions granted for directories when preopening them,
+ * which is a bitmask with flag values from enum #wasi_dir_perms_enum.
  */
-#define WASMTIME_WASI_DIR_PERMS_WRITE 2
+typedef size_t wasi_dir_perms;
 
 /**
- * \brief This file can be read.
+ * \brief The permissions granted for files when preopening a directory.
  */
-#define WASMTIME_WASI_FILE_PERMS_READ 1
+enum wasi_file_perms_enum {
+  /**
+   * \brief Files can be read.
+   */
+  WASMTIME_WASI_FILE_PERMS_READ = 1,
+
+  /**
+   * \brief Files can be written to.
+   */
+  WASMTIME_WASI_FILE_PERMS_WRITE = 2,
+};
 
 /**
- * \brief This file can be written to.
+ * \brief The max permissions granted a file within a preopened directory,
+ * which is a bitmask with flag values from enum #wasi_file_perms_enum.
  */
-#define WASMTIME_WASI_FILE_PERMS_WRITE 2
+typedef size_t wasi_file_perms;
 
 /**
  * \brief Configures a "preopened directory" to be available to WASI APIs.
@@ -211,8 +232,8 @@ WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t *config);
 WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t *config,
                                              const char *host_path,
                                              const char *guest_path,
-                                             size_t dir_perms,
-                                             size_t file_perms);
+                                             wasi_dir_perms dir_perms,
+                                             wasi_file_perms file_perms);
 
 #undef own
 


### PR DESCRIPTION
As part of https://github.com/bytecodealliance/wasmtime-py/issues/251, I want to use the File/Directory permission constants from the C API in Python. As defines, this is a bit tricky. Rather than hard-code them on the Python side, this PR makes them into an enum, and the existing C-to-Python logic is able to see & emit them. I have some work in progress which does this, see the [resulting generated code](https://github.com/bytecodealliance/wasmtime-py/compare/main...jder:wasmtime-py:update-dev?expand=1#diff-1ed8724e6e665b1b666545ea15177bcff0c3dbf8e2d7159ac115babd8c29e32bR1975-R1985) and the [nicer wrappers around them](https://github.com/bytecodealliance/wasmtime-py/compare/main...jder:wasmtime-py:update-dev?expand=1#diff-c4520ab85798819dc0b98db7de4f96f8e8b6ce0f2e7ab9c330a949f69836920c).