### PR TITLE
Expose wasmparser from environ for use in wasmtime-py

### DIFF
--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -48,6 +48,8 @@ pub use crate::types::*;
 pub use crate::vmoffsets::*;
 pub use object;
 
+pub use wasmparser;
+
 #[cfg(feature = "compile")]
 mod compile;
 #[cfg(feature = "compile")]


### PR DESCRIPTION
As discussed in https://github.com/bytecodealliance/wasmtime-py/issues/251#issuecomment-2469592812, this re-exposes wasmparser from the environ crate (it was previously exposed before #9342 landed), since wasmtime-py uses it.