### PR TITLE
Store one fiber stack in a `Store<T>`

### DIFF
--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -21,6 +21,14 @@ cfg_if::cfg_if! {
 /// Represents an execution stack to use for a fiber.
 pub struct FiberStack(imp::FiberStack);
 
+fn _assert_send_sync() {
+    fn _assert_send<T: Send>() {}
+    fn _assert_sync<T: Sync>() {}
+
+    _assert_send::<FiberStack>();
+    _assert_sync::<FiberStack>();
+}
+
 impl FiberStack {
     /// Creates a new fiber stack of the given size.
     pub fn new(size: usize) -> io::Result<Self> {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2118,8 +2118,10 @@ at https://bytecodealliance.org/security.
         self.async_state.last_fiber_stack = Some(stack);
     }
 
-    #[cfg(feature = "async")]
+    /// Releases the last fiber stack to the underlying instance allocator, if
+    /// present.
     fn flush_fiber_stack(&mut self) {
+        #[cfg(feature = "async")]
         if let Some(stack) = self.async_state.last_fiber_stack.take() {
             unsafe {
                 self.engine.allocator().deallocate_fiber_stack(stack);


### PR DESCRIPTION
This commit stores a single fiber stack in `Store<T>` as a cache to be used throughout the lifetime of the `Store`. This should help amortize the cost of allocating a stack for use in a store because the same stack can be used continuously throughout the lifetime of the `Store<T>`. This notably reduces contention on the lock used to manage the pooling allocator when possible.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
