### PR TITLE
Update extended-const fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -124,7 +124,6 @@ impl Config {
     pub fn make_wast_test_compliant(&mut self, test: &WastTest) -> WastConfig {
         // Enable/disable some proposals that aren't configurable in wasm-smith
         // but are configurable in Wasmtime.
-        self.module_config.extended_const_enabled = test.config.extended_const.unwrap_or(false);
         self.module_config.function_references_enabled = test
             .config
             .function_references
@@ -148,6 +147,7 @@ impl Config {
         config.reference_types_enabled = config.gc_enabled
             || self.module_config.function_references_enabled
             || test.config.reference_types.unwrap_or(false);
+        config.extended_const_enabled = test.config.extended_const.unwrap_or(false);
         if test.config.multi_memory.unwrap_or(false) {
             config.max_memories = limits::MEMORIES_PER_MODULE as usize;
         } else {
@@ -241,7 +241,7 @@ impl Config {
             .wasm_gc(self.module_config.config.gc_enabled)
             .wasm_custom_page_sizes(self.module_config.config.custom_page_sizes_enabled)
             .wasm_wide_arithmetic(self.module_config.config.wide_arithmetic_enabled)
-            .wasm_extended_const(self.module_config.extended_const_enabled)
+            .wasm_extended_const(self.module_config.config.extended_const_enabled)
             .wasm_component_model_more_flags(self.module_config.component_model_more_flags)
             .native_unwind_info(cfg!(target_os = "windows") || self.wasmtime.native_unwind_info)
             .cranelift_nan_canonicalization(self.wasmtime.canonicalize_nans)

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -15,8 +15,6 @@ pub struct ModuleConfig {
     // in our `*.wast` testing so keep knobs here so they can be read during
     // config-to-`wasmtime::Config` translation.
     #[allow(missing_docs)]
-    pub extended_const_enabled: bool,
-    #[allow(missing_docs)]
     pub function_references_enabled: bool,
     #[allow(missing_docs)]
     pub component_model_more_flags: bool,
@@ -44,6 +42,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
         let _ = config.simd_enabled;
         let _ = config.relaxed_simd_enabled;
         let _ = config.tail_call_enabled;
+        let _ = config.extended_const_enabled;
         config.exceptions_enabled = false;
         config.gc_enabled = false;
         config.custom_page_sizes_enabled = u.arbitrary()?;
@@ -64,7 +63,6 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
         config.disallow_traps = u.ratio(9, 10)?;
 
         Ok(ModuleConfig {
-            extended_const_enabled: false,
             component_model_more_flags: false,
             function_references_enabled: config.gc_enabled,
             config,

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -35,7 +35,7 @@ impl WasmiEngine {
             .wasm_reference_types(config.reference_types_enabled)
             .wasm_tail_call(config.tail_call_enabled)
             .wasm_multi_memory(config.max_memories > 1)
-            .wasm_extended_const(true);
+            .wasm_extended_const(config.extended_const_enabled);
         Self {
             engine: wasmi::Engine::new(&wasmi_config),
         }

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -25,7 +25,7 @@ column is below.
 | [`multi-memory`]         | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`threads`]              | ✅      | ✅    | ✅[^9]   | ❌[^3] | ✅  | ✅    |
 | [`tail-call`]            | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
-| [`extended-const`]       | ✅      | ✅    | ✅       | ❌[^4] | ✅  | ✅    |
+| [`extended-const`]       | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 
 [^1]: The `component-model` proposal is not at phase 4 in the standardization
     process but it is still enabled-by-default in Wasmtime.
@@ -33,8 +33,6 @@ column is below.
     lines of `wasm-smith` are not implemented for components.
 [^3]: Fuzzing with threads is an open implementation question that is expected
     to get fleshed out as the [`shared-everything-threads`] proposal advances.
-[^4]: This was a mistake in Wasmtime's stabilization process. Support for
-    [`extended-const`] is not yet implemented in `wasm-smith`.
 [^5]: Support for the C API for components is desired by many embedders but
     does not currently have anyone lined up to implement it.
 [^9]: There are [known
@@ -51,7 +49,7 @@ column is below.
 | [`function-references`]  | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
 | [`gc`] [^6]              | ✅      | ✅    | ❌[^7]   | ❌     | ✅  | ❌    |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
-| [`custom-page-sizes`]    | ❌      | ✅    | ⚠️[^8]    | ✅     | ✅  | ❌    |
+| [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ❌    |
 
 [^6]: There is also a [tracking
     issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for the
@@ -59,8 +57,6 @@ column is below.
 [^7]: The implementation of GC has [known performance
     issues](https://github.com/bytecodealliance/wasmtime/issues/9351) which can
     affect non-GC code when the GC proposal is enabled.
-[^8]: Using custom-page-sizes is [known to have issues when combined with shared
-    memories](https://github.com/bytecodealliance/wasmtime/issues/9523).
 
 ## Unimplemented proposals
 


### PR DESCRIPTION
* Remove the one-off configuration option for this which now duplicates what's in `wasm-smith`.
* Reach whether or not the feature is enabled from `wasm-smith`.
* Update docs of wasm proposals for some recent changes (e.g. `extended-const` is fuzzed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
