### PR TITLE
Cranelift: add option to use new single-pass register allocator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+
+[[package]]
 name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,9 +274,12 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byte-array-literals"
@@ -2547,15 +2556,16 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+checksum = "cb13cfdd822509d57e9cf3021df28af2771dd4d9ac99d938d2fba85d3a9209c6"
 dependencies = [
+ "allocator-api2",
+ "bumpalo",
  "hashbrown 0.14.3",
  "log",
  "rustc-hash 2.0.0",
  "serde",
- "slice-group-by",
  "smallvec",
 ]
 
@@ -2881,12 +2891,6 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "slice-group-by"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.10.2"
+regalloc2 = "0.11.0"
 
 # cap-std family:
 target-lexicon = "0.12.16"

--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -31,6 +31,20 @@ pub(crate) fn define() -> SettingGroup {
     );
 
     settings.add_enum(
+        "regalloc_algorithm",
+        "Algorithm to use in register allocator.",
+        r#"
+            Supported options:
+
+            - `backtracking`: A backtracking allocator with range splitting; more expensive
+                              but generates better code.
+            - `single_pass`: A single-pass algorithm that yields quick compilation but
+                             results in code with more register spills and moves.
+        "#,
+        vec!["backtracking", "single_pass"],
+    );
+
+    settings.add_enum(
         "opt_level",
         "Optimization level for generated code.",
         r#"

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -509,6 +509,7 @@ mod tests {
         let f = Flags::new(b);
         let actual = f.to_string();
         let expected = r#"[shared]
+regalloc_algorithm = "backtracking"
 opt_level = "none"
 tls_model = "none"
 stack_switch_model = "none"

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -42,6 +42,9 @@ wasmtime_option_group! {
         /// Optimization level of generated code (0-2, s; default: 2)
         pub opt_level: Option<wasmtime::OptLevel>,
 
+        /// Register allocator algorithm choice.
+        pub regalloc_algorithm: Option<wasmtime::RegallocAlgorithm>,
+
         /// Do not allow Wasm linear memories to move in the host process's
         /// address space.
         pub memory_may_move: Option<bool>,
@@ -583,6 +586,11 @@ impl CommonOptions {
         match_feature! {
             ["cranelift" : self.opts.opt_level]
             level => config.cranelift_opt_level(level),
+            _ => err,
+        }
+        match_feature! {
+            ["cranelift": self.opts.regalloc_algorithm]
+            algo => config.cranelift_regalloc_algorithm(algo),
             _ => err,
         }
         match_feature! {

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -374,6 +374,20 @@ impl WasmtimeOptionValue for wasmtime::OptLevel {
     }
 }
 
+impl WasmtimeOptionValue for wasmtime::RegallocAlgorithm {
+    const VAL_HELP: &'static str = "=backtracking|single-pass";
+    fn parse(val: Option<&str>) -> Result<Self> {
+        match String::parse(val)?.as_str() {
+            "backtracking" => Ok(wasmtime::RegallocAlgorithm::Backtracking),
+            "single-pass" => Ok(wasmtime::RegallocAlgorithm::SinglePass),
+            other => bail!(
+                "unknown regalloc algorithm`{}`, only backtracking,single-pass accepted",
+                other
+            ),
+        }
+    }
+}
+
 impl WasmtimeOptionValue for wasmtime::Strategy {
     const VAL_HELP: &'static str = "=winch|cranelift";
     fn parse(val: Option<&str>) -> Result<Self> {

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -246,6 +246,7 @@ impl Config {
             .native_unwind_info(cfg!(target_os = "windows") || self.wasmtime.native_unwind_info)
             .cranelift_nan_canonicalization(self.wasmtime.canonicalize_nans)
             .cranelift_opt_level(self.wasmtime.opt_level.to_wasmtime())
+            .cranelift_regalloc_algorithm(self.wasmtime.regalloc_algorithm.to_wasmtime())
             .consume_fuel(self.wasmtime.consume_fuel)
             .epoch_interruption(self.wasmtime.epoch_interruption)
             .memory_guaranteed_dense_image_size(std::cmp::min(
@@ -474,6 +475,7 @@ impl<'a> Arbitrary<'a> for Config {
 #[derive(Arbitrary, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct WasmtimeConfig {
     opt_level: OptLevel,
+    regalloc_algorithm: RegallocAlgorithm,
     debug_info: bool,
     canonicalize_nans: bool,
     interruptable: bool,
@@ -689,6 +691,21 @@ impl OptLevel {
             OptLevel::None => wasmtime::OptLevel::None,
             OptLevel::Speed => wasmtime::OptLevel::Speed,
             OptLevel::SpeedAndSize => wasmtime::OptLevel::SpeedAndSize,
+        }
+    }
+}
+
+#[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Hash)]
+enum RegallocAlgorithm {
+    Backtracking,
+    SinglePass,
+}
+
+impl RegallocAlgorithm {
+    fn to_wasmtime(&self) -> wasmtime::RegallocAlgorithm {
+        match self {
+            RegallocAlgorithm::Backtracking => wasmtime::RegallocAlgorithm::Backtracking,
+            RegallocAlgorithm::SinglePass => wasmtime::RegallocAlgorithm::SinglePass,
         }
     }
 }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -351,6 +351,7 @@ impl Engine {
             | "enable_pcc"
             | "regalloc_checker"
             | "regalloc_verbose_logs"
+            | "regalloc_algorithm"
             | "is_pic"
             | "bb_padding_log2_minus_one"
             | "machine_code_cfg_info"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -171,7 +171,7 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[wildcard-audits.regalloc2]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
-user-id = 3726
+user-id = 3726 # Chris Fallin (cfallin)
 start = "2021-12-03"
 end = "2025-07-30"
 notes = "We (Bytecode Alliance) are the primary authors of regalloc2 and co-develop it with Cranelift/Wasmtime, with the same code-review, testing/fuzzing, and security standards."
@@ -179,7 +179,7 @@ notes = "We (Bytecode Alliance) are the primary authors of regalloc2 and co-deve
 [[wildcard-audits.regalloc2]]
 who = "Trevor Elliott <telliott@fastly.com>"
 criteria = "safe-to-deploy"
-user-id = 187138 # Trevor Elliott (elliottt)
+user-id = 187138
 start = "2022-11-29"
 end = "2025-07-30"
 notes = """
@@ -933,6 +933,15 @@ delta = "0.8.2 -> 0.8.7"
 notes = """
 Shuffling of features in this update and while there are updates to `unsafe`
 code it's no different than before and the usage remains the same.
+"""
+
+[[audits.allocator-api2]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.18 -> 0.2.20"
+notes = """
+The changes appear to be reasonable updates from Rust's stdlib imported into
+`allocator-api2`'s copy of this code.
 """
 
 [[audits.ambient-authority]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -267,8 +267,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.bumpalo]]
-version = "3.14.0"
-when = "2023-09-14"
+version = "3.16.0"
+when = "2024-04-08"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
@@ -669,11 +669,11 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.10.2"
-when = "2024-09-11"
-user-id = 187138
-user-login = "elliottt"
-user-name = "Trevor Elliott"
+version = "0.11.0"
+when = "2024-11-15"
+user-id = 3726
+user-login = "cfallin"
+user-name = "Chris Fallin"
 
 [[publisher.regex]]
 version = "1.9.1"
@@ -1651,6 +1651,12 @@ user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.allocator-api2]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.18"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.android_system_properties]]


### PR DESCRIPTION
In bytecodealliance/regalloc2#181, @d-sonuga added a fast single-pass algorithm option to regalloc2, in addition to its existing backtracking allocator. This produces code much more quickly, at the expense of code quality. Sometimes this tradeoff is desirable (e.g. when performing a debug build in a fast-iteration development situation, or in an initial JIT tier).

This PR adds a Cranelift option to select the RA2 algorithm, plumbs it through to a Wasmtime option, and adds the option to Wasmtime fuzzing as well.

An initial compile-time measurement in Wasmtime: `spidermonkey.wasm` builds in 1.383s with backtracking (existing algorithm), and 1.065s with single-pass. The resulting binary runs a simple Fibonacci benchmark in 2.060s with backtracking vs. 3.455s with single-pass.

Hence, the single-pass algorithm yields a 23% compile-time reduction, at the cost of a 67% runtime increase.

Fixes #9596.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
