### PR TITLE
Disable extended-const for the spec interpreter

### DIFF
--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -27,6 +27,7 @@ impl SpecInterpreter {
         config.relaxed_simd_enabled = false;
         config.custom_page_sizes_enabled = false;
         config.wide_arithmetic_enabled = false;
+        config.extended_const_enabled = false;
 
         Self
     }


### PR DESCRIPTION
It doesn't yet implement this proposal.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
