### PR TITLE
Fix an off-by-one error in translating bounds checks

### DIFF
--- a/crates/cranelift/src/translate/code_translator/bounds_checks.rs
+++ b/crates/cranelift/src/translate/code_translator/bounds_checks.rs
@@ -144,7 +144,7 @@ where
     // different bounds checks and optimizations of those bounds checks. It is
     // intentionally written in a straightforward case-matching style that will
     // hopefully make it easy to port to ISLE one day.
-    if offset_and_size >= heap.memory.maximum_byte_size().unwrap_or(u64::MAX) {
+    if offset_and_size > heap.memory.maximum_byte_size().unwrap_or(u64::MAX) {
         // Special case: trap immediately if `offset + access_size >
         // max_memory_size`, since we will end up being out-of-bounds regardless
         // of the given `index`.

--- a/crates/fuzzing/src/oracles/memory.rs
+++ b/crates/fuzzing/src/oracles/memory.rs
@@ -235,7 +235,8 @@ pub fn check_memory_accesses(input: MemoryAccesses) {
     };
 
     do_accesses(&mut store, "initial size");
-    let _ = memory.grow(&mut store, u64::from(growth));
+    let res = memory.grow(&mut store, u64::from(growth));
+    log::debug!("grow {growth} -> {res:?}");
     do_accesses(&mut store, "after growing");
 }
 

--- a/tests/misc_testsuite/custom-page-sizes/custom-page-sizes.wast
+++ b/tests/misc_testsuite/custom-page-sizes/custom-page-sizes.wast
@@ -109,3 +109,13 @@
 (module
   (memory (import "m" "large-pages-memory") 0 (pagesize 65536))
 )
+
+(module
+  (memory 8 8 (pagesize 0x1))
+  (func (export "load64") (param i32) (result i64)
+    local.get 0
+    i64.load
+  )
+)
+
+(assert_return (invoke "load64" (i32.const 0)) (i64.const 0))


### PR DESCRIPTION
Unconditionally trapping accesses had an off-by-one introduced in #9576 which caused loads to produce a trap when they should succeed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
