### PR TITLE
Remove feature validation from Wasmtime

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2016,25 +2016,6 @@ impl Config {
             panic!("should have returned an error by now")
         }
 
-        if features.contains(WasmFeatures::REFERENCE_TYPES)
-            && !features.contains(WasmFeatures::BULK_MEMORY)
-        {
-            bail!("feature 'reference_types' requires 'bulk_memory' to be enabled");
-        }
-        if features.contains(WasmFeatures::THREADS) && !features.contains(WasmFeatures::BULK_MEMORY)
-        {
-            bail!("feature 'threads' requires 'bulk_memory' to be enabled");
-        }
-        if features.contains(WasmFeatures::FUNCTION_REFERENCES)
-            && !features.contains(WasmFeatures::REFERENCE_TYPES)
-        {
-            bail!("feature 'function_references' requires 'reference_types' to be enabled");
-        }
-        if features.contains(WasmFeatures::GC)
-            && !features.contains(WasmFeatures::FUNCTION_REFERENCES)
-        {
-            bail!("feature 'gc' requires 'function_references' to be enabled");
-        }
         #[cfg(feature = "async")]
         if self.async_support && self.max_wasm_stack > self.async_stack_size {
             bail!("max_wasm_stack size cannot exceed the async_stack_size");


### PR DESCRIPTION
Some of this originated in #917 but nowadays it shouldn't be necessary to control proposals like this. Instead it's probably best nowadays to throw configuration at `wasmparser` and use its definition of features to determine whether constructs make sense or not. This reduces the amount of bits and pieces Wasmtime has to do and avoids interactions such as #9622.

Closes #9622

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
