### PR TITLE
Skip the rlimited-memory test under QEMU

### DIFF
--- a/tests/rlimited-memory.rs
+++ b/tests/rlimited-memory.rs
@@ -43,6 +43,20 @@ fn custom_limiter_detect_os_oom_failure() -> Result<()> {
         return Ok(());
     }
 
+    // Skip this test if it looks like we're in a cross-compiled situation,
+    // and we're emulating this test for a different platform. In that
+    // scenario QEMU ignores the data rlimit, which this test relies on. See
+    // QEMU commits 5dfa88f7162f ("linux-user: do setrlimit selectively") and
+    // 055d92f8673c ("linux-user: do prlimit selectively") for more
+    // information.
+    if std::env::vars()
+        .filter(|(k, _v)| k.starts_with("CARGO_TARGET") && k.ends_with("RUNNER"))
+        .count()
+        > 0
+    {
+        return Ok(());
+    }
+
     // Default behavior of on-demand memory allocation so that a
     // memory grow will hit Linux for a larger mmap.
     let mut config = Config::new();


### PR DESCRIPTION
After the rework of the QEMU memory management, which landed in v8.0.0 and introduced interval trees instead of individual page descriptors - similar to how the Linux kernel does it - it became possible to run the WASMTIME_TEST_NO_HOG_MEMORY tests under it.

The only exception is the rlimited-memory test, which relies on the underlying OS enforcing the RLIMIT_DATA limit. QEMU chose to ignore this limit, because it interferes with its JIT.

Skip this test when using emulation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
