### PR TITLE
Remove `PartialEq` implementations from CLI flags

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -912,31 +912,3 @@ impl CommonOptions {
         Ok(())
     }
 }
-
-impl PartialEq for CommonOptions {
-    fn eq(&self, other: &CommonOptions) -> bool {
-        let mut me = self.clone();
-        me.configure();
-        let mut other = other.clone();
-        other.configure();
-        let CommonOptions {
-            opts_raw: _,
-            codegen_raw: _,
-            debug_raw: _,
-            wasm_raw: _,
-            wasi_raw: _,
-            configured: _,
-
-            opts,
-            codegen,
-            debug,
-            wasm,
-            wasi,
-        } = me;
-        opts == other.opts
-            && codegen == other.codegen
-            && debug == other.debug
-            && wasm == other.wasm
-            && wasi == other.wasi
-    }
-}

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -25,7 +25,7 @@ const AFTER_HELP: &str =
         wasmtime compile --target x86_64-unknown-linux -Ccranelift-skylake foo.wasm\n";
 
 /// Compiles a WebAssembly module.
-#[derive(Parser, PartialEq)]
+#[derive(Parser)]
 #[command(
     version,
     after_help = AFTER_HELP,

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -8,7 +8,7 @@ use wasmtime::Strategy;
 use wasmtime_cli_flags::CommonOptions;
 
 /// Explore the compilation of a WebAssembly module to native code.
-#[derive(Parser, PartialEq)]
+#[derive(Parser)]
 pub struct ExploreCommand {
     #[command(flatten)]
     common: CommonOptions,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -39,7 +39,7 @@ fn parse_preloads(s: &str) -> Result<(String, PathBuf)> {
 }
 
 /// Runs a WebAssembly module
-#[derive(Parser, PartialEq)]
+#[derive(Parser)]
 pub struct RunCommand {
     #[command(flatten)]
     #[allow(missing_docs)]

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -67,7 +67,7 @@ const DEFAULT_ADDR: std::net::SocketAddr = std::net::SocketAddr::new(
 );
 
 /// Runs a WebAssembly module
-#[derive(Parser, PartialEq)]
+#[derive(Parser)]
 pub struct ServeCommand {
     #[command(flatten)]
     run: RunCommon,

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -8,7 +8,7 @@ use wasmtime_cli_flags::CommonOptions;
 use wasmtime_wast::{SpectestConfig, WastContext};
 
 /// Runs a WebAssembly test script file
-#[derive(Parser, PartialEq)]
+#[derive(Parser)]
 pub struct WastCommand {
     #[command(flatten)]
     common: CommonOptions,

--- a/src/common.rs
+++ b/src/common.rs
@@ -38,7 +38,7 @@ impl RunTarget {
 }
 
 /// Common command line arguments for run commands.
-#[derive(Parser, PartialEq)]
+#[derive(Parser)]
 pub struct RunCommon {
     #[command(flatten)]
     pub common: CommonOptions,


### PR DESCRIPTION
These are historical artifacts from when the pre-Wasmtime-13 CLI was supported but they're no longer needed nowadays.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
