### PR TITLE
Use a helper method to invoke `VMFuncRef::array_call`

### DIFF
--- a/benches/call.rs
+++ b/benches/call.rs
@@ -189,9 +189,7 @@ fn bench_host_to_wasm<Params, Results>(
             for (i, param) in params.iter().enumerate() {
                 space[i] = param.to_raw(&mut *store).unwrap();
             }
-            untyped
-                .call_unchecked(&mut *store, space.as_mut_ptr(), space.len())
-                .unwrap();
+            untyped.call_unchecked(&mut *store, &mut space[..]).unwrap();
             for (i, expected) in results.iter().enumerate() {
                 let ty = expected.ty(&store).unwrap();
                 let actual = Val::from_raw(&mut *store, space[i], ty);

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -391,7 +391,8 @@ pub unsafe extern "C" fn wasmtime_func_call_unchecked(
     args_and_results_len: usize,
     trap_ret: &mut *mut wasm_trap_t,
 ) -> Option<Box<wasmtime_error_t>> {
-    match func.call_unchecked(store, args_and_results, args_and_results_len) {
+    let slice = std::ptr::slice_from_raw_parts_mut(args_and_results, args_and_results_len);
+    match func.call_unchecked(store, slice) {
         Ok(()) => None,
         Err(trap) => store_err(trap, trap_ret),
     }

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -470,8 +470,10 @@ impl Func {
             crate::Func::call_unchecked_raw(
                 store,
                 export.func_ref,
-                space.as_mut_ptr().cast(),
-                mem::size_of_val(space) / mem::size_of::<ValRaw>(),
+                core::ptr::slice_from_raw_parts_mut(
+                    space.as_mut_ptr().cast(),
+                    mem::size_of_val(space) / mem::size_of::<ValRaw>(),
+                ),
             )?;
 
             // Note that `.assume_init_ref()` here is unsafe but we're relying
@@ -620,8 +622,7 @@ impl Func {
                 crate::Func::call_unchecked_raw(
                     &mut store,
                     func.func_ref,
-                    &post_return_arg as *const ValRaw as *mut ValRaw,
-                    1,
+                    core::ptr::slice_from_raw_parts(&post_return_arg, 1).cast_mut(),
                 )?;
             }
 

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -1034,7 +1034,7 @@ impl ResourceAny {
         // destructors have al been previously type-checked and are guaranteed
         // to take one i32 argument and return no results, so the parameters
         // here should be configured correctly.
-        unsafe { crate::Func::call_unchecked_raw(store, dtor, args.as_mut_ptr(), args.len()) }
+        unsafe { crate::Func::call_unchecked_raw(store, dtor, &mut args) }
     }
 
     fn lower_to_index<U>(&self, cx: &mut LowerContext<'_, U>, ty: InterfaceType) -> Result<u32> {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1056,34 +1056,23 @@ impl Func {
     pub unsafe fn call_unchecked(
         &self,
         mut store: impl AsContextMut,
-        params_and_returns: *mut ValRaw,
-        params_and_returns_capacity: usize,
+        params_and_returns: *mut [ValRaw],
     ) -> Result<()> {
         let mut store = store.as_context_mut();
         let data = &store.0.store_data()[self.0];
         let func_ref = data.export().func_ref;
-        Self::call_unchecked_raw(
-            &mut store,
-            func_ref,
-            params_and_returns,
-            params_and_returns_capacity,
-        )
+        Self::call_unchecked_raw(&mut store, func_ref, params_and_returns)
     }
 
     pub(crate) unsafe fn call_unchecked_raw<T>(
         store: &mut StoreContextMut<'_, T>,
         func_ref: NonNull<VMFuncRef>,
-        params_and_returns: *mut ValRaw,
-        params_and_returns_capacity: usize,
+        params_and_returns: *mut [ValRaw],
     ) -> Result<()> {
         invoke_wasm_and_catch_traps(store, |caller| {
-            let func_ref = func_ref.as_ref();
-            (func_ref.array_call)(
-                func_ref.vmctx,
-                caller.cast::<VMOpaqueContext>(),
-                params_and_returns,
-                params_and_returns_capacity,
-            )
+            func_ref
+                .as_ref()
+                .array_call(caller.cast::<VMOpaqueContext>(), params_and_returns)
         })
     }
 
@@ -1256,7 +1245,10 @@ impl Func {
         }
 
         unsafe {
-            self.call_unchecked(&mut *store, values_vec.as_mut_ptr(), values_vec_size)?;
+            self.call_unchecked(
+                &mut *store,
+                core::ptr::slice_from_raw_parts_mut(values_vec.as_mut_ptr(), values_vec_size),
+            )?;
         }
 
         for ((i, slot), val) in results.iter_mut().enumerate().zip(&values_vec) {

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -213,13 +213,13 @@ where
 
         let result = invoke_wasm_and_catch_traps(store, |caller| {
             let (func_ref, storage) = &mut captures;
-            let func_ref = func_ref.as_ref();
-            (func_ref.array_call)(
-                func_ref.vmctx,
-                VMOpaqueContext::from_vmcontext(caller),
-                (storage as *mut Storage<_, _>) as *mut ValRaw,
-                mem::size_of_val::<Storage<_, _>>(storage) / mem::size_of::<ValRaw>(),
-            );
+            let storage_len = mem::size_of_val::<Storage<_, _>>(storage) / mem::size_of::<ValRaw>();
+            let storage: *mut Storage<_, _> = storage;
+            let storage = storage.cast::<ValRaw>();
+            let storage = core::ptr::slice_from_raw_parts_mut(storage, storage_len);
+            func_ref
+                .as_ref()
+                .array_call(VMOpaqueContext::from_vmcontext(caller), storage);
         });
 
         let (_, storage) = captures;

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -362,13 +362,9 @@ impl Instance {
         let caller_vmctx = instance.vmctx();
         unsafe {
             super::func::invoke_wasm_and_catch_traps(store, |_default_caller| {
-                let func = f.func_ref.as_ref().array_call;
-                func(
-                    f.func_ref.as_ref().vmctx,
-                    VMOpaqueContext::from_vmcontext(caller_vmctx),
-                    [].as_mut_ptr(),
-                    0,
-                )
+                f.func_ref
+                    .as_ref()
+                    .array_call(VMOpaqueContext::from_vmcontext(caller_vmctx), &mut [])
             })?;
         }
         Ok(())

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -690,6 +690,34 @@ pub struct VMFuncRef {
 unsafe impl Send for VMFuncRef {}
 unsafe impl Sync for VMFuncRef {}
 
+impl VMFuncRef {
+    /// Invokes the `array_call` field of this `VMFuncRef` with the supplied
+    /// arguments.
+    ///
+    /// This will invoke the function pointer in the `array_call` field with:
+    ///
+    /// * the `callee` vmctx as `self.vmctx`
+    /// * the `caller` as `caller` specified here
+    /// * the args pointer as `args_and_results`
+    /// * the args length as `args_and_results`
+    ///
+    /// The `args_and_results` area must be large enough to both load all
+    /// arguments from and store all results to.
+    ///
+    /// # Unsafety
+    ///
+    /// This method is unsafe because it can be called with any pointers. They
+    /// must all be valid for this wasm function call to proceed.
+    pub unsafe fn array_call(&self, caller: *mut VMOpaqueContext, args_and_results: *mut [ValRaw]) {
+        (self.array_call)(
+            self.vmctx,
+            caller,
+            args_and_results.cast(),
+            args_and_results.len(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod test_vm_func_ref {
     use super::VMFuncRef;

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -100,7 +100,7 @@ fn call_wrapped_func() -> Result<(), Error> {
                 Val::F32(3.0f32.to_bits()).to_raw(&mut store)?,
                 Val::F64(4.0f64.to_bits()).to_raw(&mut store)?,
             ];
-            f.call_unchecked(&mut store, args.as_mut_ptr(), args.len())?;
+            f.call_unchecked(&mut store, &mut args)?;
         }
         n += 1;
 


### PR DESCRIPTION
This is intended to encapsulate the usage of a native raw pointer and in the future act as a dispatch point for invoking Pulley instead of native code.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
