### PR TITLE
Move `memory_init_cow` option to `Tunables`

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -117,6 +117,9 @@ define_tunables! {
         /// Whether or not the host will be using native signals (e.g. SIGILL,
         /// SIGSEGV, etc) to implement traps.
         pub signals_based_traps: bool,
+
+        /// Whether CoW images might be used to initialize linear memories.
+        pub memory_init_cow: bool,
     }
 
     pub struct ConfigTunables {
@@ -175,6 +178,7 @@ impl Tunables {
             relaxed_simd_deterministic: false,
             winch_callable: false,
             signals_based_traps: true,
+            memory_init_cow: true,
         }
     }
 

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -796,7 +796,7 @@ impl FunctionIndices {
                 // can either at runtime be implemented as a single memcpy to
                 // initialize memory or otherwise enabling virtual-memory-tricks
                 // such as mmap'ing from a file to get copy-on-write.
-                if engine.config().memory_init_cow {
+                if engine.tunables().memory_init_cow {
                     let align = compiler.page_size_align();
                     let max_always_allowed = engine.config().memory_guaranteed_dense_image_size;
                     translation.try_static_init(align, max_always_allowed);

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -376,6 +376,7 @@ impl Metadata<'_> {
             relaxed_simd_deterministic,
             winch_callable,
             signals_based_traps,
+            memory_init_cow,
             // This doesn't affect compilation, it's just a runtime setting.
             memory_reservation_for_growth: _,
 
@@ -437,6 +438,11 @@ impl Metadata<'_> {
             signals_based_traps,
             other.signals_based_traps,
             "Signals-based traps",
+        )?;
+        Self::check_bool(
+            memory_init_cow,
+            other.memory_init_cow,
+            "memory initialization with CoW",
         )?;
 
         Ok(())

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1163,7 +1163,7 @@ fn _assert_send_sync() {
 fn memory_images(engine: &Engine, module: &CompiledModule) -> Result<Option<ModuleMemoryImages>> {
     // If initialization via copy-on-write is explicitly disabled in
     // configuration then this path is skipped entirely.
-    if !engine.config().memory_init_cow {
+    if !engine.tunables().memory_init_cow {
         return Ok(None);
     }
 

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -131,6 +131,7 @@ impl RuntimeMemoryCreator for DefaultMemoryCreator {
         if tunables.signals_based_traps
             || tunables.memory_guard_size > 0
             || tunables.memory_reservation > 0
+            || tunables.memory_init_cow
         {
             return Ok(Box::new(MmapMemory::new(ty, tunables, minimum, maximum)?));
         }

--- a/crates/wasmtime/src/runtime/vm/memory/malloc.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/malloc.rs
@@ -34,6 +34,9 @@ impl MallocMemory {
         if tunables.memory_reservation > 0 {
             bail!("malloc memory is only compatible with no ahead-of-time memory reservation");
         }
+        if tunables.memory_init_cow {
+            bail!("malloc memory cannot be used with CoW images");
+        }
 
         let byte_size = minimum
             .checked_add(


### PR DESCRIPTION
This commit moves the configuration option from `Config` to `Tunables` to ensure that the memory allocation backend has access to it and then it's used to specifically avoid choosing a malloc-based memory because CoW isn't compatible with malloc.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
