### PR TITLE
Cranelift: rework isle-in-source-tree functionality.

### DIFF
--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -128,10 +128,6 @@ souper-harvest = ["souper-ir", "souper-ir/stringify"]
 # Report any ISLE errors in pretty-printed style.
 isle-errors = ["cranelift-isle/fancy-errors"]
 
-# Put ISLE generated files in isle_generated_code/, for easier
-# inspection, rather than inside of target/.
-isle-in-source-tree = []
-
 # Enable tracking how long passes take in Cranelift.
 #
 # Enabled by default.


### PR DESCRIPTION
Per #9625 and #9588, a downstream user of Cranelift was misusing the `isle-in-source-tree` feature, enabling it indiscriminately even in published crates (wasmerio/wasmer#5202). This went against the intent of the feature, to be a way for local developers to observe the generated source. As such, it ran afoul of some safety checks for that purpose, and also polluted users' Cargo caches in a way that we cannot now fix except in future releases.

The best we can do is probably to take away features that are liable to be misused. Following discussion in today's Cranelift weekly meeting, we decided to provide this functionality under an environment variable instead. This allows folks who know what they're doing to get the same behavior, but does not expose a feature to crate users.

Fixes #9625.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
