### PR TITLE
Fix `cargo vet` on `main`

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -525,6 +525,14 @@ start = "2021-10-29"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-wasi-config]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2025-07-30"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasmtime-wasi-crypto]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -151,6 +151,9 @@ audit-as-crates-io = false
 [policy.wasmtime-wasi]
 audit-as-crates-io = true
 
+[policy.wasmtime-wasi-config]
+audit-as-crates-io = true
+
 [policy.wasmtime-wasi-http]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -137,6 +137,10 @@ audited_as = "26.0.1"
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "28.0.0"
+audited_as = "27.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -1060,6 +1064,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi]]
 version = "26.0.1"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-config]]
+version = "27.0.0"
+when = "2024-11-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Looks like we've been thwarted again where CI starts failing after a release due to `cargo vet` configuration. As with historical iterations of this style of change I continue to not know how to either fix this or prevent this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
