### PR TITLE
Optimize a test exercising Cranelift's limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
+ "wasm-encoder",
  "wasmparser",
  "wasmtime",
  "wasmtime-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ object = { workspace = true, features = ['std'] }
 wasmtime-test-macros = { path = "crates/test-macros" }
 pulley-interpreter = { workspace = true, features = ["disas"] }
 wasmtime-wast-util = { path = 'crates/wast-util' }
+wasm-encoder = { workspace = true }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }

--- a/tests/all/code_too_large.rs
+++ b/tests/all/code_too_large.rs
@@ -1,10 +1,11 @@
 #![cfg(not(miri))]
 
+use wasm_encoder::Instruction as I;
 use wasmtime::*;
 
 #[test]
 fn code_too_large_without_panic() -> Result<()> {
-    const N: usize = 120000;
+    const N: usize = 80000;
 
     // Build a module with a function whose body will allocate too many
     // temporaries for our current (Cranelift-based) compiler backend to
@@ -12,19 +13,47 @@ fn code_too_large_without_panic() -> Result<()> {
     // and return it programmatically, rather than panic'ing. If we ever
     // improve our compiler backend to actually handle such a large
     // function body, we'll need to increase the limits here too!
-    let mut s = String::new();
-    s.push_str("(module\n");
-    s.push_str("(table 1 1 funcref)\n");
-    s.push_str("(func (export \"\") (result i32)\n");
-    s.push_str("i32.const 0\n");
-    for _ in 0..N {
-        s.push_str("table.get 0\n");
-        s.push_str("ref.is_null\n");
-    }
-    s.push_str("))\n");
+    let mut module = wasm_encoder::Module::default();
 
-    let store = Store::<()>::default();
-    let result = Module::new(store.engine(), &s);
+    let mut types = wasm_encoder::TypeSection::new();
+    types.ty().function([], [wasm_encoder::ValType::I32]);
+    module.section(&types);
+
+    let mut funcs = wasm_encoder::FunctionSection::new();
+    funcs.function(0);
+    module.section(&funcs);
+
+    let mut tables = wasm_encoder::TableSection::new();
+    tables.table(wasm_encoder::TableType {
+        element_type: wasm_encoder::RefType::FUNCREF,
+        table64: false,
+        minimum: 1,
+        maximum: Some(1),
+        shared: false,
+    });
+    module.section(&tables);
+
+    let mut exports = wasm_encoder::ExportSection::new();
+    exports.export("", wasm_encoder::ExportKind::Func, 0);
+    module.section(&exports);
+
+    let mut func = wasm_encoder::Function::new([]);
+    func.instruction(&I::I32Const(0));
+    for _ in 0..N {
+        func.instruction(&I::TableGet(0));
+        func.instruction(&I::RefIsNull);
+    }
+    func.instruction(&I::End);
+    let mut code = wasm_encoder::CodeSection::new();
+    code.function(&func);
+    module.section(&code);
+
+    let mut config = Config::new();
+    config.cranelift_opt_level(OptLevel::None);
+    let engine = Engine::new(&config)?;
+
+    let store = Store::new(&engine, ());
+    let result = Module::new(store.engine(), &module.finish());
     match result {
         Err(e) => assert!(e
             .to_string()


### PR DESCRIPTION
This is a test which generates a wasm function that exceeds Cranelift's limits of virtual registers. Previously in debug mode this test took upwards of 40 seconds to execute and now it takes around 5. The main optimization here was to disable Cranelift optimizations. The test has also been updated to generate the module with `wasm-encoder` instead of `wast` to skip the text parsing step too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
