### PR TITLE
Add a type-level distinction between aligned and possibly-unaligned Mmaps

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -46,8 +46,9 @@ use super::{VMArrayRef, VMGcObjectDataMut, VMStructRef};
 use crate::hash_set::HashSet;
 use crate::prelude::*;
 use crate::runtime::vm::{
-    ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
-    GcProgress, GcRootsIter, GcRuntime, Mmap, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
+    mmap::AlignedLength, ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap,
+    GcHeapObject, GcProgress, GcRootsIter, GcRuntime, Mmap, TypedGcRef, VMExternRef, VMGcHeader,
+    VMGcRef,
 };
 use core::ops::{Deref, DerefMut, Range};
 use core::{
@@ -90,7 +91,7 @@ struct DrcHeap {
     // NB: this box shouldn't be strictly necessary, but it makes upholding the
     // safety invariants of the `vmctx_gc_heap_data` more obviously correct.
     activations_table: Box<VMGcRefActivationsTable>,
-    heap: Mmap,
+    heap: Mmap<AlignedLength>,
     free_list: FreeList,
 }
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -8,8 +8,9 @@ use super::*;
 use crate::{
     prelude::*,
     vm::{
-        ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
-        GcProgress, GcRootsIter, Mmap, SendSyncUnsafeCell, TypedGcRef, VMGcHeader, VMGcRef,
+        mmap::AlignedLength, ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection,
+        GcHeap, GcHeapObject, GcProgress, GcRootsIter, Mmap, SendSyncUnsafeCell, TypedGcRef,
+        VMGcHeader, VMGcRef,
     },
     GcHeapOutOfMemory,
 };
@@ -54,7 +55,7 @@ struct NullHeap {
     no_gc_count: usize,
 
     /// The actual GC heap.
-    heap: Mmap,
+    heap: Mmap<AlignedLength>,
 }
 
 /// The common header for all arrays in the null collector.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -56,8 +56,8 @@ use super::{
 };
 use crate::runtime::vm::mpk::{self, ProtectionKey, ProtectionMask};
 use crate::runtime::vm::{
-    CompiledModuleId, InstanceAllocationRequest, InstanceLimits, Memory, MemoryImageSlot, Mmap,
-    MpkEnabled, PoolingInstanceAllocatorConfig,
+    mmap::AlignedLength, CompiledModuleId, InstanceAllocationRequest, InstanceLimits, Memory,
+    MemoryImageSlot, Mmap, MpkEnabled, PoolingInstanceAllocatorConfig,
 };
 use crate::{prelude::*, vm::round_usize_up_to_host_pages};
 use std::ffi::c_void;
@@ -101,7 +101,7 @@ struct Stripe {
 /// ```
 #[derive(Debug)]
 pub struct MemoryPool {
-    mapping: Mmap,
+    mapping: Mmap<AlignedLength>,
     /// This memory pool is stripe-aware. If using  memory protection keys, this
     /// will contain one stripe per available key; otherwise, a single stripe
     /// with an empty key.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -4,7 +4,8 @@ use super::{
 };
 use crate::prelude::*;
 use crate::runtime::vm::{
-    InstanceAllocationRequest, Mmap, PoolingInstanceAllocatorConfig, SendSyncPtr, Table,
+    mmap::AlignedLength, InstanceAllocationRequest, Mmap, PoolingInstanceAllocatorConfig,
+    SendSyncPtr, Table,
 };
 use crate::{runtime::vm::sys::vm::commit_pages, vm::round_usize_up_to_host_pages};
 use std::mem;
@@ -18,7 +19,7 @@ use wasmtime_environ::{Module, Tunables};
 #[derive(Debug)]
 pub struct TablePool {
     index_allocator: SimpleIndexAllocator,
-    mapping: Mmap,
+    mapping: Mmap<AlignedLength>,
     table_size: usize,
     max_total_tables: usize,
     tables_per_instance: usize,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -6,7 +6,9 @@ use super::{
 };
 use crate::prelude::*;
 use crate::runtime::vm::sys::vm::commit_pages;
-use crate::runtime::vm::{round_usize_up_to_host_pages, Mmap, PoolingInstanceAllocatorConfig};
+use crate::runtime::vm::{
+    mmap::AlignedLength, round_usize_up_to_host_pages, Mmap, PoolingInstanceAllocatorConfig,
+};
 
 /// Represents a pool of execution stacks (used for the async fiber implementation).
 ///
@@ -20,7 +22,7 @@ use crate::runtime::vm::{round_usize_up_to_host_pages, Mmap, PoolingInstanceAllo
 /// from the pool.
 #[derive(Debug)]
 pub struct StackPool {
-    mapping: Mmap,
+    mapping: Mmap<AlignedLength>,
     stack_size: usize,
     max_stacks: usize,
     page_size: usize,

--- a/crates/wasmtime/src/runtime/vm/memory/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/mmap.rs
@@ -3,7 +3,7 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::memory::RuntimeLinearMemory;
-use crate::runtime::vm::mmap::Mmap;
+use crate::runtime::vm::mmap::{AlignedLength, Mmap};
 use crate::runtime::vm::{round_usize_up_to_host_pages, usize_is_multiple_of_host_page_size};
 use wasmtime_environ::Tunables;
 
@@ -11,7 +11,7 @@ use wasmtime_environ::Tunables;
 #[derive(Debug)]
 pub struct MmapMemory {
     // The underlying allocation.
-    mmap: Mmap,
+    mmap: Mmap<AlignedLength>,
 
     // The current length of this Wasm memory, in bytes.
     //

--- a/crates/wasmtime/src/runtime/vm/mmap_vec.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap_vec.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 #[cfg(feature = "signals-based-traps")]
-use crate::runtime::vm::Mmap;
+use crate::runtime::vm::{mmap::UnalignedLength, Mmap};
 use alloc::sync::Arc;
 use core::ops::{Deref, Range};
 #[cfg(feature = "std")]
@@ -29,7 +29,10 @@ pub enum MmapVec {
     Vec(Vec<u8>),
     #[doc(hidden)]
     #[cfg(feature = "signals-based-traps")]
-    Mmap { mmap: Mmap, len: usize },
+    Mmap {
+        mmap: Mmap<UnalignedLength>,
+        len: usize,
+    },
 }
 
 impl MmapVec {
@@ -39,7 +42,11 @@ impl MmapVec {
     /// smaller than the region mapped by the `Mmap`. The returned `MmapVec`
     /// will only have at most `size` bytes accessible.
     #[cfg(feature = "signals-based-traps")]
-    fn new_mmap(mmap: Mmap, len: usize) -> MmapVec {
+    fn new_mmap<M>(mmap: M, len: usize) -> MmapVec
+    where
+        M: Into<Mmap<UnalignedLength>>,
+    {
+        let mmap = mmap.into();
         assert!(len <= mmap.len());
         MmapVec::Mmap { mmap, len }
     }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -20,7 +20,7 @@ pub struct Mmap {
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "illumos", target_os = "linux"))] {
         // On illumos, by default, mmap reserves what it calls "swap space" ahead of time, so that
-        // memory accesses are guaranteed not to fail once mmap succeeds. NORESERVE is for cases
+        // memory accesses a`re guaranteed not to fail once mmap succeeds. NORESERVE is for cases
         // where that memory is never meant to be accessed -- e.g. memory that's used as guard
         // pages.
         //
@@ -135,6 +135,9 @@ impl Mmap {
 
     #[inline]
     pub fn len(&self) -> usize {
+        // Note: while the start of memory is host page-aligned, the length might
+        // not be, and in particular is not aligned for file-backed mmaps. Be
+        // careful!
         self.memory.as_ptr().len()
     }
 


### PR DESCRIPTION
In the wasmtime codebase there are two kinds of mmaps: those that are always backed by anonymous memory and are always aligned, and those that are possibly file-backed and so the length might be unaligned. In https://github.com/bytecodealliance/wasmtime/pull/9620 I accidentally mixed the two up in a way that was a ticking time bomb.

To resolve this, add a type parameter to `Mmap` to distinguish between the cases. All of wasmtime's users are clearly either one or the other, so it's quite simple in the end.