### PR TITLE
Compile wasm builtins with the `tail` convention, not host

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -516,7 +516,7 @@ impl wasmtime_environ::Compiler for Compiler {
         let isa = &*self.isa;
         let ptr_size = isa.pointer_bytes();
         let pointer_type = isa.pointer_type();
-        let sigs = BuiltinFunctionSignatures::new(isa);
+        let sigs = BuiltinFunctionSignatures::new(isa, &self.tunables);
         let wasm_sig = sigs.wasm_signature(index);
         let host_sig = sigs.host_signature(index);
 

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -516,10 +516,12 @@ impl wasmtime_environ::Compiler for Compiler {
         let isa = &*self.isa;
         let ptr_size = isa.pointer_bytes();
         let pointer_type = isa.pointer_type();
-        let sig = BuiltinFunctionSignatures::new(isa).signature(index);
+        let sigs = BuiltinFunctionSignatures::new(isa);
+        let wasm_sig = sigs.wasm_signature(index);
+        let host_sig = sigs.host_signature(index);
 
         let mut compiler = self.function_compiler();
-        let func = ir::Function::with_name_signature(Default::default(), sig.clone());
+        let func = ir::Function::with_name_signature(Default::default(), wasm_sig.clone());
         let (mut builder, block0) = compiler.builder(func);
         let vmctx = builder.block_params(block0)[0];
 
@@ -554,8 +556,10 @@ impl wasmtime_environ::Compiler for Compiler {
         // Forward all our own arguments to the libcall itself, and then return
         // all the same results as the libcall.
         let block_params = builder.block_params(block0).to_vec();
-        let sig = builder.func.import_signature(sig);
-        let call = builder.ins().call_indirect(sig, func_addr, &block_params);
+        let host_sig = builder.func.import_signature(host_sig);
+        let call = builder
+            .ins()
+            .call_indirect(host_sig, func_addr, &block_params);
         let results = builder.func.dfg.inst_results(call).to_vec();
         builder.ins().return_(&results);
         builder.finalize();

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -49,7 +49,7 @@ impl BuiltinFunctions {
         if let Some(f) = cache {
             return *f;
         }
-        let signature = func.import_signature(self.types.signature(index));
+        let signature = func.import_signature(self.types.wasm_signature(index));
         let name =
             ir::ExternalName::User(func.declare_imported_user_function(ir::UserExternalName {
                 namespace: crate::NS_WASMTIME_BUILTIN,

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -37,9 +37,9 @@ pub(crate) struct BuiltinFunctions {
 }
 
 impl BuiltinFunctions {
-    fn new(isa: &dyn TargetIsa) -> Self {
+    fn new(isa: &dyn TargetIsa, tunables: &Tunables) -> Self {
         Self {
-            types: BuiltinFunctionSignatures::new(isa),
+            types: BuiltinFunctionSignatures::new(isa, tunables),
             builtins: [None; BuiltinFunctionIndex::builtin_functions_total_number() as usize],
         }
     }
@@ -169,7 +169,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         wmemcheck: bool,
         wasm_func_ty: &'module_environment WasmFuncType,
     ) -> Self {
-        let builtin_functions = BuiltinFunctions::new(isa);
+        let builtin_functions = BuiltinFunctions::new(isa, tunables);
 
         // Avoid unused warning in default build.
         #[cfg(not(feature = "wmemcheck"))]

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -11,7 +11,7 @@ use wasmtime_environ::{
     FunctionLoc, ModuleTranslation, ModuleTypesBuilder, PrimaryMap, RelocationTarget,
     StaticModuleIndex, TrapEncodingBuilder, Tunables, VMOffsets, WasmFunctionInfo,
 };
-use winch_codegen::{BuiltinFunctions, TargetIsa};
+use winch_codegen::{BuiltinFunctions, CallingConvention, TargetIsa};
 
 /// Function compilation context.
 /// This struct holds information that can be shared globally across
@@ -51,7 +51,11 @@ impl Compiler {
             let vmoffsets = VMOffsets::new(pointer_size, &translation.module);
             CompilationContext {
                 allocations: Default::default(),
-                builtins: BuiltinFunctions::new(&vmoffsets, self.isa.wasmtime_call_conv()),
+                builtins: BuiltinFunctions::new(
+                    &vmoffsets,
+                    self.isa.wasmtime_call_conv(),
+                    CallingConvention::Default,
+                ),
             }
         })
     }

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -9,7 +9,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx) -> i64 system_v
+;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     fn0 = colocated u1:16 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -22,7 +22,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     sig1 = (i64 vmctx, i64) tail
 ;;     sig2 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u1:35 sig0

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -22,7 +22,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     sig1 = (i64 vmctx, i64) tail
 ;;     sig2 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u1:35 sig0

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -23,8 +23,8 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+136
 ;;     sig0 = (i64 vmctx, i64) tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
-;;     sig2 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
+;;     sig2 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     fn1 = colocated u1:35 sig2
 ;;     stack_limit = gv2

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -18,7 +18,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -84,7 +84,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:29 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -15,8 +15,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
-;;     sig1 = (i64 vmctx, i64) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
+;;     sig1 = (i64 vmctx, i64) -> i32 uext tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     fn1 = colocated u1:28 sig1
 ;;     stack_limit = gv2

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i64) -> i32 uext tail
 ;;     fn0 = colocated u1:28 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:35 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:35 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:35 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -109,7 +109,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -16,7 +16,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -17,7 +17,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -76,7 +76,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -22,7 +22,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     sig1 = (i64 vmctx, i64) tail
 ;;     sig2 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u1:35 sig0

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -22,7 +22,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     sig1 = (i64 vmctx, i64) tail
 ;;     sig2 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u1:35 sig0

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -23,8 +23,8 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+136
 ;;     sig0 = (i64 vmctx, i64) tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
-;;     sig2 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
+;;     sig2 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     fn1 = colocated u1:35 sig2
 ;;     stack_limit = gv2

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:29 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i64) -> i32 uext tail
 ;;     fn0 = colocated u1:28 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i64) -> i32 uext tail
 ;;     fn0 = colocated u1:28 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:35 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:35 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext tail
 ;;     fn0 = colocated u1:35 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -16,7 +16,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -17,7 +17,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -29,7 +29,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;
@@ -77,7 +77,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -15,7 +15,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -15,7 +15,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -69,7 +69,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -20,7 +20,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+104
 ;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i32 uext, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i32 uext, i32 uext) tail
 ;;     fn0 = colocated u1:6 sig0
 ;;     stack_limit = gv2
 ;;
@@ -41,7 +41,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext) tail
 ;;     fn0 = colocated u1:8 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -38,7 +38,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64) tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -20,7 +20,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -67,7 +67,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) tail
 ;;     fn0 = colocated u1:1 sig0
 ;;     stack_limit = gv2
 ;;
@@ -90,7 +90,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) system_v
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) tail
 ;;     fn0 = colocated u1:1 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -22,7 +22,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -112,7 +112,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -22,7 +22,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -114,7 +114,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i32) -> i32 system_v
+;;     sig0 = (i64 vmctx, i32) -> i32 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -22,7 +22,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;
@@ -124,7 +124,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -23,7 +23,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;
@@ -127,7 +127,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i32 uext) system_v
+;;     sig0 = (i64 vmctx, i32 uext) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -132,7 +132,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig0 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:9 sig0
 ;;     stack_limit = gv2
@@ -187,7 +187,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
-;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 system_v
+;;     sig1 = (i64 vmctx, i32 uext, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;


### PR DESCRIPTION
This commit updates how Cranelift compiles the shims that go from WebAssembly to various libcall builtins (e.g. `memory.grow`). Previously the small trampolines in Cranelift were compiled with the native host calling convention and this commit instead changes them to the wasm calling convention (e.g. "tail"). This helps keep caller/callee matched with calling conventions in wasm code itself and shifts the boundary of the wasm->host transition to the indirect call of the host function pointer itself. The general hope is that this makes Pulley a bit easier since it'll want to minimize handling of wasm->host transitions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
