### PR TITLE
wmemcheck support for additional allocation functions and granular memory

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -909,10 +909,10 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     }
 
     #[cfg(feature = "wmemcheck")]
-    fn hook_before_allocator(&mut self, builder: &mut FunctionBuilder) {
-        let memcheck_off = self.builtin_functions.before_allocator(builder.func);
+    fn check_allocator_start(&mut self, builder: &mut FunctionBuilder) {
+        let allocator_start = self.builtin_functions.allocator_start(builder.func);
         let vmctx = self.vmctx_val(&mut builder.cursor());
-        builder.ins().call(memcheck_off, &[vmctx]);
+        builder.ins().call(allocator_start, &[vmctx]);
     }
 
     #[cfg(feature = "wmemcheck")]
@@ -3071,7 +3071,7 @@ impl<'module_environment> crate::translate::FuncEnvironment
                 Some("posix_memalign") |
                 Some("aligned_alloc") |
                 Some("malloc_usable_size") =>
-                    self.hook_before_allocator(builder),
+                    self.check_allocator_start(builder),
                 _ => ()
             }
         }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -586,6 +586,112 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     }
 
     #[cfg(feature = "wmemcheck")]
+    fn hook_calloc_exit(&mut self, builder: &mut FunctionBuilder, retvals: &[ir::Value]) {
+        let check_calloc = self.builtin_functions.check_calloc(builder.func);
+        let vmctx = self.vmctx_val(&mut builder.cursor());
+        let func_args = builder
+            .func
+            .dfg
+            .block_params(builder.func.layout.entry_block().unwrap());
+        let (count, size) = if func_args.len() < 4 {
+            return;
+        } else {
+            (func_args[2], func_args[3])
+        };
+        let retval = if retvals.len() < 1 {
+            return;
+        } else {
+            retvals[0]
+        };
+        builder.ins().call(check_calloc, &[vmctx, retval, count, size]);
+    }
+
+    #[cfg(feature = "wmemcheck")]
+    fn hook_realloc_exit(&mut self, builder: &mut FunctionBuilder, retvals: &[ir::Value]) {
+        let check_realloc = self.builtin_functions.check_realloc(builder.func);
+        let vmctx = self.vmctx_val(&mut builder.cursor());
+        let func_args = builder
+            .func
+            .dfg
+            .block_params(builder.func.layout.entry_block().unwrap());
+        let (ptr, len) = if func_args.len() < 4 {
+            return;
+        } else {
+            // If a function named `realloc` has at least two arguments, we assume the
+            // first arguments are the pointer and requested allocation size.
+            (func_args[2], func_args[3])
+        };
+        let retval = if retvals.len() < 1 {
+            return;
+        } else {
+            retvals[0]
+        };
+        builder.ins().call(check_realloc, &[vmctx, retval, ptr, len]);
+    }
+
+    #[cfg(feature = "wmemcheck")]
+    fn hook_malloc_usable_size_exit(&mut self, builder: &mut FunctionBuilder, retvals: &[ir::Value]) {
+        let check_malloc_usable_size = self.builtin_functions.check_malloc_usable_size(builder.func);
+        let vmctx = self.vmctx_val(&mut builder.cursor());
+        let func_args = builder
+            .func
+            .dfg
+            .block_params(builder.func.layout.entry_block().unwrap());
+        let ptr = if func_args.len() < 3 {
+            return;
+        } else {
+            func_args[2]
+        };
+        let retval = if retvals.len() < 1 {
+            return;
+        } else {
+            retvals[0]
+        };
+        builder.ins().call(check_malloc_usable_size, &[vmctx, retval, ptr]);
+    }
+
+    #[cfg(feature = "wmemcheck")]
+    fn hook_posix_memalign_exit(&mut self, builder: &mut FunctionBuilder) {
+        let check_posix_memalign = self.builtin_functions.check_posix_memalign(builder.func);
+        let vmctx = self.vmctx_val(&mut builder.cursor());
+        let func_args = builder
+            .func
+            .dfg
+            .block_params(builder.func.layout.entry_block().unwrap());
+        let (outptr, _alignment, size) = if func_args.len() < 5 {
+            return;
+        } else {
+            // If a function named `malloc` has at least one argument, we assume the
+            // first argument is the requested allocation size.
+            (func_args[2], func_args[3], func_args[4])
+        };
+        builder.ins().call(check_posix_memalign, &[vmctx, outptr, size]);
+    }
+
+    #[cfg(feature = "wmemcheck")]
+    fn hook_aligned_alloc(&mut self, builder: &mut FunctionBuilder, retvals: &[ir::Value]) {
+        let check_malloc = self.builtin_functions.check_malloc(builder.func);
+        let vmctx = self.vmctx_val(&mut builder.cursor());
+        let func_args = builder
+            .func
+            .dfg
+            .block_params(builder.func.layout.entry_block().unwrap());
+        let (_alignment, size) = if func_args.len() < 4 {
+            return;
+        } else {
+            // If a function named `malloc` has at least one argument, we assume the
+            // first argument is the requested allocation size.
+            (func_args[2], func_args[3])
+        };
+        let retval = if retvals.len() < 1 {
+            return;
+        } else {
+            retvals[0]
+        };
+        builder.ins().call(check_malloc, &[vmctx, retval, size]);
+    }
+
+    #[cfg(feature = "wmemcheck")]
     fn hook_free_exit(&mut self, builder: &mut FunctionBuilder) {
         let check_free = self.builtin_functions.check_free(builder.func);
         let vmctx = self.vmctx_val(&mut builder.cursor());
@@ -927,17 +1033,10 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     }
 
     #[cfg(feature = "wmemcheck")]
-    fn check_malloc_start(&mut self, builder: &mut FunctionBuilder) {
-        let malloc_start = self.builtin_functions.malloc_start(builder.func);
+    fn hook_memcheck_off(&mut self, builder: &mut FunctionBuilder) {
+        let memcheck_off = self.builtin_functions.memcheck_off(builder.func);
         let vmctx = self.vmctx_val(&mut builder.cursor());
-        builder.ins().call(malloc_start, &[vmctx]);
-    }
-
-    #[cfg(feature = "wmemcheck")]
-    fn check_free_start(&mut self, builder: &mut FunctionBuilder) {
-        let free_start = self.builtin_functions.free_start(builder.func);
-        let vmctx = self.vmctx_val(&mut builder.cursor());
-        builder.ins().call(free_start, &[vmctx]);
+        builder.ins().call(memcheck_off, &[vmctx]);
     }
 
     #[cfg(feature = "wmemcheck")]
@@ -3088,11 +3187,22 @@ impl<'module_environment> crate::translate::FuncEnvironment
 
         #[cfg(feature = "wmemcheck")]
         if self.wmemcheck {
-            let func_name = self.current_func_name(builder);
-            if func_name == Some("malloc") {
-                self.check_malloc_start(builder);
-            } else if func_name == Some("free") {
-                self.check_free_start(builder);
+            match self.current_func_name(builder) {
+                Some("__wrap_malloc") | Some("malloc") =>
+                    self.hook_memcheck_off(builder),
+                Some("__wrap_calloc") | Some("calloc") =>
+                    self.hook_memcheck_off(builder),
+                Some("__wrap_realloc") | Some("realloc") =>
+                    self.hook_memcheck_off(builder),
+                Some("__wrap_malloc_usable_size") | Some("malloc_usable_size") =>
+                    self.hook_memcheck_off(builder),
+                Some("__wrap_posix_memalign") | Some("posix_memalign") =>
+                    self.hook_memcheck_off(builder),
+                Some("__wrap_aligned_alloc") | Some("aligned_alloc") =>
+                    self.hook_memcheck_off(builder),
+                Some("__wrap_free") | Some("free") =>
+                    self.hook_memcheck_off(builder),
+                _ => ()
             }
         }
 
@@ -3141,11 +3251,23 @@ impl<'module_environment> crate::translate::FuncEnvironment
     #[cfg(feature = "wmemcheck")]
     fn handle_before_return(&mut self, retvals: &[ir::Value], builder: &mut FunctionBuilder) {
         if self.wmemcheck {
-            let func_name = self.current_func_name(builder);
-            if func_name == Some("malloc") {
-                self.hook_malloc_exit(builder, retvals);
-            } else if func_name == Some("free") {
-                self.hook_free_exit(builder);
+            let name = self.current_func_name(builder);
+            match name {
+                Some("__wrap_malloc") | Some("malloc") =>
+                    self.hook_malloc_exit(builder, retvals),
+                Some("__wrap_calloc") | Some("calloc") =>
+                    self.hook_calloc_exit(builder, retvals),
+                Some("__wrap_realloc") | Some("realloc") =>
+                    self.hook_realloc_exit(builder, retvals),
+                Some("__wrap_malloc_usable_size") | Some("malloc_usable_size") =>
+                    self.hook_malloc_usable_size_exit(builder, retvals),
+                Some("__wrap_posix_memalign") | Some("posix_memalign") =>
+                    self.hook_posix_memalign_exit(builder),
+                Some("__wrap_aligned_alloc") | Some("aligned_alloc") =>
+                    self.hook_aligned_alloc(builder, retvals),
+                Some("__wrap_free") | Some("free") =>
+                    self.hook_free_exit(builder),
+                _ => ()
             }
         }
     }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3064,15 +3064,14 @@ impl<'module_environment> crate::translate::FuncEnvironment
         #[cfg(feature = "wmemcheck")]
         if self.wmemcheck {
             match self.current_func_name(builder) {
-                Some("malloc") |
-                Some("free") |
-                Some("calloc") |
-                Some("realloc") |
-                Some("posix_memalign") |
-                Some("aligned_alloc") |
-                Some("malloc_usable_size") =>
-                    self.check_allocator_start(builder),
-                _ => ()
+                Some("malloc")
+                | Some("free")
+                | Some("calloc")
+                | Some("realloc")
+                | Some("posix_memalign")
+                | Some("aligned_alloc")
+                | Some("malloc_usable_size") => self.check_allocator_start(builder),
+                _ => (),
             }
         }
 
@@ -3140,18 +3139,22 @@ impl<'module_environment> crate::translate::FuncEnvironment
                     self.hook_memcheck_exit(builder, check_realloc, 2, retvals)
                 }
                 Some("posix_memalign") => {
-                    let check_posix_memalign = self.builtin_functions.check_posix_memalign(builder.func);
+                    let check_posix_memalign =
+                        self.builtin_functions.check_posix_memalign(builder.func);
                     self.hook_memcheck_exit(builder, check_posix_memalign, 3, retvals)
                 }
                 Some("aligned_alloc") => {
-                    let check_aligned_alloc = self.builtin_functions.check_aligned_alloc(builder.func);
+                    let check_aligned_alloc =
+                        self.builtin_functions.check_aligned_alloc(builder.func);
                     self.hook_memcheck_exit(builder, check_aligned_alloc, 2, retvals)
                 }
                 Some("malloc_usable_size") => {
-                    let check_malloc_usable_size = self.builtin_functions.check_malloc_usable_size(builder.func);
+                    let check_malloc_usable_size = self
+                        .builtin_functions
+                        .check_malloc_usable_size(builder.func);
                     self.hook_memcheck_exit(builder, check_malloc_usable_size, 1, retvals)
                 }
-                _ => ()
+                _ => (),
             }
         }
     }

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -43,7 +43,7 @@ macro_rules! foreach_builtin_function {
             new_epoch(vmctx: vmctx) -> i64;
             // Invoked before memory allocation functions are called.
             #[cfg(feature = "wmemcheck")]
-            before_allocator(vmctx: vmctx);
+            allocator_start(vmctx: vmctx);
             // Invoked before malloc returns.
             #[cfg(feature = "wmemcheck")]
             check_malloc(vmctx: vmctx, addr: i32, len: i32) -> i32;
@@ -58,7 +58,7 @@ macro_rules! foreach_builtin_function {
             check_realloc(vmctx: vmctx, end_addr: i32, start_addr: i32, len: i32) -> i32;
             // Invoked before posix_memalign returns.
             #[cfg(feature = "wmemcheck")]
-            check_posix_memalign(vmctx: vmctx, outptr: i32, alignment: i32, size: i32) -> i32;
+            check_posix_memalign(vmctx: vmctx, result: i32, outptr: i32, alignment: i32, size: i32) -> i32;
             // Invoked before aligned_alloc returns.
             #[cfg(feature = "wmemcheck")]
             check_aligned_alloc(vmctx: vmctx, outptr: i32, alignment: i32, size: i32) -> i32;

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -41,24 +41,30 @@ macro_rules! foreach_builtin_function {
             out_of_gas(vmctx: vmctx);
             // Invoked when we reach a new epoch.
             new_epoch(vmctx: vmctx) -> i64;
+            // Invoked before memory allocation functions are called.
+            #[cfg(feature = "wmemcheck")]
+            before_allocator(vmctx: vmctx);
             // Invoked before malloc returns.
             #[cfg(feature = "wmemcheck")]
             check_malloc(vmctx: vmctx, addr: i32, len: i32) -> i32;
+            // Invoked before the free returns.
+            #[cfg(feature = "wmemcheck")]
+            check_free(vmctx: vmctx, addr: i32) -> i32;
             // Invoked before calloc returns.
             #[cfg(feature = "wmemcheck")]
             check_calloc(vmctx: vmctx, addr: i32, count: i32, size: i32) -> i32;
             // Invoked before realloc returns.
             #[cfg(feature = "wmemcheck")]
             check_realloc(vmctx: vmctx, end_addr: i32, start_addr: i32, len: i32) -> i32;
+            // Invoked before posix_memalign returns.
+            #[cfg(feature = "wmemcheck")]
+            check_posix_memalign(vmctx: vmctx, outptr: i32, alignment: i32, size: i32) -> i32;
+            // Invoked before aligned_alloc returns.
+            #[cfg(feature = "wmemcheck")]
+            check_aligned_alloc(vmctx: vmctx, outptr: i32, alignment: i32, size: i32) -> i32;
             // Invoked before malloc_usable_size returns.
             #[cfg(feature = "wmemcheck")]
             check_malloc_usable_size(vmctx: vmctx, len: i32, addr: i32) -> i32;
-            // Invoked before posix_memalign returns.
-            #[cfg(feature = "wmemcheck")]
-            check_posix_memalign(vmctx: vmctx, outptr: i32, size: i32) -> i32;
-            // Invoked before the free returns.
-            #[cfg(feature = "wmemcheck")]
-            check_free(vmctx: vmctx, addr: i32) -> i32;
             // Invoked before a load is executed.
             #[cfg(feature = "wmemcheck")]
             check_load(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
@@ -71,10 +77,6 @@ macro_rules! foreach_builtin_function {
             // Invoked before memory.grow is called.
             #[cfg(feature = "wmemcheck")]
             update_mem_size(vmctx: vmctx, num_bytes: i32);
-
-            // Invoked before stuff is called.
-            #[cfg(feature = "wmemcheck")]
-            memcheck_off(vmctx: vmctx);
 
             // Drop a non-stack GC reference (eg an overwritten table entry)
             // once it will no longer be used again. (Note: `val` is not of type

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -44,6 +44,18 @@ macro_rules! foreach_builtin_function {
             // Invoked before malloc returns.
             #[cfg(feature = "wmemcheck")]
             check_malloc(vmctx: vmctx, addr: i32, len: i32) -> i32;
+            // Invoked before calloc returns.
+            #[cfg(feature = "wmemcheck")]
+            check_calloc(vmctx: vmctx, addr: i32, count: i32, size: i32) -> i32;
+            // Invoked before realloc returns.
+            #[cfg(feature = "wmemcheck")]
+            check_realloc(vmctx: vmctx, end_addr: i32, start_addr: i32, len: i32) -> i32;
+            // Invoked before malloc_usable_size returns.
+            #[cfg(feature = "wmemcheck")]
+            check_malloc_usable_size(vmctx: vmctx, len: i32, addr: i32) -> i32;
+            // Invoked before posix_memalign returns.
+            #[cfg(feature = "wmemcheck")]
+            check_posix_memalign(vmctx: vmctx, outptr: i32, size: i32) -> i32;
             // Invoked before the free returns.
             #[cfg(feature = "wmemcheck")]
             check_free(vmctx: vmctx, addr: i32) -> i32;
@@ -53,18 +65,16 @@ macro_rules! foreach_builtin_function {
             // Invoked before a store is executed.
             #[cfg(feature = "wmemcheck")]
             check_store(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
-            // Invoked after malloc is called.
-            #[cfg(feature = "wmemcheck")]
-            malloc_start(vmctx: vmctx);
-            // Invoked after free is called.
-            #[cfg(feature = "wmemcheck")]
-            free_start(vmctx: vmctx);
             // Invoked when wasm stack pointer is updated.
             #[cfg(feature = "wmemcheck")]
             update_stack_pointer(vmctx: vmctx, value: i32);
             // Invoked before memory.grow is called.
             #[cfg(feature = "wmemcheck")]
             update_mem_size(vmctx: vmctx, num_bytes: i32);
+
+            // Invoked before stuff is called.
+            #[cfg(feature = "wmemcheck")]
+            memcheck_off(vmctx: vmctx);
 
             // Drop a non-stack GC reference (eg an overwritten table entry)
             // once it will no longer be used again. (Note: `val` is not of type

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -336,7 +336,7 @@ impl Instance {
                             .unwrap_or(0)
                             * 64
                             * 1024;
-                        Some(Wmemcheck::new(size as usize, 4))
+                        Some(Wmemcheck::new(size as usize, 4, false))
                     } else {
                         None
                     }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -336,7 +336,7 @@ impl Instance {
                             .unwrap_or(0)
                             * 64
                             * 1024;
-                        Some(Wmemcheck::new(size as usize))
+                        Some(Wmemcheck::new(size as usize, 4))
                     } else {
                         None
                     }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -63,8 +63,10 @@ use core::time::Duration;
 use wasmtime_environ::Unsigned;
 use wasmtime_environ::{DataIndex, ElemIndex, FuncIndex, MemoryIndex, TableIndex, Trap};
 #[cfg(feature = "wmemcheck")]
-use wasmtime_wmemcheck::AccessError::{
-    DoubleMalloc, InvalidFree, InvalidRead, InvalidWrite, OutOfBounds,
+use wasmtime_wmemcheck::{
+    AccessError, AccessError::{
+        DoubleMalloc, InvalidFree, InvalidRead, InvalidRealloc, InvalidWrite, OutOfBounds,
+    }
 };
 
 /// Raw functions which are actually called from compiled code.
@@ -1108,6 +1110,30 @@ fn new_epoch(store: &mut dyn VMStore, _instance: &mut Instance) -> Result<u64> {
     store.new_epoch()
 }
 
+#[cfg(feature = "wmemcheck")]
+fn check_memcheck_result(result: Result<(), AccessError>) -> Result<u32> {
+    match result {
+        Ok(()) => {
+            Ok(0)
+        }
+        Err(DoubleMalloc { addr, len }) => {
+            bail!("Double malloc at addr {:#x} of size {}", addr, len)
+        }
+        Err(OutOfBounds { addr, len }) => {
+            bail!("Malloc out of bounds at addr {:#x} of size {}", addr, len)
+        }
+        Err(InvalidFree { addr }) => {
+            bail!("Invalid free at addr {:#x}", addr)
+        }
+        Err(InvalidRealloc { addr }) => {
+            bail!("Invalid realloc at addr {:#x}", addr)
+        }
+        _ => {
+            panic!("unreachable")
+        }
+    }
+}
+
 // Hook for validating malloc using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 unsafe fn check_malloc(
@@ -1117,22 +1143,9 @@ unsafe fn check_malloc(
     len: u32,
 ) -> Result<u32> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
-        let result = wmemcheck_state.malloc(addr as usize, len as usize);
+        let result = wmemcheck_state.allocate(addr as usize, len as usize, false);
         wmemcheck_state.memcheck_on();
-        match result {
-            Ok(()) => {
-                return Ok(0);
-            }
-            Err(DoubleMalloc { addr, len }) => {
-                bail!("Double malloc at addr {:#x} of size {}", addr, len)
-            }
-            Err(OutOfBounds { addr, len }) => {
-                bail!("Malloc out of bounds at addr {:#x} of size {}", addr, len);
-            }
-            _ => {
-                panic!("unreachable")
-            }
-        }
+        return check_memcheck_result(result);
     }
     Ok(0)
 }
@@ -1143,46 +1156,57 @@ unsafe fn check_free(_store: &mut dyn VMStore, instance: &mut Instance, addr: u3
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.free(addr as usize);
         wmemcheck_state.memcheck_on();
-        match result {
-            Ok(()) => {
-                return Ok(0);
-            }
-            Err(InvalidFree { addr }) => {
-                bail!("Invalid free at addr {:#x}", addr)
-            }
-            _ => {
-                panic!("unreachable")
-            }
-        }
+        return check_memcheck_result(result);
     }
     Ok(0)
 }
 
 // Hook for validating calloc using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-unsafe fn check_calloc(store: &mut dyn VMStore, instance: &mut Instance, addr: u32, count: u32, size: u32) -> Result<u32> {
-    check_malloc(store, instance, addr, count * size)
+unsafe fn check_calloc(
+    _store: &mut dyn VMStore,
+    instance: &mut Instance,
+    addr: u32,
+    count: u32,
+    size: u32,
+) -> Result<u32> {
+    if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
+        let result = wmemcheck_state.allocate(addr as usize, (count * size) as usize, true);
+        wmemcheck_state.memcheck_on();
+        return check_memcheck_result(result);
+    }
+    Ok(0)
 }
 
 // Hook for validating realloc using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-unsafe fn check_realloc(store: &mut dyn VMStore, instance: &mut Instance, end_addr: u32, start_addr: u32, len: u32) -> Result<u32> {
-    check_free(store, instance, start_addr)?;
-    check_malloc(store, instance, end_addr, len)
+unsafe fn check_realloc(_store: &mut dyn VMStore, instance: &mut Instance, end_addr: u32, start_addr: u32, len: u32) -> Result<u32> {
+    if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
+        let result = wmemcheck_state.realloc(end_addr as usize, start_addr as usize, len as usize);
+        wmemcheck_state.memcheck_on();
+        return check_memcheck_result(result);
+    }
+    Ok(0)
 }
 
 
 // Hook for validating posix_memalign using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-unsafe fn check_posix_memalign(store: &mut dyn VMStore, instance: &mut Instance, outptr: u32, _alignment: u32, size: u32) -> Result<u32> {
-    for (_, entry) in instance.exports() {
-        if let wasmtime_environ::EntityIndex::Memory(mem_index) = entry {
-            let mem = instance.get_memory(*mem_index);
-            let out = *(mem.base.offset(outptr as isize) as *mut u32);
-            return check_malloc(store, instance, out, size)
+unsafe fn check_posix_memalign(store: &mut dyn VMStore, instance: &mut Instance, error: u32, outptr: u32, _alignment: u32, size: u32) -> Result<u32> {
+    if let Some(_) = &mut instance.wmemcheck_state {
+        if error != 0 {
+            return Ok(0);
         }
+        for (_, entry) in instance.exports() {
+            if let wasmtime_environ::EntityIndex::Memory(mem_index) = entry {
+                let mem = instance.get_memory(*mem_index);
+                let out_ptr = *(mem.base.offset(outptr as isize) as *mut u32);
+                return check_malloc(store, instance, out_ptr, size);
+            }
+        }
+        todo!("Why is there no memory?")
     }
-    todo!("Why is there no memory?")
+    Ok(0)
 }
 
 // Hook for validating aligned_alloc using wmemcheck_state.
@@ -1195,8 +1219,7 @@ unsafe fn check_aligned_alloc(store: &mut dyn VMStore, instance: &mut Instance, 
 #[cfg(feature = "wmemcheck")]
 unsafe fn check_malloc_usable_size(store: &mut dyn VMStore, instance: &mut Instance, len: u32, addr: u32) -> Result<u32> {
     // Since the wasm program has checked that the entire allocation is usable, mark it as allocated, similar to realloc
-    check_free(store, instance, addr)?;
-    check_malloc(store, instance, addr, len)
+    check_realloc(store, instance, addr, addr, len)
 }
 
 // Hook for validating load using wmemcheck_state.
@@ -1257,8 +1280,9 @@ fn check_store(
     Ok(0)
 }
 
+// Hook for turning wmemcheck load/store validation off when entering an allocator function.
 #[cfg(feature = "wmemcheck")]
-fn before_allocator(_store: &mut dyn VMStore, instance: &mut Instance) {
+fn allocator_start(_store: &mut dyn VMStore, instance: &mut Instance) {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         wmemcheck_state.memcheck_off();
     }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1137,40 +1137,6 @@ unsafe fn check_malloc(
     Ok(0)
 }
 
-// Hook for validating calloc using wmemcheck_state.
-#[cfg(feature = "wmemcheck")]
-unsafe fn check_calloc(store: &mut dyn VMStore, instance: &mut Instance, addr: u32, count: u32, size: u32) -> Result<u32> {
-    check_malloc(store, instance, addr, count * size)
-}
-
-// Hook for validating realloc using wmemcheck_state.
-#[cfg(feature = "wmemcheck")]
-unsafe fn check_realloc(store: &mut dyn VMStore, instance: &mut Instance, end_addr: u32, start_addr: u32, len: u32) -> Result<u32> {
-    check_free(store, instance, start_addr)?;
-    check_malloc(store, instance, end_addr, len)
-}
-
-// Hook for validating malloc_usable_size using wmemcheck_state.
-#[cfg(feature = "wmemcheck")]
-unsafe fn check_malloc_usable_size(store: &mut dyn VMStore, instance: &mut Instance, len: u32, addr: u32) -> Result<u32> {
-    check_free(store, instance, addr)?;
-    check_malloc(store, instance, addr, len)
-}
-
-
-// Hook for validating posix_memalign using wmemcheck_state.
-#[cfg(feature = "wmemcheck")]
-unsafe fn check_posix_memalign(store: &mut dyn VMStore, instance: &mut Instance, outptr: u32, size: u32) -> Result<u32> {
-    for (_, entry) in instance.exports() {
-        if let wasmtime_environ::EntityIndex::Memory(mem_index) = entry {
-            let mem = instance.get_memory(*mem_index);
-            let out = *(mem.base.offset(outptr as isize) as *mut u32);
-            return check_malloc(store, instance, out, size)
-        }
-    }
-    todo!("Why is there no memory?")
-}
-
 // Hook for validating free using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 unsafe fn check_free(_store: &mut dyn VMStore, instance: &mut Instance, addr: u32) -> Result<u32> {
@@ -1192,28 +1158,45 @@ unsafe fn check_free(_store: &mut dyn VMStore, instance: &mut Instance, addr: u3
     Ok(0)
 }
 
+// Hook for validating calloc using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-fn log_allocation_previous_to(instance: &mut Instance, addr: usize) {
-    if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
-        if let Some((prev_malloc, prev_len)) = wmemcheck_state.malloc_previous_to(addr) {
-            println!("previous malloc'd range was {:#x}..{:#x}", prev_malloc, prev_malloc + prev_len);
-            for (_, entry) in instance.exports() {
-                if let wasmtime_environ::EntityIndex::Memory(mem_index) = entry {
-                    let mem = instance.get_memory(*mem_index);
-                    for i in 0..prev_len {
-                        if i > 0 && i % 40 == 0 {
-                            println!();
-                        }
-                        unsafe {
-                            print!("{:02x} ", *mem.base.offset((prev_malloc + i) as isize));
-                        }
-                    }
-                    println!();
-                    break
-                }
-            }
+unsafe fn check_calloc(store: &mut dyn VMStore, instance: &mut Instance, addr: u32, count: u32, size: u32) -> Result<u32> {
+    check_malloc(store, instance, addr, count * size)
+}
+
+// Hook for validating realloc using wmemcheck_state.
+#[cfg(feature = "wmemcheck")]
+unsafe fn check_realloc(store: &mut dyn VMStore, instance: &mut Instance, end_addr: u32, start_addr: u32, len: u32) -> Result<u32> {
+    check_free(store, instance, start_addr)?;
+    check_malloc(store, instance, end_addr, len)
+}
+
+
+// Hook for validating posix_memalign using wmemcheck_state.
+#[cfg(feature = "wmemcheck")]
+unsafe fn check_posix_memalign(store: &mut dyn VMStore, instance: &mut Instance, outptr: u32, _alignment: u32, size: u32) -> Result<u32> {
+    for (_, entry) in instance.exports() {
+        if let wasmtime_environ::EntityIndex::Memory(mem_index) = entry {
+            let mem = instance.get_memory(*mem_index);
+            let out = *(mem.base.offset(outptr as isize) as *mut u32);
+            return check_malloc(store, instance, out, size)
         }
     }
+    todo!("Why is there no memory?")
+}
+
+// Hook for validating aligned_alloc using wmemcheck_state.
+#[cfg(feature = "wmemcheck")]
+unsafe fn check_aligned_alloc(store: &mut dyn VMStore, instance: &mut Instance, addr: u32, _alignment: u32, size: u32) -> Result<u32> {
+    check_malloc(store, instance, addr, size)
+}
+
+// Hook for validating malloc_usable_size using wmemcheck_state.
+#[cfg(feature = "wmemcheck")]
+unsafe fn check_malloc_usable_size(store: &mut dyn VMStore, instance: &mut Instance, len: u32, addr: u32) -> Result<u32> {
+    // Since the wasm program has checked that the entire allocation is usable, mark it as allocated, similar to realloc
+    check_free(store, instance, addr)?;
+    check_malloc(store, instance, addr, len)
 }
 
 // Hook for validating load using wmemcheck_state.
@@ -1232,7 +1215,6 @@ fn check_load(
                 return Ok(0);
             }
             Err(InvalidRead { addr, len }) => {
-                log_allocation_previous_to(instance, addr);
                 bail!("Invalid load at addr {:#x} of size {}", addr, len);
             }
             Err(OutOfBounds { addr, len }) => {
@@ -1262,7 +1244,6 @@ fn check_store(
                 return Ok(0);
             }
             Err(InvalidWrite { addr, len }) => {
-                log_allocation_previous_to(instance, addr);
                 bail!("Invalid store at addr {:#x} of size {}", addr, len)
             }
             Err(OutOfBounds { addr, len }) => {
@@ -1277,7 +1258,7 @@ fn check_store(
 }
 
 #[cfg(feature = "wmemcheck")]
-fn memcheck_off(_store: &mut dyn VMStore, instance: &mut Instance) {
+fn before_allocator(_store: &mut dyn VMStore, instance: &mut Instance) {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         wmemcheck_state.memcheck_off();
     }

--- a/crates/wmemcheck/src/lib.rs
+++ b/crates/wmemcheck/src/lib.rs
@@ -45,7 +45,11 @@ pub enum MemState {
 impl Wmemcheck {
     /// Initializes memory checker instance.
     // TODO: how to make this properly configurable?
-    pub fn new(mem_size: usize, granularity: usize, enforce_uninitialized_reads: bool) -> Wmemcheck {
+    pub fn new(
+        mem_size: usize,
+        granularity: usize,
+        enforce_uninitialized_reads: bool,
+    ) -> Wmemcheck {
         // TODO: metadata could be shrunk when granularity is greater than 1
         let metadata = vec![MemState::Unallocated; mem_size];
         let mallocs = HashMap::new();
@@ -61,7 +65,12 @@ impl Wmemcheck {
     }
 
     /// Updates memory checker memory state metadata when malloc is called.
-    pub fn allocate(&mut self, addr: usize, len: usize, initialized: bool) -> Result<(), AccessError> {
+    pub fn allocate(
+        &mut self,
+        addr: usize,
+        len: usize,
+        initialized: bool,
+    ) -> Result<(), AccessError> {
         if !self.is_in_bounds_heap(addr, len) {
             return Err(AccessError::OutOfBounds {
                 addr: addr,
@@ -86,13 +95,22 @@ impl Wmemcheck {
             }
         }
         for i in self.granular_range(addr..addr + len) {
-            self.metadata[i] = if initialized { MemState::ValidToReadWrite } else { MemState::ValidToWrite };
+            self.metadata[i] = if initialized {
+                MemState::ValidToReadWrite
+            } else {
+                MemState::ValidToWrite
+            };
         }
         self.mallocs.insert(addr, len);
         Ok(())
     }
 
-    pub fn realloc(&mut self, end_addr: usize, start_addr: usize, len: usize) -> Result<(), AccessError> {
+    pub fn realloc(
+        &mut self,
+        end_addr: usize,
+        start_addr: usize,
+        len: usize,
+    ) -> Result<(), AccessError> {
         if start_addr == 0 {
             // If ptr is NULL, realloc() is identical to a call to malloc()
             return self.allocate(end_addr, len, false);

--- a/crates/wmemcheck/src/lib.rs
+++ b/crates/wmemcheck/src/lib.rs
@@ -1,5 +1,6 @@
 use std::cmp::*;
 use std::collections::HashMap;
+use std::ops::Range;
 
 /// Memory checker for wasm guest.
 pub struct Wmemcheck {
@@ -8,23 +9,10 @@ pub struct Wmemcheck {
     pub stack_pointer: usize,
     max_stack_size: usize,
     pub flag: bool,
+    /// granularity in bytes of tracked allocations
+    pub granularity: usize,
 }
 
-impl Wmemcheck {
-    pub fn malloc_previous_to(&self, addr: usize) -> Option<(usize, usize)> {
-        let mut best: Option<(usize, usize)> = None;
-        for (base, len) in self.mallocs.iter() {
-            if let Some((prev_base, _)) = best {
-                if prev_base < *base && *base <= addr {
-                    best = Some((*base, *len));
-                }
-            } else {
-                best = Some((*base, *len));
-            }
-        }
-        best
-    }
-}
 /// Error types for memory checker.
 #[derive(Debug, PartialEq)]
 pub enum AccessError {
@@ -36,6 +24,8 @@ pub enum AccessError {
     InvalidWrite { addr: usize, len: usize },
     /// Free of non-malloc'd pointer.
     InvalidFree { addr: usize },
+    /// Reallocation of non-malloc'd pointer
+    InvalidRealloc { addr: usize },
     /// Access out of bounds of heap or stack.
     OutOfBounds { addr: usize, len: usize },
 }
@@ -53,7 +43,8 @@ pub enum MemState {
 
 impl Wmemcheck {
     /// Initializes memory checker instance.
-    pub fn new(mem_size: usize) -> Wmemcheck {
+    pub fn new(mem_size: usize, granularity: usize) -> Wmemcheck {
+        // TODO: metadata could be shrunk when granularity is greater than 1
         let metadata = vec![MemState::Unallocated; mem_size];
         let mallocs = HashMap::new();
         Wmemcheck {
@@ -62,21 +53,19 @@ impl Wmemcheck {
             stack_pointer: 0,
             max_stack_size: 0,
             flag: true,
+            granularity,
         }
     }
 
     /// Updates memory checker memory state metadata when malloc is called.
-    pub fn malloc(&mut self, addr: usize, start_len: usize) -> Result<(), AccessError> {
-        // round up to multiple of 4
-        let len = (start_len + 3) & !3;
-
+    pub fn allocate(&mut self, addr: usize, len: usize, initialized: bool) -> Result<(), AccessError> {
         if !self.is_in_bounds_heap(addr, len) {
             return Err(AccessError::OutOfBounds {
                 addr: addr,
                 len: len,
             });
         }
-        for i in addr..addr + len {
+        for i in self.granular_range(addr..addr + len) {
             match self.metadata[i] {
                 MemState::ValidToWrite => {
                     return Err(AccessError::DoubleMalloc {
@@ -93,10 +82,29 @@ impl Wmemcheck {
                 _ => {}
             }
         }
-        for i in addr..addr + len {
-            self.metadata[i] = MemState::ValidToWrite;
+        for i in self.granular_range(addr..addr + len) {
+            self.metadata[i] = if initialized { MemState::ValidToReadWrite } else { MemState::ValidToWrite };
         }
         self.mallocs.insert(addr, len);
+        Ok(())
+    }
+
+    pub fn realloc(&mut self, end_addr: usize, start_addr: usize, len: usize) -> Result<(), AccessError> {
+        if start_addr == 0 {
+            // If ptr is NULL, realloc() is identical to a call to malloc()
+            return self.allocate(end_addr, len, false);
+        }
+        if !self.mallocs.contains_key(&start_addr) {
+            return Err(AccessError::InvalidRealloc { addr: start_addr });
+        }
+        let start_len = self.mallocs[&start_addr];
+        // Copy initialization information from old allocation to new one
+        let copy_len = start_len.min(len);
+        let mut copied_metadata: Vec<MemState> = vec![];
+        copied_metadata.extend_from_slice(&self.metadata[start_addr..start_addr + copy_len]);
+        self.free(start_addr)?;
+        self.allocate(end_addr, len, false)?;
+        self.metadata[end_addr..end_addr + copy_len].clone_from_slice(&copied_metadata);
         Ok(())
     }
 
@@ -119,12 +127,12 @@ impl Wmemcheck {
                         len: len,
                     });
                 }
-                /* MemState::ValidToWrite => {
+                MemState::ValidToWrite => {
                     return Err(AccessError::InvalidRead {
                         addr: addr,
                         len: len,
                     });
-                } */
+                }
                 _ => {}
             }
         }
@@ -142,7 +150,7 @@ impl Wmemcheck {
                 len: len,
             });
         }
-        for i in addr..addr + len {
+        for i in self.granular_range(addr..addr + len) {
             if let MemState::Unallocated = self.metadata[i] {
                 return Err(AccessError::InvalidWrite {
                     addr: addr,
@@ -150,7 +158,7 @@ impl Wmemcheck {
                 });
             }
         }
-        for i in addr..addr + len {
+        for i in self.granular_range(addr..addr + len) {
             self.metadata[i] = MemState::ValidToReadWrite;
         }
         Ok(())
@@ -165,13 +173,13 @@ impl Wmemcheck {
             return Err(AccessError::InvalidFree { addr: addr });
         }
         let len = self.mallocs[&addr];
-        for i in addr..addr + len {
+        for i in self.granular_range(addr..addr + len) {
             if let MemState::Unallocated = self.metadata[i] {
                 return Err(AccessError::InvalidFree { addr: addr });
             }
         }
         self.mallocs.remove(&addr);
-        for i in addr..addr + len {
+        for i in self.granular_range(addr..addr + len) {
             self.metadata[i] = MemState::Unallocated;
         }
         Ok(())
@@ -193,11 +201,11 @@ impl Wmemcheck {
                 len: new_sp - self.stack_pointer,
             });
         } else if new_sp < self.stack_pointer {
-            for i in new_sp..self.stack_pointer + 1 {
+            for i in self.granular_range(new_sp..self.stack_pointer + 1) {
                 self.metadata[i] = MemState::ValidToReadWrite;
             }
         } else {
-            for i in self.stack_pointer..new_sp {
+            for i in self.granular_range(self.stack_pointer..new_sp) {
                 self.metadata[i] = MemState::Unallocated;
             }
         }
@@ -229,14 +237,22 @@ impl Wmemcheck {
         let to_append = vec![MemState::Unallocated; num_bytes];
         self.metadata.extend(to_append);
     }
+
+    fn granular_range(&self, byte_range: Range<usize>) -> Range<usize> {
+        // Round start of range down to granularity
+        let start = (byte_range.start / self.granularity) * self.granularity;
+        // Round end of range up to granularity
+        let end = ((byte_range.end + self.granularity - 1) / self.granularity) * self.granularity;
+        start..end
+    }
 }
 
 #[test]
 fn basic_wmemcheck() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
     wmemcheck_state.set_stack_size(1024);
-    assert!(wmemcheck_state.malloc(0x1000, 32).is_ok());
+    assert!(wmemcheck_state.allocate(0x1000, 32, false).is_ok());
     assert!(wmemcheck_state.write(0x1000, 4).is_ok());
     assert!(wmemcheck_state.read(0x1000, 4).is_ok());
     assert_eq!(wmemcheck_state.mallocs, HashMap::from([(0x1000, 32)]));
@@ -246,9 +262,9 @@ fn basic_wmemcheck() {
 
 #[test]
 fn read_before_initializing() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
-    assert!(wmemcheck_state.malloc(0x1000, 32).is_ok());
+    assert!(wmemcheck_state.allocate(0x1000, 32, false).is_ok());
     assert_eq!(
         wmemcheck_state.read(0x1000, 4),
         Err(AccessError::InvalidRead {
@@ -262,9 +278,9 @@ fn read_before_initializing() {
 
 #[test]
 fn use_after_free() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
-    assert!(wmemcheck_state.malloc(0x1000, 32).is_ok());
+    assert!(wmemcheck_state.allocate(0x1000, 32, false).is_ok());
     assert!(wmemcheck_state.write(0x1000, 4).is_ok());
     assert!(wmemcheck_state.write(0x1000, 4).is_ok());
     assert!(wmemcheck_state.free(0x1000).is_ok());
@@ -279,9 +295,9 @@ fn use_after_free() {
 
 #[test]
 fn double_free() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
-    assert!(wmemcheck_state.malloc(0x1000, 32).is_ok());
+    assert!(wmemcheck_state.allocate(0x1000, 32, false).is_ok());
     assert!(wmemcheck_state.write(0x1000, 4).is_ok());
     assert!(wmemcheck_state.free(0x1000).is_ok());
     assert_eq!(
@@ -292,17 +308,17 @@ fn double_free() {
 
 #[test]
 fn out_of_bounds_malloc() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
     assert_eq!(
-        wmemcheck_state.malloc(640 * 1024, 1),
+        wmemcheck_state.allocate(640 * 1024, 1, false),
         Err(AccessError::OutOfBounds {
             addr: 640 * 1024,
             len: 1
         })
     );
     assert_eq!(
-        wmemcheck_state.malloc(640 * 1024 - 10, 15),
+        wmemcheck_state.allocate(640 * 1024 - 10, 15, false),
         Err(AccessError::OutOfBounds {
             addr: 640 * 1024 - 10,
             len: 15
@@ -313,9 +329,9 @@ fn out_of_bounds_malloc() {
 
 #[test]
 fn out_of_bounds_read() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
-    assert!(wmemcheck_state.malloc(640 * 1024 - 24, 24).is_ok());
+    assert!(wmemcheck_state.allocate(640 * 1024 - 24, 24, false).is_ok());
     assert_eq!(
         wmemcheck_state.read(640 * 1024 - 24, 25),
         Err(AccessError::OutOfBounds {
@@ -327,18 +343,18 @@ fn out_of_bounds_read() {
 
 #[test]
 fn double_malloc() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
-    assert!(wmemcheck_state.malloc(0x1000, 32).is_ok());
+    assert!(wmemcheck_state.allocate(0x1000, 32, false).is_ok());
     assert_eq!(
-        wmemcheck_state.malloc(0x1000, 32),
+        wmemcheck_state.allocate(0x1000, 32, false),
         Err(AccessError::DoubleMalloc {
             addr: 0x1000,
             len: 32
         })
     );
     assert_eq!(
-        wmemcheck_state.malloc(0x1002, 32),
+        wmemcheck_state.allocate(0x1002, 32, false),
         Err(AccessError::DoubleMalloc {
             addr: 0x1002,
             len: 32
@@ -349,18 +365,18 @@ fn double_malloc() {
 
 #[test]
 fn error_type() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
-    assert!(wmemcheck_state.malloc(0x1000, 32).is_ok());
+    assert!(wmemcheck_state.allocate(0x1000, 32, false).is_ok());
     assert_eq!(
-        wmemcheck_state.malloc(0x1000, 32),
+        wmemcheck_state.allocate(0x1000, 32, false),
         Err(AccessError::DoubleMalloc {
             addr: 0x1000,
             len: 32
         })
     );
     assert_eq!(
-        wmemcheck_state.malloc(640 * 1024, 32),
+        wmemcheck_state.allocate(640 * 1024, 32, false),
         Err(AccessError::OutOfBounds {
             addr: 640 * 1024,
             len: 32
@@ -371,12 +387,12 @@ fn error_type() {
 
 #[test]
 fn update_sp_no_error() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
     wmemcheck_state.set_stack_size(1024);
     assert!(wmemcheck_state.update_stack_pointer(768).is_ok());
     assert_eq!(wmemcheck_state.stack_pointer, 768);
-    assert!(wmemcheck_state.malloc(1024 * 2, 32).is_ok());
+    assert!(wmemcheck_state.allocate(1024 * 2, 32, false).is_ok());
     assert!(wmemcheck_state.free(1024 * 2).is_ok());
     assert!(wmemcheck_state.update_stack_pointer(896).is_ok());
     assert_eq!(wmemcheck_state.stack_pointer, 896);
@@ -385,18 +401,18 @@ fn update_sp_no_error() {
 
 #[test]
 fn bad_stack_malloc() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
     wmemcheck_state.set_stack_size(1024);
 
     assert!(wmemcheck_state.update_stack_pointer(0).is_ok());
     assert_eq!(wmemcheck_state.stack_pointer, 0);
     assert_eq!(
-        wmemcheck_state.malloc(512, 32),
+        wmemcheck_state.allocate(512, 32, false),
         Err(AccessError::OutOfBounds { addr: 512, len: 32 })
     );
     assert_eq!(
-        wmemcheck_state.malloc(1022, 32),
+        wmemcheck_state.allocate(1022, 32, false),
         Err(AccessError::OutOfBounds {
             addr: 1022,
             len: 32
@@ -406,7 +422,7 @@ fn bad_stack_malloc() {
 
 #[test]
 fn stack_full_empty() {
-    let mut wmemcheck_state = Wmemcheck::new(640 * 1024);
+    let mut wmemcheck_state = Wmemcheck::new(640 * 1024, 1);
 
     wmemcheck_state.set_stack_size(1024);
 
@@ -418,7 +434,7 @@ fn stack_full_empty() {
 
 #[test]
 fn from_test_program() {
-    let mut wmemcheck_state = Wmemcheck::new(1024 * 1024 * 128);
+    let mut wmemcheck_state = Wmemcheck::new(1024 * 1024 * 128, 1);
     wmemcheck_state.set_stack_size(70864);
     assert!(wmemcheck_state.write(70832, 1).is_ok());
     assert!(wmemcheck_state.read(1138, 1).is_ok());


### PR DESCRIPTION
I was recently tracking down a memory corruption bug in swift and found the wmemcheck tool to be very helpful. Since the runtime of swift is fairly large, it required some extra features to remove false positives. I was able to modify wmemcheck to be useful enough for the job.

I'd like to contribute the changes, many of which overlap with parts of issue https://github.com/bytecodealliance/wasmtime/issues/7037 . In particular, I needed to add the following:

- support for the other memory functions exported by wasi-libc (calloc, realloc, posix_memalign, aligned_alloc, malloc_usable_size) from https://github.com/WebAssembly/wasi-libc/blob/c47daaf6c69f82835fc92d9e14361803dfa794fa/dlmalloc/src/dlmalloc.c#L67
- tracking memory in 4-byte chunks instead of 1-byte. e.g. wasi-libc's strlen loads strings 4 bytes at a time, and possibly beyond the end of the string for efficiency.
- disabling the check for reading uninitialized memory.

The last 2 possibly should be hidden behind options, but I'm not familiar enough with the code base or how others use this tool to know what the right approach would be.