### PR TITLE
Fix Pulley `TrapIf` patch offset

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -149,7 +149,7 @@ fn pulley_emit<P>(
             let label = sink.defer_trap(*code);
 
             let cur_off = sink.cur_offset();
-            sink.use_label_at_offset(cur_off, label, LabelUse::Jump(3));
+            sink.use_label_at_offset(cur_off + 3, label, LabelUse::Jump(3));
 
             use ir::condcodes::IntCC::*;
             use OperandSize::*;

--- a/cranelift/filetests/filetests/isa/pulley32/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/trap.clif
@@ -29,7 +29,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -49,7 +49,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -69,7 +69,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -89,7 +89,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -124,7 +124,7 @@ block2:
 ;        6: 00                              ret
 ;        7: 14 05 2a                        xconst8 x5, 42
 ;        a: 14 06 00                        xconst8 x6, 0
-;        d: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0xd
+;        d: 0c 05 06 08 00 00 00            br_if_xneq64 x5, x6, 0x8    // target = 0x15
 ;       14: 00                              ret
 ;       15: 00                              ret
 
@@ -158,7 +158,7 @@ block2:
 ;        0: 03 00 14 00 00 00               br_if x0, 0x14    // target = 0x14
 ;        6: 14 04 00                        xconst8 x4, 0
 ;        9: 14 05 00                        xconst8 x5, 0
-;        c: 0c 00 00 00 00 00 00            br_if_xneq64 x0, x0, 0x0    // target = 0xc
+;        c: 0b 04 05 09 00 00 00            br_if_xeq64 x4, x5, 0x9    // target = 0x15
 ;       13: 00                              ret
 ;       14: 00                              ret
 ;       15: 00                              ret

--- a/cranelift/filetests/filetests/isa/pulley64/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/trap.clif
@@ -29,7 +29,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -49,7 +49,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -69,7 +69,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -89,7 +89,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0x3
+;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
 ;        a: 00                              ret
 ;        b: 00                              ret
 
@@ -124,7 +124,7 @@ block2:
 ;        6: 00                              ret
 ;        7: 14 05 2a                        xconst8 x5, 42
 ;        a: 14 06 00                        xconst8 x6, 0
-;        d: 0b 00 00 00 00 00 00            br_if_xeq64 x0, x0, 0x0    // target = 0xd
+;        d: 0c 05 06 08 00 00 00            br_if_xneq64 x5, x6, 0x8    // target = 0x15
 ;       14: 00                              ret
 ;       15: 00                              ret
 
@@ -158,7 +158,7 @@ block2:
 ;        0: 03 00 14 00 00 00               br_if x0, 0x14    // target = 0x14
 ;        6: 14 04 00                        xconst8 x4, 0
 ;        9: 14 05 00                        xconst8 x5, 0
-;        c: 0c 00 00 00 00 00 00            br_if_xneq64 x0, x0, 0x0    // target = 0xc
+;        c: 0b 04 05 09 00 00 00            br_if_xeq64 x4, x5, 0x9    // target = 0x15
 ;       13: 00                              ret
 ;       14: 00                              ret
 ;       15: 00                              ret

--- a/tests/disas/pulley/loads.wat
+++ b/tests/disas/pulley/loads.wat
@@ -1,0 +1,52 @@
+;;! target = "pulley32"
+;;! test = "compile"
+;;! flags = "-Ccranelift-enable-heap-access-spectre-mitigation=no"
+
+(module
+  (memory 0)
+  (func $i32 (param i32) (result i32)
+    local.get 0
+    i32.load
+  )
+
+  (func $i64 (param i32) (result i64)
+    local.get 0
+    i64.load
+  )
+)
+
+;; wasm[0]::function[0]::i32:
+;;       xconst8 spilltmp0, -16
+;;       xadd32 sp, sp, spilltmp0
+;;       store64_offset8 sp, 8, lr
+;;       store64 sp, fp
+;;       xmov fp, sp
+;;       load32_u_offset8 x6, x0, 52
+;;       br_if_xult32 x6, x2, 0x1f    // target = 0x33
+;;   1b: load32_u_offset8 x7, x0, 48
+;;       xadd32 x7, x7, x2
+;;       load32_u x0, x7
+;;       load64_offset8 lr, sp, 8
+;;       load64 fp, sp
+;;       xconst8 spilltmp0, 16
+;;       xadd32 sp, sp, spilltmp0
+;;       ret
+;;   33: ret
+;;
+;; wasm[0]::function[1]::i64:
+;;       xconst8 spilltmp0, -16
+;;       xadd32 sp, sp, spilltmp0
+;;       store64_offset8 sp, 8, lr
+;;       store64 sp, fp
+;;       xmov fp, sp
+;;       load32_u_offset8 x6, x0, 52
+;;       br_if_xult32 x6, x2, 0x1f    // target = 0x33
+;;   1b: load32_u_offset8 x7, x0, 48
+;;       xadd32 x7, x7, x2
+;;       load64 x0, x7
+;;       load64_offset8 lr, sp, 8
+;;       load64 fp, sp
+;;       xconst8 spilltmp0, 16
+;;       xadd32 sp, sp, spilltmp0
+;;       ret
+;;   33: ret


### PR DESCRIPTION
A missing `+N` meant that the instruction opcode was overwritten rather than the relative jump offset.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
