### PR TITLE
pulley: Simplify opcode disassembler

### DIFF
--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -223,7 +223,7 @@ impl<'a> OpVisitor for Disassembler<'a> {
             let mut need_space = false;
             for byte in &self.raw_bytecode[self.start..][..size] {
                 let space = if need_space { " " } else { "" };
-                write!(&mut self.disas, "{}{byte:02x}", space).unwrap();
+                write!(&mut self.disas, "{space}{byte:02x}").unwrap();
                 need_space = true;
             }
             for _ in 0..11_usize.saturating_sub(size) {


### PR DESCRIPTION
* Pull some code out of a macro.
* Share one macro across disassembly both opcodes and extended opcodes.
* Make the bulk of disassembly a standalone function not inside of a macro.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
