### PR TITLE
pulley: Add a simple disassembler example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,10 +2461,12 @@ dependencies = [
 name = "pulley-interpreter"
 version = "28.0.0"
 dependencies = [
+ "anyhow",
  "arbitrary",
  "cranelift-bitset",
  "env_logger 0.11.5",
  "log",
+ "object",
  "sptr",
 ]
 

--- a/pulley/Cargo.toml
+++ b/pulley/Cargo.toml
@@ -20,6 +20,8 @@ sptr = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }
+object = { workspace = true, features = ['std'] }
+anyhow = { workspace = true, features = ['std'] }
 
 [features]
 std = []
@@ -31,3 +33,7 @@ interp = ["decode", "encode"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[example]]
+name = "objdump"
+required-features = ["disas"]

--- a/pulley/examples/objdump.rs
+++ b/pulley/examples/objdump.rs
@@ -1,0 +1,48 @@
+//! Small helper utility to disassemble `*.cwasm` files produced by Wasmtime.
+//!
+//! Run with:
+//!
+//!     cargo run --example objdump -F disas -p pulley-interpreter foo.cwasm
+
+use anyhow::{bail, Result};
+use object::{File, Object as _, ObjectSection, ObjectSymbol, SectionKind, SymbolKind};
+use pulley_interpreter::decode::Decoder;
+use pulley_interpreter::disas::Disassembler;
+
+fn main() -> Result<()> {
+    let cwasm = std::fs::read(std::env::args().nth(1).unwrap())?;
+
+    let image = File::parse(&cwasm[..])?;
+
+    let text = match image.sections().find(|s| s.kind() == SectionKind::Text) {
+        Some(section) => section.data()?,
+        None => bail!("no text section"),
+    };
+
+    for sym in image.symbols() {
+        if !sym.is_definition() {
+            continue;
+        }
+        if sym.kind() != SymbolKind::Text {
+            continue;
+        }
+        let address = sym.address();
+        let size = sym.size();
+        if size == 0 {
+            continue;
+        }
+
+        let name = sym.name()?;
+        let code = &text[address as usize..][..size as usize];
+
+        println!("{address:#08x}: <{name}>:");
+        let mut disas = Disassembler::new(code);
+        disas.start_offset(address as usize);
+        let result = Decoder::decode_all(&mut disas);
+        println!("{}", disas.disas());
+        if let Err(e) = result {
+            println!("        : error disassembling: {e:?}");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Should be useful when inspecting `*.cwasm` files since the system-default `objdump` doesn't work.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
