### PR TITLE
pulley: Implement a new `br_table` instruction

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -22,7 +22,7 @@
     (Unwind (inst UnwindInst))
 
     ;; Implementation of `br_table`, uses `idx` to jump to one of `targets` or
-    ;; jumps to `default` is it's out-of-bounds.
+    ;; jumps to `default` if it's out-of-bounds.
     (BrTable
       (idx XReg)
       (default MachLabel)

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -21,6 +21,13 @@
     ;; A pseudo-instruction to update unwind info.
     (Unwind (inst UnwindInst))
 
+    ;; Implementation of `br_table`, uses `idx` to jump to one of `targets` or
+    ;; jumps to `default` is it's out-of-bounds.
+    (BrTable
+      (idx XReg)
+      (default MachLabel)
+      (targets BoxVecMachLabel))
+
     ;;;; Actual Instructions ;;;;
 
     ;; Raise a trap.
@@ -546,6 +553,10 @@
       (let ((dst WritableXReg (temp_writable_xreg))
             (_ Unit (emit (MInst.BitcastIntFromFloat64 dst src))))
         dst))
+
+(decl gen_br_table (XReg MachLabel BoxVecMachLabel) Unit)
+(rule (gen_br_table idx default labels)
+      (emit (MInst.BrTable idx default labels)))
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -104,8 +104,8 @@ where
         // (with an `EmitIsland`). We check this in debug builds. This is `mut`
         // to allow disabling the check for `JTSequence`, which is always
         // emitted following an `EmitIsland`.
-        let start = sink.cur_offset();
-        pulley_emit(self, sink, emit_info, state, start);
+        let mut start = sink.cur_offset();
+        pulley_emit(self, sink, emit_info, state, &mut start);
 
         let end = sink.cur_offset();
         assert!(
@@ -124,9 +124,9 @@ where
 fn pulley_emit<P>(
     inst: &Inst,
     sink: &mut MachBuffer<InstAndKind<P>>,
-    _emit_info: &EmitInfo,
+    emit_info: &EmitInfo,
     state: &mut EmitState<P>,
-    start_offset: u32,
+    start_offset: &mut u32,
 ) where
     P: PulleyTargetKind,
 {
@@ -218,8 +218,8 @@ fn pulley_emit<P>(
         Inst::IndirectCall { .. } => todo!(),
 
         Inst::Jump { label } => {
-            sink.use_label_at_offset(start_offset + 1, *label, LabelUse::Jump(1));
-            sink.add_uncond_branch(start_offset, start_offset + 5, *label);
+            sink.use_label_at_offset(*start_offset + 1, *label, LabelUse::Jump(1));
+            sink.add_uncond_branch(*start_offset, *start_offset + 5, *label);
             enc::jump(sink, 0x00000000);
         }
 
@@ -229,7 +229,7 @@ fn pulley_emit<P>(
             not_taken,
         } => {
             // If taken.
-            let taken_start = start_offset + 2;
+            let taken_start = *start_offset + 2;
             let taken_end = taken_start + 4;
 
             sink.use_label_at_offset(taken_start, *taken, LabelUse::Jump(2));
@@ -237,10 +237,10 @@ fn pulley_emit<P>(
             enc::br_if_not(&mut inverted, c, 0x00000000);
             debug_assert_eq!(
                 inverted.len(),
-                usize::try_from(taken_end - start_offset).unwrap()
+                usize::try_from(taken_end - *start_offset).unwrap()
             );
 
-            sink.add_cond_branch(start_offset, taken_end, *taken, &inverted);
+            sink.add_cond_branch(*start_offset, taken_end, *taken, &inverted);
             enc::br_if(sink, c, 0x00000000);
             debug_assert_eq!(sink.cur_offset(), taken_end);
 
@@ -261,7 +261,7 @@ fn pulley_emit<P>(
         } => {
             br_if_cond_helper(
                 sink,
-                start_offset,
+                *start_offset,
                 *src1,
                 *src2,
                 taken,
@@ -279,7 +279,7 @@ fn pulley_emit<P>(
         } => {
             br_if_cond_helper(
                 sink,
-                start_offset,
+                *start_offset,
                 *src1,
                 *src2,
                 taken,
@@ -297,7 +297,7 @@ fn pulley_emit<P>(
         } => {
             br_if_cond_helper(
                 sink,
-                start_offset,
+                *start_offset,
                 *src1,
                 *src2,
                 taken,
@@ -315,7 +315,7 @@ fn pulley_emit<P>(
         } => {
             br_if_cond_helper(
                 sink,
-                start_offset,
+                *start_offset,
                 *src1,
                 *src2,
                 taken,
@@ -333,7 +333,7 @@ fn pulley_emit<P>(
         } => {
             br_if_cond_helper(
                 sink,
-                start_offset,
+                *start_offset,
                 *src1,
                 *src2,
                 taken,
@@ -351,7 +351,7 @@ fn pulley_emit<P>(
         } => {
             br_if_cond_helper(
                 sink,
-                start_offset,
+                *start_offset,
                 *src1,
                 *src2,
                 taken,
@@ -484,6 +484,47 @@ fn pulley_emit<P>(
         Inst::BitcastIntFromFloat64 { dst, src } => enc::bitcast_int_from_float_64(sink, dst, src),
         Inst::BitcastFloatFromInt32 { dst, src } => enc::bitcast_float_from_int_32(sink, dst, src),
         Inst::BitcastFloatFromInt64 { dst, src } => enc::bitcast_float_from_int_64(sink, dst, src),
+
+        Inst::BrTable {
+            idx,
+            default,
+            targets,
+        } => {
+            // Encode the `br_table32` instruction directly which expects the
+            // next `amt` 4-byte integers to all be relative offsets. Each
+            // offset is the pc-relative offset of the branch destination.
+            //
+            // Pulley clamps the branch targets to the `amt` specified so the
+            // final branch target is the default jump target.
+            //
+            // Note that this instruction may have many branch targets so it
+            // manually checks to see if an island is needed. If so we emit a
+            // jump around the island before the `br_table32` itself gets
+            // emitted.
+            let amt = u32::try_from(targets.len() + 1).expect("too many branch targets");
+            let br_table_size = amt * 4 + 6;
+            if sink.island_needed(br_table_size) {
+                let label = sink.get_label();
+                <InstAndKind<P>>::from(Inst::Jump { label }).emit(sink, emit_info, state);
+                sink.emit_island(br_table_size, &mut state.ctrl_plane);
+                sink.bind_label(label, &mut state.ctrl_plane);
+            }
+            enc::br_table32(sink, *idx, amt);
+            for target in targets.iter() {
+                let offset = sink.cur_offset();
+                sink.use_label_at_offset(offset, *target, LabelUse::Jump(0));
+                sink.put4(0);
+            }
+            let offset = sink.cur_offset();
+            sink.use_label_at_offset(offset, *default, LabelUse::Jump(0));
+            sink.put4(0);
+
+            // We manually handled `emit_island` above when dealing with
+            // `island_needed` so update the starting offset to the current
+            // offset so this instruction doesn't accidentally trigger
+            // the assertion that we're always under worst-case-size.
+            *start_offset = sink.cur_offset();
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -244,6 +244,10 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_use(src);
             collector.reg_def(dst);
         }
+
+        Inst::BrTable { idx, .. } => {
+            collector.reg_use(idx);
+        }
     }
 }
 
@@ -370,6 +374,7 @@ where
             | Inst::BrIfXslteq32 { .. }
             | Inst::BrIfXult32 { .. }
             | Inst::BrIfXulteq32 { .. } => MachTerminator::Cond,
+            Inst::BrTable { .. } => MachTerminator::Indirect,
             _ => MachTerminator::None,
         }
     }
@@ -437,8 +442,8 @@ where
         }
     }
 
-    fn gen_jump(_target: MachLabel) -> Self {
-        todo!()
+    fn gen_jump(target: MachLabel) -> Self {
+        Inst::Jump { label: target }.into()
     }
 
     fn worst_case_size() -> CodeOffset {
@@ -838,6 +843,15 @@ impl Inst {
                 let dst = format_reg(*dst.to_reg());
                 let src = format_reg(**src);
                 format!("{dst} = bitcast_float_from_int64 {src}")
+            }
+
+            Inst::BrTable {
+                idx,
+                default,
+                targets,
+            } => {
+                let idx = format_reg(**idx);
+                format!("br_table {idx} {default:?} {targets:?}")
             }
         }
     }

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -49,10 +49,8 @@
       (lower_brif_of_icmp32 (IntCC.UnsignedLessThanOrEqual) b a then else))
 
 ;; Branch tables.
-(decl lower_br_table (Reg MachLabelSlice) Unit)
-(extern constructor lower_br_table lower_br_table)
-(rule (lower_branch (br_table index _) targets)
-      (lower_br_table index targets))
+(rule (lower_branch (br_table index _) (jump_table_targets default targets))
+      (gen_br_table index default targets))
 
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -51,10 +51,6 @@ where
     crate::isle_lower_prelude_methods!(InstAndKind<P>);
     crate::isle_prelude_caller_methods!(PulleyABICallSite<P>);
 
-    fn lower_br_table(&mut self, _index: Reg, _targets: &[MachLabel]) -> Unit {
-        todo!()
-    }
-
     fn vreg_new(&mut self, r: Reg) -> VReg {
         VReg::new(r).unwrap()
     }

--- a/cranelift/filetests/filetests/isa/pulley32/br_table.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/br_table.clif
@@ -1,0 +1,69 @@
+test compile precise-output
+target pulley32
+
+function %br_table(i32) -> i32 {
+block0(v0: i32):
+  br_table v0, block4, [block1, block2, block2, block3]
+
+block1:
+  v1 = iconst.i32 1
+  jump block5(v1)
+
+block2:
+  v2 = iconst.i32 2
+  jump block5(v2)
+
+block3:
+  v3 = iconst.i32 3
+  jump block5(v3)
+
+block4:
+  v4 = iconst.i32 4
+  jump block5(v4)
+
+block5(v5: i32):
+  v6 = iadd.i32 v0, v5
+  return v6
+}
+
+; VCode:
+; block0:
+;   br_table x0 MachLabel(6) [MachLabel(5), MachLabel(1), MachLabel(2), MachLabel(3)]
+; block1:
+;   jump label4
+; block2:
+;   jump label4
+; block3:
+;   x5 = xconst8 3
+;   jump label7
+; block4:
+;   x5 = xconst8 2
+;   jump label7
+; block5:
+;   x5 = xconst8 1
+;   jump label7
+; block6:
+;   x5 = xconst8 4
+;   jump label7
+; block7:
+;   x0 = xadd32 x0, x5
+;   ret
+;
+; Disassembled:
+; br_table32 x0, 5
+; 0x29    // target = 0x2f
+; 0x1d    // target = 0x27
+; 0x19    // target = 0x27
+; 0xd    // target = 0x1f
+; 0x21    // target = 0x37
+; jump 0xd    // target = 0x27
+; xconst8 x5, 3
+; jump 0x18    // target = 0x3a
+; xconst8 x5, 2
+; jump 0x10    // target = 0x3a
+; xconst8 x5, 1
+; jump 0x8    // target = 0x3a
+; xconst8 x5, 4
+; xadd32 x0, x0, x5
+; ret
+

--- a/cranelift/filetests/filetests/isa/pulley64/br_table.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/br_table.clif
@@ -1,0 +1,69 @@
+test compile precise-output
+target pulley64
+
+function %br_table(i32) -> i32 {
+block0(v0: i32):
+  br_table v0, block4, [block1, block2, block2, block3]
+
+block1:
+  v1 = iconst.i32 1
+  jump block5(v1)
+
+block2:
+  v2 = iconst.i32 2
+  jump block5(v2)
+
+block3:
+  v3 = iconst.i32 3
+  jump block5(v3)
+
+block4:
+  v4 = iconst.i32 4
+  jump block5(v4)
+
+block5(v5: i32):
+  v6 = iadd.i32 v0, v5
+  return v6
+}
+
+; VCode:
+; block0:
+;   br_table x0 MachLabel(6) [MachLabel(5), MachLabel(1), MachLabel(2), MachLabel(3)]
+; block1:
+;   jump label4
+; block2:
+;   jump label4
+; block3:
+;   x5 = xconst8 3
+;   jump label7
+; block4:
+;   x5 = xconst8 2
+;   jump label7
+; block5:
+;   x5 = xconst8 1
+;   jump label7
+; block6:
+;   x5 = xconst8 4
+;   jump label7
+; block7:
+;   x0 = xadd32 x0, x5
+;   ret
+;
+; Disassembled:
+; br_table32 x0, 5
+; 0x29    // target = 0x2f
+; 0x1d    // target = 0x27
+; 0x19    // target = 0x27
+; 0xd    // target = 0x1f
+; 0x21    // target = 0x37
+; jump 0xd    // target = 0x27
+; xconst8 x5, 3
+; jump 0x18    // target = 0x3a
+; xconst8 x5, 2
+; jump 0x10    // target = 0x3a
+; xconst8 x5, 1
+; jump 0x8    // target = 0x3a
+; xconst8 x5, 4
+; xadd32 x0, x0, x5
+; ret
+

--- a/pulley/fuzz/src/interp.rs
+++ b/pulley/fuzz/src/interp.rs
@@ -116,6 +116,7 @@ fn op_is_safe_for_fuzzing(op: &Op) -> bool {
         Op::XPop32(_) | Op::XPop64(_) => false,
         Op::XPush32Many(_) | Op::XPush64Many(_) => false,
         Op::XPop32Many(_) | Op::XPop64Many(_) => false,
+        Op::BrTable32(_) => false,
     }
 }
 

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -95,7 +95,7 @@ impl<'a> Disassembler<'a> {
             self.after_visit();
             self.start = self.bytecode.position();
             if let Ok(offset) = PcRelOffset::decode(self.bytecode()) {
-                offset.disas(self.start, &mut self.temp);
+                offset.disas(self.start + self.start_offset, &mut self.temp);
             }
         }
     }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1161,6 +1161,15 @@ impl OpVisitor for Interpreter<'_> {
         self.state[dst].set_f64(f64::from_ne_bytes(val.to_ne_bytes()));
         ControlFlow::Continue(())
     }
+
+    fn br_table32(&mut self, idx: XReg, amt: u32) -> ControlFlow<Done> {
+        let idx = self.state[idx].get_u32().min(amt - 1) as isize;
+        // SAFETY: part of the contract of the interpreter is only dealing with
+        // valid bytecode, so this offset should be safe.
+        self.pc = unsafe { self.pc.offset(idx * 4) };
+        let rel = unwrap_uninhabited(PcRelOffset::decode(&mut self.pc));
+        self.pc_rel_jump(rel, 0)
+    }
 }
 
 impl ExtendedOpVisitor for Interpreter<'_> {

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -60,6 +60,14 @@ macro_rules! for_each_op {
             /// Branch if unsigned `a <= b`.
             br_if_xulteq64 = BrIfXulteq64 { a: XReg, b: XReg, offset: PcRelOffset };
 
+            /// Branch to the label indicated by `idx`.
+            ///
+            /// After this instruction are `amt` instances of `PcRelOffset`
+            /// and the `idx` selects which one will be branched to. The value
+            /// of `idx` is clamped to `amt - 1` (e.g. the last offset is the
+            /// "default" one.
+            br_table32 = BrTable32 { idx: XReg, amt: u32 };
+
             /// Move between `x` registers.
             xmov = Xmov { dst: XReg, src: XReg };
             /// Move between `f` registers.

--- a/pulley/tests/all/disas.rs
+++ b/pulley/tests/all/disas.rs
@@ -156,3 +156,34 @@ ret
         "#,
     );
 }
+
+#[test]
+fn disassemble_br_table() {
+    let mut bytecode = Vec::new();
+    PushFrame {}.encode(&mut bytecode);
+    BrTable32 {
+        idx: XReg::x1,
+        amt: 4,
+    }
+    .encode(&mut bytecode);
+    bytecode.extend_from_slice(&0_i32.to_le_bytes());
+    bytecode.extend_from_slice(&0_i32.to_le_bytes());
+    bytecode.extend_from_slice(&0_i32.to_le_bytes());
+    bytecode.extend_from_slice(&0_i32.to_le_bytes());
+    PopFrame {}.encode(&mut bytecode);
+
+    assert_disas_with_disassembler(
+        disas::Disassembler::new(&bytecode)
+            .hexdump(false)
+            .offsets(false),
+        r#"
+push_frame
+br_table32 x1, 4
+0x0    // target = 0x7
+0x0    // target = 0xb
+0x0    // target = 0xf
+0x0    // target = 0x13
+pop_frame
+        "#,
+    );
+}

--- a/tests/disas/pulley/br_table.wat
+++ b/tests/disas/pulley/br_table.wat
@@ -1,0 +1,48 @@
+;;! target = "pulley64"
+;;! test = "compile"
+
+(module
+    (func (param i32) (result i32)
+      block $a
+        block $b
+          block $c
+            local.get 0
+            br_table $a $b $c
+          end
+          i32.const 0
+          return
+        end
+        i32.const 1
+        return
+      end
+      i32.const 2
+    )
+)
+;; wasm[0]::function[0]:
+;;       xconst8 spilltmp0, -16
+;;       xadd32 sp, sp, spilltmp0
+;;       store64_offset8 sp, 8, lr
+;;       store64 sp, fp
+;;       xmov fp, sp
+;;       br_table32 x2, 3
+;;       0x1d    // target = 0x33
+;;       0x8    // target = 0x22
+;;       0x26    // target = 0x44
+;;   22: xconst8 x0, 1
+;;       load64_offset8 lr, sp, 8
+;;       load64 fp, sp
+;;       xconst8 spilltmp0, 16
+;;       xadd32 sp, sp, spilltmp0
+;;       ret
+;;   33: xconst8 x0, 2
+;;   36: load64_offset8 lr, sp, 8
+;;   3a: load64 fp, sp
+;;   3d: xconst8 spilltmp0, 16
+;;   40: xadd32 sp, sp, spilltmp0
+;;   43: ret
+;;   44: xconst8 x0, 0
+;;   47: load64_offset8 lr, sp, 8
+;;   4b: load64 fp, sp
+;;   4e: xconst8 spilltmp0, 16
+;;   51: xadd32 sp, sp, spilltmp0
+;;   54: ret


### PR DESCRIPTION
This is intended to match WebAssembly's `br_table` and Cranelift's version as well. This is implemented as a new `br_table32` opcode where a 32-bit number of branch targets are encoded after `br_table32` all as a `PcRelOffset`, a 32-bit offset. This helps bake in a more "macro opcode" into the interpreter rather than a handful of more primitive opcodes that would achieve the same result with loads/indirect jumps/comparisons/etc.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
