### PR TITLE
pulley: Don't include hex dumps in CLIF golden output

### DIFF
--- a/cranelift/filetests/filetests/isa/pulley32/brif-icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif-icmp.clif
@@ -26,11 +26,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 05 00 01 0b 00 00 00            br_if_xeq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xeq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ne(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -57,11 +57,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 06 00 01 0b 00 00 00            br_if_xneq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xneq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ult(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -88,11 +88,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 09 00 01 0b 00 00 00            br_if_xult32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xult32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ule(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -119,11 +119,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 0a 00 01 0b 00 00 00            br_if_xulteq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xulteq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_slt(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -150,11 +150,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 07 00 01 0b 00 00 00            br_if_xslt32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslt32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_sle(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -181,11 +181,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 08 00 01 0b 00 00 00            br_if_xslteq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslteq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ugt(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -212,11 +212,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 09 01 00 0b 00 00 00            br_if_xult32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xult32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_uge(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -243,11 +243,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 0a 01 00 0b 00 00 00            br_if_xulteq32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xulteq32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_sgt(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -274,11 +274,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 07 01 00 0b 00 00 00            br_if_xslt32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslt32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_sge(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -305,11 +305,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 08 01 00 0b 00 00 00            br_if_xslteq32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslteq32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_uextend_icmp_eq(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -337,9 +337,9 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 05 00 01 0b 00 00 00            br_if_xeq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xeq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif.clif
@@ -25,11 +25,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_i16(i16) -> i8 {
 block0(v0: i16):
@@ -55,11 +55,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_i32(i32) -> i8 {
 block0(v0: i32):
@@ -85,11 +85,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_i64(i64) -> i8 {
 block0(v0: i64):
@@ -115,11 +115,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -147,12 +147,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 05 04                        xeq32 x5, x0, x1
-;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
-;        9: 14 00 00                        xconst8 x0, 0
-;        c: 00                              ret
-;        d: 14 00 01                        xconst8 x0, 1
-;       10: 00                              ret
+; xeq32 x5, x0, x1
+; br_if x5, 0xa    // target = 0xd
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i16(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -180,12 +180,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 05 04                        xneq32 x5, x0, x1
-;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
-;        9: 14 00 00                        xconst8 x0, 0
-;        c: 00                              ret
-;        d: 14 00 01                        xconst8 x0, 1
-;       10: 00                              ret
+; xneq32 x5, x0, x1
+; br_if x5, 0xa    // target = 0xd
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i32(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -212,11 +212,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 07 00 01 0b 00 00 00            br_if_xslt32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 00                        xconst8 x0, 0
-;        a: 00                              ret
-;        b: 14 00 01                        xconst8 x0, 1
-;        e: 00                              ret
+; br_if_xslt32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i64(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -244,10 +244,10 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 25 00                        xulteq64 x5, x1, x0
-;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
-;        9: 14 00 00                        xconst8 x0, 0
-;        c: 00                              ret
-;        d: 14 00 01                        xconst8 x0, 1
-;       10: 00                              ret
+; xulteq64 x5, x1, x0
+; br_if x5, 0xa    // target = 0xd
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -29,19 +29,19 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 00 00                        xconst8 x0, 0
-;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
-;       18: 14 00 01                        xconst8 x0, 1
-;       1b: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       1f: 28 1d 1b                        load64 fp, sp
-;       22: 14 1e 10                        xconst8 spilltmp0, 16
-;       25: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       28: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 x0, 0
+; call 0x0    // target = 0x13
+; xconst8 x0, 1
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_args_i32_rets_i32() -> i32 {
     fn0 = colocated %g(i32) -> i32
@@ -70,19 +70,19 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 00 00                        xconst8 x0, 0
-;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
-;       18: 14 00 01                        xconst8 x0, 1
-;       1b: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       1f: 28 1d 1b                        load64 fp, sp
-;       22: 14 1e 10                        xconst8 spilltmp0, 16
-;       25: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       28: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 x0, 0
+; call 0x0    // target = 0x13
+; xconst8 x0, 1
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_args_i64_i32_i64_i32() {
     fn0 = colocated %g(i64, i32, i64, i32)
@@ -115,21 +115,21 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 00 00                        xconst8 x0, 0
-;       13: 14 01 01                        xconst8 x1, 1
-;       16: 14 02 02                        xconst8 x2, 2
-;       19: 14 03 03                        xconst8 x3, 3
-;       1c: 01 00 00 00 00                  call 0x0    // target = 0x1c
-;       21: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       25: 28 1d 1b                        load64 fp, sp
-;       28: 14 1e 10                        xconst8 spilltmp0, 16
-;       2b: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       2e: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 x0, 0
+; xconst8 x1, 1
+; xconst8 x2, 2
+; xconst8 x3, 3
+; call 0x0    // target = 0x1c
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_rets_i64_i64_i64_i64() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64
@@ -160,20 +160,20 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 01 00 00 00 00                  call 0x0    // target = 0x10
-;       15: 19 04 08                        xadd64 x4, x0, x2
-;       18: 19 23 0c                        xadd64 x3, x1, x3
-;       1b: 19 80 0c                        xadd64 x0, x4, x3
-;       1e: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       22: 28 1d 1b                        load64 fp, sp
-;       25: 14 1e 10                        xconst8 spilltmp0, 16
-;       28: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       2b: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; call 0x0    // target = 0x10
+; xadd64 x4, x0, x2
+; xadd64 x3, x1, x3
+; xadd64 x0, x4, x3
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_stack_args() {
     fn0 = colocated %g(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64)
@@ -225,43 +225,43 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 1e d0                        xconst8 spilltmp0, -48
-;       13: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       16: 14 0f 00                        xconst8 x15, 0
-;       19: 30 1b 0f                        store64 sp, x15
-;       1c: 32 1b 08 0f                     store64_offset8 sp, 8, x15
-;       20: 32 1b 10 0f                     store64_offset8 sp, 16, x15
-;       24: 32 1b 18 0f                     store64_offset8 sp, 24, x15
-;       28: 32 1b 20 0f                     store64_offset8 sp, 32, x15
-;       2c: 32 1b 28 0f                     store64_offset8 sp, 40, x15
-;       30: 11 00 0f                        xmov x0, x15
-;       33: 11 01 0f                        xmov x1, x15
-;       36: 11 02 0f                        xmov x2, x15
-;       39: 11 03 0f                        xmov x3, x15
-;       3c: 11 04 0f                        xmov x4, x15
-;       3f: 11 05 0f                        xmov x5, x15
-;       42: 11 06 0f                        xmov x6, x15
-;       45: 11 07 0f                        xmov x7, x15
-;       48: 11 08 0f                        xmov x8, x15
-;       4b: 11 09 0f                        xmov x9, x15
-;       4e: 11 0a 0f                        xmov x10, x15
-;       51: 11 0b 0f                        xmov x11, x15
-;       54: 11 0c 0f                        xmov x12, x15
-;       57: 11 0d 0f                        xmov x13, x15
-;       5a: 11 0e 0f                        xmov x14, x15
-;       5d: 01 00 00 00 00                  call 0x0    // target = 0x5d
-;       62: 14 1e 30                        xconst8 spilltmp0, 48
-;       65: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       68: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       6c: 28 1d 1b                        load64 fp, sp
-;       6f: 14 1e 10                        xconst8 spilltmp0, 16
-;       72: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       75: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 spilltmp0, -48
+; xadd32 sp, sp, spilltmp0
+; xconst8 x15, 0
+; store64 sp, x15
+; store64_offset8 sp, 8, x15
+; store64_offset8 sp, 16, x15
+; store64_offset8 sp, 24, x15
+; store64_offset8 sp, 32, x15
+; store64_offset8 sp, 40, x15
+; xmov x0, x15
+; xmov x1, x15
+; xmov x2, x15
+; xmov x3, x15
+; xmov x4, x15
+; xmov x5, x15
+; xmov x6, x15
+; xmov x7, x15
+; xmov x8, x15
+; xmov x9, x15
+; xmov x10, x15
+; xmov x11, x15
+; xmov x12, x15
+; xmov x13, x15
+; xmov x14, x15
+; call 0x0    // target = 0x5d
+; xconst8 spilltmp0, 48
+; xadd32 sp, sp, spilltmp0
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_stack_rets() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64
@@ -355,56 +355,56 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 1e c0                        xconst8 spilltmp0, -64
-;       13: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       16: 32 1b 38 10                     store64_offset8 sp, 56, x16
-;       1a: 32 1b 30 12                     store64_offset8 sp, 48, x18
-;       1e: 11 00 1b                        xmov x0, sp
-;       21: 01 00 00 00 00                  call 0x0    // target = 0x21
-;       26: 11 10 0d                        xmov x16, x13
-;       29: 11 12 0b                        xmov x18, x11
-;       2c: 28 19 1b                        load64 x25, sp
-;       2f: 2b 0b 1b 08                     load64_offset8 x11, sp, 8
-;       33: 2b 0d 1b 10                     load64_offset8 x13, sp, 16
-;       37: 2b 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
-;       3b: 2b 11 1b 20                     load64_offset8 x17, sp, 32
-;       3f: 19 1e 04                        xadd64 spilltmp0, x0, x1
-;       42: 19 5d 0c                        xadd64 fp, x2, x3
-;       45: 19 85 14                        xadd64 x5, x4, x5
-;       48: 19 c6 1c                        xadd64 x6, x6, x7
-;       4b: 19 07 25                        xadd64 x7, x8, x9
-;       4e: 11 00 12                        xmov x0, x18
-;       51: 19 44 01                        xadd64 x4, x10, x0
-;       54: 11 0a 10                        xmov x10, x16
-;       57: 19 88 29                        xadd64 x8, x12, x10
-;       5a: 19 ce 3d                        xadd64 x14, x14, x15
-;       5d: 19 2f 2f                        xadd64 x15, x25, x11
-;       60: 19 6d 35                        xadd64 x13, x11, x13
-;       63: 19 e0 47                        xadd64 x0, spilltmp1, x17
-;       66: 19 c1 77                        xadd64 x1, spilltmp0, fp
-;       69: 19 a2 18                        xadd64 x2, x5, x6
-;       6c: 19 e3 10                        xadd64 x3, x7, x4
-;       6f: 19 0e 39                        xadd64 x14, x8, x14
-;       72: 19 ed 35                        xadd64 x13, x15, x13
-;       75: 19 0f 00                        xadd64 x15, x0, x0
-;       78: 19 20 08                        xadd64 x0, x1, x2
-;       7b: 19 6e 38                        xadd64 x14, x3, x14
-;       7e: 19 ad 3d                        xadd64 x13, x13, x15
-;       81: 19 0e 38                        xadd64 x14, x0, x14
-;       84: 19 ad 35                        xadd64 x13, x13, x13
-;       87: 19 c0 35                        xadd64 x0, x14, x13
-;       8a: 2b 10 1b 38                     load64_offset8 x16, sp, 56
-;       8e: 2b 12 1b 30                     load64_offset8 x18, sp, 48
-;       92: 14 1e 40                        xconst8 spilltmp0, 64
-;       95: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       98: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       9c: 28 1d 1b                        load64 fp, sp
-;       9f: 14 1e 10                        xconst8 spilltmp0, 16
-;       a2: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       a5: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 spilltmp0, -64
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 56, x16
+; store64_offset8 sp, 48, x18
+; xmov x0, sp
+; call 0x0    // target = 0x21
+; xmov x16, x13
+; xmov x18, x11
+; load64 x25, sp
+; load64_offset8 x11, sp, 8
+; load64_offset8 x13, sp, 16
+; load64_offset8 spilltmp1, sp, 24
+; load64_offset8 x17, sp, 32
+; xadd64 spilltmp0, x0, x1
+; xadd64 fp, x2, x3
+; xadd64 x5, x4, x5
+; xadd64 x6, x6, x7
+; xadd64 x7, x8, x9
+; xmov x0, x18
+; xadd64 x4, x10, x0
+; xmov x10, x16
+; xadd64 x8, x12, x10
+; xadd64 x14, x14, x15
+; xadd64 x15, x25, x11
+; xadd64 x13, x11, x13
+; xadd64 x0, spilltmp1, x17
+; xadd64 x1, spilltmp0, fp
+; xadd64 x2, x5, x6
+; xadd64 x3, x7, x4
+; xadd64 x14, x8, x14
+; xadd64 x13, x15, x13
+; xadd64 x15, x0, x0
+; xadd64 x0, x1, x2
+; xadd64 x14, x3, x14
+; xadd64 x13, x13, x15
+; xadd64 x14, x0, x14
+; xadd64 x13, x13, x13
+; xadd64 x0, x14, x13
+; load64_offset8 x16, sp, 56
+; load64_offset8 x18, sp, 48
+; xconst8 spilltmp0, 64
+; xadd32 sp, sp, spilltmp0
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/get_stack_pointer.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/get_stack_pointer.clif
@@ -13,6 +13,6 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 43 02 00 00                     get_sp x0
-;        4: 00                              ret
+; get_sp x0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/iadd.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/iadd.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 04                        xadd32 x0, x0, x1
-;        3: 00                              ret
+; xadd32 x0, x0, x1
+; ret
 
 function %i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 04                        xadd32 x0, x0, x1
-;        3: 00                              ret
+; xadd32 x0, x0, x1
+; ret
 
 function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 04                        xadd32 x0, x0, x1
-;        3: 00                              ret
+; xadd32 x0, x0, x1
+; ret
 
 function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -58,6 +58,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 00 04                        xadd64 x0, x0, x1
-;        3: 00                              ret
+; xadd64 x0, x0, x1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/icmp.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 00 04                        xeq32 x0, x0, x1
-;        3: 00                              ret
+; xeq32 x0, x0, x1
+; ret
 
 function %i16_eq(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 00 04                        xeq32 x0, x0, x1
-;        3: 00                              ret
+; xeq32 x0, x0, x1
+; ret
 
 function %i32_eq(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 00 04                        xeq32 x0, x0, x1
-;        3: 00                              ret
+; xeq32 x0, x0, x1
+; ret
 
 function %i64_eq(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -58,8 +58,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 04                        xeq64 x0, x0, x1
-;        3: 00                              ret
+; xeq64 x0, x0, x1
+; ret
 
 function %i8_ne(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -73,8 +73,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 00 04                        xneq32 x0, x0, x1
-;        3: 00                              ret
+; xneq32 x0, x0, x1
+; ret
 
 function %i16_ne(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -88,8 +88,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 00 04                        xneq32 x0, x0, x1
-;        3: 00                              ret
+; xneq32 x0, x0, x1
+; ret
 
 function %i32_ne(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -103,8 +103,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 00 04                        xneq32 x0, x0, x1
-;        3: 00                              ret
+; xneq32 x0, x0, x1
+; ret
 
 function %i64_ne(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -118,8 +118,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 04                        xneq64 x0, x0, x1
-;        3: 00                              ret
+; xneq64 x0, x0, x1
+; ret
 
 function %i8_ult(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -133,8 +133,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 00 04                        xult32 x0, x0, x1
-;        3: 00                              ret
+; xult32 x0, x0, x1
+; ret
 
 function %i16_ult(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -148,8 +148,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 00 04                        xult32 x0, x0, x1
-;        3: 00                              ret
+; xult32 x0, x0, x1
+; ret
 
 function %i32_ult(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -163,8 +163,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 00 04                        xult32 x0, x0, x1
-;        3: 00                              ret
+; xult32 x0, x0, x1
+; ret
 
 function %i64_ult(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -178,8 +178,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 04                        xult64 x0, x0, x1
-;        3: 00                              ret
+; xult64 x0, x0, x1
+; ret
 
 function %i8_ule(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -193,8 +193,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 00 04                        xulteq32 x0, x0, x1
-;        3: 00                              ret
+; xulteq32 x0, x0, x1
+; ret
 
 function %i16_ule(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -208,8 +208,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 00 04                        xulteq32 x0, x0, x1
-;        3: 00                              ret
+; xulteq32 x0, x0, x1
+; ret
 
 function %i32_ule(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -223,8 +223,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 00 04                        xulteq32 x0, x0, x1
-;        3: 00                              ret
+; xulteq32 x0, x0, x1
+; ret
 
 function %i64_ule(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -238,8 +238,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 04                        xulteq64 x0, x0, x1
-;        3: 00                              ret
+; xulteq64 x0, x0, x1
+; ret
 
 function %i8_slt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -253,8 +253,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 00 04                        xslt32 x0, x0, x1
-;        3: 00                              ret
+; xslt32 x0, x0, x1
+; ret
 
 function %i16_slt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -268,8 +268,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 00 04                        xslt32 x0, x0, x1
-;        3: 00                              ret
+; xslt32 x0, x0, x1
+; ret
 
 function %i32_slt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -283,8 +283,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 00 04                        xslt32 x0, x0, x1
-;        3: 00                              ret
+; xslt32 x0, x0, x1
+; ret
 
 function %i64_slt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -298,8 +298,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 04                        xslt64 x0, x0, x1
-;        3: 00                              ret
+; xslt64 x0, x0, x1
+; ret
 
 function %i8_sle(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -313,8 +313,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 00 04                        xslteq32 x0, x0, x1
-;        3: 00                              ret
+; xslteq32 x0, x0, x1
+; ret
 
 function %i16_sle(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -328,8 +328,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 00 04                        xslteq32 x0, x0, x1
-;        3: 00                              ret
+; xslteq32 x0, x0, x1
+; ret
 
 function %i32_sle(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -343,8 +343,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 00 04                        xslteq32 x0, x0, x1
-;        3: 00                              ret
+; xslteq32 x0, x0, x1
+; ret
 
 function %i64_sle(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -358,8 +358,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 04                        xslteq64 x0, x0, x1
-;        3: 00                              ret
+; xslteq64 x0, x0, x1
+; ret
 
 function %i8_ugt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -373,8 +373,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 20 00                        xult32 x0, x1, x0
-;        3: 00                              ret
+; xult32 x0, x1, x0
+; ret
 
 function %i16_ugt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -388,8 +388,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 20 00                        xult32 x0, x1, x0
-;        3: 00                              ret
+; xult32 x0, x1, x0
+; ret
 
 function %i32_ugt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -403,8 +403,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 20 00                        xult32 x0, x1, x0
-;        3: 00                              ret
+; xult32 x0, x1, x0
+; ret
 
 function %i64_ugt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -418,8 +418,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 20 00                        xult64 x0, x1, x0
-;        3: 00                              ret
+; xult64 x0, x1, x0
+; ret
 
 function %i8_sgt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -433,8 +433,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 20 00                        xslt32 x0, x1, x0
-;        3: 00                              ret
+; xslt32 x0, x1, x0
+; ret
 
 function %i16_sgt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -448,8 +448,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 20 00                        xslt32 x0, x1, x0
-;        3: 00                              ret
+; xslt32 x0, x1, x0
+; ret
 
 function %i32_sgt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -463,8 +463,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 20 00                        xslt32 x0, x1, x0
-;        3: 00                              ret
+; xslt32 x0, x1, x0
+; ret
 
 function %i64_sgt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -478,8 +478,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 20 00                        xslt64 x0, x1, x0
-;        3: 00                              ret
+; xslt64 x0, x1, x0
+; ret
 
 function %i8_uge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -493,8 +493,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 20 00                        xulteq32 x0, x1, x0
-;        3: 00                              ret
+; xulteq32 x0, x1, x0
+; ret
 
 function %i16_uge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -508,8 +508,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 20 00                        xulteq32 x0, x1, x0
-;        3: 00                              ret
+; xulteq32 x0, x1, x0
+; ret
 
 function %i32_uge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -523,8 +523,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 20 00                        xulteq32 x0, x1, x0
-;        3: 00                              ret
+; xulteq32 x0, x1, x0
+; ret
 
 function %i64_uge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -538,8 +538,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 20 00                        xulteq64 x0, x1, x0
-;        3: 00                              ret
+; xulteq64 x0, x1, x0
+; ret
 
 function %i8_sge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -553,8 +553,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 20 00                        xslteq32 x0, x1, x0
-;        3: 00                              ret
+; xslteq32 x0, x1, x0
+; ret
 
 function %i16_sge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -568,8 +568,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 20 00                        xslteq32 x0, x1, x0
-;        3: 00                              ret
+; xslteq32 x0, x1, x0
+; ret
 
 function %i32_sge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -583,8 +583,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 20 00                        xslteq32 x0, x1, x0
-;        3: 00                              ret
+; xslteq32 x0, x1, x0
+; ret
 
 function %i64_sge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -598,6 +598,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 20 00                        xslteq64 x0, x1, x0
-;        3: 00                              ret
+; xslteq64 x0, x1, x0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/iconst.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/iconst.clif
@@ -13,8 +13,8 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 15 00 ff 00                     xconst16 x0, 255
-;        4: 00                              ret
+; xconst16 x0, 255
+; ret
 
 function %i16() -> i16 {
 block0:
@@ -28,8 +28,8 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 ff ff 00 00               xconst32 x0, 65535
-;        6: 00                              ret
+; xconst32 x0, 65535
+; ret
 
 function %i32() -> i32 {
 block0:
@@ -43,8 +43,8 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 ff ff ff ff               xconst32 x0, -1
-;        6: 00                              ret
+; xconst32 x0, -1
+; ret
 
 function %i64() -> i64 {
 block0:
@@ -58,6 +58,6 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 17 00 ff ff ff ff ff ff ff ff   xconst64 x0, -1
-;        a: 00                              ret
+; xconst64 x0, -1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/jump.clif
@@ -30,9 +30,9 @@ block3(v3: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0e 00 00 00               br_if x0, 0xe    // target = 0xe
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 02 08 00 00 00                  jump 0x8    // target = 0x11
-;        e: 14 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+; br_if x0, 0xe    // target = 0xe
+; xconst8 x0, 0
+; jump 0x8    // target = 0x11
+; xconst8 x0, 1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/load.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/load.clif
@@ -13,8 +13,8 @@ block0(v0: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 26 00 00                        load32_u x0, x0
-;        3: 00                              ret
+; load32_u x0, x0
+; ret
 
 function %load_i64(i32) -> i64 {
 block0(v0: i32):
@@ -28,8 +28,8 @@ block0(v0: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 28 00 00                        load64 x0, x0
-;        3: 00                              ret
+; load64 x0, x0
+; ret
 
 function %load_i32_with_offset(i32) -> i32 {
 block0(v0: i32):
@@ -43,8 +43,8 @@ block0(v0: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 29 00 00 04                     load32_u_offset8 x0, x0, 4
-;        4: 00                              ret
+; load32_u_offset8 x0, x0, 4
+; ret
 
 function %load_i64_with_offset(i32) -> i64 {
 block0(v0: i32):
@@ -58,6 +58,6 @@ block0(v0: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 2b 00 00 08                     load64_offset8 x0, x0, 8
-;        4: 00                              ret
+; load64_offset8 x0, x0, 8
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/stack_addr.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/stack_addr.clif
@@ -27,19 +27,19 @@ block0():
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 1e f0                        xconst8 spilltmp0, -16
-;       13: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       16: 11 00 1b                        xmov x0, sp
-;       19: 14 1e 10                        xconst8 spilltmp0, 16
-;       1c: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       1f: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       23: 28 1d 1b                        load64 fp, sp
-;       26: 14 1e 10                        xconst8 spilltmp0, 16
-;       29: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       2c: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; xmov x0, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/store.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/store.clif
@@ -13,8 +13,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 2f 01 00                        store32 x1, x0
-;        3: 00                              ret
+; store32 x1, x0
+; ret
 
 function %store_i64(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -28,8 +28,8 @@ block0(v0: i64, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 30 01 00                        store64 x1, x0
-;        3: 00                              ret
+; store64 x1, x0
+; ret
 
 function %store_i32_with_offset(i32, i32) {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 31 01 04 00                     store32_offset8 x1, 4, x0
-;        4: 00                              ret
+; store32_offset8 x1, 4, x0
+; ret
 
 function %store_i64_with_offset(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -58,6 +58,6 @@ block0(v0: i64, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 32 01 08 00                     store64_offset8 x1, 8, x0
-;        4: 00                              ret
+; store64_offset8 x1, 8, x0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/trap.clif
@@ -11,7 +11,7 @@ block0:
 ;   trap // code = TrapCode(1)
 ;
 ; Disassembled:
-;        0: 43 00 00                        trap
+; trap
 
 function %trapnz(i64) {
 block0(v0: i64):
@@ -28,10 +28,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xeq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapz(i64) {
 block0(v0: i64):
@@ -48,10 +48,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xneq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapnz_icmp_fold(i64) {
 block0(v0: i64):
@@ -68,10 +68,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xeq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapz_icmp_fold(i64) {
 block0(v0: i64):
@@ -88,10 +88,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xneq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapnz_iconst_fold(i64) {
 block0(v0: i64):
@@ -120,13 +120,13 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 07 00 00 00               br_if x0, 0x7    // target = 0x7
-;        6: 00                              ret
-;        7: 14 05 2a                        xconst8 x5, 42
-;        a: 14 06 00                        xconst8 x6, 0
-;        d: 0c 05 06 08 00 00 00            br_if_xneq64 x5, x6, 0x8    // target = 0x15
-;       14: 00                              ret
-;       15: 43 00 00                        trap
+; br_if x0, 0x7    // target = 0x7
+; ret
+; xconst8 x5, 42
+; xconst8 x6, 0
+; br_if_xneq64 x5, x6, 0x8    // target = 0x15
+; ret
+; trap
 
 function %trapz_iconst_fold(i64) {
 block0(v0: i64):
@@ -155,11 +155,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 14 00 00 00               br_if x0, 0x14    // target = 0x14
-;        6: 14 04 00                        xconst8 x4, 0
-;        9: 14 05 00                        xconst8 x5, 0
-;        c: 0b 04 05 09 00 00 00            br_if_xeq64 x4, x5, 0x9    // target = 0x15
-;       13: 00                              ret
-;       14: 00                              ret
-;       15: 43 00 00                        trap
+; br_if x0, 0x14    // target = 0x14
+; xconst8 x4, 0
+; xconst8 x5, 0
+; br_if_xeq64 x4, x5, 0x9    // target = 0x15
+; ret
+; ret
+; trap
 

--- a/cranelift/filetests/filetests/isa/pulley64/brif-icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif-icmp.clif
@@ -26,11 +26,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 05 00 01 0b 00 00 00            br_if_xeq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xeq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ne(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -57,11 +57,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 06 00 01 0b 00 00 00            br_if_xneq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xneq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ult(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -88,11 +88,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 09 00 01 0b 00 00 00            br_if_xult32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xult32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ule(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -119,11 +119,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 0a 00 01 0b 00 00 00            br_if_xulteq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xulteq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_slt(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -150,11 +150,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 07 00 01 0b 00 00 00            br_if_xslt32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslt32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_sle(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -181,11 +181,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 08 00 01 0b 00 00 00            br_if_xslteq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslteq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_ugt(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -212,11 +212,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 09 01 00 0b 00 00 00            br_if_xult32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xult32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_uge(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -243,11 +243,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 0a 01 00 0b 00 00 00            br_if_xulteq32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xulteq32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_sgt(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -274,11 +274,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 07 01 00 0b 00 00 00            br_if_xslt32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslt32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_icmp_sge(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -305,11 +305,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 08 01 00 0b 00 00 00            br_if_xslteq32 x1, x0, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xslteq32 x1, x0, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 
 function %brif_uextend_icmp_eq(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -337,9 +337,9 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 05 00 01 0b 00 00 00            br_if_xeq32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 01                        xconst8 x0, 1
-;        a: 00                              ret
-;        b: 14 00 02                        xconst8 x0, 2
-;        e: 00                              ret
+; br_if_xeq32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 1
+; ret
+; xconst8 x0, 2
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif.clif
@@ -25,11 +25,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_i16(i16) -> i8 {
 block0(v0: i16):
@@ -55,11 +55,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_i32(i32) -> i8 {
 block0(v0: i32):
@@ -85,11 +85,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_i64(i64) -> i8 {
 block0(v0: i64):
@@ -115,11 +115,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0a 00 00 00               br_if x0, 0xa    // target = 0xa
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 00                              ret
-;        a: 14 00 01                        xconst8 x0, 1
-;        d: 00                              ret
+; br_if x0, 0xa    // target = 0xa
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -147,12 +147,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 05 04                        xeq32 x5, x0, x1
-;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
-;        9: 14 00 00                        xconst8 x0, 0
-;        c: 00                              ret
-;        d: 14 00 01                        xconst8 x0, 1
-;       10: 00                              ret
+; xeq32 x5, x0, x1
+; br_if x5, 0xa    // target = 0xd
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i16(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -180,12 +180,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 05 04                        xneq32 x5, x0, x1
-;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
-;        9: 14 00 00                        xconst8 x0, 0
-;        c: 00                              ret
-;        d: 14 00 01                        xconst8 x0, 1
-;       10: 00                              ret
+; xneq32 x5, x0, x1
+; br_if x5, 0xa    // target = 0xd
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i32(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -212,11 +212,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 07 00 01 0b 00 00 00            br_if_xslt32 x0, x1, 0xb    // target = 0xb
-;        7: 14 00 00                        xconst8 x0, 0
-;        a: 00                              ret
-;        b: 14 00 01                        xconst8 x0, 1
-;        e: 00                              ret
+; br_if_xslt32 x0, x1, 0xb    // target = 0xb
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 
 function %brif_icmp_i64(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -244,10 +244,10 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 25 00                        xulteq64 x5, x1, x0
-;        3: 03 05 0a 00 00 00               br_if x5, 0xa    // target = 0xd
-;        9: 14 00 00                        xconst8 x0, 0
-;        c: 00                              ret
-;        d: 14 00 01                        xconst8 x0, 1
-;       10: 00                              ret
+; xulteq64 x5, x1, x0
+; br_if x5, 0xa    // target = 0xd
+; xconst8 x0, 0
+; ret
+; xconst8 x0, 1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -29,19 +29,19 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 00 00                        xconst8 x0, 0
-;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
-;       18: 14 00 01                        xconst8 x0, 1
-;       1b: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       1f: 28 1d 1b                        load64 fp, sp
-;       22: 14 1e 10                        xconst8 spilltmp0, 16
-;       25: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       28: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 x0, 0
+; call 0x0    // target = 0x13
+; xconst8 x0, 1
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_args_i32_rets_i32() -> i32 {
     fn0 = colocated %g(i32) -> i32
@@ -70,19 +70,19 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 00 00                        xconst8 x0, 0
-;       13: 01 00 00 00 00                  call 0x0    // target = 0x13
-;       18: 14 00 01                        xconst8 x0, 1
-;       1b: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       1f: 28 1d 1b                        load64 fp, sp
-;       22: 14 1e 10                        xconst8 spilltmp0, 16
-;       25: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       28: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 x0, 0
+; call 0x0    // target = 0x13
+; xconst8 x0, 1
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_args_i64_i32_i64_i32() {
     fn0 = colocated %g(i64, i32, i64, i32)
@@ -115,21 +115,21 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 00 00                        xconst8 x0, 0
-;       13: 14 01 01                        xconst8 x1, 1
-;       16: 14 02 02                        xconst8 x2, 2
-;       19: 14 03 03                        xconst8 x3, 3
-;       1c: 01 00 00 00 00                  call 0x0    // target = 0x1c
-;       21: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       25: 28 1d 1b                        load64 fp, sp
-;       28: 14 1e 10                        xconst8 spilltmp0, 16
-;       2b: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       2e: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 x0, 0
+; xconst8 x1, 1
+; xconst8 x2, 2
+; xconst8 x3, 3
+; call 0x0    // target = 0x1c
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_rets_i64_i64_i64_i64() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64
@@ -160,20 +160,20 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 01 00 00 00 00                  call 0x0    // target = 0x10
-;       15: 19 04 08                        xadd64 x4, x0, x2
-;       18: 19 23 0c                        xadd64 x3, x1, x3
-;       1b: 19 80 0c                        xadd64 x0, x4, x3
-;       1e: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       22: 28 1d 1b                        load64 fp, sp
-;       25: 14 1e 10                        xconst8 spilltmp0, 16
-;       28: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       2b: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; call 0x0    // target = 0x10
+; xadd64 x4, x0, x2
+; xadd64 x3, x1, x3
+; xadd64 x0, x4, x3
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_stack_args() {
     fn0 = colocated %g(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64)
@@ -225,43 +225,43 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 1e d0                        xconst8 spilltmp0, -48
-;       13: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       16: 14 0f 00                        xconst8 x15, 0
-;       19: 30 1b 0f                        store64 sp, x15
-;       1c: 32 1b 08 0f                     store64_offset8 sp, 8, x15
-;       20: 32 1b 10 0f                     store64_offset8 sp, 16, x15
-;       24: 32 1b 18 0f                     store64_offset8 sp, 24, x15
-;       28: 32 1b 20 0f                     store64_offset8 sp, 32, x15
-;       2c: 32 1b 28 0f                     store64_offset8 sp, 40, x15
-;       30: 11 00 0f                        xmov x0, x15
-;       33: 11 01 0f                        xmov x1, x15
-;       36: 11 02 0f                        xmov x2, x15
-;       39: 11 03 0f                        xmov x3, x15
-;       3c: 11 04 0f                        xmov x4, x15
-;       3f: 11 05 0f                        xmov x5, x15
-;       42: 11 06 0f                        xmov x6, x15
-;       45: 11 07 0f                        xmov x7, x15
-;       48: 11 08 0f                        xmov x8, x15
-;       4b: 11 09 0f                        xmov x9, x15
-;       4e: 11 0a 0f                        xmov x10, x15
-;       51: 11 0b 0f                        xmov x11, x15
-;       54: 11 0c 0f                        xmov x12, x15
-;       57: 11 0d 0f                        xmov x13, x15
-;       5a: 11 0e 0f                        xmov x14, x15
-;       5d: 01 00 00 00 00                  call 0x0    // target = 0x5d
-;       62: 14 1e 30                        xconst8 spilltmp0, 48
-;       65: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       68: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       6c: 28 1d 1b                        load64 fp, sp
-;       6f: 14 1e 10                        xconst8 spilltmp0, 16
-;       72: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       75: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 spilltmp0, -48
+; xadd32 sp, sp, spilltmp0
+; xconst8 x15, 0
+; store64 sp, x15
+; store64_offset8 sp, 8, x15
+; store64_offset8 sp, 16, x15
+; store64_offset8 sp, 24, x15
+; store64_offset8 sp, 32, x15
+; store64_offset8 sp, 40, x15
+; xmov x0, x15
+; xmov x1, x15
+; xmov x2, x15
+; xmov x3, x15
+; xmov x4, x15
+; xmov x5, x15
+; xmov x6, x15
+; xmov x7, x15
+; xmov x8, x15
+; xmov x9, x15
+; xmov x10, x15
+; xmov x11, x15
+; xmov x12, x15
+; xmov x13, x15
+; xmov x14, x15
+; call 0x0    // target = 0x5d
+; xconst8 spilltmp0, 48
+; xadd32 sp, sp, spilltmp0
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 
 function %colocated_stack_rets() -> i64 {
     fn0 = colocated %g() -> i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64
@@ -355,56 +355,56 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 1e c0                        xconst8 spilltmp0, -64
-;       13: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       16: 32 1b 38 10                     store64_offset8 sp, 56, x16
-;       1a: 32 1b 30 12                     store64_offset8 sp, 48, x18
-;       1e: 11 00 1b                        xmov x0, sp
-;       21: 01 00 00 00 00                  call 0x0    // target = 0x21
-;       26: 11 10 0d                        xmov x16, x13
-;       29: 11 12 0b                        xmov x18, x11
-;       2c: 28 19 1b                        load64 x25, sp
-;       2f: 2b 0b 1b 08                     load64_offset8 x11, sp, 8
-;       33: 2b 0d 1b 10                     load64_offset8 x13, sp, 16
-;       37: 2b 1f 1b 18                     load64_offset8 spilltmp1, sp, 24
-;       3b: 2b 11 1b 20                     load64_offset8 x17, sp, 32
-;       3f: 19 1e 04                        xadd64 spilltmp0, x0, x1
-;       42: 19 5d 0c                        xadd64 fp, x2, x3
-;       45: 19 85 14                        xadd64 x5, x4, x5
-;       48: 19 c6 1c                        xadd64 x6, x6, x7
-;       4b: 19 07 25                        xadd64 x7, x8, x9
-;       4e: 11 00 12                        xmov x0, x18
-;       51: 19 44 01                        xadd64 x4, x10, x0
-;       54: 11 0a 10                        xmov x10, x16
-;       57: 19 88 29                        xadd64 x8, x12, x10
-;       5a: 19 ce 3d                        xadd64 x14, x14, x15
-;       5d: 19 2f 2f                        xadd64 x15, x25, x11
-;       60: 19 6d 35                        xadd64 x13, x11, x13
-;       63: 19 e0 47                        xadd64 x0, spilltmp1, x17
-;       66: 19 c1 77                        xadd64 x1, spilltmp0, fp
-;       69: 19 a2 18                        xadd64 x2, x5, x6
-;       6c: 19 e3 10                        xadd64 x3, x7, x4
-;       6f: 19 0e 39                        xadd64 x14, x8, x14
-;       72: 19 ed 35                        xadd64 x13, x15, x13
-;       75: 19 0f 00                        xadd64 x15, x0, x0
-;       78: 19 20 08                        xadd64 x0, x1, x2
-;       7b: 19 6e 38                        xadd64 x14, x3, x14
-;       7e: 19 ad 3d                        xadd64 x13, x13, x15
-;       81: 19 0e 38                        xadd64 x14, x0, x14
-;       84: 19 ad 35                        xadd64 x13, x13, x13
-;       87: 19 c0 35                        xadd64 x0, x14, x13
-;       8a: 2b 10 1b 38                     load64_offset8 x16, sp, 56
-;       8e: 2b 12 1b 30                     load64_offset8 x18, sp, 48
-;       92: 14 1e 40                        xconst8 spilltmp0, 64
-;       95: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       98: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       9c: 28 1d 1b                        load64 fp, sp
-;       9f: 14 1e 10                        xconst8 spilltmp0, 16
-;       a2: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       a5: 00                              ret
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 spilltmp0, -64
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 56, x16
+; store64_offset8 sp, 48, x18
+; xmov x0, sp
+; call 0x0    // target = 0x21
+; xmov x16, x13
+; xmov x18, x11
+; load64 x25, sp
+; load64_offset8 x11, sp, 8
+; load64_offset8 x13, sp, 16
+; load64_offset8 spilltmp1, sp, 24
+; load64_offset8 x17, sp, 32
+; xadd64 spilltmp0, x0, x1
+; xadd64 fp, x2, x3
+; xadd64 x5, x4, x5
+; xadd64 x6, x6, x7
+; xadd64 x7, x8, x9
+; xmov x0, x18
+; xadd64 x4, x10, x0
+; xmov x10, x16
+; xadd64 x8, x12, x10
+; xadd64 x14, x14, x15
+; xadd64 x15, x25, x11
+; xadd64 x13, x11, x13
+; xadd64 x0, spilltmp1, x17
+; xadd64 x1, spilltmp0, fp
+; xadd64 x2, x5, x6
+; xadd64 x3, x7, x4
+; xadd64 x14, x8, x14
+; xadd64 x13, x15, x13
+; xadd64 x15, x0, x0
+; xadd64 x0, x1, x2
+; xadd64 x14, x3, x14
+; xadd64 x13, x13, x15
+; xadd64 x14, x0, x14
+; xadd64 x13, x13, x13
+; xadd64 x0, x14, x13
+; load64_offset8 x16, sp, 56
+; load64_offset8 x18, sp, 48
+; xconst8 spilltmp0, 64
+; xadd32 sp, sp, spilltmp0
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/get_stack_pointer.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/get_stack_pointer.clif
@@ -13,6 +13,6 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 43 02 00 00                     get_sp x0
-;        4: 00                              ret
+; get_sp x0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/iadd.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/iadd.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 04                        xadd32 x0, x0, x1
-;        3: 00                              ret
+; xadd32 x0, x0, x1
+; ret
 
 function %i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 04                        xadd32 x0, x0, x1
-;        3: 00                              ret
+; xadd32 x0, x0, x1
+; ret
 
 function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 18 00 04                        xadd32 x0, x0, x1
-;        3: 00                              ret
+; xadd32 x0, x0, x1
+; ret
 
 function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -58,6 +58,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 19 00 04                        xadd64 x0, x0, x1
-;        3: 00                              ret
+; xadd64 x0, x0, x1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/icmp.clif
@@ -13,8 +13,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 00 04                        xeq32 x0, x0, x1
-;        3: 00                              ret
+; xeq32 x0, x0, x1
+; ret
 
 function %i16_eq(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -28,8 +28,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 00 04                        xeq32 x0, x0, x1
-;        3: 00                              ret
+; xeq32 x0, x0, x1
+; ret
 
 function %i32_eq(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 20 00 04                        xeq32 x0, x0, x1
-;        3: 00                              ret
+; xeq32 x0, x0, x1
+; ret
 
 function %i64_eq(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -58,8 +58,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1a 00 04                        xeq64 x0, x0, x1
-;        3: 00                              ret
+; xeq64 x0, x0, x1
+; ret
 
 function %i8_ne(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -73,8 +73,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 00 04                        xneq32 x0, x0, x1
-;        3: 00                              ret
+; xneq32 x0, x0, x1
+; ret
 
 function %i16_ne(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -88,8 +88,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 00 04                        xneq32 x0, x0, x1
-;        3: 00                              ret
+; xneq32 x0, x0, x1
+; ret
 
 function %i32_ne(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -103,8 +103,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 21 00 04                        xneq32 x0, x0, x1
-;        3: 00                              ret
+; xneq32 x0, x0, x1
+; ret
 
 function %i64_ne(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -118,8 +118,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1b 00 04                        xneq64 x0, x0, x1
-;        3: 00                              ret
+; xneq64 x0, x0, x1
+; ret
 
 function %i8_ult(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -133,8 +133,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 00 04                        xult32 x0, x0, x1
-;        3: 00                              ret
+; xult32 x0, x0, x1
+; ret
 
 function %i16_ult(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -148,8 +148,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 00 04                        xult32 x0, x0, x1
-;        3: 00                              ret
+; xult32 x0, x0, x1
+; ret
 
 function %i32_ult(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -163,8 +163,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 00 04                        xult32 x0, x0, x1
-;        3: 00                              ret
+; xult32 x0, x0, x1
+; ret
 
 function %i64_ult(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -178,8 +178,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 00 04                        xult64 x0, x0, x1
-;        3: 00                              ret
+; xult64 x0, x0, x1
+; ret
 
 function %i8_ule(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -193,8 +193,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 00 04                        xulteq32 x0, x0, x1
-;        3: 00                              ret
+; xulteq32 x0, x0, x1
+; ret
 
 function %i16_ule(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -208,8 +208,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 00 04                        xulteq32 x0, x0, x1
-;        3: 00                              ret
+; xulteq32 x0, x0, x1
+; ret
 
 function %i32_ule(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -223,8 +223,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 00 04                        xulteq32 x0, x0, x1
-;        3: 00                              ret
+; xulteq32 x0, x0, x1
+; ret
 
 function %i64_ule(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -238,8 +238,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 00 04                        xulteq64 x0, x0, x1
-;        3: 00                              ret
+; xulteq64 x0, x0, x1
+; ret
 
 function %i8_slt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -253,8 +253,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 00 04                        xslt32 x0, x0, x1
-;        3: 00                              ret
+; xslt32 x0, x0, x1
+; ret
 
 function %i16_slt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -268,8 +268,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 00 04                        xslt32 x0, x0, x1
-;        3: 00                              ret
+; xslt32 x0, x0, x1
+; ret
 
 function %i32_slt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -283,8 +283,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 00 04                        xslt32 x0, x0, x1
-;        3: 00                              ret
+; xslt32 x0, x0, x1
+; ret
 
 function %i64_slt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -298,8 +298,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 00 04                        xslt64 x0, x0, x1
-;        3: 00                              ret
+; xslt64 x0, x0, x1
+; ret
 
 function %i8_sle(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -313,8 +313,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 00 04                        xslteq32 x0, x0, x1
-;        3: 00                              ret
+; xslteq32 x0, x0, x1
+; ret
 
 function %i16_sle(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -328,8 +328,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 00 04                        xslteq32 x0, x0, x1
-;        3: 00                              ret
+; xslteq32 x0, x0, x1
+; ret
 
 function %i32_sle(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -343,8 +343,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 00 04                        xslteq32 x0, x0, x1
-;        3: 00                              ret
+; xslteq32 x0, x0, x1
+; ret
 
 function %i64_sle(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -358,8 +358,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 00 04                        xslteq64 x0, x0, x1
-;        3: 00                              ret
+; xslteq64 x0, x0, x1
+; ret
 
 function %i8_ugt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -373,8 +373,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 20 00                        xult32 x0, x1, x0
-;        3: 00                              ret
+; xult32 x0, x1, x0
+; ret
 
 function %i16_ugt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -388,8 +388,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 20 00                        xult32 x0, x1, x0
-;        3: 00                              ret
+; xult32 x0, x1, x0
+; ret
 
 function %i32_ugt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -403,8 +403,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 24 20 00                        xult32 x0, x1, x0
-;        3: 00                              ret
+; xult32 x0, x1, x0
+; ret
 
 function %i64_ugt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -418,8 +418,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1e 20 00                        xult64 x0, x1, x0
-;        3: 00                              ret
+; xult64 x0, x1, x0
+; ret
 
 function %i8_sgt(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -433,8 +433,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 20 00                        xslt32 x0, x1, x0
-;        3: 00                              ret
+; xslt32 x0, x1, x0
+; ret
 
 function %i16_sgt(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -448,8 +448,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 20 00                        xslt32 x0, x1, x0
-;        3: 00                              ret
+; xslt32 x0, x1, x0
+; ret
 
 function %i32_sgt(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -463,8 +463,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 22 20 00                        xslt32 x0, x1, x0
-;        3: 00                              ret
+; xslt32 x0, x1, x0
+; ret
 
 function %i64_sgt(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -478,8 +478,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1c 20 00                        xslt64 x0, x1, x0
-;        3: 00                              ret
+; xslt64 x0, x1, x0
+; ret
 
 function %i8_uge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -493,8 +493,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 20 00                        xulteq32 x0, x1, x0
-;        3: 00                              ret
+; xulteq32 x0, x1, x0
+; ret
 
 function %i16_uge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -508,8 +508,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 20 00                        xulteq32 x0, x1, x0
-;        3: 00                              ret
+; xulteq32 x0, x1, x0
+; ret
 
 function %i32_uge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -523,8 +523,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 25 20 00                        xulteq32 x0, x1, x0
-;        3: 00                              ret
+; xulteq32 x0, x1, x0
+; ret
 
 function %i64_uge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -538,8 +538,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1f 20 00                        xulteq64 x0, x1, x0
-;        3: 00                              ret
+; xulteq64 x0, x1, x0
+; ret
 
 function %i8_sge(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -553,8 +553,8 @@ block0(v0: i8, v1: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 20 00                        xslteq32 x0, x1, x0
-;        3: 00                              ret
+; xslteq32 x0, x1, x0
+; ret
 
 function %i16_sge(i16, i16) -> i8 {
 block0(v0: i16, v1: i16):
@@ -568,8 +568,8 @@ block0(v0: i16, v1: i16):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 20 00                        xslteq32 x0, x1, x0
-;        3: 00                              ret
+; xslteq32 x0, x1, x0
+; ret
 
 function %i32_sge(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -583,8 +583,8 @@ block0(v0: i32, v1: i32):
 ;   ret
 ;
 ; Disassembled:
-;        0: 23 20 00                        xslteq32 x0, x1, x0
-;        3: 00                              ret
+; xslteq32 x0, x1, x0
+; ret
 
 function %i64_sge(i64, i64) -> i8 {
 block0(v0: i64, v1: i64):
@@ -598,6 +598,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 1d 20 00                        xslteq64 x0, x1, x0
-;        3: 00                              ret
+; xslteq64 x0, x1, x0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/iconst.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/iconst.clif
@@ -13,8 +13,8 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 15 00 ff 00                     xconst16 x0, 255
-;        4: 00                              ret
+; xconst16 x0, 255
+; ret
 
 function %i16() -> i16 {
 block0:
@@ -28,8 +28,8 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 ff ff 00 00               xconst32 x0, 65535
-;        6: 00                              ret
+; xconst32 x0, 65535
+; ret
 
 function %i32() -> i32 {
 block0:
@@ -43,8 +43,8 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 16 00 ff ff ff ff               xconst32 x0, -1
-;        6: 00                              ret
+; xconst32 x0, -1
+; ret
 
 function %i64() -> i64 {
 block0:
@@ -58,6 +58,6 @@ block0:
 ;   ret
 ;
 ; Disassembled:
-;        0: 17 00 ff ff ff ff ff ff ff ff   xconst64 x0, -1
-;        a: 00                              ret
+; xconst64 x0, -1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/jump.clif
@@ -30,9 +30,9 @@ block3(v3: i8):
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 0e 00 00 00               br_if x0, 0xe    // target = 0xe
-;        6: 14 00 00                        xconst8 x0, 0
-;        9: 02 08 00 00 00                  jump 0x8    // target = 0x11
-;        e: 14 00 01                        xconst8 x0, 1
-;       11: 00                              ret
+; br_if x0, 0xe    // target = 0xe
+; xconst8 x0, 0
+; jump 0x8    // target = 0x11
+; xconst8 x0, 1
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/load.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/load.clif
@@ -13,8 +13,8 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 26 00 00                        load32_u x0, x0
-;        3: 00                              ret
+; load32_u x0, x0
+; ret
 
 function %load_i64(i64) -> i64 {
 block0(v0: i64):
@@ -28,8 +28,8 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 28 00 00                        load64 x0, x0
-;        3: 00                              ret
+; load64 x0, x0
+; ret
 
 function %load_i32_with_offset(i64) -> i32 {
 block0(v0: i64):
@@ -43,8 +43,8 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 29 00 00 04                     load32_u_offset8 x0, x0, 4
-;        4: 00                              ret
+; load32_u_offset8 x0, x0, 4
+; ret
 
 function %load_i64_with_offset(i64) -> i64 {
 block0(v0: i64):
@@ -58,6 +58,6 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 2b 00 00 08                     load64_offset8 x0, x0, 8
-;        4: 00                              ret
+; load64_offset8 x0, x0, 8
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/stack_addr.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/stack_addr.clif
@@ -27,20 +27,19 @@ block0():
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 1e f0                        xconst8 spilltmp0, -16
-;        3: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;        6: 32 1b 08 1c                     store64_offset8 sp, 8, lr
-;        a: 30 1b 1d                        store64 sp, fp
-;        d: 11 1d 1b                        xmov fp, sp
-;       10: 14 1e f0                        xconst8 spilltmp0, -16
-;       13: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       16: 11 00 1b                        xmov x0, sp
-;       19: 14 1e 10                        xconst8 spilltmp0, 16
-;       1c: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       1f: 2b 1c 1b 08                     load64_offset8 lr, sp, 8
-;       23: 28 1d 1b                        load64 fp, sp
-;       26: 14 1e 10                        xconst8 spilltmp0, 16
-;       29: 18 7b 7b                        xadd32 sp, sp, spilltmp0
-;       2c: 00                              ret
-
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; store64_offset8 sp, 8, lr
+; store64 sp, fp
+; xmov fp, sp
+; xconst8 spilltmp0, -16
+; xadd32 sp, sp, spilltmp0
+; xmov x0, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; load64_offset8 lr, sp, 8
+; load64 fp, sp
+; xconst8 spilltmp0, 16
+; xadd32 sp, sp, spilltmp0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/store.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/store.clif
@@ -13,8 +13,8 @@ block0(v0: i32, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 2f 01 00                        store32 x1, x0
-;        3: 00                              ret
+; store32 x1, x0
+; ret
 
 function %store_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -28,8 +28,8 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 30 01 00                        store64 x1, x0
-;        3: 00                              ret
+; store64 x1, x0
+; ret
 
 function %store_i32_with_offset(i32, i64) {
 block0(v0: i32, v1: i64):
@@ -43,8 +43,8 @@ block0(v0: i32, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 31 01 04 00                     store32_offset8 x1, 4, x0
-;        4: 00                              ret
+; store32_offset8 x1, 4, x0
+; ret
 
 function %store_i64_with_offset(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -58,6 +58,6 @@ block0(v0: i64, v1: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 32 01 08 00                     store64_offset8 x1, 8, x0
-;        4: 00                              ret
+; store64_offset8 x1, 8, x0
+; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/trap.clif
@@ -11,7 +11,7 @@ block0:
 ;   trap // code = TrapCode(1)
 ;
 ; Disassembled:
-;        0: 43 00 00                        trap
+; trap
 
 function %trapnz(i64) {
 block0(v0: i64):
@@ -28,10 +28,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xeq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapz(i64) {
 block0(v0: i64):
@@ -48,10 +48,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xneq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapnz_icmp_fold(i64) {
 block0(v0: i64):
@@ -68,10 +68,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0b 00 02 08 00 00 00            br_if_xeq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xeq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapz_icmp_fold(i64) {
 block0(v0: i64):
@@ -88,10 +88,10 @@ block0(v0: i64):
 ;   ret
 ;
 ; Disassembled:
-;        0: 14 02 2a                        xconst8 x2, 42
-;        3: 0c 00 02 08 00 00 00            br_if_xneq64 x0, x2, 0x8    // target = 0xb
-;        a: 00                              ret
-;        b: 43 00 00                        trap
+; xconst8 x2, 42
+; br_if_xneq64 x0, x2, 0x8    // target = 0xb
+; ret
+; trap
 
 function %trapnz_iconst_fold(i64) {
 block0(v0: i64):
@@ -120,13 +120,13 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 07 00 00 00               br_if x0, 0x7    // target = 0x7
-;        6: 00                              ret
-;        7: 14 05 2a                        xconst8 x5, 42
-;        a: 14 06 00                        xconst8 x6, 0
-;        d: 0c 05 06 08 00 00 00            br_if_xneq64 x5, x6, 0x8    // target = 0x15
-;       14: 00                              ret
-;       15: 43 00 00                        trap
+; br_if x0, 0x7    // target = 0x7
+; ret
+; xconst8 x5, 42
+; xconst8 x6, 0
+; br_if_xneq64 x5, x6, 0x8    // target = 0x15
+; ret
+; trap
 
 function %trapz_iconst_fold(i64) {
 block0(v0: i64):
@@ -155,11 +155,11 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-;        0: 03 00 14 00 00 00               br_if x0, 0x14    // target = 0x14
-;        6: 14 04 00                        xconst8 x4, 0
-;        9: 14 05 00                        xconst8 x5, 0
-;        c: 0b 04 05 09 00 00 00            br_if_xeq64 x4, x5, 0x9    // target = 0x15
-;       13: 00                              ret
-;       14: 00                              ret
-;       15: 43 00 00                        trap
+; br_if x0, 0x14    // target = 0x14
+; xconst8 x4, 0
+; xconst8 x5, 0
+; br_if_xeq64 x4, x5, 0x9    // target = 0x15
+; ret
+; ret
+; trap
 


### PR DESCRIPTION
As opcodes are added/removed this causes a lot of churn in these tests, so skip the hex dump/offsets and instead just print the instructions

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
