### PR TITLE
wasi-http: make the buffer and budget capacity of the OutgoingBody writer configurable

### DIFF
--- a/crates/test-programs/src/bin/http_outbound_request_large_post.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_large_post.rs
@@ -3,8 +3,11 @@ use std::io::{self, Read};
 use test_programs::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    // TODO: ensure more than 700 bytes is allowed without error
-    const LEN: usize = 700;
+    // Make sure the final body is larger than 1024*1024, but we cannot allocate
+    // so much memory directly in the wasm program, so we use the `repeat`
+    // method to increase the body size.
+    const LEN: usize = 1024;
+    const REPEAT: usize = 1025;
     let mut buffer = [0; LEN];
     let addr = std::env::var("HTTP_SERVER").unwrap();
     io::repeat(0b001).read_exact(&mut buffer).unwrap();
@@ -13,7 +16,7 @@ fn main() {
         Scheme::Http,
         &addr,
         "/post",
-        Some(&buffer),
+        Some(&buffer.repeat(REPEAT)),
         None,
         None,
         None,
@@ -26,5 +29,5 @@ fn main() {
     assert_eq!(res.status, 200);
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "POST");
-    assert_eq!(res.body.len(), LEN);
+    assert_eq!(res.body.len(), LEN * REPEAT);
 }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -125,6 +125,19 @@ pub trait WasiHttpView: Send {
     fn is_forbidden_header(&mut self, _name: &HeaderName) -> bool {
         false
     }
+
+    /// Number of distinct write calls to the outgoing body's output-stream
+    /// that the implementation will buffer.
+    /// Default: 1.
+    fn outgoing_body_buffer_chunks(&mut self) -> usize {
+        1
+    }
+
+    /// Maximum size allowed in a write call to the outgoing body's output-stream.
+    /// Default: 1024 * 1024.
+    fn outgoing_body_chunk_size(&mut self) -> usize {
+        1024 * 1024
+    }
 }
 
 impl<T: ?Sized + WasiHttpView> WasiHttpView for &mut T {
@@ -156,6 +169,14 @@ impl<T: ?Sized + WasiHttpView> WasiHttpView for &mut T {
     fn is_forbidden_header(&mut self, name: &HeaderName) -> bool {
         T::is_forbidden_header(self, name)
     }
+
+    fn outgoing_body_buffer_chunks(&mut self) -> usize {
+        T::outgoing_body_buffer_chunks(self)
+    }
+
+    fn outgoing_body_chunk_size(&mut self) -> usize {
+        T::outgoing_body_chunk_size(self)
+    }
 }
 
 impl<T: ?Sized + WasiHttpView> WasiHttpView for Box<T> {
@@ -186,6 +207,14 @@ impl<T: ?Sized + WasiHttpView> WasiHttpView for Box<T> {
 
     fn is_forbidden_header(&mut self, name: &HeaderName) -> bool {
         T::is_forbidden_header(self, name)
+    }
+
+    fn outgoing_body_buffer_chunks(&mut self) -> usize {
+        T::outgoing_body_buffer_chunks(self)
+    }
+
+    fn outgoing_body_chunk_size(&mut self) -> usize {
+        T::outgoing_body_chunk_size(self)
     }
 }
 
@@ -232,6 +261,14 @@ impl<T: WasiHttpView> WasiHttpView for WasiHttpImpl<T> {
 
     fn is_forbidden_header(&mut self, name: &HeaderName) -> bool {
         self.0.is_forbidden_header(name)
+    }
+
+    fn outgoing_body_buffer_chunks(&mut self) -> usize {
+        self.0.outgoing_body_buffer_chunks()
+    }
+
+    fn outgoing_body_chunk_size(&mut self) -> usize {
+        self.0.outgoing_body_chunk_size()
     }
 }
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -391,6 +391,8 @@ where
         &mut self,
         request: Resource<HostOutgoingRequest>,
     ) -> wasmtime::Result<Result<Resource<HostOutgoingBody>, ()>> {
+        let buffer_chunks = self.outgoing_body_buffer_chunks();
+        let chunk_size = self.outgoing_body_chunk_size();
         let req = self
             .table()
             .get_mut(&request)
@@ -405,7 +407,8 @@ where
             Err(e) => return Ok(Err(e)),
         };
 
-        let (host_body, hyper_body) = HostOutgoingBody::new(StreamContext::Request, size);
+        let (host_body, hyper_body) =
+            HostOutgoingBody::new(StreamContext::Request, size, buffer_chunks, chunk_size);
 
         req.body = Some(hyper_body);
 
@@ -751,6 +754,8 @@ where
         &mut self,
         id: Resource<HostOutgoingResponse>,
     ) -> wasmtime::Result<Result<Resource<HostOutgoingBody>, ()>> {
+        let buffer_chunks = self.outgoing_body_buffer_chunks();
+        let chunk_size = self.outgoing_body_chunk_size();
         let resp = self.table().get_mut(&id)?;
 
         if resp.body.is_some() {
@@ -762,7 +767,8 @@ where
             Err(e) => return Ok(Err(e)),
         };
 
-        let (host, body) = HostOutgoingBody::new(StreamContext::Response, size);
+        let (host, body) =
+            HostOutgoingBody::new(StreamContext::Response, size, buffer_chunks, chunk_size);
 
         resp.body.replace(body);
 


### PR DESCRIPTION
Please refer to issue #9653 for the background and reasons for the changes.

fix #9653

cc @alexcrichton @pchickey 