### PR TITLE
Simplify some trap handling in `wasmtime` runtime

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -311,7 +311,7 @@ unsafe fn call_host_and_handle_result<T>(
 
     match res {
         Ok(()) => {}
-        Err(e) => crate::trap::raise(e),
+        Err(e) => crate::runtime::vm::raise_user_trap(e),
     }
 }
 

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2371,7 +2371,7 @@ impl HostContext {
 
         match result {
             Ok(val) => val,
-            Err(err) => crate::trap::raise(err),
+            Err(err) => crate::runtime::vm::raise_user_trap(err),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -61,7 +61,7 @@ unsafe extern "C" fn array_call_shim<F>(
         // call-site, which gets unwrapped in `Trap::from_runtime` later on as we
         // convert from the internal `Trap` type to our own `Trap` type in this
         // crate.
-        Err(trap) => crate::trap::raise(trap.into()),
+        Err(err) => crate::runtime::vm::raise_user_trap(err),
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -132,10 +132,7 @@ mod trampolines {
                     match result {
                         Ok(ret) => shims!(@convert_ret ret $($pname: $param)*),
                         Err(err) => crate::runtime::vm::traphandlers::raise_trap(
-                            crate::runtime::vm::traphandlers::TrapReason::User {
-                                error: err,
-                                needs_backtrace: true,
-                            },
+                            crate::runtime::vm::traphandlers::TrapReason::User(err)
                         ),
                     }
                 }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -199,12 +199,7 @@ fn memory32_grow(
     memory_index: u32,
 ) -> Result<*mut u8, TrapReason> {
     let memory_index = MemoryIndex::from_u32(memory_index);
-    let result = match instance
-        .memory_grow(store, memory_index, delta)
-        .map_err(|error| TrapReason::User {
-            error,
-            needs_backtrace: true,
-        })? {
+    let result = match instance.memory_grow(store, memory_index, delta)? {
         Some(size_in_bytes) => size_in_bytes / instance.memory_page_size(memory_index),
         None => usize::max_value(),
     };


### PR DESCRIPTION
The `needs_backtrace` field on `TrapReason` is an old artifact of having the `wasmtime` and `wasmtime-runtime` crates split and there's no longer any need for that. This commit removes the field and directly queries it from the error as necessary when capturing backtraces.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
