### PR TITLE
Simplify signature of `catch_traps` in Wasmtime

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1602,14 +1602,7 @@ pub(crate) fn invoke_wasm_and_catch_traps<T>(
             exit_wasm(store, exit);
             return Err(trap);
         }
-        let result = crate::runtime::vm::catch_traps(
-            store.0.signal_handler(),
-            store.0.engine().config().wasm_backtrace,
-            store.0.engine().config().coredump_on_trap,
-            store.0.async_guard_range(),
-            store.0.default_caller(),
-            closure,
-        );
+        let result = crate::runtime::vm::catch_traps(store, closure);
         exit_wasm(store, exit);
         store.0.call_hook(CallHook::ReturningFromWasm)?;
         result.map_err(|t| crate::trap::from_runtime_box(store.0, t))

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -254,8 +254,7 @@ mod call_thread_state {
             let limits = unsafe { *Instance::from_vmctx(caller, |i| i.runtime_limits()) };
 
             // Don't try to plumb #[cfg] everywhere for this field, just pretend
-            // we're using it on miri to silence compiler warnings.
-            #[cfg(miri)]
+            // we're using it on miri/windows to silence compiler warnings.
             let _: Range<_> = store.async_guard_range();
 
             CallThreadState {

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -253,6 +253,11 @@ mod call_thread_state {
         pub(super) fn new(store: &mut StoreOpaque, caller: *mut VMContext) -> CallThreadState {
             let limits = unsafe { *Instance::from_vmctx(caller, |i| i.runtime_limits()) };
 
+            // Don't try to plumb #[cfg] everywhere for this field, just pretend
+            // we're using it on miri to silence compiler warnings.
+            #[cfg(miri)]
+            let _: Range<_> = store.async_guard_range();
+
             CallThreadState {
                 unwind: UnsafeCell::new(MaybeUninit::uninit()),
                 jmp_buf: Cell::new(ptr::null()),


### PR DESCRIPTION
Now that `wasmtime-runtime` and `wasmtime` are merged there's no need to pass all arguments individually, it's possible to forward along the whole `Store`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
