### PR TITLE
Remove return value from wmemcheck libcalls

### DIFF
--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -43,16 +43,16 @@ macro_rules! foreach_builtin_function {
             new_epoch(vmctx: vmctx) -> i64;
             // Invoked before malloc returns.
             #[cfg(feature = "wmemcheck")]
-            check_malloc(vmctx: vmctx, addr: i32, len: i32) -> i32;
+            check_malloc(vmctx: vmctx, addr: i32, len: i32);
             // Invoked before the free returns.
             #[cfg(feature = "wmemcheck")]
-            check_free(vmctx: vmctx, addr: i32) -> i32;
+            check_free(vmctx: vmctx, addr: i32);
             // Invoked before a load is executed.
             #[cfg(feature = "wmemcheck")]
-            check_load(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
+            check_load(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32);
             // Invoked before a store is executed.
             #[cfg(feature = "wmemcheck")]
-            check_store(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> i32;
+            check_store(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32);
             // Invoked after malloc is called.
             #[cfg(feature = "wmemcheck")]
             malloc_start(vmctx: vmctx);

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1115,14 +1115,12 @@ unsafe fn check_malloc(
     instance: &mut Instance,
     addr: u32,
     len: u32,
-) -> Result<u32> {
+) -> Result<()> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.malloc(addr as usize, len as usize);
         wmemcheck_state.memcheck_on();
         match result {
-            Ok(()) => {
-                return Ok(0);
-            }
+            Ok(()) => {}
             Err(DoubleMalloc { addr, len }) => {
                 bail!("Double malloc at addr {:#x} of size {}", addr, len)
             }
@@ -1134,19 +1132,17 @@ unsafe fn check_malloc(
             }
         }
     }
-    Ok(0)
+    Ok(())
 }
 
 // Hook for validating free using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-unsafe fn check_free(_store: &mut dyn VMStore, instance: &mut Instance, addr: u32) -> Result<u32> {
+unsafe fn check_free(_store: &mut dyn VMStore, instance: &mut Instance, addr: u32) -> Result<()> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.free(addr as usize);
         wmemcheck_state.memcheck_on();
         match result {
-            Ok(()) => {
-                return Ok(0);
-            }
+            Ok(()) => {}
             Err(InvalidFree { addr }) => {
                 bail!("Invalid free at addr {:#x}", addr)
             }
@@ -1155,7 +1151,7 @@ unsafe fn check_free(_store: &mut dyn VMStore, instance: &mut Instance, addr: u3
             }
         }
     }
-    Ok(0)
+    Ok(())
 }
 
 // Hook for validating load using wmemcheck_state.
@@ -1166,13 +1162,11 @@ fn check_load(
     num_bytes: u32,
     addr: u32,
     offset: u32,
-) -> Result<u32> {
+) -> Result<()> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.read(addr as usize + offset as usize, num_bytes as usize);
         match result {
-            Ok(()) => {
-                return Ok(0);
-            }
+            Ok(()) => {}
             Err(InvalidRead { addr, len }) => {
                 bail!("Invalid load at addr {:#x} of size {}", addr, len);
             }
@@ -1184,7 +1178,7 @@ fn check_load(
             }
         }
     }
-    Ok(0)
+    Ok(())
 }
 
 // Hook for validating store using wmemcheck_state.
@@ -1195,13 +1189,11 @@ fn check_store(
     num_bytes: u32,
     addr: u32,
     offset: u32,
-) -> Result<u32> {
+) -> Result<()> {
     if let Some(wmemcheck_state) = &mut instance.wmemcheck_state {
         let result = wmemcheck_state.write(addr as usize + offset as usize, num_bytes as usize);
         match result {
-            Ok(()) => {
-                return Ok(0);
-            }
+            Ok(()) => {}
             Err(InvalidWrite { addr, len }) => {
                 bail!("Invalid store at addr {:#x} of size {}", addr, len)
             }
@@ -1213,7 +1205,7 @@ fn check_store(
             }
         }
     }
-    Ok(0)
+    Ok(())
 }
 
 // Hook for turning wmemcheck load/store validation off when entering a malloc function.


### PR DESCRIPTION
This isn't used in the compiled code so don't bake it in.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
