### PR TITLE
Use `NonNull` for `VMFuncRef` in more places

### DIFF
--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -163,7 +163,8 @@ impl Table {
         unsafe {
             match (*table).get(gc_store, index)? {
                 runtime::TableElement::FuncRef(f) => {
-                    f.map(|f| Func::from_vm_func_ref(&mut store, f).into())
+                    let func = f.map(|f| Func::from_vm_func_ref(&mut store, f));
+                    Some(func.into())
                 }
 
                 runtime::TableElement::UninitFunc => {

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -163,8 +163,7 @@ impl Table {
         unsafe {
             match (*table).get(gc_store, index)? {
                 runtime::TableElement::FuncRef(f) => {
-                    let func = Func::from_vm_func_ref(&mut store, f);
-                    Some(func.into())
+                    f.map(|f| Func::from_vm_func_ref(&mut store, f).into())
                 }
 
                 runtime::TableElement::UninitFunc => {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -573,12 +573,11 @@ impl Func {
 
     pub(crate) unsafe fn from_vm_func_ref(
         store: &mut StoreOpaque,
-        raw: *mut VMFuncRef,
-    ) -> Option<Func> {
-        let func_ref = NonNull::new(raw)?;
+        func_ref: NonNull<VMFuncRef>,
+    ) -> Func {
         debug_assert!(func_ref.as_ref().type_index != VMSharedTypeIndex::default());
         let export = ExportFunction { func_ref };
-        Some(Func::from_wasmtime_function(export, store))
+        Func::from_wasmtime_function(export, store)
     }
 
     /// Creates a new `Func` from the given Rust closure.
@@ -1091,7 +1090,7 @@ impl Func {
     }
 
     pub(crate) unsafe fn _from_raw(store: &mut StoreOpaque, raw: *mut c_void) -> Option<Func> {
-        Func::from_vm_func_ref(store, raw.cast())
+        Some(Func::from_vm_func_ref(store, NonNull::new(raw.cast())?))
     }
 
     /// Extracts the raw value of this `Func`, which is owned by `store`.

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -10,7 +10,7 @@ use core::ffi::c_void;
 use core::marker;
 use core::mem::{self, MaybeUninit};
 use core::num::NonZeroUsize;
-use core::ptr::{self};
+use core::ptr::{self, NonNull};
 use wasmtime_environ::VMSharedTypeIndex;
 
 /// A statically typed WebAssembly function.
@@ -566,9 +566,8 @@ unsafe impl WasmTy for Func {
 
     #[inline]
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        let p = ptr.get_funcref();
-        debug_assert!(!p.is_null());
-        Func::from_vm_func_ref(store, p.cast()).unwrap()
+        let p = NonNull::new(ptr.get_funcref()).unwrap().cast();
+        Func::from_vm_func_ref(store, p)
     }
 }
 
@@ -617,7 +616,8 @@ unsafe impl WasmTy for Option<Func> {
 
     #[inline]
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        Func::from_vm_func_ref(store, ptr.get_funcref().cast())
+        let ptr = NonNull::new(ptr.get_funcref())?.cast();
+        Some(Func::from_vm_func_ref(store, ptr))
     }
 }
 

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -974,14 +974,14 @@ impl Ref {
         match (self, ty.heap_type().top()) {
             (Ref::Func(None), HeapType::Func) => {
                 assert!(ty.is_nullable());
-                Ok(TableElement::FuncRef(ptr::null_mut()))
+                Ok(TableElement::FuncRef(None))
             }
             (Ref::Func(Some(f)), HeapType::Func) => {
                 debug_assert!(
                     f.comes_from_same_store(&store),
                     "checked in `ensure_matches_ty`"
                 );
-                Ok(TableElement::FuncRef(f.vm_func_ref(&mut store).as_ptr()))
+                Ok(TableElement::FuncRef(Some(f.vm_func_ref(&mut store))))
             }
 
             (Ref::Extern(e), HeapType::Extern) => match e {

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -44,7 +44,7 @@ impl<'a> ConstEvalContext<'a> {
 
     fn ref_func(&mut self, index: FuncIndex) -> Result<ValRaw> {
         Ok(ValRaw::funcref(
-            self.instance.get_func_ref(index).unwrap().cast(),
+            self.instance.get_func_ref(index).unwrap().as_ptr().cast(),
         ))
     }
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/arrayref.rs
@@ -172,10 +172,7 @@ impl VMArrayRef {
                         .func_ref_table
                         .get_untyped(func_ref_id);
                     Val::FuncRef(unsafe {
-                        Func::from_vm_func_ref(
-                            store,
-                            func_ref.map_or(core::ptr::null_mut(), |f| f.as_ptr()),
-                        )
+                        func_ref.map(|p| Func::from_vm_func_ref(store, p.as_non_null()))
                     })
                 }
                 otherwise => unreachable!("not a top type: {otherwise:?}"),

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
@@ -166,10 +166,7 @@ impl VMStructRef {
                         .func_ref_table
                         .get_untyped(func_ref_id);
                     Val::FuncRef(unsafe {
-                        Func::from_vm_func_ref(
-                            store,
-                            func_ref.map_or(core::ptr::null_mut(), |f| f.as_ptr()),
-                        )
+                        func_ref.map(|p| Func::from_vm_func_ref(store, p.as_non_null()))
                     })
                 }
                 otherwise => unreachable!("not a top type: {otherwise:?}"),

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -8,6 +8,7 @@ use crate::runtime::vm::table::Table;
 use crate::runtime::vm::{CompiledModuleId, ModuleRuntimeInfo, VMFuncRef, VMGcRef, VMStore};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::vm::VMGlobalDefinition;
+use core::ptr::NonNull;
 use core::{any::Any, mem, ptr};
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, HostPtr, InitMemory, MemoryInitialization,
@@ -594,7 +595,7 @@ fn initialize_tables(
                     }
 
                     WasmHeapTopType::Func => {
-                        let funcref = raw.get_funcref().cast::<VMFuncRef>();
+                        let funcref = NonNull::new(raw.get_funcref().cast::<VMFuncRef>());
                         let items = (0..table.size()).map(|_| funcref);
                         table.init_func(0, items).err2anyhow()?;
                     }


### PR DESCRIPTION
This commit switches to using `NonNull<VMFuncRef>` in more places instead of `*mut VMFuncRef`. A few minor locations benefitted from this by removing some otherwise extraneous checks but most places have been updated to mostly do the same as before. The goal of this commit is to make it more clear about what returns a nullable reference and what never returns a nullable reference. Additionally some constructors now unconditionally work with `NonNull<T>` instead of checking for null internally.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
