### PR TITLE
Move float-to-int conversion libcalls into compiled code

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -378,10 +378,6 @@ impl BuiltinFunctionSignatures {
         AbiParam::new(ir::types::I64)
     }
 
-    fn f64(&self) -> AbiParam {
-        AbiParam::new(ir::types::F64)
-    }
-
     fn u8(&self) -> AbiParam {
         AbiParam::new(ir::types::I8)
     }

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -198,16 +198,6 @@ macro_rules! foreach_builtin_function {
 
             // Raises an unconditional trap.
             trap(vmctx: vmctx, code: u8);
-
-            // Implementation of `i{32,64}.trunc_f{32,64}_{u,s}` when host trap
-            // handlers are disabled. These will raise a trap if necessary. Note
-            // that f32 inputs are always converted to f64 as the argument. Also
-            // note that the signed-ness of the result is not reflected in the
-            // type here.
-            f64_to_i64(vmctx: vmctx, float: f64) -> i64;
-            f64_to_u64(vmctx: vmctx, float: f64) -> i64;
-            f64_to_i32(vmctx: vmctx, float: f64) -> i32;
-            f64_to_u32(vmctx: vmctx, float: f64) -> i32;
         }
     };
 }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -60,7 +60,6 @@ use crate::runtime::vm::vmcontext::VMFuncRef;
 use crate::runtime::vm::{Instance, TrapReason, VMGcRef, VMStore};
 #[cfg(feature = "threads")]
 use core::time::Duration;
-use wasmtime_environ::Unsigned;
 use wasmtime_environ::{DataIndex, ElemIndex, FuncIndex, MemoryIndex, TableIndex, Trap};
 #[cfg(feature = "wmemcheck")]
 use wasmtime_wmemcheck::AccessError::{
@@ -141,7 +140,6 @@ pub mod raw {
 
         (@ty i32) => (u32);
         (@ty i64) => (u64);
-        (@ty f64) => (f64);
         (@ty u8) => (u8);
         (@ty reference) => (u32);
         (@ty pointer) => (*mut u8);
@@ -1244,70 +1242,6 @@ fn trap(_store: &mut dyn VMStore, _instance: &mut Instance, code: u8) -> Result<
     Err(TrapReason::Wasm(
         wasmtime_environ::Trap::from_u8(code).unwrap(),
     ))
-}
-
-fn f64_to_i64(
-    _store: &mut dyn VMStore,
-    _instance: &mut Instance,
-    val: f64,
-) -> Result<u64, TrapReason> {
-    if val.is_nan() {
-        return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
-    }
-    let val = relocs::truncf64(val);
-    if val <= -9223372036854777856.0 || val >= 9223372036854775808.0 {
-        return Err(TrapReason::Wasm(Trap::IntegerOverflow));
-    }
-    #[allow(clippy::cast_possible_truncation)]
-    return Ok((val as i64).unsigned());
-}
-
-fn f64_to_u64(
-    _store: &mut dyn VMStore,
-    _instance: &mut Instance,
-    val: f64,
-) -> Result<u64, TrapReason> {
-    if val.is_nan() {
-        return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
-    }
-    let val = relocs::truncf64(val);
-    if val <= -1.0 || val >= 18446744073709551616.0 {
-        return Err(TrapReason::Wasm(Trap::IntegerOverflow));
-    }
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    return Ok(val as u64);
-}
-
-fn f64_to_i32(
-    _store: &mut dyn VMStore,
-    _instance: &mut Instance,
-    val: f64,
-) -> Result<u32, TrapReason> {
-    if val.is_nan() {
-        return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
-    }
-    let val = relocs::truncf64(val);
-    if val <= -2147483649.0 || val >= 2147483648.0 {
-        return Err(TrapReason::Wasm(Trap::IntegerOverflow));
-    }
-    #[allow(clippy::cast_possible_truncation)]
-    return Ok((val as i32).unsigned());
-}
-
-fn f64_to_u32(
-    _store: &mut dyn VMStore,
-    _instance: &mut Instance,
-    val: f64,
-) -> Result<u32, TrapReason> {
-    if val.is_nan() {
-        return Err(TrapReason::Wasm(Trap::BadConversionToInteger));
-    }
-    let val = relocs::truncf64(val);
-    if val <= -1.0 || val >= 4294967296.0 {
-        return Err(TrapReason::Wasm(Trap::IntegerOverflow));
-    }
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    return Ok(val as u32);
 }
 
 /// This module contains functions which are used for resolving relocations at

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -796,7 +796,6 @@ macro_rules! define_builtin_array {
 
     (@ty i32) => (u32);
     (@ty i64) => (u64);
-    (@ty f64) => (f64);
     (@ty u8) => (u8);
     (@ty reference) => (u32);
     (@ty pointer) => (*mut u8);


### PR DESCRIPTION
This commit moves these conversion libcalls into compiled code to make them easier to work with on Pulley since there's no need to manage the hostcall boundary. This should in theory also speed things up slightly relative to actually calling out to the libcall itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
