### PR TITLE
[RFC] Move MemoryImageSource::map_at to mmap module

### DIFF
--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::{
     CompiledModuleId, GcHeapAllocationIndex, Imports, InstanceAllocationRequest, InstanceAllocator,
-    InstanceAllocatorImpl, Memory, MemoryAllocationIndex, ModuleRuntimeInfo,
+    InstanceAllocatorImpl, Memory, MemoryAllocationIndex, MemoryBase, ModuleRuntimeInfo,
     OnDemandInstanceAllocator, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, StorePtr,
     Table, TableAllocationIndex,
 };
@@ -89,8 +89,8 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
         self.mem.grow_to(new_size)
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        self.mem.as_ptr()
+    fn base(&self) -> MemoryBase<'_> {
+        MemoryBase::new_raw(self.mem.as_ptr())
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -64,7 +64,7 @@ pub use crate::runtime::vm::instance::{
     PoolingInstanceAllocatorConfig,
 };
 pub use crate::runtime::vm::memory::{
-    Memory, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory,
+    Memory, MemoryBase, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory,
 };
 pub use crate::runtime::vm::mmap_vec::MmapVec;
 pub use crate::runtime::vm::mpk::MpkEnabled;
@@ -97,7 +97,7 @@ mod mmap;
 cfg_if::cfg_if! {
     if #[cfg(feature = "signals-based-traps")] {
         pub use crate::runtime::vm::byte_count::*;
-        pub use crate::runtime::vm::mmap::Mmap;
+        pub use crate::runtime::vm::mmap::{Mmap, MmapOffset, MmapOffsetRaw};
         pub use self::cow::{MemoryImage, MemoryImageSlot, ModuleMemoryImages};
     } else {
         pub use self::cow_disabled::{MemoryImage, MemoryImageSlot, ModuleMemoryImages};

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -77,11 +77,11 @@
 use crate::prelude::*;
 use crate::runtime::vm::vmcontext::VMMemoryDefinition;
 #[cfg(feature = "signals-based-traps")]
-use crate::runtime::vm::HostAlignedByteCount;
+use crate::runtime::vm::{HostAlignedByteCount, MmapOffset};
 use crate::runtime::vm::{MemoryImage, MemoryImageSlot, VMStore, WaitResult};
 use alloc::sync::Arc;
-use core::ops::Range;
 use core::time::Duration;
+use core::{marker::PhantomData, ops::Range};
 use wasmtime_environ::{Trap, Tunables};
 
 #[cfg(feature = "signals-based-traps")]
@@ -160,7 +160,10 @@ pub trait RuntimeLinearMemory: Send + Sync {
     fn grow_to(&mut self, size: usize) -> Result<()>;
 
     /// Returns a pointer to the base of this linear memory allocation.
-    fn base_ptr(&self) -> *mut u8;
+    ///
+    /// This is either a raw pointer, or a reference to an mmap along with an
+    /// offset within it.
+    fn base<'a>(&'a self) -> MemoryBase<'a>;
 
     /// Internal method for Wasmtime when used in conjunction with CoW images.
     /// This is used to inform the underlying memory that the size of memory has
@@ -172,6 +175,42 @@ pub trait RuntimeLinearMemory: Send + Sync {
     fn set_byte_size(&mut self, len: usize) {
         let _ = len;
         panic!("CoW images used with this memory and it doesn't support it");
+    }
+}
+
+/// The base pointer of a memory allocation.
+#[derive(Clone, Copy, Debug)]
+pub enum MemoryBase<'a> {
+    /// A raw pointer into memory.
+    Raw {
+        ptr: *mut u8,
+        // If the signals-based-traps feature isn't enabled, we need to ensure
+        // that the lifetime param is referenced. 'a is covariant so &'a () is
+        // appropriate.
+        _phantom: PhantomData<&'a ()>,
+    },
+
+    /// An mmap along with an offset into it.
+    #[cfg(feature = "signals-based-traps")]
+    Mmap(MmapOffset<'a>),
+}
+
+impl<'a> MemoryBase<'a> {
+    /// Creates a new `MemoryBase` from a raw pointer.
+    pub fn new_raw(ptr: *mut u8) -> Self {
+        Self::Raw {
+            ptr,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Returns the actual memory address in memory that is represented by this base.
+    pub fn as_mut_ptr(&self) -> *mut u8 {
+        match self {
+            Self::Raw { ptr, .. } => *ptr,
+            #[cfg(feature = "signals-based-traps")]
+            Self::Mmap(mmap_offset) => mmap_offset.as_mut_ptr(),
+        }
     }
 }
 
@@ -488,16 +527,36 @@ impl LocalMemory {
                 // `RuntimeLinearMemory::byte_size` is not a multiple of the host page
                 // size. See https://github.com/bytecodealliance/wasmtime/issues/9660.
                 if let Ok(byte_size) = HostAlignedByteCount::new(alloc.byte_size()) {
-                    let mut slot = MemoryImageSlot::create(
-                        alloc.base_ptr().cast(),
-                        byte_size,
-                        alloc.byte_capacity(),
-                    );
-                    // On drop, we will unmap our mmap'd range that this slot was
-                    // mapped on top of, so there is no need for the slot to wipe
-                    // it with an anonymous mapping first.
+                    // memory_image is CoW-based so it is expected to be backed
+                    // by an mmap.
+                    let mmap_offset = match alloc.base() {
+                        MemoryBase::Mmap(offset) => offset,
+                        MemoryBase::Raw { .. } => {
+                            unreachable!("memory_image is Some only for mmap-based memories")
+                        }
+                    };
+
+                    let mut slot =
+                        MemoryImageSlot::create(mmap_offset, byte_size, alloc.byte_capacity());
+                    // On drop, we will unmap our mmap'd range that this slot
+                    // was mapped on top of, so there is no need for the slot to
+                    // wipe it with an anonymous mapping first.
+                    //
+                    // Note that this code would be incorrect if clear-on-drop
+                    // were enabled. That's because in the struct definition,
+                    // `memory_image` above is listed after `alloc`. Rust drops
+                    // fields in the order they're defined, so `memory_image`
+                    // would be dropped after `alloc`. If clear-on-drop were
+                    // enabled, `memory_image` would end up remapping a bunch of
+                    // memory after it was unmapped by the `alloc` drop.
                     slot.no_clear_on_drop();
-                    slot.instantiate(alloc.byte_size(), Some(image), ty, tunables)?;
+                    slot.instantiate(
+                        mmap_offset.mmap(),
+                        alloc.byte_size(),
+                        Some(image),
+                        ty,
+                        tunables,
+                    )?;
                     Some(slot)
                 } else {
                     None
@@ -569,7 +628,7 @@ impl LocalMemory {
 
         // Save the original base pointer to assert the invariant that growth up
         // to the byte capacity never relocates the base pointer.
-        let base_ptr_before = self.alloc.base_ptr();
+        let base_ptr_before = self.alloc.base().as_mut_ptr();
         let required_to_not_move_memory = new_byte_size <= self.alloc.byte_capacity();
 
         let result = (|| -> Result<()> {
@@ -618,7 +677,7 @@ impl LocalMemory {
                 // On successful growth double-check that the base pointer
                 // didn't move if it shouldn't have.
                 if required_to_not_move_memory {
-                    assert_eq!(base_ptr_before, self.alloc.base_ptr());
+                    assert_eq!(base_ptr_before, self.alloc.base().as_mut_ptr());
                 }
 
                 Ok(Some((old_byte_size, new_byte_size)))
@@ -638,7 +697,7 @@ impl LocalMemory {
 
     pub fn vmmemory(&mut self) -> VMMemoryDefinition {
         VMMemoryDefinition {
-            base: self.alloc.base_ptr(),
+            base: self.alloc.base().as_mut_ptr(),
             current_length: self.alloc.byte_size().into(),
         }
     }
@@ -655,7 +714,7 @@ impl LocalMemory {
     }
 
     pub fn wasm_accessible(&self) -> Range<usize> {
-        let base = self.alloc.base_ptr() as usize;
+        let base = self.alloc.base().as_mut_ptr() as usize;
         // From the base add:
         //
         // * max(capacity, reservation) -- all memory is guaranteed to have at

--- a/crates/wasmtime/src/runtime/vm/memory/malloc.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/malloc.rs
@@ -5,7 +5,7 @@
 //! handle memory allocation failures.
 
 use crate::prelude::*;
-use crate::runtime::vm::memory::RuntimeLinearMemory;
+use crate::runtime::vm::memory::{MemoryBase, RuntimeLinearMemory};
 use crate::runtime::vm::SendSyncPtr;
 use core::mem;
 use core::ptr::NonNull;
@@ -86,8 +86,8 @@ impl RuntimeLinearMemory for MallocMemory {
         Ok(())
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        self.base_ptr.as_ptr()
+    fn base(&self) -> MemoryBase<'_> {
+        MemoryBase::new_raw(self.base_ptr.as_ptr())
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/memory/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/mmap.rs
@@ -6,6 +6,8 @@ use crate::runtime::vm::memory::RuntimeLinearMemory;
 use crate::runtime::vm::{mmap::AlignedLength, HostAlignedByteCount, Mmap};
 use wasmtime_environ::Tunables;
 
+use super::MemoryBase;
+
 /// A linear memory instance.
 #[derive(Debug)]
 pub struct MmapMemory {
@@ -217,7 +219,11 @@ impl RuntimeLinearMemory for MmapMemory {
         self.len = len;
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        unsafe { self.mmap.as_mut_ptr().add(self.pre_guard_size.byte_count()) }
+    fn base(&self) -> MemoryBase<'_> {
+        MemoryBase::Mmap(
+            self.mmap
+                .offset(self.pre_guard_size)
+                .expect("pre_guard_size is in bounds"),
+        )
     }
 }

--- a/crates/wasmtime/src/runtime/vm/memory/static_.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/static_.rs
@@ -3,7 +3,7 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::memory::RuntimeLinearMemory;
-use crate::runtime::vm::SendSyncPtr;
+use crate::runtime::vm::{MemoryBase, SendSyncPtr};
 use core::ptr::NonNull;
 
 /// A "static" memory where the lifetime of the backing memory is managed
@@ -73,7 +73,14 @@ impl RuntimeLinearMemory for StaticMemory {
         self.size = len;
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        self.base.as_ptr()
+    fn base(&self) -> MemoryBase<'_> {
+        // XXX: Returning a raw pointer isn't quite right. A `StaticMemory` is
+        // usually created via a pre-existing `Mmap` instance, but we lose that
+        // info since we store a raw pointer above. However, retaining that info
+        // is tricky because it would introduce a lifetime param into
+        // `StaticMemory`.
+        //
+        // One solution would be to store `Arc<Mmap>`.
+        MemoryBase::new_raw(self.base.as_ptr())
     }
 }

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -223,13 +223,13 @@ impl<T> Mmap<T> {
     /// Return the allocated memory as a pointer to u8.
     #[inline]
     pub fn as_ptr(&self) -> *const u8 {
-        self.sys.as_ptr()
+        self.sys.as_ptr().as_ptr() as *const u8
     }
 
     /// Return the allocated memory as a mutable pointer to u8.
     #[inline]
     pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.sys.as_mut_ptr()
+        self.sys.as_ptr().as_ptr()
     }
 
     /// Return the length of the allocated memory.

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -69,13 +69,8 @@ impl Mmap {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    #[inline]
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.memory.as_ptr().cast()
+    pub fn as_ptr(&self) -> SendSyncPtr<u8> {
+        self.memory.cast()
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -1,6 +1,6 @@
 use super::cvt;
 use crate::prelude::*;
-use crate::runtime::vm::sys::capi;
+use crate::runtime::vm::sys::{capi, vm::MemoryImageSource};
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use core::ops::Range;
 use core::ptr::{self, NonNull};
@@ -103,6 +103,26 @@ impl Mmap {
 
         cvt(capi::wasmtime_mprotect(base, len, capi::PROT_READ))?;
         Ok(())
+    }
+
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        source_offset: u64,
+        memory_offset: HostAlignedByteCount,
+        memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        assert_eq!(source_offset, 0);
+        let base = self
+            .memory
+            .as_ptr()
+            .byte_add(memory_offset.byte_count())
+            .cast();
+        cvt(capi::wasmtime_memory_image_map_at(
+            image_source.image_ptr().as_ptr(),
+            base,
+            memory_len.byte_count(),
+        ))
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
@@ -79,13 +79,9 @@ impl MemoryImageSource {
         }
     }
 
-    pub unsafe fn map_at(&self, base: *mut u8, len: usize, offset: u64) -> Result<()> {
-        assert_eq!(offset, 0);
-        cvt(capi::wasmtime_memory_image_map_at(
-            self.data.as_ptr(),
-            base,
-            len,
-        ))
+    #[inline]
+    pub(super) fn image_ptr(&self) -> SendSyncPtr<capi::wasmtime_memory_image> {
+        self.data
     }
 
     pub unsafe fn remap_as_zeros_at(&self, base: *mut u8, len: usize) -> Result<()> {

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -6,6 +6,7 @@
 //! but it's enough to get various tests running relying on memories and such.
 
 use crate::prelude::*;
+use crate::runtime::vm::sys::vm::MemoryImageSource;
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use std::alloc::{self, Layout};
 use std::fs::File;
@@ -90,6 +91,16 @@ impl Mmap {
 
     pub unsafe fn make_readonly(&self, _range: Range<usize>) -> Result<()> {
         Ok(())
+    }
+
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        _source_offset: u64,
+        _memory_offset: HostAlignedByteCount,
+        _memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        match *image_source {}
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -71,12 +71,9 @@ impl Mmap {
         Ok(())
     }
 
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.memory.as_ptr().cast()
+    #[inline]
+    pub fn as_ptr(&self) -> SendSyncPtr<u8> {
+        self.memory.cast()
     }
 
     pub fn len(&self) -> usize {

--- a/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
@@ -1,3 +1,4 @@
+use crate::runtime::vm::{HostAlignedByteCount, MmapOffset};
 use crate::vm::sys::DecommitBehavior;
 use std::fs::File;
 use std::io;
@@ -47,10 +48,6 @@ impl MemoryImageSource {
 
     pub fn from_data(_data: &[u8]) -> io::Result<Option<MemoryImageSource>> {
         Ok(None)
-    }
-
-    pub unsafe fn map_at(&self, _base: *mut u8, _len: usize, _offset: u64) -> io::Result<()> {
-        match *self {}
     }
 
     pub unsafe fn remap_as_zeros_at(&self, _base: *mut u8, _len: usize) -> io::Result<()> {

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -128,13 +128,8 @@ impl Mmap {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    #[inline]
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.memory.as_ptr().cast()
+    pub fn as_ptr(&self) -> SendSyncPtr<u8> {
+        self.memory.cast()
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::runtime::vm::sys::vm::MemoryImageSource;
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -206,6 +207,16 @@ impl Mmap {
             bail!(io::Error::last_os_error());
         }
         Ok(())
+    }
+
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        _source_offset: u64,
+        _memory_offset: HostAlignedByteCount,
+        _memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        match *image_source {}
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -168,13 +168,8 @@ impl Mmap {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    #[inline]
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.memory.as_ptr().cast()
+    pub fn as_ptr(&self) -> SendSyncPtr<u8> {
+        self.memory.cast()
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
@@ -65,10 +65,6 @@ impl MemoryImageSource {
         Ok(None)
     }
 
-    pub unsafe fn map_at(&self, _base: *mut u8, _len: usize, _offset: u64) -> io::Result<()> {
-        match *self {}
-    }
-
     pub unsafe fn remap_as_zeros_at(&self, _base: *mut u8, _len: usize) -> io::Result<()> {
         match *self {}
     }


### PR DESCRIPTION
This is part of the work to centralize memory management into the `mmap`
module. This commit introduces a few structures which aid in that process, and
starts converting one of the functions (`MemoryImageSource::map_at`) into this
module.

The structures introduced are:

* `MemoryBase`: `RuntimeLinearMemory::base_ptr` is now
  `RuntimeLinearMemory::base`, which returns a `MemoryBase`. This is either a
  raw pointer or an mmap + an offset into it.

* `MmapOffset`: A combination of a reference to an mmap and an offset into it.
  Logically represents a pointer into a mapped section of memory.

* `MmapOffsetRaw`: Some components like `MemoryImageSlot` logically work on
  borrowed memory, but adding lifetime parameters to them would introduce
  self-reference issues. Instead, store a raw form of the `MmapOffset` such
  that it can be reconstructed at runtime. This should work for most future
  work here, but not all of it -- I've written out some comments along with
  ideas.

On Zulip there was a suggestion to use `Arc<Mmap>` rather than a lifetime
parameter. To be honest it's quite appealing! One of the challenges though
is that `Mmap` has several `&mut` methods. The methods fall into two categories:

* Methods like [`make_accessible`](https://github.com/bytecodealliance/wasmtime/blob/0e3e863a57cd28e1ce9be628fd0d8df192077305/crates/wasmtime/src/runtime/vm/mmap.rs#L139), which can be changed to be `&self` since the OS performs synchronization of mapped memory.
* Methods like `slice_mut`, which are quite difficult to turn into `&self` methods. It would be too easy to call `self.slice_mut(0..host_page_size()); self.slice_mut(0..host_page_size());` and cause an insta-UB. I spent some time looking at how to do this but found it too difficult :(