### PR TITLE
Put MemoryPool and MmapMemory mmaps behind Arc

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -65,7 +65,7 @@ use crate::{
 };
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use wasmtime_environ::{DefinedMemoryIndex, Module, Tunables};
 
 /// A set of allocator slots.
@@ -104,7 +104,7 @@ struct Stripe {
 /// ```
 #[derive(Debug)]
 pub struct MemoryPool {
-    mapping: Mmap<AlignedLength>,
+    mapping: Arc<Mmap<AlignedLength>>,
     /// This memory pool is stripe-aware. If using  memory protection keys, this
     /// will contain one stripe per available key; otherwise, a single stripe
     /// with an empty key.
@@ -244,7 +244,7 @@ impl MemoryPool {
 
         let pool = Self {
             stripes,
-            mapping,
+            mapping: Arc::new(mapping),
             image_slots,
             layout,
             memories_per_instance: usize::try_from(config.limits.max_memories_per_module).unwrap(),

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -51,8 +51,8 @@ impl Mmap {
         anyhow::bail!("not supported on this platform");
     }
 
-    pub fn make_accessible(
-        &mut self,
+    pub unsafe fn make_accessible(
+        &self,
         start: HostAlignedByteCount,
         len: HostAlignedByteCount,
     ) -> Result<()> {

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -30,8 +30,11 @@ impl Mmap {
     }
 
     pub fn new(size: HostAlignedByteCount) -> Result<Self> {
-        let mut ret = Mmap::reserve(size)?;
-        ret.make_accessible(HostAlignedByteCount::ZERO, size)?;
+        let ret = Mmap::reserve(size)?;
+        // SAFETY: The memory was just created so no one else has access to it.
+        unsafe {
+            ret.make_accessible(HostAlignedByteCount::ZERO, size)?;
+        }
         Ok(ret)
     }
 
@@ -54,8 +57,8 @@ impl Mmap {
         bail!("not supported on miri");
     }
 
-    pub fn make_accessible(
-        &mut self,
+    pub unsafe fn make_accessible(
+        &self,
         start: HostAlignedByteCount,
         len: HostAlignedByteCount,
     ) -> Result<()> {

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -109,8 +109,8 @@ impl Mmap {
         Ok(Mmap { memory })
     }
 
-    pub fn make_accessible(
-        &mut self,
+    pub unsafe fn make_accessible(
+        &self,
         start: HostAlignedByteCount,
         len: HostAlignedByteCount,
     ) -> Result<()> {

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -146,8 +146,8 @@ impl Mmap {
         }
     }
 
-    pub fn make_accessible(
-        &mut self,
+    pub unsafe fn make_accessible(
+        &self,
         start: HostAlignedByteCount,
         len: HostAlignedByteCount,
     ) -> Result<()> {


### PR DESCRIPTION
In upcoming work we're going to centralize memory management inside `Mmap`.  In order to do that, we need memory that logically borrows from the `Mmap` to have access to it. That turns out to be possible to do by passing in `&Mmap` in some situations but very difficult in others (see #9681 for an attempt that was a real hassle to get working and still had a bunch of incomplete questions within it).

To prepare for this work, start moving these uses to be behind `Arc`. These aren't cloned at the moment, but they will be in the future.
