### PR TITLE
Move MemoryImageSource::map_at to mmap module

### DIFF
--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::{
     CompiledModuleId, GcHeapAllocationIndex, Imports, InstanceAllocationRequest, InstanceAllocator,
-    InstanceAllocatorImpl, Memory, MemoryAllocationIndex, ModuleRuntimeInfo,
+    InstanceAllocatorImpl, Memory, MemoryAllocationIndex, MemoryBase, ModuleRuntimeInfo,
     OnDemandInstanceAllocator, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, StorePtr,
     Table, TableAllocationIndex,
 };
@@ -89,8 +89,8 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
         self.mem.grow_to(new_size)
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        self.mem.as_ptr()
+    fn base(&self) -> MemoryBase {
+        MemoryBase::new_raw(self.mem.as_ptr())
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -73,7 +73,7 @@ pub use crate::runtime::vm::instance::{
 };
 pub use crate::runtime::vm::interpreter::*;
 pub use crate::runtime::vm::memory::{
-    Memory, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory,
+    Memory, MemoryBase, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory,
 };
 pub use crate::runtime::vm::mmap_vec::MmapVec;
 pub use crate::runtime::vm::mpk::MpkEnabled;
@@ -107,7 +107,7 @@ mod mmap;
 cfg_if::cfg_if! {
     if #[cfg(feature = "signals-based-traps")] {
         pub use crate::runtime::vm::byte_count::*;
-        pub use crate::runtime::vm::mmap::Mmap;
+        pub use crate::runtime::vm::mmap::{Mmap, MmapOffset};
         pub use self::cow::{MemoryImage, MemoryImageSlot, ModuleMemoryImages};
     } else {
         pub use self::cow_disabled::{MemoryImage, MemoryImageSlot, ModuleMemoryImages};

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -57,13 +57,12 @@ use super::{
 use crate::prelude::*;
 use crate::runtime::vm::{
     mmap::AlignedLength, CompiledModuleId, InstanceAllocationRequest, InstanceLimits, Memory,
-    MemoryImageSlot, Mmap, MpkEnabled, PoolingInstanceAllocatorConfig,
+    MemoryBase, MemoryImageSlot, Mmap, MmapOffset, MpkEnabled, PoolingInstanceAllocatorConfig,
 };
 use crate::{
     runtime::vm::mpk::{self, ProtectionKey, ProtectionMask},
     vm::HostAlignedByteCount,
 };
-use std::ffi::c_void;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use wasmtime_environ::{DefinedMemoryIndex, Module, Tunables};
@@ -357,7 +356,7 @@ impl MemoryPool {
                     <= u64::try_from(self.layout.bytes_to_next_stripe_slot().byte_count()).unwrap()
             );
 
-            let base_ptr = self.get_base(allocation_index);
+            let base = self.get_base(allocation_index);
             let base_capacity = self.layout.max_memory_bytes;
 
             let mut slot = self.take_memory_image_slot(allocation_index);
@@ -385,7 +384,7 @@ impl MemoryPool {
             Memory::new_static(
                 ty,
                 tunables,
-                base_ptr,
+                MemoryBase::Mmap(base),
                 base_capacity.byte_count(),
                 slot,
                 unsafe { &mut *request.store.get().unwrap() },
@@ -471,7 +470,7 @@ impl MemoryPool {
         }
     }
 
-    fn get_base(&self, allocation_index: MemoryAllocationIndex) -> *mut u8 {
+    fn get_base(&self, allocation_index: MemoryAllocationIndex) -> MmapOffset {
         assert!(allocation_index.index() < self.layout.num_slots);
         let offset = self
             .layout
@@ -479,12 +478,7 @@ impl MemoryPool {
             .checked_mul(allocation_index.index())
             .and_then(|c| c.checked_add(self.layout.pre_slab_guard_bytes))
             .expect("slot_bytes * index + pre_slab_guard_bytes overflows");
-        unsafe {
-            self.mapping
-                .as_ptr()
-                .offset(offset.byte_count() as isize)
-                .cast_mut()
-        }
+        self.mapping.offset(offset).expect("offset is in bounds")
     }
 
     /// Take ownership of the given image slot. Must be returned via
@@ -497,7 +491,7 @@ impl MemoryPool {
 
         maybe_slot.unwrap_or_else(|| {
             MemoryImageSlot::create(
-                self.get_base(allocation_index) as *mut c_void,
+                self.get_base(allocation_index),
                 HostAlignedByteCount::ZERO,
                 self.layout.max_memory_bytes.byte_count(),
             )
@@ -822,7 +816,7 @@ mod tests {
 
         for i in 0..5 {
             let index = MemoryAllocationIndex(i);
-            let ptr = pool.get_base(index);
+            let ptr = pool.get_base(index).as_mut_ptr();
             assert_eq!(
                 ptr as usize - base,
                 i as usize * pool.layout.slot_bytes.byte_count()

--- a/crates/wasmtime/src/runtime/vm/memory/malloc.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/malloc.rs
@@ -5,7 +5,7 @@
 //! handle memory allocation failures.
 
 use crate::prelude::*;
-use crate::runtime::vm::memory::RuntimeLinearMemory;
+use crate::runtime::vm::memory::{MemoryBase, RuntimeLinearMemory};
 use crate::runtime::vm::SendSyncPtr;
 use core::mem;
 use core::ptr::NonNull;
@@ -80,8 +80,8 @@ impl RuntimeLinearMemory for MallocMemory {
         Ok(())
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        self.base_ptr.as_ptr()
+    fn base(&self) -> MemoryBase {
+        MemoryBase::Raw(self.base_ptr)
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/memory/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/mmap.rs
@@ -7,6 +7,8 @@ use crate::runtime::vm::{mmap::AlignedLength, HostAlignedByteCount, Mmap};
 use alloc::sync::Arc;
 use wasmtime_environ::Tunables;
 
+use super::MemoryBase;
+
 /// A linear memory instance.
 #[derive(Debug)]
 pub struct MmapMemory {
@@ -223,7 +225,11 @@ impl RuntimeLinearMemory for MmapMemory {
         self.len = len;
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        unsafe { self.mmap.as_mut_ptr().add(self.pre_guard_size.byte_count()) }
+    fn base(&self) -> MemoryBase {
+        MemoryBase::Mmap(
+            self.mmap
+                .offset(self.pre_guard_size)
+                .expect("pre_guard_size is in bounds"),
+        )
     }
 }

--- a/crates/wasmtime/src/runtime/vm/memory/static_.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/static_.rs
@@ -3,15 +3,14 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::memory::RuntimeLinearMemory;
-use crate::runtime::vm::SendSyncPtr;
-use core::ptr::NonNull;
+use crate::runtime::vm::MemoryBase;
 
 /// A "static" memory where the lifetime of the backing memory is managed
 /// elsewhere. Currently used with the pooling allocator.
 pub struct StaticMemory {
     /// The base pointer of this static memory, wrapped up in a send/sync
     /// wrapper.
-    base: SendSyncPtr<u8>,
+    base: MemoryBase,
 
     /// The byte capacity of the `base` pointer.
     capacity: usize,
@@ -22,7 +21,7 @@ pub struct StaticMemory {
 
 impl StaticMemory {
     pub fn new(
-        base_ptr: *mut u8,
+        base: MemoryBase,
         base_capacity: usize,
         initial_size: usize,
         maximum_size: Option<usize>,
@@ -43,7 +42,7 @@ impl StaticMemory {
         };
 
         Ok(Self {
-            base: SendSyncPtr::new(NonNull::new(base_ptr).unwrap()),
+            base,
             capacity: base_capacity,
             size: initial_size,
         })
@@ -73,7 +72,7 @@ impl RuntimeLinearMemory for StaticMemory {
         self.size = len;
     }
 
-    fn base_ptr(&self) -> *mut u8 {
-        self.base.as_ptr()
+    fn base(&self) -> MemoryBase {
+        self.base.clone()
     }
 }

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -231,13 +231,13 @@ impl<T> Mmap<T> {
     /// Return the allocated memory as a pointer to u8.
     #[inline]
     pub fn as_ptr(&self) -> *const u8 {
-        self.sys.as_ptr()
+        self.sys.as_send_sync_ptr().as_ptr() as *const u8
     }
 
     /// Return the allocated memory as a mutable pointer to u8.
     #[inline]
     pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.sys.as_mut_ptr()
+        self.sys.as_send_sync_ptr().as_ptr()
     }
 
     /// Return the length of the allocated memory.

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -3,10 +3,11 @@
 
 use super::HostAlignedByteCount;
 use crate::prelude::*;
-use crate::runtime::vm::sys::mmap;
+use crate::runtime::vm::sys::{mmap, vm::MemoryImageSource};
+use alloc::sync::Arc;
 use core::ops::Range;
 #[cfg(feature = "std")]
-use std::{fs::File, sync::Arc};
+use std::fs::File;
 
 /// A marker type for an [`Mmap`] where both the start address and length are a
 /// multiple of the host page size.
@@ -130,6 +131,26 @@ impl Mmap<AlignedLength> {
     pub fn len_aligned(&self) -> HostAlignedByteCount {
         // SAFETY: The type parameter indicates that self.sys.len() is aligned.
         unsafe { HostAlignedByteCount::new_unchecked(self.sys.len()) }
+    }
+
+    /// Return a struct representing a page-aligned offset into the mmap.
+    ///
+    /// Returns an error if `offset >= self.len_aligned()`.
+    pub fn offset(self: &Arc<Self>, offset: HostAlignedByteCount) -> Result<MmapOffset> {
+        if offset >= self.len_aligned() {
+            bail!(
+                "offset {} is not in bounds for mmap: {}",
+                offset,
+                self.len_aligned()
+            );
+        }
+
+        Ok(MmapOffset::new(self.clone(), offset))
+    }
+
+    /// Return an `MmapOffset` corresponding to zero bytes into the mmap.
+    pub fn zero_offset(self: &Arc<Self>) -> MmapOffset {
+        MmapOffset::new(self.clone(), HostAlignedByteCount::ZERO)
     }
 
     /// Make the memory starting at `start` and extending for `len` bytes
@@ -321,6 +342,76 @@ fn _assert() {
 impl From<Mmap<AlignedLength>> for Mmap<UnalignedLength> {
     fn from(mmap: Mmap<AlignedLength>) -> Mmap<UnalignedLength> {
         mmap.into_unaligned()
+    }
+}
+
+/// A reference to an [`Mmap`], along with a host-page-aligned index within it.
+///
+/// The main invariant this type asserts is that the index is in bounds within
+/// the `Mmap` (i.e. `self.mmap[self.offset]` is valid). In the future, this
+/// type may also assert other invariants.
+#[derive(Clone, Debug)]
+pub struct MmapOffset {
+    mmap: Arc<Mmap<AlignedLength>>,
+    offset: HostAlignedByteCount,
+}
+
+impl MmapOffset {
+    #[inline]
+    fn new(mmap: Arc<Mmap<AlignedLength>>, offset: HostAlignedByteCount) -> Self {
+        // Note < rather than <=. This currently cannot represent the logical
+        // end of the mmap. We may need to change this if that becomes
+        // necessary.
+        assert!(
+            offset < mmap.len_aligned(),
+            "offset {} is in bounds (< {})",
+            offset,
+            mmap.len_aligned(),
+        );
+        Self { mmap, offset }
+    }
+
+    /// Returns the mmap this offset is within.
+    #[inline]
+    pub fn mmap(&self) -> &Arc<Mmap<AlignedLength>> {
+        &self.mmap
+    }
+
+    /// Returns the host-page-aligned offset within the mmap.
+    #[inline]
+    pub fn offset(&self) -> HostAlignedByteCount {
+        self.offset
+    }
+
+    /// Returns the raw pointer in memory represented by this offset.
+    #[inline]
+    pub fn as_mut_ptr(&self) -> *mut u8 {
+        // SAFETY: constructor checks that offset is within this allocation.
+        unsafe { self.mmap().as_mut_ptr().byte_add(self.offset.byte_count()) }
+    }
+
+    /// Maps an image into the mmap with read/write permissions.
+    ///
+    /// The image is mapped at `self.mmap.as_ptr() + self.offset +
+    /// memory_offset`.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that noone else has a reference to this memory.
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        source_offset: u64,
+        memory_offset: HostAlignedByteCount,
+        memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        let total_offset = self
+            .offset
+            .checked_add(memory_offset)
+            .expect("self.offset + memory_offset is in bounds");
+        self.mmap
+            .sys
+            .map_image_at(image_source, source_offset, total_offset, memory_len)
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -69,13 +69,8 @@ impl Mmap {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    #[inline]
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.memory.as_ptr().cast()
+    pub fn as_send_sync_ptr(&self) -> SendSyncPtr<u8> {
+        self.memory.cast()
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mmap.rs
@@ -1,6 +1,6 @@
 use super::cvt;
 use crate::prelude::*;
-use crate::runtime::vm::sys::capi;
+use crate::runtime::vm::sys::{capi, vm::MemoryImageSource};
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use core::ops::Range;
 use core::ptr::{self, NonNull};
@@ -103,6 +103,26 @@ impl Mmap {
 
         cvt(capi::wasmtime_mprotect(base, len, capi::PROT_READ))?;
         Ok(())
+    }
+
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        source_offset: u64,
+        memory_offset: HostAlignedByteCount,
+        memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        assert_eq!(source_offset, 0);
+        let base = self
+            .memory
+            .as_ptr()
+            .byte_add(memory_offset.byte_count())
+            .cast();
+        cvt(capi::wasmtime_memory_image_map_at(
+            image_source.image_ptr().as_ptr(),
+            base,
+            memory_len.byte_count(),
+        ))
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
@@ -79,13 +79,9 @@ impl MemoryImageSource {
         }
     }
 
-    pub unsafe fn map_at(&self, base: *mut u8, len: usize, offset: u64) -> Result<()> {
-        assert_eq!(offset, 0);
-        cvt(capi::wasmtime_memory_image_map_at(
-            self.data.as_ptr(),
-            base,
-            len,
-        ))
+    #[inline]
+    pub(super) fn image_ptr(&self) -> SendSyncPtr<capi::wasmtime_memory_image> {
+        self.data
     }
 
     pub unsafe fn remap_as_zeros_at(&self, base: *mut u8, len: usize) -> Result<()> {

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -66,7 +66,7 @@ impl Mmap {
         // initialized for miri-level checking.
         unsafe {
             std::ptr::write_bytes(
-                self.as_mut_ptr().add(start.byte_count()),
+                self.as_send_sync_ptr().as_ptr().add(start.byte_count()),
                 0u8,
                 len.byte_count(),
             );
@@ -74,12 +74,9 @@ impl Mmap {
         Ok(())
     }
 
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.memory.as_ptr().cast()
+    #[inline]
+    pub fn as_send_sync_ptr(&self) -> SendSyncPtr<u8> {
+        self.memory.cast()
     }
 
     pub fn len(&self) -> usize {
@@ -106,7 +103,7 @@ impl Drop for Mmap {
         }
         unsafe {
             let layout = make_layout(self.len());
-            alloc::dealloc(self.as_mut_ptr(), layout);
+            alloc::dealloc(self.as_send_sync_ptr().as_ptr(), layout);
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -6,6 +6,7 @@
 //! but it's enough to get various tests running relying on memories and such.
 
 use crate::prelude::*;
+use crate::runtime::vm::sys::vm::MemoryImageSource;
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use std::alloc::{self, Layout};
 use std::fs::File;
@@ -93,6 +94,16 @@ impl Mmap {
 
     pub unsafe fn make_readonly(&self, _range: Range<usize>) -> Result<()> {
         Ok(())
+    }
+
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        _source_offset: u64,
+        _memory_offset: HostAlignedByteCount,
+        _memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        match *image_source {}
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
@@ -49,10 +49,6 @@ impl MemoryImageSource {
         Ok(None)
     }
 
-    pub unsafe fn map_at(&self, _base: *mut u8, _len: usize, _offset: u64) -> io::Result<()> {
-        match *self {}
-    }
-
     pub unsafe fn remap_as_zeros_at(&self, _base: *mut u8, _len: usize) -> io::Result<()> {
         match *self {}
     }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::runtime::vm::sys::vm::MemoryImageSource;
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use rustix::mm::{mprotect, MprotectFlags};
 use std::ops::Range;
@@ -169,6 +170,28 @@ impl Mmap {
 
         mprotect(base, len, MprotectFlags::READ)?;
 
+        Ok(())
+    }
+
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        source_offset: u64,
+        memory_offset: HostAlignedByteCount,
+        memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        unsafe {
+            let map_base = self.memory.as_ptr().byte_add(memory_offset.byte_count());
+            let ptr = rustix::mm::mmap(
+                map_base.cast(),
+                memory_len.byte_count(),
+                rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
+                rustix::mm::MapFlags::PRIVATE | rustix::mm::MapFlags::FIXED,
+                image_source.as_file(),
+                source_offset,
+            )?;
+            assert_eq!(map_base.cast(), ptr);
+        };
         Ok(())
     }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -123,13 +123,8 @@ impl Mmap {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        self.memory.as_ptr() as *const u8
-    }
-
-    #[inline]
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.memory.as_ptr().cast()
+    pub fn as_send_sync_ptr(&self) -> SendSyncPtr<u8> {
+        self.memory.cast()
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
@@ -1,6 +1,6 @@
 use crate::runtime::vm::sys::DecommitBehavior;
 use rustix::fd::AsRawFd;
-use rustix::mm::{mmap, mmap_anonymous, mprotect, MapFlags, MprotectFlags, ProtFlags};
+use rustix::mm::{mmap_anonymous, mprotect, MapFlags, MprotectFlags, ProtFlags};
 use std::fs::File;
 use std::io;
 #[cfg(feature = "std")]
@@ -146,26 +146,13 @@ impl MemoryImageSource {
         Ok(Some(MemoryImageSource::Memfd(memfd)))
     }
 
-    fn as_file(&self) -> &File {
+    pub(super) fn as_file(&self) -> &File {
         match *self {
             #[cfg(feature = "std")]
             MemoryImageSource::Mmap(ref file) => file,
             #[cfg(target_os = "linux")]
             MemoryImageSource::Memfd(ref memfd) => memfd.as_file(),
         }
-    }
-
-    pub unsafe fn map_at(&self, base: *mut u8, len: usize, offset: u64) -> io::Result<()> {
-        let ptr = mmap(
-            base.cast(),
-            len,
-            ProtFlags::READ | ProtFlags::WRITE,
-            MapFlags::PRIVATE | MapFlags::FIXED,
-            self.as_file(),
-            offset,
-        )?;
-        assert_eq!(base, ptr.cast());
-        Ok(())
     }
 
     pub unsafe fn remap_as_zeros_at(&self, base: *mut u8, len: usize) -> io::Result<()> {

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::runtime::vm::sys::vm::MemoryImageSource;
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -211,6 +212,16 @@ impl Mmap {
             bail!(io::Error::last_os_error());
         }
         Ok(())
+    }
+
+    pub unsafe fn map_image_at(
+        &self,
+        image_source: &MemoryImageSource,
+        _source_offset: u64,
+        _memory_offset: HostAlignedByteCount,
+        _memory_len: HostAlignedByteCount,
+    ) -> Result<()> {
+        match *image_source {}
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
@@ -65,10 +65,6 @@ impl MemoryImageSource {
         Ok(None)
     }
 
-    pub unsafe fn map_at(&self, _base: *mut u8, _len: usize, _offset: u64) -> io::Result<()> {
-        match *self {}
-    }
-
     pub unsafe fn remap_as_zeros_at(&self, _base: *mut u8, _len: usize) -> io::Result<()> {
         match *self {}
     }


### PR DESCRIPTION
This is part of the work to centralize memory management into the `mmap`
module. This commit introduces a few structures which aid in that process, and
starts converting one of the functions (`MemoryImageSource::map_at`) into this
module.

The structures introduced are:

* `MemoryBase`: `RuntimeLinearMemory::base_ptr` is now
  `RuntimeLinearMemory::base`, which returns a `MemoryBase`. This is either a
  raw pointer or an `MmapOffset` as described below.

* `MmapOffset`: A combination of a reference to an mmap and an offset into it.
  Logically represents a pointer into a mapped section of memory.

In future work, we'll move more image-mapping code over to `Mmap` instances.