### PR TITLE
Update MSRV to 1.81.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -28,7 +28,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2024-10-22" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2024-11-28" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.80.0"
+rust-version = "1.81.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -52,7 +52,6 @@ pub mod bindings {
     wit_bindgen_rust_macro::generate!({
         path: "../wasi/wit",
         world: "wasi:cli/command",
-        std_feature,
         raw_strings,
         runtime_path: "crate::bindings::wit_bindgen_rt_shim",
         // Automatically generated bindings for these functions will allocate
@@ -70,7 +69,6 @@ pub mod bindings {
     wit_bindgen_rust_macro::generate!({
         path: "../wasi/wit",
         world: "wasi:cli/imports",
-        std_feature,
         raw_strings,
         runtime_path: "crate::bindings::wit_bindgen_rt_shim",
         // Automatically generated bindings for these functions will allocate
@@ -100,7 +98,6 @@ pub mod bindings {
             }
         "#,
         world: "wasmtime:adapter/adapter",
-        std_feature,
         raw_strings,
         runtime_path: "crate::bindings::wit_bindgen_rt_shim",
         skip: ["poll"],

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -216,6 +216,7 @@ component-model = [
 wmemcheck = [
   "dep:wasmtime-wmemcheck",
   "wasmtime-cranelift?/wmemcheck",
+  "wasmtime-winch?/wmemcheck",
   "wasmtime-environ/wmemcheck",
   "std",
 ]
@@ -270,18 +271,30 @@ runtime = [
 gc = [
   "wasmtime-environ/gc",
   "wasmtime-cranelift?/gc",
+  "wasmtime-winch?/gc",
   "signals-based-traps",    # not ported to non-mmap schemes yet
 ]
 
 # Enable the deferred reference counting garbage collector.
-gc-drc = ["gc", "wasmtime-environ/gc-drc", "wasmtime-cranelift?/gc-drc"]
+gc-drc = [
+  "gc",
+  "wasmtime-environ/gc-drc",
+  "wasmtime-cranelift?/gc-drc",
+  "wasmtime-winch?/gc-drc",
+]
 
 # Enable the null garbage collector.
-gc-null = ["gc", "wasmtime-environ/gc-null", "wasmtime-cranelift?/gc-null"]
+gc-null = [
+  "gc",
+  "wasmtime-environ/gc-null",
+  "wasmtime-cranelift?/gc-null",
+  "wasmtime-winch?/gc-null",
+]
 
 # Enable runtime support for the WebAssembly threads proposal.
 threads = [
   "wasmtime-cranelift?/threads",
+  "wasmtime-winch?/threads",
   "std",
   "signals-based-traps",
 ]

--- a/crates/winch/Cargo.toml
+++ b/crates/winch/Cargo.toml
@@ -28,3 +28,8 @@ component-model = [
     "wasmtime-cranelift/component-model",
 ]
 all-arch = ["winch-codegen/all-arch"]
+gc = ['winch-codegen/gc']
+gc-drc = ['winch-codegen/gc-drc']
+gc-null = ['winch-codegen/gc-null']
+threads = ['winch-codegen/threads']
+wmemcheck = ['winch-codegen/wmemcheck']

--- a/examples/min-platform/embedding/src/allocator.rs
+++ b/examples/min-platform/embedding/src/allocator.rs
@@ -74,7 +74,7 @@ unsafe impl dlmalloc::Allocator for MyAllocator {
                 (ptr::null_mut(), 0, 0)
             } else {
                 INITIAL_HEAP_ALLOCATED = true;
-                (INITIAL_HEAP.as_mut_ptr(), INITIAL_HEAP_SIZE, 0)
+                (ptr::addr_of_mut!(INITIAL_HEAP).cast(), INITIAL_HEAP_SIZE, 0)
             }
         }
     }

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -33,3 +33,8 @@ all-arch = [
     "x64",
     "arm64",
 ]
+gc = ['wasmtime-environ/gc']
+gc-drc = ['wasmtime-environ/gc-drc']
+gc-null = ['wasmtime-environ/gc-null']
+threads = ['wasmtime-environ/threads']
+wmemcheck = ['wasmtime-environ/wmemcheck']


### PR DESCRIPTION
Coupled with today's release of Rust 1.83 this bumps our MSRV on Wasmtime to 1.81. This also updates the nightly used for testing too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
