### PR TITLE
Don't statically enumerate host signatures in Pulley

### DIFF
--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1245,77 +1245,8 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
-    /// This instructions is sort of like a `call` instruction except that it
-    /// delegates to the host itself. That means that ABI details are baked in
-    /// here such as where various arguments are.
-    ///
-    /// This will load the arguments from the `xN` registers, the first being
-    /// the function pointer on the host to call. Since we don't have a
-    /// libffi-like solution here the way this works is that the
-    /// `for_each_host_signature!` macro statically enumerates all possible
-    /// signatures. The `sig` payload here selects one of the mwhich we dispatch
-    /// to here. Note that we mostly just try to get the width of each argument
-    /// correct, whether or not it's a pointer is not actually tracked here.
-    /// That means that, like the rest of Pulley, this isn't compatible with
-    /// strict provenance pointer rules.
     fn call_indirect_host(&mut self, sig: u8) -> ControlFlow<Done> {
-        let raw = self.state[XReg::x0].get_ptr::<u8>();
-        let mut n = 0;
-        let mut arg = 1;
-
-        type I8 = i8;
-        type I32 = i32;
-        type I64 = i64;
-
-        macro_rules! call_host {
-            ($(fn($($args:ident),*) $(-> $ret:ident)?;)*) => {$(
-                // We're relying on LLVM to boil away most of this boilerplate
-                // as this is a bunch of `if` statements that should be a
-                // `match`.
-                if sig == n {
-                    union Convert {
-                        raw: *mut u8,
-                        f: unsafe extern "C" fn($($args),*) $(-> $ret)?,
-                    }
-                    let ptr = Convert { raw }.f;
-
-                    // Arguments are loaded from subsequent registers after
-                    // `x0` and are tracked by `arg`.
-                    let ret = ptr(
-                        $({
-                            let reg = XReg::new_unchecked(arg);
-                            arg += 1;
-                            let reg = &self.state[reg];
-                            call_host!(@get $args reg)
-                        },)*
-                    );
-                    let _ = arg; // ignore the last increment of `arg`
-
-                    // If this function produce a result the ABI is that we
-                    // place it into `x0`.
-                    let dst = &mut self.state[XReg::x0];
-                    $(call_host!(@set $ret dst ret);)?
-                    let _ = (ret, dst); // ignore if there was no return value
-                }
-                n += 1;
-            )*};
-
-            (@get I8 $reg:ident) => ($reg.get_i32() as i8);
-            (@get I32 $reg:ident) => ($reg.get_i32());
-            (@get I64 $reg:ident) => ($reg.get_i64());
-
-            (@set I8 $dst:ident $val:ident) => ($dst.set_i32($val.into()););
-            (@set I32 $dst:ident $val:ident) => ($dst.set_i32($val););
-            (@set I64 $dst:ident $val:ident) => ($dst.set_i64($val););
-
-        }
-
-        unsafe {
-            for_each_host_signature!(call_host);
-        }
-
-        let _ = n; // ignore the last increment of `n`
-
-        ControlFlow::Continue(())
+        let _ = sig; // TODO: should stash this somewhere
+        ControlFlow::Break(Done::ReturnToHost)
     }
 }

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -212,64 +212,6 @@ macro_rules! for_each_extended_op {
     };
 }
 
-/// All known signatures that Wasmtime needs to invoke for host functions.
-///
-/// This is used in conjunction with the `call_indirect_host` opcode to jump
-/// from interpreter bytecode back into the host to peform tasks such as
-/// `memory.grow` or call imported host functions.
-///
-/// Each function signature here correspond to a "builtin" either for core wasm
-/// or for the component model. This also includes the "array call abi" for
-/// calling host functions.
-///
-/// TODO: this probably needs a "pointer type" to avoid doubling the size of
-/// this on 32-bit platforms. That's left for a future refactoring when it's
-/// easier to start compiling everything for 32-bit platforms. That'll require
-/// more of the pulley backend fleshed out and the integration with Wasmtime
-/// more fleshed out as well.
-#[macro_export]
-macro_rules! for_each_host_signature {
-    ($m:ident) => {
-        $m! {
-            fn(I64, I32, I32, I32) -> I32;
-            fn(I64, I32, I32) -> I32;
-            fn(I64, I32, I32) -> I64;
-            fn(I64, I64, I32, I64, I64, I64, I8, I64, I64) -> I8;
-            fn(I64, I64, I64, I64, I64) -> I64;
-            fn(I64, I64, I64, I64) -> I64;
-            fn(I64, I64, I64) -> I64;
-            fn(I64, I64, I64);
-            fn(I64);
-            fn(I64, I32, I32, I32, I32, I32);
-            fn(I64, I32) -> I32;
-            fn(I64, I32, I32, I32, I32, I32, I32);
-            fn(I64, I32, I32, I32, I32) -> I32;
-            fn(I64, I32, I32, I64, I32, I32);
-            fn(I64, I32, I32, I64, I64, I64);
-            fn(I64, I32, I32) -> I32;
-            fn(I64, I32, I32) -> I64;
-            fn(I64, I32, I64, I32, I64);
-            fn(I64, I32, I64, I32) -> I64;
-            fn(I64, I32, I64, I32, I64, I64);
-            fn(I64, I32, I64, I32, I64) -> I32;
-            fn(I64, I32, I64, I32, I64);
-            fn(I64, I32, I64, I32) -> I32;
-            fn(I64, I32, I64, I64, I64) -> I32;
-            fn(I64, I32, I64, I64, I64);
-            fn(I64, I32, I64, I64) -> I64;
-            fn(I64, I32, I64) -> I64;
-            fn(I64, I32) -> I64;
-            fn(I64, I32);
-            fn(I64, I64, I32) -> I64;
-            fn(I64, I64, I64, I64) -> I8;
-            fn(I64, I64) -> I32;
-            fn(I64, I8);
-            fn(I64) -> I64;
-            fn(I64);
-        }
-    };
-}
-
 #[cfg(feature = "decode")]
 pub mod decode;
 #[cfg(feature = "disas")]


### PR DESCRIPTION
I'm doing some other refactoring which makes it a pain to maintain a list in two locations of what all the host signatures are. Instead remove the pulley `for_each_host_signature!` macro entirely. My thinking is to instead implement a different system for host calls in pulley:

* The same relocation-style mechanism is used with some number-embedded-in-the-bytecode.
* The interpreter exits with "imma call the host" when it sees this special opcode.
* The interpreter embedder, aka Wasmtime, is responsible for then invoking the actual function pointer.
* Wasmtime already has static knowledge of all its function signatures, e.g. via various macros.

This will prevent the need to list all function signatures twice and risk them getting out of sync. Most of the Pulley-level integration work here is left to a future commit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
