### PR TITLE
Start using `#[expect]` instead of `#[allow]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ manual_strip = 'warn'
 unnecessary_mut_passed = 'warn'
 unnecessary_fallible_conversions = 'warn'
 unnecessary_cast = 'warn'
+allow_attributes_without_reason = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/benches/call.rs
+++ b/benches/call.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
+
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
 use std::fmt::Debug;

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case)]
+#![expect(non_snake_case, reason = "DSL style here")]
 
 use crate::cdsl::instructions::{
     AllInstructions, InstructionBuilder as Inst, InstructionGroupBuilder,

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -10,6 +10,7 @@
 // built for one platform we don't have to worry too much about trimming
 // everything down.
 #![cfg_attr(not(feature = "all-arch"), allow(dead_code))]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 #[allow(unused_imports)] // #[macro_use] is required for no_std
 #[macro_use]

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -145,7 +145,7 @@ macro_rules! entity_impl {
 
         impl $entity {
             /// Create a new instance from a `u32`.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn from_u32(x: u32) -> Self {
                 debug_assert!(x < $crate::__core::u32::MAX);
@@ -153,21 +153,21 @@ macro_rules! entity_impl {
             }
 
             /// Return the underlying index value as a `u32`.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn as_u32(self) -> u32 {
                 self.0
             }
 
             /// Return the raw bit encoding for this instance.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn as_bits(self) -> u32 {
                 self.0
             }
 
             /// Create a new instance from the raw bit encoding.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn from_bits(x: u32) -> Self {
                 $entity(x)
@@ -225,7 +225,7 @@ macro_rules! entity_impl {
 
         impl $entity {
             /// Create a new instance from a `u32`.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn from_u32(x: u32) -> Self {
                 debug_assert!(x < $crate::__core::u32::MAX);
@@ -234,7 +234,7 @@ macro_rules! entity_impl {
             }
 
             /// Return the underlying index value as a `u32`.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn as_u32(self) -> u32 {
                 let $arg = self;

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -4,6 +4,7 @@
 //! available filetest commands.
 
 #![deny(missing_docs)]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 pub use crate::function_runner::TestFileCompiler;
 use crate::runner::TestRunner;

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -157,6 +157,7 @@
 
 #![deny(missing_docs)]
 #![no_std]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 #[allow(unused_imports)] // #[macro_use] is required for no_std
 #[macro_use]

--- a/cranelift/interpreter/src/lib.rs
+++ b/cranelift/interpreter/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! This module is a project for interpreting Cranelift IR.
 
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
+
 pub mod address;
 pub mod environment;
 pub mod frame;

--- a/cranelift/isle/isle/src/lib.rs
+++ b/cranelift/isle/isle/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 macro_rules! declare_id {
     (

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 #![no_std]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -4,6 +4,7 @@
 //! testing Cranelift, but is not essential for a JIT compiler.
 
 #![deny(missing_docs)]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 pub use crate::error::{Location, ParseError, ParseResult};
 pub use crate::isaspec::{parse_option, parse_options, IsaSpec, ParseOptionError};

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -987,7 +987,7 @@ impl<'a> CrashCheckContext<'a> {
         }
     }
 
-    #[cfg_attr(test, allow(unreachable_code))]
+    #[cfg_attr(test, expect(unreachable_code, reason = "test-specific code"))]
     fn check_for_crash(&mut self, func: &Function) -> CheckResult {
         self.context.clear();
 

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -12,7 +12,7 @@
 //! but otherwise an accompanying `wasmtime.h` API is provided which is more
 //! specific to Wasmtime and has fewer gymnastics to implement.
 
-#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![expect(non_camel_case_types, reason = "matching C style, not Rust")]
 
 pub use wasmtime;
 

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -47,7 +47,7 @@ macro_rules! wasmtime_option_group {
         }
 
         #[derive(Clone, Debug,PartialEq)]
-        #[allow(non_camel_case_types)]
+        #[expect(non_camel_case_types, reason = "macro-generated code")]
         enum $option {
             $(
                 $opt($payload),

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 macro_rules! gentest {
     ($id:ident $name:tt $path:tt) => {

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -3,7 +3,11 @@
 // FIXME: this whole crate opts-in to these two noisier-than-default lints, but
 // this module has lots of hits on this warning which aren't the easiest to
 // resolve. Ideally all warnings would be resolved here though.
-#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "haven't had a chance to fix these yet"
+)]
 
 use crate::CompiledFunctionMetadata;
 use core::fmt;

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -1,5 +1,3 @@
-#![allow(trivial_numeric_casts)]
-
 use super::address_transform::AddressTransform;
 use crate::debug::ModuleMemoryOffset;
 use crate::translate::get_vmctx_value_label;
@@ -796,6 +794,7 @@ impl std::fmt::Debug for JumpTargetMarker {
 }
 
 #[cfg(test)]
+#[expect(trivial_numeric_casts, reason = "macro-generated code")]
 mod tests {
     use super::{
         compile_expression, AddressTransform, CompiledExpression, CompiledExpressionPart,

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -119,7 +119,7 @@ fn replace_pointer_type(
     macro_rules! add_tag {
         ($parent_id:ident, $tag:expr => $die:ident as $die_id:ident { $($a:path = $v:expr),* }) => {
             let $die_id = comp_unit.add($parent_id, $tag);
-            #[allow(unused_variables)]
+            #[allow(unused_variables, reason = "sometimes not used below")]
             let $die = comp_unit.get_mut($die_id);
             $( $die.set($a, $v); )*
         };

--- a/crates/cranelift/src/debug/write_debuginfo.rs
+++ b/crates/cranelift/src/debug/write_debuginfo.rs
@@ -8,14 +8,12 @@ use cranelift_codegen::isa::{
 use gimli::write::{Address, Dwarf, EndianVec, FrameTable, Result, Sections, Writer};
 use gimli::{RunTimeEndian, SectionId};
 
-#[allow(missing_docs)]
 pub struct DwarfSection {
     pub name: &'static str,
     pub body: Vec<u8>,
     pub relocs: Vec<DwarfSectionReloc>,
 }
 
-#[allow(missing_docs)]
 #[derive(Clone)]
 pub struct DwarfSectionReloc {
     pub target: DwarfSectionRelocTarget,
@@ -24,7 +22,6 @@ pub struct DwarfSectionReloc {
     pub size: u8,
 }
 
-#[allow(missing_docs)]
 #[derive(Clone)]
 pub enum DwarfSectionRelocTarget {
     Func(usize),

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -287,7 +287,7 @@ struct UnwindInfoBuilder<'a> {
 // platforms. Note that all of these specifiers here are relative to a "base
 // address" which we define as the base of where the text section is eventually
 // loaded.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching Windows style, not Rust")]
 struct RUNTIME_FUNCTION {
     begin: u32,
     end: u32,

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -274,7 +274,7 @@ macro_rules! declare_indexes {
          )*
     ) => {
         $( #[$this_attr] )*
-        #[allow(missing_docs)]
+        #[expect(missing_docs, reason = "macro-generated")]
         pub const fn $this_name() -> Self {
             Self($index)
         }

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -118,7 +118,7 @@ pub struct FunctionBodyData<'a> {
 }
 
 #[derive(Debug, Default)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct DebugInfoData<'a> {
     pub dwarf: Dwarf<'a>,
     pub name_section: NameSection<'a>,
@@ -131,13 +131,13 @@ pub struct DebugInfoData<'a> {
     pub debug_tu_index: gimli::DebugTuIndex<Reader<'a>>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing")]
 pub type Dwarf<'input> = gimli::Dwarf<Reader<'input>>;
 
 type Reader<'input> = gimli::EndianSlice<'input, gimli::LittleEndian>;
 
 #[derive(Debug, Default)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct NameSection<'a> {
     pub module_name: Option<&'a str>,
     pub func_names: HashMap<FuncIndex, &'a str>,
@@ -145,7 +145,7 @@ pub struct NameSection<'a> {
 }
 
 #[derive(Debug, Default)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct WasmFileInfo {
     pub path: Option<PathBuf>,
     pub code_section_offset: u64,
@@ -154,7 +154,7 @@ pub struct WasmFileInfo {
 }
 
 #[derive(Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct FunctionMetadata {
     pub params: Box<[WasmValType]>,
     pub locals: Box<[(u32, WasmValType)]>,

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -37,8 +37,8 @@ use std::hash::Hash;
 use std::ops::Index;
 use wasmparser::component_types::ComponentCoreModuleTypeId;
 
+/// High-level representation of a component as a "data-flow graph".
 #[derive(Default)]
-#[allow(missing_docs)]
 pub struct ComponentDfg {
     /// Same as `Component::import_types`
     pub import_types: PrimaryMap<ImportIndex, (String, TypeDef)>,
@@ -153,7 +153,7 @@ pub enum SideEffect {
 macro_rules! id {
     ($(pub struct $name:ident(u32);)*) => ($(
         #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs, reason = "tedious to document")]
         pub struct $name(u32);
         cranelift_entity::entity_impl!($name);
     )*)
@@ -169,7 +169,7 @@ id! {
 }
 
 /// Same as `info::InstantiateModule`
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "tedious to document variants")]
 pub enum Instance {
     Static(StaticModuleIndex, Box<[CoreDef]>),
     Import(
@@ -179,7 +179,7 @@ pub enum Instance {
 }
 
 /// Same as `info::Export`
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "tedious to document variants")]
 pub enum Export {
     LiftedFunction {
         ty: TypeFuncIndex,
@@ -203,7 +203,7 @@ pub enum Export {
 
 /// Same as `info::CoreDef`, except has an extra `Adapter` variant.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "tedious to document variants")]
 pub enum CoreDef {
     Export(CoreExport<EntityIndex>),
     InstanceFlags(RuntimeComponentInstanceIndex),
@@ -230,14 +230,14 @@ where
 
 /// Same as `info::CoreExport`
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct CoreExport<T> {
     pub instance: InstanceId,
     pub item: ExportItem<T>,
 }
 
 impl<T> CoreExport<T> {
-    #[allow(missing_docs)]
+    #[expect(missing_docs, reason = "self-describing function")]
     pub fn map_index<U>(self, f: impl FnOnce(T) -> U) -> CoreExport<U> {
         CoreExport {
             instance: self.instance,
@@ -251,7 +251,7 @@ impl<T> CoreExport<T> {
 
 /// Same as `info::Trampoline`
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub enum Trampoline {
     LowerImport {
         import: RuntimeImportIndex,
@@ -277,7 +277,7 @@ pub enum Trampoline {
 
 /// Same as `info::CanonicalOptions`
 #[derive(Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct CanonicalOptions {
     pub instance: RuntimeComponentInstanceIndex,
     pub string_encoding: StringEncoding,
@@ -287,7 +287,7 @@ pub struct CanonicalOptions {
 }
 
 /// Same as `info::Resource`
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct Resource {
     pub rep: WasmValType,
     pub dtor: Option<CoreDef>,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -457,7 +457,7 @@ pub struct CanonicalOptions {
 // `extern "C" fn()` function argument which is called from cranelift-compiled
 // code so we must know the representation of this.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[repr(u8)]
 pub enum StringEncoding {
     Utf8,
@@ -469,7 +469,7 @@ pub enum StringEncoding {
 ///
 /// Note that each transcoding operation may have a unique signature depending
 /// on the precise operation.
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum Transcode {
     Copy(FixedEncoding),
@@ -525,7 +525,7 @@ impl Transcode {
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum FixedEncoding {
     Utf8,
     Utf16,

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -169,7 +169,6 @@ struct Translation<'data> {
 // fully determined due to resources until instantiations are known which is
 // tracked during the inlining phase. This means that all type information below
 // is straight from `wasmparser`'s passes.
-#[allow(missing_docs)]
 enum LocalInitializer<'data> {
     // imports
     Import(ComponentImportName<'data>, ComponentEntityType),

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -208,7 +208,7 @@ pub use crate::{FuncIndex, GlobalIndex, MemoryIndex, TableIndex};
 /// Equivalent of `EntityIndex` but for the component model instead of core
 /// wasm.
 #[derive(Debug, Clone, Copy)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum ComponentItem {
     Func(ComponentFuncIndex),
     Module(ModuleIndex),
@@ -439,7 +439,7 @@ pub struct TypeFunc {
 /// forms where for non-primitive types a `ComponentTypes` structure is used to
 /// lookup further information based on the index found here.
 #[derive(Serialize, Deserialize, Copy, Clone, Hash, Eq, PartialEq, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum InterfaceType {
     Bool,
     S8,
@@ -1036,7 +1036,6 @@ pub struct FlatTypes<'a> {
     pub memory64: &'a [FlatType],
 }
 
-#[allow(missing_docs)]
 impl FlatTypes<'_> {
     /// Returns the number of flat types used to represent this type.
     ///
@@ -1051,7 +1050,7 @@ impl FlatTypes<'_> {
 // regardless to changes in the core wasm type system since this will only
 // ever use integers/floats for the foreseeable future.
 #[derive(PartialEq, Eq, Copy, Clone)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum FlatType {
     I32,
     I64,

--- a/crates/environ/src/gc.rs
+++ b/crates/environ/src/gc.rs
@@ -233,7 +233,6 @@ impl GcLayout {
 /// themselves. The array elements must be aligned to the element type's natural
 /// alignment.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // Not used yet, but added for completeness.
 pub struct GcArrayLayout {
     /// The size of this array object, without any elements.
     ///
@@ -329,7 +328,7 @@ impl GcStructLayout {
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum VMGcKind {
     ExternRef      = 0b01000 << 27,
     AnyRef         = 0b10000 << 27,

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -25,7 +25,7 @@ pub struct CompiledFunctionInfo {
 /// Information about a function, such as trap information, address map,
 /// and stack maps.
 #[derive(Serialize, Deserialize, Default)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct WasmFunctionInfo {
     pub start_srcloc: FilePos,
     pub stack_maps: Box<[StackMapInformation]>,

--- a/crates/environ/src/obj.rs
+++ b/crates/environ/src/obj.rs
@@ -138,7 +138,7 @@ pub const ELF_WASMTIME_DWARF: &str = ".wasmtime.dwarf";
 macro_rules! libcalls {
     ($($rust:ident = $sym:tt)*) => (
         #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs, reason = "self-describing variants")]
         pub enum LibCall {
             $($rust,)*
         }

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -22,7 +22,7 @@ pub struct TrapInformation {
 // These need to be kept in sync.
 #[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum Trap {
     /// The current stack space was exhausted.
     StackOverflow,

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -27,7 +27,7 @@ macro_rules! define_tunables {
 
         /// Optional tunable configuration options used in `wasmtime::Config`
         #[derive(Default, Clone)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs, reason = "macro-generated fields")]
         pub struct $config_tunables {
             $(pub $field: Option<$field_ty>,)*
         }

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -405,7 +405,7 @@ impl EngineOrModuleTypeIndex {
 
 /// WebAssembly heap type -- equivalent of `wasmparser`'s HeapType
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum WasmHeapType {
     // External types.
     Extern,
@@ -886,7 +886,7 @@ impl TypeTrace for WasmStructType {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing type")]
 pub struct WasmCompositeType {
     /// The type defined inside the composite type.
     pub inner: WasmCompositeInnerType,
@@ -910,7 +910,7 @@ impl fmt::Display for WasmCompositeType {
 
 /// A function, array, or struct type.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum WasmCompositeInnerType {
     Array(WasmArrayType),
     Func(WasmFuncType),
@@ -927,7 +927,7 @@ impl fmt::Display for WasmCompositeInnerType {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing functions")]
 impl WasmCompositeInnerType {
     #[inline]
     pub fn is_array(&self) -> bool {
@@ -1042,7 +1042,7 @@ impl fmt::Display for WasmSubType {
 /// Implicitly define all of these helper functions to handle only unshared
 /// types; essentially, these act like `is_unshared_*` functions until shared
 /// support is implemented.
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing functions")]
 impl WasmSubType {
     #[inline]
     pub fn is_func(&self) -> bool {
@@ -1347,7 +1347,6 @@ impl From<GlobalIndex> for EntityIndex {
 
 /// A type of an item in a wasm module where an item is typically something that
 /// can be exported.
-#[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EntityType {
     /// A global variable with the specified content type
@@ -1560,7 +1559,7 @@ impl ConstExpr {
 }
 
 /// The subset of Wasm opcodes that are constant.
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ConstOp {
     I32Const(i32),
@@ -1646,7 +1645,7 @@ impl ConstOp {
 
 /// The type that can be used to index into [Memory] and [Table].
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum IndexType {
     I32,
     I64,
@@ -1654,7 +1653,7 @@ pub enum IndexType {
 
 /// The size range of resizeable storage associated with [Memory] types and [Table] types.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct Limits {
     pub min: u64,
     pub max: Option<u64>,
@@ -1879,7 +1878,7 @@ impl Memory {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing error struct")]
 pub struct SizeOverflow;
 
 impl fmt::Display for SizeOverflow {
@@ -1933,7 +1932,7 @@ impl From<wasmparser::TagType> for Tag {
 }
 
 /// Helpers used to convert a `wasmparser` type to a type in this crate.
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing functions")]
 pub trait TypeConvert {
     /// Converts a wasmparser table type into a wasmtime type
     fn convert_global_type(&self, ty: &wasmparser::GlobalType) -> Global {

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::allow_attributes, reason = "crate not migrated yet")]
+
 use anyhow::Error;
 use std::any::Any;
 use std::cell::Cell;

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -50,9 +50,9 @@ unsafe impl Send for BasePtr {}
 unsafe impl Sync for BasePtr {}
 
 enum FiberStackStorage {
-    Mmap(#[allow(dead_code)] MmapFiberStack),
+    Mmap(MmapFiberStack),
     Unmanaged(usize),
-    Custom(#[allow(dead_code)] Box<dyn RuntimeFiberStack>),
+    Custom(Box<dyn RuntimeFiberStack>),
 }
 
 impl FiberStack {
@@ -201,7 +201,7 @@ extern "C" {
     );
     #[wasmtime_versioned_export_macros::versioned_link]
     fn wasmtime_fiber_switch(top_of_stack: *mut u8);
-    #[allow(dead_code)] // only used in inline assembly for some platforms
+    #[allow(dead_code, reason = "only used on some platforms for inline asm")]
     #[wasmtime_versioned_export_macros::versioned_link]
     fn wasmtime_fiber_start();
 }

--- a/crates/fuzzing/src/generators/api.rs
+++ b/crates/fuzzing/src/generators/api.rs
@@ -29,7 +29,7 @@ struct Swarm {
 
 /// A call to one of Wasmtime's public APIs.
 #[derive(Arbitrary, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub enum ApiCall {
     StoreNew(Config),
     ModuleNew { id: usize, wasm: Vec<u8> },

--- a/crates/fuzzing/src/generators/codegen_settings.rs
+++ b/crates/fuzzing/src/generators/codegen_settings.rs
@@ -8,7 +8,6 @@ pub enum CodegenSettings {
     /// Use the host's feature set.
     Native,
     /// Generate a modified flag set for the current host.
-    #[allow(dead_code)]
     Target {
         /// The target triple of the host.
         target: String,
@@ -35,7 +34,7 @@ impl CodegenSettings {
 }
 
 impl<'a> Arbitrary<'a> for CodegenSettings {
-    #[allow(unused_macros, unused_variables)]
+    #[expect(unused_variables, reason = "macro-generated code")]
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         // Helper macro to enable clif features based on what the native host
         // supports. If the input says to enable a feature and the host doesn't

--- a/crates/fuzzing/src/generators/memory.rs
+++ b/crates/fuzzing/src/generators/memory.rs
@@ -132,7 +132,7 @@ pub enum MemoryConfig {
 /// Represents a normal memory configuration for Wasmtime with the given
 /// static and dynamic memory sizes.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct NormalMemoryConfig {
     pub memory_reservation: Option<u64>,
     pub memory_guard_size: Option<u64>,

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -7,16 +7,14 @@ use arbitrary::{Arbitrary, Unstructured};
 /// Internally this uses `wasm-smith`'s own `Config` but we further refine
 /// the defaults here as well.
 #[derive(Debug, Clone)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct ModuleConfig {
-    #[allow(missing_docs)]
     pub config: wasm_smith::Config,
 
     // These knobs aren't exposed in `wasm-smith` at this time but are exposed
     // in our `*.wast` testing so keep knobs here so they can be read during
     // config-to-`wasmtime::Config` translation.
-    #[allow(missing_docs)]
     pub function_references_enabled: bool,
-    #[allow(missing_docs)]
     pub component_model_more_flags: bool,
 }
 

--- a/crates/fuzzing/src/generators/pooling_config.rs
+++ b/crates/fuzzing/src/generators/pooling_config.rs
@@ -5,7 +5,7 @@ use wasmtime::MpkEnabled;
 
 /// Configuration for `wasmtime::PoolingAllocationStrategy`.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing field names")]
 pub struct PoolingAllocationConfig {
     pub total_component_instances: u32,
     pub total_core_instances: u32,

--- a/crates/fuzzing/src/generators/single_inst_module.rs
+++ b/crates/fuzzing/src/generators/single_inst_module.rs
@@ -31,9 +31,9 @@ pub struct SingleInstModule<'a> {
 /// of these types.
 #[derive(Clone)]
 enum NanType {
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "expected to be used in the future")]
     F32,
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "expected to be used in the future")]
     F64,
     F32x4,
     F64x2,

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -174,6 +174,7 @@ macro_rules! define_table_ops {
             )*
         }
 
+        #[expect(unused_comparisons, reason = "macro-generated code")]
         fn add_table_op(
             ops: &mut TableOps,
             u: &mut Unstructured,
@@ -184,7 +185,6 @@ macro_rules! define_table_ops {
 
             // Add all the choices of valid `TableOp`s we could generate.
             $(
-                #[allow(unused_comparisons)]
                 if $( $(($limit as fn(&TableOps) -> $ty)(&*ops) > 0 &&)* )? *stack >= $params {
                     choices.push(|_ops, _u, stack| {
                         *stack = *stack - $params + $results;

--- a/crates/fuzzing/src/generators/value.rs
+++ b/crates/fuzzing/src/generators/value.rs
@@ -7,7 +7,7 @@ use wasmtime::HeapType;
 /// A value passed to and from evaluation. Note that reference types are not
 /// (yet) supported.
 #[derive(Clone, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub enum DiffValue {
     I32(i32),
     I64(i64),
@@ -274,7 +274,7 @@ impl PartialEq for DiffValue {
 
 /// Enumerate the supported value types.
 #[derive(Copy, Clone, Debug, Arbitrary, Hash)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum DiffValueType {
     I32,
     I64,
@@ -310,7 +310,6 @@ impl TryFrom<wasmtime::ValType> for DiffValueType {
 
 /// Enumerate the types of v128.
 #[derive(Copy, Clone, Debug, Arbitrary, Hash)]
-#[allow(missing_docs)]
 pub enum DiffSimdTy {
     I8x16,
     I16x8,

--- a/crates/fuzzing/src/generators/wast_test.rs
+++ b/crates/fuzzing/src/generators/wast_test.rs
@@ -8,7 +8,7 @@ include!(concat!(env!("OUT_DIR"), "/wasttests.rs"));
 /// A wast test from this repository.
 #[derive(Debug)]
 pub struct WastTest {
-    #[allow(missing_docs)]
+    #[expect(missing_docs, reason = "self-describing field")]
     pub test: wasmtime_wast_util::WastTest,
 }
 

--- a/crates/fuzzing/wasm-spec-interpreter/src/lib.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/src/lib.rs
@@ -20,7 +20,6 @@ pub enum SpecValue {
 }
 
 /// Represents a WebAssembly export from the OCaml interpreter side.
-#[allow(dead_code)]
 pub enum SpecExport {
     Global(SpecValue),
     Memory(Vec<u8>),

--- a/crates/fuzzing/wasm-spec-interpreter/src/without_library.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/src/without_library.rs
@@ -8,12 +8,10 @@
 
 use crate::{SpecExport, SpecInstance, SpecValue};
 
-#[allow(dead_code)]
 pub fn instantiate(_module: &[u8]) -> Result<SpecInstance, String> {
     fail_at_runtime()
 }
 
-#[allow(dead_code)]
 pub fn interpret(
     _instance: &SpecInstance,
     _name: &str,
@@ -22,7 +20,6 @@ pub fn interpret(
     fail_at_runtime()
 }
 
-#[allow(dead_code)]
 pub fn interpret_legacy(
     _module: &[u8],
     _parameters: Option<Vec<SpecValue>>,
@@ -41,5 +38,4 @@ fn fail_at_runtime() -> ! {
     );
 }
 
-#[allow(dead_code)]
 pub fn setup_ocaml_runtime() {}

--- a/crates/jit-icache-coherence/src/libc.rs
+++ b/crates/jit-icache-coherence/src/libc.rs
@@ -104,6 +104,7 @@ mod details {
 }
 
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+#[expect(non_upper_case_globals, reason = "matching C style")]
 fn riscv_flush_icache(start: u64, end: u64) -> Result<()> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "one-core")] {
@@ -121,10 +122,8 @@ fn riscv_flush_icache(start: u64, end: u64) -> Result<()> {
                     {
                         // The syscall isn't defined in `libc`, so we define the syscall number here.
                         // https://github.com/torvalds/linux/search?q=__NR_arch_specific_syscall
-                        #[allow(non_upper_case_globals)]
                         const  __NR_arch_specific_syscall :i64 = 244;
                         // https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/tools/arch/riscv/include/uapi/asm/unistd.h#L40
-                        #[allow(non_upper_case_globals)]
                         const sys_riscv_flush_icache :i64 =  __NR_arch_specific_syscall + 15;
                         sys_riscv_flush_icache
                     },
@@ -132,9 +131,7 @@ fn riscv_flush_icache(start: u64, end: u64) -> Result<()> {
                     start, // start
                     end, // end
                     {
-                        #[allow(non_snake_case)]
                         const SYS_RISCV_FLUSH_ICACHE_LOCAL :i64 = 1;
-                        #[allow(non_snake_case)]
                         const SYS_RISCV_FLUSH_ICACHE_ALL :i64 = SYS_RISCV_FLUSH_ICACHE_LOCAL;
                         SYS_RISCV_FLUSH_ICACHE_ALL
                     }, // flags

--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -93,7 +93,7 @@ impl<T, const L: u32, const H: u32> Deref for VecInRange<T, L, H> {
 }
 
 /// Represents a component model interface type
-#[allow(missing_docs)]
+#[allow(missing_docs, reason = "self-describing")]
 #[derive(Debug, Clone)]
 pub enum Type {
     Bool,

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -69,6 +69,7 @@
 
 #![warn(clippy::cast_sign_loss)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 pub mod clocks;
 mod ctx;

--- a/crates/wasi-common/tests/all/main.rs
+++ b/crates/wasi-common/tests/all/main.rs
@@ -12,7 +12,7 @@ pub fn prepare_workspace(exe_name: &str) -> Result<TempDir> {
 
 macro_rules! assert_test_exists {
     ($name:ident) => {
-        #[allow(unused_imports)]
+        #[expect(unused_imports, reason = "just here to ensure a name exists")]
         use self::$name as _;
     };
 }

--- a/crates/wasi-config/tests/main.rs
+++ b/crates/wasi-config/tests/main.rs
@@ -46,7 +46,7 @@ async fn run_wasi(path: &str, ctx: Ctx) -> Result<()> {
 
 macro_rules! assert_test_exists {
     ($name:ident) => {
-        #[allow(unused_imports)]
+        #[expect(unused_imports, reason = "only here to ensure name exists")]
         use self::$name as _;
     };
 }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -216,6 +216,7 @@
 #![deny(missing_docs)]
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 mod error;
 mod http_impl;

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -118,7 +118,7 @@ impl Drop for Ctx {
 // assertion of the existence of the test function itself.
 macro_rules! assert_test_exists {
     ($name:ident) => {
-        #[allow(unused_imports)]
+        #[expect(unused_imports, reason = "only here to ensure a name exists")]
         use self::$name as _;
     };
 }

--- a/crates/wasi-keyvalue/tests/main.rs
+++ b/crates/wasi-keyvalue/tests/main.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
+
 use anyhow::{anyhow, Result};
 use test_programs_artifacts::{foreach_keyvalue, KEYVALUE_MAIN_COMPONENT};
 use wasmtime::{

--- a/crates/wasi-nn/tests/check/mod.rs
+++ b/crates/wasi-nn/tests/check/mod.rs
@@ -4,6 +4,8 @@
 //! - that various backends can be located on the system (see sub-modules)
 //! - that certain ML model artifacts can be downloaded and cached.
 
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
+
 #[allow(unused_imports)]
 use anyhow::{anyhow, Context, Result};
 use std::{

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -11,6 +11,7 @@
         unreachable_code
     )
 )]
+#![expect(clippy::allow_attributes, reason = "crate not migrated yet")]
 
 use crate::bindings::wasi::clocks::{monotonic_clock, wall_clock};
 use crate::bindings::wasi::io::poll;
@@ -2154,7 +2155,6 @@ pub unsafe extern "C" fn poll_oneoff(
         }
 
         #[link(wasm_import_module = "wasi:io/poll@0.2.2")]
-        #[allow(improper_ctypes)] // FIXME(bytecodealliance/wit-bindgen#684)
         extern "C" {
             #[link_name = "poll"]
             fn poll_import(pollables: *const Pollable, len: usize, rval: *mut ReadyList);
@@ -2719,7 +2719,7 @@ const _: () = {
     let _size_assert: [(); PAGE_SIZE] = [(); size_of::<State>()];
 };
 
-#[allow(unused)]
+#[expect(unused, reason = "not used in all configurations")]
 #[repr(i32)]
 enum AllocationState {
     StackUnallocated,
@@ -2729,7 +2729,7 @@ enum AllocationState {
     StateAllocated,
 }
 
-#[allow(improper_ctypes)]
+#[expect(improper_ctypes, reason = "types behind pointers")]
 extern "C" {
     fn get_state_ptr() -> *mut State;
     fn set_state_ptr(state: *mut State);

--- a/crates/wasi-preview1-component-adapter/src/macros.rs
+++ b/crates/wasi-preview1-component-adapter/src/macros.rs
@@ -5,14 +5,14 @@
 
 use crate::bindings::wasi::cli::stderr::get_stderr;
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "useful for debugging")]
 #[doc(hidden)]
 pub fn print(message: &[u8]) {
     let _ = get_stderr().blocking_write_and_flush(message);
 }
 
 /// A minimal `eprint` for debugging.
-#[allow(unused_macros)]
+#[allow(unused_macros, reason = "useful for debugging")]
 macro_rules! eprint {
     ($arg:tt) => {{
         // We have to expand string literals into byte arrays to prevent them
@@ -23,7 +23,7 @@ macro_rules! eprint {
 }
 
 /// A minimal `eprintln` for debugging.
-#[allow(unused_macros)]
+#[allow(unused_macros, reason = "useful for debugging")]
 macro_rules! eprintln {
     ($arg:tt) => {{
         // We have to expand string literals into byte arrays to prevent them
@@ -33,7 +33,7 @@ macro_rules! eprintln {
     }};
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "useful for debugging")]
 #[doc(hidden)]
 pub fn eprint_unreachable(line: u32) {
     eprint!("unreachable executed at adapter line ");
@@ -57,7 +57,7 @@ fn eprint_u32(x: u32) {
     }
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "useful for debugging")]
 #[doc(hidden)]
 pub fn unreachable(line: u32) -> ! {
     crate::macros::eprint_unreachable(line);
@@ -88,7 +88,7 @@ macro_rules! unreachable {
     }};
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "useful for debugging")]
 #[doc(hidden)]
 pub fn assert_fail(line: u32) -> ! {
     eprint!("assertion failed at adapter line ");

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -181,6 +181,7 @@
 //! [`ResourceTable`]: wasmtime::component::ResourceTable
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 use wasmtime::component::Linker;
 

--- a/crates/wasi/tests/all/api.rs
+++ b/crates/wasi/tests/all/api.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
+
 use anyhow::Result;
 use std::io::Write;
 use std::sync::Mutex;

--- a/crates/wasi/tests/all/main.rs
+++ b/crates/wasi/tests/all/main.rs
@@ -80,7 +80,7 @@ impl Drop for Ctx {
 // assertion of the existence of the test function itself.
 macro_rules! assert_test_exists {
     ($name:ident) => {
-        #[allow(unused_imports)]
+        #[expect(unused_imports, reason = "just here to ensure a name exists")]
         use self::$name as _;
     };
 }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -288,6 +288,7 @@
 // and will prevent the doc build from failing.
 #![cfg_attr(feature = "default", warn(rustdoc::broken_intra_doc_links))]
 #![no_std]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 #[cfg(any(feature = "std", unix, windows))]
 #[macro_use]

--- a/crates/wiggle/tests/errors.rs
+++ b/crates/wiggle/tests/errors.rs
@@ -99,7 +99,7 @@ mod convert_multiple_error_types {
 
     /// Test that we can map multiple types of errors.
     #[derive(Debug, thiserror::Error)]
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "testing codegen below")]
     pub enum AnotherRichError {
         #[error("I've had this many cups of coffee and can't even think straight: {0}")]
         TooMuchCoffee(usize),

--- a/crates/wiggle/tests/keywords.rs
+++ b/crates/wiggle/tests/keywords.rs
@@ -32,8 +32,7 @@ mod module_trait_fn_and_arg_test {
              )",
     });
     impl<'a> self_::Self_ for WasiCtx<'a> {
-        #[allow(unused_variables)]
-        fn fn_(&mut self, _memory: &mut wiggle::GuestMemory<'_>, use_: u32, virtual_: u32) {
+        fn fn_(&mut self, _memory: &mut wiggle::GuestMemory<'_>, _use_: u32, _virtual_: u32) {
             unimplemented!();
         }
     }

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -31,6 +31,8 @@
 //! $ sysctl vm.max_map_count=$LARGER_LIMIT
 //! ```
 
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
+
 use anyhow::anyhow;
 use bytesize::ByteSize;
 use clap::Parser;

--- a/fuzz/fuzz_targets/component_api.rs
+++ b/fuzz/fuzz_targets/component_api.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
 use wasmtime_fuzzing::oracles;

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(pulley_tail_calls, allow(incomplete_features, unstable_features))]
 #![deny(missing_docs)]
 #![no_std]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate implements the Wasmtime command line tools.
 
 #![deny(missing_docs)]
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 pub mod commands;
 

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 #![cfg_attr(miri, allow(dead_code, unused_imports))]
 
 mod arrays;

--- a/winch/codegen/src/lib.rs
+++ b/winch/codegen/src/lib.rs
@@ -1,5 +1,6 @@
 //! Code generation library for Winch.
 
+#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 // Unless this library is compiled with `all-arch`, the rust compiler
 // is going to emit dead code warnings. This directive is fine as long
 // as we configure to run CI at least once with the `all-arch` feature


### PR DESCRIPTION
In Rust 1.81, our new MSRV, a new feature was added to Rust to use `#[expect]` to control lint levels. This new lint annotation will silence a lint but will itself cause a lint if it doesn't actually silence anything. This is quite useful to ensure that annotations don't get stale over time.

Another feature is the ability to use a `reason` directive on the attribute with a string explaining why the attribute is there. This string is then rendered in compiler messages if a warning or error happens.

This commit migrates applies a few changes across the workspace:

* Some `#[allow]` are changed to `#[expect]` with a `reason`.
* Some `#[allow]` have a `reason` added if the lint conditionally fires (mostly related to macros).
* Some `#[allow]` are removed since the lint doesn't actually fire.
* The workspace configures `clippy::allow_attributes_without_reason = 'warn'` as a "ratchet" to prevent future regressions.
* Many crates are annotated to allow `allow_attributes_without_reason` during this transitionary period.

The end-state is that all crates should use
`#[expect(..., reason = "...")]` for any lint that unconditionally fires but is expected. The `#[allow(..., reason = "...")]` lint should be used for conditionally firing lints, primarily in macro-related code. The `allow_attributes_without_reason = 'warn'` level is intended to be permanent but the transitionary
`#[expect(clippy::allow_attributes_without_reason)]` crate annotations to go away over time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
