### PR TITLE
cranelift-entity: Make PackedOption and EntityList have guaranteed layout

### DIFF
--- a/cranelift/entity/src/list.rs
+++ b/cranelift/entity/src/list.rs
@@ -45,7 +45,7 @@ use serde_derive::{Deserialize, Serialize};
 /// The `EntityList` itself is designed to have the smallest possible footprint. This is important
 /// because it is used inside very compact data structures like `InstructionData`. The list
 /// contains only a 32-bit index into the pool's memory vector, pointing to the first element of
-/// the list.
+/// the list. A zero value represents the empty list, which is returned by `EntityList::default`.
 ///
 /// The pool is just a single `Vec<T>` containing all of the allocated lists. Each list is
 /// represented as three contiguous parts:

--- a/cranelift/entity/src/list.rs
+++ b/cranelift/entity/src/list.rs
@@ -64,6 +64,7 @@ use serde_derive::{Deserialize, Serialize};
 /// reserved for the empty list which isn't allocated in the vector.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[repr(C)]
 pub struct EntityList<T: EntityRef + ReservedValue> {
     index: u32,
     unused: PhantomData<T>,

--- a/cranelift/entity/src/packed_option.rs
+++ b/cranelift/entity/src/packed_option.rs
@@ -22,6 +22,9 @@ pub trait ReservedValue {
 }
 
 /// Packed representation of `Option<T>`.
+///
+/// This is a wrapper around a `T`, using `T::reserved_value` to represent
+/// `None`.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]

--- a/cranelift/entity/src/packed_option.rs
+++ b/cranelift/entity/src/packed_option.rs
@@ -24,6 +24,7 @@ pub trait ReservedValue {
 /// Packed representation of `Option<T>`.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[repr(transparent)]
 pub struct PackedOption<T: ReservedValue>(T);
 
 impl<T: ReservedValue> PackedOption<T> {


### PR DESCRIPTION
Adds optional implementations of `Pod` and `Zeroable` for `EntityList` and `PackedOption`.

This helps avoid some unsafe code in my downstream crates. 