### PR TITLE
Update wasm-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]
@@ -1579,6 +1584,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -3193,7 +3202,7 @@ dependencies = [
  "cargo_metadata",
  "heck 0.5.0",
  "wasmtime",
- "wit-component",
+ "wit-component 0.221.2",
 ]
 
 [[package]]
@@ -3591,7 +3600,7 @@ name = "verify-component-adapter"
 version = "28.0.0"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wat",
 ]
 
@@ -3683,7 +3692,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi",
- "wasm-encoder",
+ "wasm-encoder 0.221.2",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3748,7 +3757,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf48234b389415b226a4daef6562933d38c7b28a8b8f64c5c4130dad1561ab7"
 dependencies = [
  "leb128",
- "wasmparser",
+ "wasmparser 0.220.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
+dependencies = [
+ "leb128",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
@@ -3763,36 +3782,52 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.220.0",
+ "wasmparser 0.220.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a7018a96c4f55a8f339954c66e09728f2d6112689000e58f15f6a6d7436e8f"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.221.2",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.220.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "553a9e14f4ee7b428b52a4d4b226f919231ccf59a2977dfaa0f1709905eb7578"
+checksum = "2512b64553d7c800b798e8e0d0e2e209e76f9330f66ed59991893590ae03cfa3"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.221.2",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.220.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7d273cf1df3c10f9067cb48796d1a6d1daa3ceb99c3f07d822e5bdeefb34f9"
+checksum = "ebbaf9c781fb7091b79ad3baa40862b3afccb2949575bb73bdd77643ed40338c"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "indexmap 2.2.6",
  "leb128",
- "wasm-encoder",
+ "wasm-encoder 0.221.2",
 ]
 
 [[package]]
@@ -3805,14 +3840,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.220.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7358e6333c4cbd9d285aafff0430f17abbfea76856346ae77dde64d43831688b"
+checksum = "a3bf15c65cc690791565c9f983bad120330e37f55ce2473161f2c0aaa534c7da"
 dependencies = [
  "indexmap 2.2.6",
  "logos",
  "thiserror",
- "wit-parser",
+ "wit-parser 0.221.2",
 ]
 
 [[package]]
@@ -3870,6 +3905,18 @@ dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
+dependencies = [
+ "bitflags 2.6.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.2.6",
+ "semver",
  "serde",
 ]
 
@@ -3884,13 +3931,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.220.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae749f2c66587777ce9ad0e8c632e72c77574336b17d2f040a47cffbd92198c7"
+checksum = "a80742ff1b9e6d8c231ac7c7247782c6fc5bce503af760bca071811e5fc9ee56"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
@@ -3935,9 +3982,9 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder",
+ "wasm-encoder 0.221.2",
  "wasm-wave",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -4078,8 +4125,8 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.221.2",
+ "wasmparser 0.221.2",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -4096,10 +4143,10 @@ dependencies = [
  "wasmtime-wasi-threads",
  "wasmtime-wast",
  "wasmtime-wast-util",
- "wast 220.0.0",
+ "wast 221.0.2",
  "wat",
  "windows-sys 0.59.0",
- "wit-component",
+ "wit-component 0.221.2",
 ]
 
 [[package]]
@@ -4132,7 +4179,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.221.2",
 ]
 
 [[package]]
@@ -4158,7 +4205,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -4184,8 +4231,8 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.221.2",
+ "wasmparser 0.221.2",
  "wasmprinter",
  "wasmtime-component-util",
  "wat",
@@ -4199,7 +4246,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger 0.11.5",
  "libfuzzer-sys",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -4258,7 +4305,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -4279,12 +4326,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder",
+ "wasm-encoder 0.221.2",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -4455,7 +4502,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 220.0.0",
+ "wast 221.0.2",
 ]
 
 [[package]]
@@ -4477,7 +4524,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -4490,7 +4537,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.2.6",
- "wit-parser",
+ "wit-parser 0.221.2",
 ]
 
 [[package]]
@@ -4508,24 +4555,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "220.0.0"
+version = "221.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e708c8de08751fd66e70961a32bae9d71901f14a70871e181cb8461a3bb3165"
+checksum = "fcc4470b9de917ba199157d1f0ae104f2ae362be728c43e68c571c7715bd629e"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder",
+ "wasm-encoder 0.221.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.220.0"
+version = "1.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4f1d7d59614ba690541360102b995c4eb1b9ed373701d5102cc1a968b1c5a3"
+checksum = "6b1f3c6d82af47286494c6caea1d332037f5cbeeac82bbf5ef59cb8c201c466e"
 dependencies = [
- "wast 220.0.0",
+ "wast 221.0.2",
 ]
 
 [[package]]
@@ -4666,7 +4713,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.221.2",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4905,7 +4952,7 @@ checksum = "19857cff2a480fece56ea43f9199322ee5014688a3539ebf8d29ae62d75a3a1f"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.220.0",
 ]
 
 [[package]]
@@ -4928,9 +4975,9 @@ dependencies = [
  "indexmap 2.2.6",
  "prettyplease",
  "syn 2.0.60",
- "wasm-metadata",
+ "wasm-metadata 0.220.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.220.0",
 ]
 
 [[package]]
@@ -4961,10 +5008,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.220.0",
+ "wasm-metadata 0.220.0",
+ "wasmparser 0.220.0",
+ "wit-parser 0.220.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6b907a1af1f2cf2160d7fe2ff5967cef120dc5c034d22593a1f24e40272cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "indexmap 2.2.6",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.221.2",
+ "wasm-metadata 0.221.2",
+ "wasmparser 0.221.2",
+ "wit-parser 0.221.2",
 ]
 
 [[package]]
@@ -4982,7 +5048,25 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.220.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,16 +277,16 @@ wit-bindgen = { version = "0.35.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.35.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.220.0", default-features = false }
-wat = "1.220.0"
-wast = "220.0.0"
-wasmprinter = "0.220.0"
-wasm-encoder = "0.220.0"
-wasm-smith = "0.220.0"
-wasm-mutate = "0.220.0"
-wit-parser = "0.220.0"
-wit-component = "0.220.0"
-wasm-wave = "0.220.0"
+wasmparser = { version = "0.221.2", default-features = false, features = ['simd'] }
+wat = "1.221.2"
+wast = "221.0.2"
+wasmprinter = "0.221.2"
+wasm-encoder = "0.221.2"
+wasm-smith = "0.221.2"
+wasm-mutate = "0.221.2"
+wit-parser = "0.221.2"
+wit-component = "0.221.2"
+wasm-wave = "0.221.2"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -2944,6 +2944,9 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             let (res1, res2) = builder.ins().isplit(result);
             state.push2(res1, res2);
         }
+
+        // catch-all as `Operator` is `#[non_exhaustive]`
+        op => return Err(wasm_unsupported!("operator {op:?}")),
     };
     Ok(())
 }

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -320,14 +320,11 @@ impl WastTest {
                 "spec_testsuite/ref_is_null.wast",
                 "spec_testsuite/ref_null.wast",
                 "spec_testsuite/select.wast",
-                "spec_testsuite/table-sub.wast",
                 "spec_testsuite/table_fill.wast",
                 "spec_testsuite/table_get.wast",
                 "spec_testsuite/table_grow.wast",
                 "spec_testsuite/table_set.wast",
                 "spec_testsuite/table_size.wast",
-                "spec_testsuite/unreached-invalid.wast",
-                "spec_testsuite/call_indirect.wast",
                 // simd-related failures
                 "annotations/simd_lane.wast",
                 "memory64/simd.wast",
@@ -408,7 +405,7 @@ impl WastTest {
         for part in self.path.iter() {
             // Not implemented in Wasmtime yet
             if part == "exception-handling" {
-                return !self.path.ends_with("binary.wast");
+                return !self.path.ends_with("binary.wast") && !self.path.ends_with("exports.wast");
             }
 
             if part == "memory64" {
@@ -416,7 +413,6 @@ impl WastTest {
                     // wasmtime doesn't implement exceptions yet
                     "imports.wast",
                     "ref_null.wast",
-                    "exports.wast",
                     "throw.wast",
                     "throw_ref.wast",
                     "try_table.wast",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1675,6 +1675,15 @@ criteria = "safe-to-deploy"
 delta = "1.0.26 -> 1.0.28"
 notes = "No new `unsafe` and no large changes in function. This diff is mostly refactoring with a lot of docs, CI, test changes. Adds some defensive clearing out of certain variables as a safeguard."
 
+[[audits.foldhash]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = """
+Only a minor amount of `unsafe` code in this crate related to global per-process
+initialization which looks correct to me.
+"""
+
 [[audits.foreign-types]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -4116,7 +4125,7 @@ end = "2024-07-14"
 criteria = "safe-to-deploy"
 user-id = 2915 # Amanieu d'Antras (Amanieu)
 start = "2019-04-02"
-end = "2024-07-11"
+end = "2025-12-02"
 
 [[trusted.indexmap]]
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -569,8 +569,8 @@ user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
 [[publisher.hashbrown]]
-version = "0.14.5"
-when = "2024-04-28"
+version = "0.15.2"
+when = "2024-11-25"
 user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
@@ -937,50 +937,50 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-encoder]]
-version = "0.219.1"
-when = "2024-10-10"
+version = "0.220.0"
+when = "2024-11-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-encoder]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasm-metadata]]
-version = "0.219.1"
-when = "2024-10-10"
+version = "0.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-metadata]]
 version = "0.220.0"
 when = "2024-11-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasm-metadata]]
+version = "0.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-wave]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmparser]]
-version = "0.219.1"
-when = "2024-10-10"
+version = "0.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmparser]]
 version = "0.220.0"
 when = "2024-11-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmparser]]
+version = "0.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmprinter]]
-version = "0.220.0"
-when = "2024-11-12"
+version = "0.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1129,14 +1129,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wast]]
-version = "220.0.0"
-when = "2024-11-12"
+version = "221.0.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wat]]
-version = "1.220.0"
-when = "2024-11-12"
+version = "1.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1384,26 +1384,26 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-component]]
-version = "0.219.1"
-when = "2024-10-10"
+version = "0.220.0"
+when = "2024-11-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-component]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-parser]]
-version = "0.219.1"
-when = "2024-10-10"
+version = "0.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-parser]]
 version = "0.220.0"
 when = "2024-11-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-parser]]
+version = "0.221.2"
+when = "2024-12-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Mostly comes with a split in `wasmparser` of simd/other ops since it's now possible to disable the `simd` feature at compile time (which we don't use in Wasmtime right now).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
