### PR TITLE
Update to regalloc2 0.11.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,13 +2604,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb13cfdd822509d57e9cf3021df28af2771dd4d9ac99d938d2fba85d3a9209c6"
+checksum = "145c1c267e14f20fb0f88aa76a1c5ffec42d592c1d28b3cd9148ae35916158d3"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
  "log",
  "rustc-hash 2.0.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,7 +257,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.11.0"
+regalloc2 = "0.11.1"
 
 # cap-std family:
 target-lexicon = "0.12.16"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1830,6 +1830,11 @@ criteria = "safe-to-deploy"
 delta = "0.13.1 -> 0.13.2"
 notes = "I read through the diff between v0.13.1 and v0.13.2, and verified that the changes made matched up with the changelog entries. There were very few changes between these two releases, and it was easy to verify what they did."
 
+[[audits.hashbrown]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.5 -> 0.15.2"
+
 [[audits.heck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -568,6 +568,13 @@ user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
+[[publisher.hashbrown]]
+version = "0.14.5"
+when = "2024-04-28"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
 [[publisher.indexmap]]
 version = "2.2.6"
 when = "2024-03-23"
@@ -673,8 +680,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.11.0"
-when = "2024-11-15"
+version = "0.11.1"
+when = "2024-12-02"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"


### PR DESCRIPTION
Pulls in a fix for a performance regression related to Rust's new standard library sort function.

(This is a semver-compatible upgrade to our existing 0.11.0 dep so should be pulled in by non-locked builds automatically, but let's do it explicitly to set the minimum version and get our vetting data updated too.)