### PR TITLE
winch: Improve frame handling

### DIFF
--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -212,21 +212,6 @@ impl ABIOperand {
             _ => unreachable!(),
         }
     }
-
-    /// Get the register associated to this [`ABIOperand`].
-    pub fn get_reg(&self) -> Option<Reg> {
-        match *self {
-            ABIOperand::Reg { reg, .. } => Some(reg),
-            _ => None,
-        }
-    }
-
-    /// Get the type associated to this [`ABIOperand`].
-    pub fn ty(&self) -> WasmValType {
-        match *self {
-            ABIOperand::Reg { ty, .. } | ABIOperand::Stack { ty, .. } => ty,
-        }
-    }
 }
 
 /// Information about the [`ABIOperand`] information used in [`ABISig`].

--- a/winch/codegen/src/codegen/bounds.rs
+++ b/winch/codegen/src/codegen/bounds.rs
@@ -4,7 +4,7 @@
 use super::env::HeapData;
 use crate::{
     abi::{scratch, vmctx},
-    codegen::CodeGenContext,
+    codegen::{CodeGenContext, Emission},
     isa::reg::{writable, Reg},
     masm::{IntCmpKind, MacroAssembler, OperandSize, RegImm, TrapCode},
     stack::TypedReg,
@@ -82,7 +82,7 @@ impl Index {
 
 /// Loads the bounds of the dynamic heap.
 pub(crate) fn load_dynamic_heap_bounds<M>(
-    context: &mut CodeGenContext,
+    context: &mut CodeGenContext<Emission>,
     masm: &mut M,
     heap: &HeapData,
     ptr_size: OperandSize,
@@ -149,7 +149,7 @@ pub(crate) fn ensure_index_and_offset<M: MacroAssembler>(
 /// criteria is in bounds.
 pub(crate) fn load_heap_addr_checked<M, F>(
     masm: &mut M,
-    context: &mut CodeGenContext,
+    context: &mut CodeGenContext<Emission>,
     ptr_size: OperandSize,
     heap: &HeapData,
     enable_spectre_mitigation: bool,

--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -58,7 +58,7 @@
 
 use crate::{
     abi::{scratch, vmctx, ABIOperand, ABISig, RetArea},
-    codegen::{BuiltinFunction, BuiltinType, Callee, CodeGenContext},
+    codegen::{BuiltinFunction, BuiltinType, Callee, CodeGenContext, Emission},
     masm::{
         CalleeKind, ContextArgs, MacroAssembler, MemMoveDirection, OperandSize, SPOffset,
         VMContextLoc,
@@ -85,7 +85,7 @@ impl FnCall {
     pub fn emit<M: MacroAssembler>(
         env: &mut FuncEnv<M::Ptr>,
         masm: &mut M,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
         callee: Callee,
     ) {
         let (kind, callee_context) = Self::lower(env, context.vmoffsets, &callee, context, masm);
@@ -129,7 +129,7 @@ impl FnCall {
         env: &mut FuncEnv<M::Ptr>,
         vmoffsets: &VMOffsets<u8>,
         callee: &Callee,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
         masm: &mut M,
     ) -> (CalleeKind, ContextArgs) {
         let ptr = vmoffsets.ptr.size();
@@ -177,7 +177,7 @@ impl FnCall {
     fn lower_import<M: MacroAssembler, P: PtrSize>(
         index: FuncIndex,
         sig: &ABISig,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
         masm: &mut M,
         vmoffsets: &VMOffsets<P>,
     ) -> (CalleeKind, ContextArgs) {
@@ -204,7 +204,7 @@ impl FnCall {
     fn lower_funcref<M: MacroAssembler>(
         sig: &ABISig,
         ptr: impl PtrSize,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
         masm: &mut M,
     ) -> (CalleeKind, ContextArgs) {
         // Pop the funcref pointer to a register and allocate a register to hold the
@@ -275,7 +275,7 @@ impl FnCall {
         sig: &ABISig,
         callee_context: &ContextArgs,
         ret_area: Option<&RetArea>,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
         masm: &mut M,
     ) {
         let arg_count = sig.params.len_without_retptr();
@@ -337,7 +337,7 @@ impl FnCall {
         reserved_space: u32,
         ret_area: Option<RetArea>,
         masm: &mut M,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
     ) {
         // Free any registers holding any function references.
         match callee_kind {

--- a/winch/codegen/src/codegen/phase.rs
+++ b/winch/codegen/src/codegen/phase.rs
@@ -1,0 +1,24 @@
+//! Type-based states to represent code generation phases.
+//! These states help enforce code generation invariants at compile time.
+//!
+//! Currently two phases are defined for code generation:
+//!
+//! * Prologue: responsible of setting up the function's frame.
+//! * Emission: emission of Wasm code to machine code.
+
+/// A code generation phase.
+pub trait CodeGenPhase {}
+
+/// The prologue phase.
+///
+/// Its main responsibility is to setup the function's frame, by creating the
+/// well known local slots. In this phase, writes to such slots is allowed.
+/// After this phase, the frame is considered immutable.
+pub struct Prologue;
+/// The code emission phase.
+///
+/// Its main responsibility is to emit Wasm code to machine code.
+pub struct Emission;
+
+impl CodeGenPhase for Prologue {}
+impl CodeGenPhase for Emission {}

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1,7 +1,7 @@
 use super::{abi::Aarch64ABI, address::Address, asm::Assembler, regs};
 use crate::{
     abi::local::LocalSlot,
-    codegen::{ptr_type_from_ptr_size, CodeGenContext, FuncEnv},
+    codegen::{ptr_type_from_ptr_size, CodeGenContext, Emission, FuncEnv},
     isa::reg::{writable, Reg, WritableReg},
     masm::{
         CalleeKind, DivKind, ExtendKind, FloatCmpKind, Imm as I, IntCmpKind,
@@ -350,11 +350,11 @@ impl Masm for MacroAssembler {
         self.asm.fabs_rr(dst.to_reg(), dst, size);
     }
 
-    fn float_round<F: FnMut(&mut FuncEnv<Self::Ptr>, &mut CodeGenContext, &mut Self)>(
+    fn float_round<F: FnMut(&mut FuncEnv<Self::Ptr>, &mut CodeGenContext<Emission>, &mut Self)>(
         &mut self,
         mode: RoundingMode,
         _env: &mut FuncEnv<Self::Ptr>,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
         size: OperandSize,
         _fallback: F,
     ) {
@@ -433,7 +433,12 @@ impl Masm for MacroAssembler {
         self.asm.shift_ir(imm, lhs, dst, kind, size)
     }
 
-    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize) {
+    fn shift(
+        &mut self,
+        context: &mut CodeGenContext<Emission>,
+        kind: ShiftKind,
+        size: OperandSize,
+    ) {
         let src = context.pop_to_reg(self, None);
         let dst = context.pop_to_reg(self, None);
 
@@ -444,11 +449,11 @@ impl Masm for MacroAssembler {
         context.stack.push(dst.into());
     }
 
-    fn div(&mut self, _context: &mut CodeGenContext, _kind: DivKind, _size: OperandSize) {
+    fn div(&mut self, _context: &mut CodeGenContext<Emission>, _kind: DivKind, _size: OperandSize) {
         todo!()
     }
 
-    fn rem(&mut self, _context: &mut CodeGenContext, _kind: RemKind, _size: OperandSize) {
+    fn rem(&mut self, _context: &mut CodeGenContext<Emission>, _kind: RemKind, _size: OperandSize) {
         todo!()
     }
 
@@ -456,7 +461,7 @@ impl Masm for MacroAssembler {
         self.asm.load_constant(0, reg);
     }
 
-    fn popcnt(&mut self, context: &mut CodeGenContext, size: OperandSize) {
+    fn popcnt(&mut self, context: &mut CodeGenContext<Emission>, size: OperandSize) {
         let src = context.pop_to_reg(self, None);
         let tmp = regs::float_scratch();
         self.asm.mov_to_fpu(src.into(), writable!(tmp), size);
@@ -700,7 +705,7 @@ impl Masm for MacroAssembler {
         todo!()
     }
 
-    fn mul_wide(&mut self, context: &mut CodeGenContext, kind: MulWideKind) {
+    fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind) {
         let _ = (context, kind);
         todo!()
     }

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -123,11 +123,12 @@ impl TargetIsa for Aarch64 {
         );
         let regalloc = RegAlloc::from(gpr, fpr);
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
-        let mut codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
+        let codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
 
-        codegen.emit(&mut body, validator)?;
-        let names = codegen.env.take_name_map();
-        let base = codegen.source_location.base;
+        let mut body_codegen = codegen.emit_prologue()?;
+        body_codegen.emit(&mut body, validator)?;
+        let names = body_codegen.env.take_name_map();
+        let base = body_codegen.source_location.base;
         Ok(CompiledFunction::new(
             masm.finalize(base),
             names,

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -134,12 +134,14 @@ impl TargetIsa for X64 {
 
         let regalloc = RegAlloc::from(gpr, fpr);
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
-        let mut codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
+        let codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
 
-        codegen.emit(&mut body, validator)?;
-        let base = codegen.source_location.base;
+        let mut body_codegen = codegen.emit_prologue()?;
 
-        let names = codegen.env.take_name_map();
+        body_codegen.emit(&mut body, validator)?;
+        let base = body_codegen.source_location.base;
+
+        let names = body_codegen.env.take_name_map();
         Ok(CompiledFunction::new(
             masm.finalize(base),
             names,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1,5 +1,5 @@
 use crate::abi::{self, align_to, scratch, LocalSlot};
-use crate::codegen::{CodeGenContext, FuncEnv};
+use crate::codegen::{CodeGenContext, Emission, FuncEnv};
 use crate::isa::reg::{writable, Reg, WritableReg};
 use cranelift_codegen::{
     binemit::CodeOffset,
@@ -744,11 +744,11 @@ pub(crate) trait MacroAssembler {
     fn float_neg(&mut self, dst: WritableReg, size: OperandSize);
 
     /// Perform a floating point floor operation.
-    fn float_round<F: FnMut(&mut FuncEnv<Self::Ptr>, &mut CodeGenContext, &mut Self)>(
+    fn float_round<F: FnMut(&mut FuncEnv<Self::Ptr>, &mut CodeGenContext<Emission>, &mut Self)>(
         &mut self,
         mode: RoundingMode,
         env: &mut FuncEnv<Self::Ptr>,
-        context: &mut CodeGenContext,
+        context: &mut CodeGenContext<Emission>,
         size: OperandSize,
         fallback: F,
     );
@@ -781,7 +781,7 @@ pub(crate) trait MacroAssembler {
     /// caller from having to deal with the architecture specific constraints
     /// we give this function access to the code generation context, allowing
     /// each implementation to decide the lowering path.
-    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize);
+    fn shift(&mut self, context: &mut CodeGenContext<Emission>, kind: ShiftKind, size: OperandSize);
 
     /// Perform division operation.
     /// Division is special in that some architectures have specific
@@ -794,10 +794,10 @@ pub(crate) trait MacroAssembler {
     /// unconstrained binary operation, the caller can decide to use
     /// the `CodeGenContext::i32_binop` or `CodeGenContext::i64_binop`
     /// functions.
-    fn div(&mut self, context: &mut CodeGenContext, kind: DivKind, size: OperandSize);
+    fn div(&mut self, context: &mut CodeGenContext<Emission>, kind: DivKind, size: OperandSize);
 
     /// Calculate remainder.
-    fn rem(&mut self, context: &mut CodeGenContext, kind: RemKind, size: OperandSize);
+    fn rem(&mut self, context: &mut CodeGenContext<Emission>, kind: RemKind, size: OperandSize);
 
     /// Compares `src1` against `src2` for the side effect of setting processor
     /// flags.
@@ -852,7 +852,7 @@ pub(crate) trait MacroAssembler {
 
     /// Count the number of 1 bits in src and put the result in dst. In x64,
     /// this will emit multiple instructions if the `has_popcnt` flag is false.
-    fn popcnt(&mut self, context: &mut CodeGenContext, size: OperandSize);
+    fn popcnt(&mut self, context: &mut CodeGenContext<Emission>, size: OperandSize);
 
     /// Converts an i64 to an i32 by discarding the high 32 bits.
     fn wrap(&mut self, dst: WritableReg, src: Reg);
@@ -1053,5 +1053,5 @@ pub(crate) trait MacroAssembler {
     ///
     /// Note that some platforms require special handling of registers in this
     /// instruction (e.g. x64) so full access to `CodeGenContext` is provided.
-    fn mul_wide(&mut self, context: &mut CodeGenContext, kind: MulWideKind);
+    fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind);
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -5,7 +5,7 @@
 //! machine code emitter.
 
 use crate::abi::RetArea;
-use crate::codegen::{control_index, Callee, CodeGen, ControlStackFrame, FnCall};
+use crate::codegen::{control_index, Callee, CodeGen, ControlStackFrame, Emission, FnCall};
 use crate::masm::{
     DivKind, ExtendKind, FloatCmpKind, IntCmpKind, MacroAssembler, MemMoveDirection, MulWideKind,
     OperandSize, RegImm, RemKind, RoundingMode, SPOffset, ShiftKind, TruncKind,
@@ -253,7 +253,7 @@ macro_rules! def_unsupported {
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
 
-impl<'a, 'translation, 'data, M> VisitOperator<'a> for CodeGen<'a, 'translation, 'data, M>
+impl<'a, 'translation, 'data, M> VisitOperator<'a> for CodeGen<'a, 'translation, 'data, M, Emission>
 where
     M: MacroAssembler,
 {
@@ -2212,7 +2212,8 @@ where
     wasmparser::for_each_visit_operator!(def_unsupported);
 }
 
-impl<'a, 'translation, 'data, M> VisitSimdOperator<'a> for CodeGen<'a, 'translation, 'data, M>
+impl<'a, 'translation, 'data, M> VisitSimdOperator<'a>
+    for CodeGen<'a, 'translation, 'data, M, Emission>
 where
     M: MacroAssembler,
 {
@@ -2231,7 +2232,7 @@ where
     wasmparser::for_each_visit_simd_operator!(def_unsupported);
 }
 
-impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M>
+impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M, Emission>
 where
     M: MacroAssembler,
 {


### PR DESCRIPTION
This commit addresses issues identified while working on issue #8091. It improves the frame handling in Winch to prevent subtle bugs and enhance the robustness of the code generation process.

Previously, there was no clear mechanism to verify when the frame was fully set up and safe to access the local slots allocated for register arguments, including the special slots used for the `VMContext`. As a result, it was possible to inadvertently read from uninitialized memory if calls were made before the frame was properly set up and sealed.

This commit introduces two main changes with the objective to help reduce the risk of introducing bugs related to the above:

* A `CodeGenPhase` trait, used via the type state pattern to clearly gate the operations allowed during each phase of the code generation process.

* Improve the semantics of locals, by clearly separating the notion of Wasm locals and special locals used by the compiler. This specialization allows a more accurate representation of the semantics of Wasm locals and their index space.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
