### PR TITLE
 Migrate libcalls to checking for traps 

### DIFF
--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -202,6 +202,7 @@ fn write_func_ref_at_addr(
         .ins()
         .call(intern_func_ref_for_gc_heap, &[vmctx, func_ref]);
     let func_ref_id = builder.func.dfg.first_result(call_inst);
+    let func_ref_id = builder.ins().ireduce(ir::types::I32, func_ref_id);
 
     // Store the id in the field.
     builder.ins().store(flags, func_ref_id, field_addr, 0);

--- a/crates/cranelift/src/gc/enabled/drc.rs
+++ b/crates/cranelift/src/gc/enabled/drc.rs
@@ -283,8 +283,8 @@ fn emit_gc_raw_alloc(
         .call(gc_alloc_raw_builtin, &[vmctx, kind, ty, size, align]);
 
     let gc_ref = builder.func.dfg.first_result(call_inst);
+    let gc_ref = builder.ins().ireduce(ir::types::I32, gc_ref);
     builder.declare_value_needs_stack_map(gc_ref);
-
     gc_ref
 }
 

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -756,7 +756,7 @@ pub fn translate_operator(
             let heap = state.get_heap(builder.func, *mem, environ)?;
             let val = state.pop1();
             environ.before_memory_grow(builder, val, heap_index);
-            state.push1(environ.translate_memory_grow(builder.cursor(), heap_index, heap, val)?)
+            state.push1(environ.translate_memory_grow(builder, heap_index, heap, val)?)
         }
         Operator::MemorySize { mem } => {
             let heap_index = MemoryIndex::from_u32(*mem);
@@ -1262,7 +1262,7 @@ pub fn translate_operator(
             // `fn translate_atomic_wait` can inspect the type of `expected` to figure out what
             // code it needs to generate, if it wants.
             let res = environ.translate_atomic_wait(
-                builder.cursor(),
+                builder,
                 heap_index,
                 heap,
                 effective_addr,
@@ -1284,7 +1284,7 @@ pub fn translate_operator(
                 environ.uadd_overflow_trap(builder, addr, offset, ir::TrapCode::HEAP_OUT_OF_BOUNDS)
             };
             let res = environ.translate_atomic_notify(
-                builder.cursor(),
+                builder,
                 heap_index,
                 heap,
                 effective_addr,
@@ -1502,14 +1502,7 @@ pub fn translate_operator(
             let src_pos = state.pop1();
             let dst_pos = state.pop1();
             environ.translate_memory_copy(
-                builder.cursor(),
-                src_index,
-                src_heap,
-                dst_index,
-                dst_heap,
-                dst_pos,
-                src_pos,
-                len,
+                builder, src_index, src_heap, dst_index, dst_heap, dst_pos, src_pos, len,
             )?;
         }
         Operator::MemoryFill { mem } => {
@@ -1518,7 +1511,7 @@ pub fn translate_operator(
             let len = state.pop1();
             let val = state.pop1();
             let dest = state.pop1();
-            environ.translate_memory_fill(builder.cursor(), heap_index, heap, dest, val, len)?;
+            environ.translate_memory_fill(builder, heap_index, heap, dest, val, len)?;
         }
         Operator::MemoryInit { data_index, mem } => {
             let heap_index = MemoryIndex::from_u32(*mem);
@@ -1527,7 +1520,7 @@ pub fn translate_operator(
             let src = state.pop1();
             let dest = state.pop1();
             environ.translate_memory_init(
-                builder.cursor(),
+                builder,
                 heap_index,
                 heap,
                 *data_index,
@@ -1548,12 +1541,7 @@ pub fn translate_operator(
             let table_index = TableIndex::from_u32(*index);
             let delta = state.pop1();
             let init_value = state.pop1();
-            state.push1(environ.translate_table_grow(
-                builder.cursor(),
-                table_index,
-                delta,
-                init_value,
-            )?);
+            state.push1(environ.translate_table_grow(builder, table_index, delta, init_value)?);
         }
         Operator::TableGet { table: index } => {
             let table_index = TableIndex::from_u32(*index);
@@ -1574,7 +1562,7 @@ pub fn translate_operator(
             let src = state.pop1();
             let dest = state.pop1();
             environ.translate_table_copy(
-                builder.cursor(),
+                builder,
                 TableIndex::from_u32(*dst_table_index),
                 TableIndex::from_u32(*src_table_index),
                 dest,
@@ -1587,7 +1575,7 @@ pub fn translate_operator(
             let len = state.pop1();
             let val = state.pop1();
             let dest = state.pop1();
-            environ.translate_table_fill(builder.cursor(), table_index, dest, val, len)?;
+            environ.translate_table_fill(builder, table_index, dest, val, len)?;
         }
         Operator::TableInit {
             elem_index,
@@ -1597,7 +1585,7 @@ pub fn translate_operator(
             let src = state.pop1();
             let dest = state.pop1();
             environ.translate_table_init(
-                builder.cursor(),
+                builder,
                 *elem_index,
                 TableIndex::from_u32(*table_index),
                 dest,

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -7,17 +7,17 @@ macro_rules! foreach_builtin_function {
             memory32_grow(vmctx: vmctx, delta: i64, index: i32) -> pointer;
             // Returns an index for wasm's `table.copy` when both tables are locally
             // defined.
-            table_copy(vmctx: vmctx, dst_index: i32, src_index: i32, dst: i64, src: i64, len: i64);
+            table_copy(vmctx: vmctx, dst_index: i32, src_index: i32, dst: i64, src: i64, len: i64) -> bool;
             // Returns an index for wasm's `table.init`.
-            table_init(vmctx: vmctx, table: i32, elem: i32, dst: i64, src: i64, len: i64);
+            table_init(vmctx: vmctx, table: i32, elem: i32, dst: i64, src: i64, len: i64) -> bool;
             // Returns an index for wasm's `elem.drop`.
             elem_drop(vmctx: vmctx, elem: i32);
             // Returns an index for wasm's `memory.copy`
-            memory_copy(vmctx: vmctx, dst_index: i32, dst: i64, src_index: i32, src: i64, len: i64);
+            memory_copy(vmctx: vmctx, dst_index: i32, dst: i64, src_index: i32, src: i64, len: i64) -> bool;
             // Returns an index for wasm's `memory.fill` instruction.
-            memory_fill(vmctx: vmctx, memory: i32, dst: i64, val: i32, len: i64);
+            memory_fill(vmctx: vmctx, memory: i32, dst: i64, val: i32, len: i64) -> bool;
             // Returns an index for wasm's `memory.init` instruction.
-            memory_init(vmctx: vmctx, memory: i32, data: i32, dst: i64, src: i32, len: i32);
+            memory_init(vmctx: vmctx, memory: i32, data: i32, dst: i64, src: i32, len: i32) -> bool;
             // Returns a value for wasm's `ref.func` instruction.
             ref_func(vmctx: vmctx, func: i32) -> pointer;
             // Returns an index for wasm's `data.drop` instruction.
@@ -27,32 +27,32 @@ macro_rules! foreach_builtin_function {
             // Returns an index for Wasm's `table.grow` instruction for `funcref`s.
             table_grow_func_ref(vmctx: vmctx, table: i32, delta: i64, init: pointer) -> pointer;
             // Returns an index for Wasm's `table.fill` instruction for `funcref`s.
-            table_fill_func_ref(vmctx: vmctx, table: i32, dst: i64, val: pointer, len: i64);
+            table_fill_func_ref(vmctx: vmctx, table: i32, dst: i64, val: pointer, len: i64) -> bool;
             // Returns an index for wasm's `memory.atomic.notify` instruction.
             #[cfg(feature = "threads")]
-            memory_atomic_notify(vmctx: vmctx, memory: i32, addr: i64, count: i32) -> i32;
+            memory_atomic_notify(vmctx: vmctx, memory: i32, addr: i64, count: i32) -> i64;
             // Returns an index for wasm's `memory.atomic.wait32` instruction.
             #[cfg(feature = "threads")]
-            memory_atomic_wait32(vmctx: vmctx, memory: i32, addr: i64, expected: i32, timeout: i64) -> i32;
+            memory_atomic_wait32(vmctx: vmctx, memory: i32, addr: i64, expected: i32, timeout: i64) -> i64;
             // Returns an index for wasm's `memory.atomic.wait64` instruction.
             #[cfg(feature = "threads")]
-            memory_atomic_wait64(vmctx: vmctx, memory: i32, addr: i64, expected: i64, timeout: i64) -> i32;
+            memory_atomic_wait64(vmctx: vmctx, memory: i32, addr: i64, expected: i64, timeout: i64) -> i64;
             // Invoked when fuel has run out while executing a function.
-            out_of_gas(vmctx: vmctx);
+            out_of_gas(vmctx: vmctx) -> bool;
             // Invoked when we reach a new epoch.
             new_epoch(vmctx: vmctx) -> i64;
             // Invoked before malloc returns.
             #[cfg(feature = "wmemcheck")]
-            check_malloc(vmctx: vmctx, addr: i32, len: i32);
+            check_malloc(vmctx: vmctx, addr: i32, len: i32) -> bool;
             // Invoked before the free returns.
             #[cfg(feature = "wmemcheck")]
-            check_free(vmctx: vmctx, addr: i32);
+            check_free(vmctx: vmctx, addr: i32) -> bool;
             // Invoked before a load is executed.
             #[cfg(feature = "wmemcheck")]
-            check_load(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32);
+            check_load(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> bool;
             // Invoked before a store is executed.
             #[cfg(feature = "wmemcheck")]
-            check_store(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32);
+            check_store(vmctx: vmctx, num_bytes: i32, addr: i32, offset: i32) -> bool;
             // Invoked after malloc is called.
             #[cfg(feature = "wmemcheck")]
             malloc_start(vmctx: vmctx);
@@ -77,7 +77,7 @@ macro_rules! foreach_builtin_function {
             // the updated `root` (so that, in the case of moving collectors,
             // callers have a valid version of `root` again).
             #[cfg(feature = "gc-drc")]
-            gc(vmctx: vmctx, root: reference) -> reference;
+            gc(vmctx: vmctx, root: i32) -> i64;
 
             // Allocate a new, uninitialized GC object and return a reference to
             // it.
@@ -88,7 +88,7 @@ macro_rules! foreach_builtin_function {
                 module_interned_type_index: i32,
                 size: i32,
                 align: i32
-            ) -> reference;
+            ) -> i64;
 
             // Intern a `funcref` into the GC heap, returning its
             // `FuncRefTableId`.
@@ -98,7 +98,7 @@ macro_rules! foreach_builtin_function {
             intern_func_ref_for_gc_heap(
                 vmctx: vmctx,
                 func_ref: pointer
-            ) -> i32;
+            ) -> i64;
 
             // Get the raw `VMFuncRef` pointer associated with a
             // `FuncRefTableId` from an earlier `intern_func_ref_for_gc_heap`
@@ -132,7 +132,7 @@ macro_rules! foreach_builtin_function {
                 data_index: i32,
                 data_offset: i32,
                 len: i32
-            ) -> reference;
+            ) -> i64;
 
             // Builtin implementation of the `array.new_elem` instruction.
             #[cfg(feature = "gc")]
@@ -142,42 +142,42 @@ macro_rules! foreach_builtin_function {
                 elem_index: i32,
                 elem_offset: i32,
                 len: i32
-            ) -> reference;
+            ) -> i64;
 
             // Builtin implementation of the `array.copy` instruction.
             #[cfg(feature = "gc")]
             array_copy(
                 vmctx: vmctx,
-                dst_array: reference,
+                dst_array: i32,
                 dst_index: i32,
-                src_array: reference,
+                src_array: i32,
                 src_index: i32,
                 len: i32
-            );
+            ) -> bool;
 
             // Builtin implementation of the `array.init_data` instruction.
             #[cfg(feature = "gc")]
             array_init_data(
                 vmctx: vmctx,
                 array_interned_type_index: i32,
-                array: reference,
+                array: i32,
                 dst_index: i32,
                 data_index: i32,
                 data_offset: i32,
                 len: i32
-            );
+            ) -> bool;
 
             // Builtin implementation of the `array.init_elem` instruction.
             #[cfg(feature = "gc")]
             array_init_elem(
                 vmctx: vmctx,
                 array_interned_type_index: i32,
-                array: reference,
+                array: i32,
                 dst: i32,
                 elem_index: i32,
                 src: i32,
                 len: i32
-            );
+            ) -> bool;
 
             // Returns whether `actual_engine_type` is a subtype of
             // `expected_engine_type`.
@@ -190,13 +190,16 @@ macro_rules! foreach_builtin_function {
 
             // Returns an index for Wasm's `table.grow` instruction for GC references.
             #[cfg(feature = "gc")]
-            table_grow_gc_ref(vmctx: vmctx, table: i32, delta: i64, init: reference) -> pointer;
+            table_grow_gc_ref(vmctx: vmctx, table: i32, delta: i64, init: i32) -> pointer;
 
             // Returns an index for Wasm's `table.fill` instruction for GC references.
             #[cfg(feature = "gc")]
-            table_fill_gc_ref(vmctx: vmctx, table: i32, dst: i64, val: reference, len: i64);
+            table_fill_gc_ref(vmctx: vmctx, table: i32, dst: i64, val: i32, len: i64) -> bool;
 
             // Raises an unconditional trap with the specified code.
+            //
+            // This is used when signals-based-traps are disabled for backends
+            // when an illegal instruction can't be executed for example.
             trap(vmctx: vmctx, code: u8);
 
             // Raises an unconditional trap where the trap information must have
@@ -288,3 +291,85 @@ macro_rules! declare_indexes {
 }
 
 foreach_builtin_function!(declare_indexes);
+
+/// Return value of [`BuiltinFunctionIndex::trap_sentinel`].
+pub enum TrapSentinel {
+    /// A falsy or zero value indicates a trap.
+    Falsy,
+    /// The value `-2` indicates a trap (used for growth-related builtins).
+    NegativeTwo,
+    /// The value `-1` indicates a trap .
+    NegativeOne,
+    /// Any negative value indicates a trap.
+    Negative,
+}
+
+impl BuiltinFunctionIndex {
+    /// Describes the return value of this builtin and what represents a trap.
+    ///
+    /// Libcalls don't raise traps themselves and instead delegate to compilers
+    /// to do so. This means that some return values of libcalls indicate a trap
+    /// is happening and this is represented with sentinel values. This function
+    /// returns the description of the sentinel value which indicates a trap, if
+    /// any. If `None` is returned from this function then this builtin cannot
+    /// generate a trap.
+    #[allow(unreachable_code, unused_macro_rules, reason = "macro-generated code")]
+    pub fn trap_sentinel(&self) -> Option<TrapSentinel> {
+        macro_rules! trap_sentinel {
+            (
+                $(
+                    $( #[$attr:meta] )*
+                    $name:ident( $( $pname:ident: $param:ident ),* ) $( -> $result:ident )?;
+                )*
+            ) => {{
+                $(
+                    $(#[$attr])*
+                    if *self == BuiltinFunctionIndex::$name() {
+                        let mut _ret = None;
+                        $(_ret = Some(trap_sentinel!(@get $name $result));)?
+                        return _ret;
+                    }
+                )*
+
+                None
+            }};
+
+            // Growth-related functions return -2 as a sentinel.
+            (@get memory32_grow pointer) => (TrapSentinel::NegativeTwo);
+            (@get table_grow_func_ref pointer) => (TrapSentinel::NegativeTwo);
+            (@get table_grow_gc_ref pointer) => (TrapSentinel::NegativeTwo);
+
+            // Atomics-related functions return a negative value indicating trap
+            // indicate a trap.
+            (@get memory_atomic_notify i64) => (TrapSentinel::Negative);
+            (@get memory_atomic_wait32 i64) => (TrapSentinel::Negative);
+            (@get memory_atomic_wait64 i64) => (TrapSentinel::Negative);
+
+            // GC-related functions return a 64-bit value which is negative to
+            // indicate a trap.
+            (@get gc i64) => (TrapSentinel::Negative);
+            (@get gc_alloc_raw i64) => (TrapSentinel::Negative);
+            (@get array_new_data i64) => (TrapSentinel::Negative);
+            (@get array_new_elem i64) => (TrapSentinel::Negative);
+
+            // The final epoch represents a trap
+            (@get new_epoch i64) => (TrapSentinel::NegativeOne);
+
+            // These libcalls can't trap
+            (@get ref_func pointer) => (return None);
+            (@get table_get_lazy_init_func_ref pointer) => (return None);
+            (@get get_interned_func_ref pointer) => (return None);
+            (@get intern_func_ref_for_gc_heap i64) => (return None);
+            (@get is_subtype i32) => (return None);
+
+            // Bool-returning functions use `false` as an indicator of a trap.
+            (@get $name:ident bool) => (TrapSentinel::Falsy);
+
+            (@get $name:ident $ret:ident) => (
+                compile_error!(concat!("no trap sentinel registered for ", stringify!($name)))
+            )
+        }
+
+        foreach_builtin_function!(trap_sentinel)
+    }
+}

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -69,10 +69,10 @@ pub use self::types_builder::*;
 macro_rules! foreach_transcoder {
     ($mac:ident) => {
         $mac! {
-            utf8_to_utf8(src: ptr_u8, len: size, dst: ptr_u8);
-            utf16_to_utf16(src: ptr_u16, len: size, dst: ptr_u16);
-            latin1_to_latin1(src: ptr_u8, len: size, dst: ptr_u8);
-            latin1_to_utf16(src: ptr_u8, len: size, dst: ptr_u16);
+            utf8_to_utf8(src: ptr_u8, len: size, dst: ptr_u8) -> bool;
+            utf16_to_utf16(src: ptr_u16, len: size, dst: ptr_u16) -> bool;
+            latin1_to_latin1(src: ptr_u8, len: size, dst: ptr_u8) -> bool;
+            latin1_to_utf16(src: ptr_u8, len: size, dst: ptr_u16) -> bool;
             utf8_to_utf16(src: ptr_u8, len: size, dst: ptr_u16) -> size;
             utf16_to_utf8(src: ptr_u16, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
             latin1_to_utf8(src: ptr_u8, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
@@ -91,8 +91,8 @@ macro_rules! foreach_transcoder {
 macro_rules! foreach_builtin_component_function {
     ($mac:ident) => {
         $mac! {
-            resource_new32(vmctx: vmctx, resource: u32, rep: u32) -> u32;
-            resource_rep32(vmctx: vmctx, resource: u32, idx: u32) -> u32;
+            resource_new32(vmctx: vmctx, resource: u32, rep: u32) -> u64;
+            resource_rep32(vmctx: vmctx, resource: u32, idx: u32) -> u64;
 
             // Returns an `Option<u32>` where `None` is "no destructor needed"
             // and `Some(val)` is "run the destructor on this rep". The option
@@ -100,10 +100,10 @@ macro_rules! foreach_builtin_component_function {
             // and bits 1-33 are the payload.
             resource_drop(vmctx: vmctx, resource: u32, idx: u32) -> u64;
 
-            resource_transfer_own(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u32;
-            resource_transfer_borrow(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u32;
+            resource_transfer_own(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
+            resource_transfer_borrow(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
             resource_enter_call(vmctx: vmctx);
-            resource_exit_call(vmctx: vmctx);
+            resource_exit_call(vmctx: vmctx) -> bool;
 
             trap(vmctx: vmctx, code: u8);
         }

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -808,7 +808,7 @@ macro_rules! define_builtin_array {
     (@ty i32) => (u32);
     (@ty i64) => (u64);
     (@ty u8) => (u8);
-    (@ty reference) => (u32);
+    (@ty bool) => (bool);
     (@ty pointer) => (*mut u8);
     (@ty vmctx) => (*mut VMContext);
 }

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -14,13 +14,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v42 = iconst.i64 0
-;; @0025                               trapnz v42, user18  ; v42 = 0
+;;                                     v43 = iconst.i64 0
+;; @0025                               trapnz v43, user18  ; v43 = 0
 ;; @0025                               v6 = iconst.i32 24
 ;; @0025                               v12 = uadd_overflow_trap v6, v6, user18  ; v6 = 24, v6 = 24
 ;; @0025                               v14 = iconst.i32 -1476395008
@@ -28,23 +28,24 @@
 ;; @0025                               v16 = iconst.i32 8
 ;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16)  ; v14 = -1476395008, v15 = 0, v16 = 8
 ;; @0025                               v7 = iconst.i32 3
-;; @0025                               v19 = load.i64 notrap aligned readonly v0+40
-;; @0025                               v20 = uextend.i64 v17
-;; @0025                               v21 = iadd v19, v20
-;;                                     v32 = iconst.i64 16
-;; @0025                               v22 = iadd v21, v32  ; v32 = 16
-;; @0025                               store notrap aligned v7, v22  ; v7 = 3
-;;                                     v34 = iconst.i64 24
-;;                                     v49 = iadd v21, v34  ; v34 = 24
-;; @0025                               store notrap aligned little v2, v49
-;;                                     v31 = iconst.i64 32
-;;                                     v56 = iadd v21, v31  ; v31 = 32
-;; @0025                               store notrap aligned little v3, v56
-;;                                     v58 = iconst.i64 40
-;;                                     v64 = iadd v21, v58  ; v58 = 40
-;; @0025                               store notrap aligned little v4, v64
+;; @0025                               v20 = load.i64 notrap aligned readonly v0+40
+;; @0025                               v18 = ireduce.i32 v17
+;; @0025                               v21 = uextend.i64 v18
+;; @0025                               v22 = iadd v20, v21
+;;                                     v33 = iconst.i64 16
+;; @0025                               v23 = iadd v22, v33  ; v33 = 16
+;; @0025                               store notrap aligned v7, v23  ; v7 = 3
+;;                                     v35 = iconst.i64 24
+;;                                     v50 = iadd v22, v35  ; v35 = 24
+;; @0025                               store notrap aligned little v2, v50
+;;                                     v32 = iconst.i64 32
+;;                                     v57 = iadd v22, v32  ; v32 = 32
+;; @0025                               store notrap aligned little v3, v57
+;;                                     v59 = iconst.i64 40
+;;                                     v65 = iadd v22, v59  ; v59 = 40
+;; @0025                               store notrap aligned little v4, v65
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v17
+;; @0029                               return v18
 ;; }

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -14,51 +14,52 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v34 = iconst.i64 3
-;;                                     v35 = ishl v6, v34  ; v34 = 3
-;;                                     v32 = iconst.i64 32
-;; @0022                               v8 = ushr v35, v32  ; v32 = 32
+;;                                     v35 = iconst.i64 3
+;;                                     v36 = ishl v6, v35  ; v35 = 3
+;;                                     v33 = iconst.i64 32
+;; @0022                               v8 = ushr v36, v33  ; v33 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 24
-;;                                     v41 = iconst.i32 3
-;;                                     v42 = ishl v3, v41  ; v41 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v42, user18  ; v5 = 24
+;;                                     v42 = iconst.i32 3
+;;                                     v43 = ishl v3, v42  ; v42 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v43, user18  ; v5 = 24
 ;; @0022                               v12 = iconst.i32 -1476395008
 ;; @0022                               v13 = iconst.i32 0
-;;                                     v39 = iconst.i32 8
-;; @0022                               v15 = call fn0(v0, v12, v13, v10, v39)  ; v12 = -1476395008, v13 = 0, v39 = 8
-;; @0022                               v17 = load.i64 notrap aligned readonly v0+40
-;; @0022                               v18 = uextend.i64 v15
-;; @0022                               v19 = iadd v17, v18
-;;                                     v33 = iconst.i64 16
-;; @0022                               v20 = iadd v19, v33  ; v33 = 16
-;; @0022                               store notrap aligned v3, v20
-;;                                     v46 = iconst.i64 24
-;;                                     v52 = iadd v19, v46  ; v46 = 24
-;; @0022                               v26 = uextend.i64 v10
-;; @0022                               v27 = iadd v19, v26
-;;                                     v31 = iconst.i64 8
-;; @0022                               jump block2(v52)
+;;                                     v40 = iconst.i32 8
+;; @0022                               v15 = call fn0(v0, v12, v13, v10, v40)  ; v12 = -1476395008, v13 = 0, v40 = 8
+;; @0022                               v18 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v16 = ireduce.i32 v15
+;; @0022                               v19 = uextend.i64 v16
+;; @0022                               v20 = iadd v18, v19
+;;                                     v34 = iconst.i64 16
+;; @0022                               v21 = iadd v20, v34  ; v34 = 16
+;; @0022                               store notrap aligned v3, v21
+;;                                     v47 = iconst.i64 24
+;;                                     v53 = iadd v20, v47  ; v47 = 24
+;; @0022                               v27 = uextend.i64 v10
+;; @0022                               v28 = iadd v20, v27
+;;                                     v32 = iconst.i64 8
+;; @0022                               jump block2(v53)
 ;;
-;;                                 block2(v28: i64):
-;; @0022                               v29 = icmp eq v28, v27
-;; @0022                               brif v29, block4, block3
+;;                                 block2(v29: i64):
+;; @0022                               v30 = icmp eq v29, v28
+;; @0022                               brif v30, block4, block3
 ;;
 ;;                                 block3:
-;; @0022                               store.i64 notrap aligned little v2, v28
-;;                                     v64 = iconst.i64 8
-;;                                     v65 = iadd.i64 v28, v64  ; v64 = 8
-;; @0022                               jump block2(v65)
+;; @0022                               store.i64 notrap aligned little v2, v29
+;;                                     v65 = iconst.i64 8
+;;                                     v66 = iadd.i64 v29, v65  ; v65 = 8
+;; @0022                               jump block2(v66)
 ;;
 ;;                                 block4:
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v15
+;; @0025                               return v16
 ;; }

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -18,7 +18,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -15,8 +15,8 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
-;;     sig1 = (i64 vmctx, i64) -> i32 uext tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
+;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     fn1 = colocated u1:28 sig1
 ;;     stack_limit = gv2
@@ -27,18 +27,20 @@
 ;; @0020                               v4 = iconst.i32 24
 ;; @0020                               v8 = iconst.i32 8
 ;; @0020                               v9 = call fn0(v0, v6, v7, v4, v8)  ; v6 = -1342177280, v7 = 0, v4 = 24, v8 = 8
-;;                                     v19 = stack_addr.i64 ss0
-;;                                     store notrap v9, v19
-;; @0020                               v16 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v11 = load.i64 notrap aligned readonly v0+40
-;; @0020                               v12 = uextend.i64 v9
-;; @0020                               v13 = iadd v11, v12
-;;                                     v21 = iconst.i64 16
-;; @0020                               v14 = iadd v13, v21  ; v21 = 16
-;; @0020                               store notrap aligned little v16, v14
-;;                                     v17 = load.i32 notrap v19
+;; @0020                               v10 = ireduce.i32 v9
+;;                                     v21 = stack_addr.i64 ss0
+;;                                     store notrap v10, v21
+;; @0020                               v17 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v18 = ireduce.i32 v17
+;; @0020                               v12 = load.i64 notrap aligned readonly v0+40
+;; @0020                               v13 = uextend.i64 v10
+;; @0020                               v14 = iadd v12, v13
+;;                                     v23 = iconst.i64 16
+;; @0020                               v15 = iadd v14, v23  ; v23 = 16
+;; @0020                               store notrap aligned little v18, v15
+;;                                     v19 = load.i32 notrap v21
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v17
+;; @0023                               return v19
 ;; }

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64) -> i32 uext tail
+;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u1:28 sig0
 ;;     stack_limit = gv2
 ;;
@@ -23,15 +23,16 @@
 ;; @0022                               v9 = uextend.i64 v2
 ;; @0022                               v10 = iconst.i64 16
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
-;;                                     v18 = iconst.i64 24
-;; @0022                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 24
+;;                                     v19 = iconst.i64 24
+;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 24
 ;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
 ;; @0022                               v17 = call fn0(v0, v3)
+;; @0022                               v18 = ireduce.i32 v17
 ;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               store notrap aligned little v17, v15
+;; @0022                               store notrap aligned little v18, v15
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -109,7 +109,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -16,7 +16,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
@@ -27,41 +27,42 @@
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v13 = load.i64 notrap aligned readonly v0+40
-;; @0021                               v14 = uextend.i64 v11
-;; @0021                               v15 = iadd v13, v14
-;;                                     v46 = iconst.i64 16
-;; @0021                               v16 = iadd v15, v46  ; v46 = 16
-;; @0021                               store notrap aligned little v3, v16  ; v3 = 0.0
-;;                                     v47 = iconst.i64 20
-;; @0021                               v17 = iadd v15, v47  ; v47 = 20
-;; @0021                               istore8 notrap aligned little v4, v17  ; v4 = 0
-;;                                     v57 = iconst.i8 1
-;; @0021                               brif v57, block3, block2  ; v57 = 1
+;; @0021                               v14 = load.i64 notrap aligned readonly v0+40
+;; @0021                               v12 = ireduce.i32 v11
+;; @0021                               v15 = uextend.i64 v12
+;; @0021                               v16 = iadd v14, v15
+;;                                     v47 = iconst.i64 16
+;; @0021                               v17 = iadd v16, v47  ; v47 = 16
+;; @0021                               store notrap aligned little v3, v17  ; v3 = 0.0
+;;                                     v48 = iconst.i64 20
+;; @0021                               v18 = iadd v16, v48  ; v48 = 20
+;; @0021                               istore8 notrap aligned little v4, v18  ; v4 = 0
+;;                                     v58 = iconst.i8 1
+;; @0021                               brif v58, block3, block2  ; v58 = 1
 ;;
 ;;                                 block2:
-;;                                     v64 = iconst.i64 0
-;; @0021                               v27 = iconst.i64 8
-;; @0021                               v28 = uadd_overflow_trap v64, v27, user1  ; v64 = 0, v27 = 8
-;; @0021                               v30 = uadd_overflow_trap v28, v27, user1  ; v27 = 8
-;; @0021                               v25 = load.i64 notrap aligned readonly v0+48
-;; @0021                               v31 = icmp ule v30, v25
-;; @0021                               trapz v31, user1
-;; @0021                               v32 = iadd.i64 v13, v28
-;; @0021                               v33 = load.i64 notrap aligned v32
-;; @0021                               trapz v31, user1
-;;                                     v50 = iconst.i64 1
-;; @0021                               v34 = iadd v33, v50  ; v50 = 1
-;; @0021                               store notrap aligned v34, v32
+;;                                     v65 = iconst.i64 0
+;; @0021                               v28 = iconst.i64 8
+;; @0021                               v29 = uadd_overflow_trap v65, v28, user1  ; v65 = 0, v28 = 8
+;; @0021                               v31 = uadd_overflow_trap v29, v28, user1  ; v28 = 8
+;; @0021                               v26 = load.i64 notrap aligned readonly v0+48
+;; @0021                               v32 = icmp ule v31, v26
+;; @0021                               trapz v32, user1
+;; @0021                               v33 = iadd.i64 v14, v29
+;; @0021                               v34 = load.i64 notrap aligned v33
+;; @0021                               trapz v32, user1
+;;                                     v51 = iconst.i64 1
+;; @0021                               v35 = iadd v34, v51  ; v51 = 1
+;; @0021                               store notrap aligned v35, v33
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v65 = iconst.i32 0
-;;                                     v48 = iconst.i64 24
-;; @0021                               v18 = iadd.i64 v15, v48  ; v48 = 24
-;; @0021                               store notrap aligned little v65, v18  ; v65 = 0
+;;                                     v66 = iconst.i32 0
+;;                                     v49 = iconst.i64 24
+;; @0021                               v19 = iadd.i64 v16, v49  ; v49 = 24
+;; @0021                               store notrap aligned little v66, v19  ; v66 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v11
+;; @0024                               return v12
 ;; }

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -17,62 +17,63 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v50 = stack_addr.i64 ss0
-;;                                     store notrap v4, v50
+;;                                     v51 = stack_addr.i64 ss0
+;;                                     store notrap v4, v51
 ;; @002a                               v8 = iconst.i32 -1342177280
 ;; @002a                               v9 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v13 = load.i64 notrap aligned readonly v0+40
-;; @002a                               v14 = uextend.i64 v11
-;; @002a                               v15 = iadd v13, v14
-;;                                     v51 = iconst.i64 16
-;; @002a                               v16 = iadd v15, v51  ; v51 = 16
-;; @002a                               store notrap aligned little v2, v16
-;;                                     v52 = iconst.i64 20
-;; @002a                               v17 = iadd v15, v52  ; v52 = 20
-;; @002a                               istore8 notrap aligned little v3, v17
-;;                                     v49 = load.i32 notrap v50
-;; @002a                               v19 = iconst.i32 -2
-;; @002a                               v20 = band v49, v19  ; v19 = -2
-;; @002a                               v21 = icmp eq v20, v9  ; v9 = 0
-;; @002a                               brif v21, block3, block2
+;; @002a                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002a                               v12 = ireduce.i32 v11
+;; @002a                               v15 = uextend.i64 v12
+;; @002a                               v16 = iadd v14, v15
+;;                                     v52 = iconst.i64 16
+;; @002a                               v17 = iadd v16, v52  ; v52 = 16
+;; @002a                               store notrap aligned little v2, v17
+;;                                     v53 = iconst.i64 20
+;; @002a                               v18 = iadd v16, v53  ; v53 = 20
+;; @002a                               istore8 notrap aligned little v3, v18
+;;                                     v50 = load.i32 notrap v51
+;; @002a                               v20 = iconst.i32 -2
+;; @002a                               v21 = band v50, v20  ; v20 = -2
+;; @002a                               v22 = icmp eq v21, v9  ; v9 = 0
+;; @002a                               brif v22, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v26 = uextend.i64 v49
-;; @002a                               v27 = iconst.i64 8
-;; @002a                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
-;; @002a                               v30 = uadd_overflow_trap v28, v27, user1  ; v27 = 8
-;; @002a                               v25 = load.i64 notrap aligned readonly v0+48
-;; @002a                               v31 = icmp ule v30, v25
-;; @002a                               trapz v31, user1
-;; @002a                               v32 = iadd.i64 v13, v28
-;; @002a                               v33 = load.i64 notrap aligned v32
-;;                                     v47 = load.i32 notrap v50
-;; @002a                               v39 = uextend.i64 v47
-;; @002a                               v41 = uadd_overflow_trap v39, v27, user1  ; v27 = 8
-;; @002a                               v43 = uadd_overflow_trap v41, v27, user1  ; v27 = 8
-;; @002a                               v44 = icmp ule v43, v25
-;; @002a                               trapz v44, user1
-;;                                     v57 = iconst.i64 1
-;; @002a                               v34 = iadd v33, v57  ; v57 = 1
-;; @002a                               v45 = iadd.i64 v13, v41
-;; @002a                               store notrap aligned v34, v45
+;; @002a                               v27 = uextend.i64 v50
+;; @002a                               v28 = iconst.i64 8
+;; @002a                               v29 = uadd_overflow_trap v27, v28, user1  ; v28 = 8
+;; @002a                               v31 = uadd_overflow_trap v29, v28, user1  ; v28 = 8
+;; @002a                               v26 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v32 = icmp ule v31, v26
+;; @002a                               trapz v32, user1
+;; @002a                               v33 = iadd.i64 v14, v29
+;; @002a                               v34 = load.i64 notrap aligned v33
+;;                                     v48 = load.i32 notrap v51
+;; @002a                               v40 = uextend.i64 v48
+;; @002a                               v42 = uadd_overflow_trap v40, v28, user1  ; v28 = 8
+;; @002a                               v44 = uadd_overflow_trap v42, v28, user1  ; v28 = 8
+;; @002a                               v45 = icmp ule v44, v26
+;; @002a                               trapz v45, user1
+;;                                     v58 = iconst.i64 1
+;; @002a                               v35 = iadd v34, v58  ; v58 = 1
+;; @002a                               v46 = iadd.i64 v14, v42
+;; @002a                               store notrap aligned v35, v46
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v46 = load.i32 notrap v50
-;;                                     v53 = iconst.i64 24
-;; @002a                               v18 = iadd.i64 v15, v53  ; v53 = 24
-;; @002a                               store notrap aligned little v46, v18
+;;                                     v47 = load.i32 notrap v51
+;;                                     v54 = iconst.i64 24
+;; @002a                               v19 = iadd.i64 v16, v54  ; v54 = 24
+;; @002a                               store notrap aligned little v47, v19
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v11
+;; @002d                               return v12
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -14,41 +14,42 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64) -> i32 uext tail
+;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u1:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;;                                     v34 = iconst.i32 0
-;; @0020                               trapnz v34, user18  ; v34 = 0
+;;                                     v35 = iconst.i32 0
+;; @0020                               trapnz v35, user18  ; v35 = 0
 ;; @0020                               v9 = load.i64 notrap aligned readonly v0+56
 ;; @0020                               v10 = load.i32 notrap aligned v9
-;;                                     v41 = iconst.i32 7
-;; @0020                               v13 = uadd_overflow_trap v10, v41, user18  ; v41 = 7
-;;                                     v48 = iconst.i32 -8
-;; @0020                               v15 = band v13, v48  ; v48 = -8
+;;                                     v42 = iconst.i32 7
+;; @0020                               v13 = uadd_overflow_trap v10, v42, user18  ; v42 = 7
+;;                                     v49 = iconst.i32 -8
+;; @0020                               v15 = band v13, v49  ; v49 = -8
 ;; @0020                               v4 = iconst.i32 16
 ;; @0020                               v16 = uadd_overflow_trap v15, v4, user18  ; v4 = 16
 ;; @0020                               v17 = uextend.i64 v16
 ;; @0020                               v21 = load.i64 notrap aligned readonly v0+48
 ;; @0020                               v22 = icmp ule v17, v21
 ;; @0020                               trapz v22, user18
-;;                                     v49 = iconst.i32 -1342177264
+;;                                     v50 = iconst.i32 -1342177264
 ;; @0020                               v19 = load.i64 notrap aligned readonly v0+40
 ;; @0020                               v23 = uextend.i64 v15
 ;; @0020                               v24 = iadd v19, v23
-;; @0020                               store notrap aligned v49, v24  ; v49 = -1342177264
+;; @0020                               store notrap aligned v50, v24  ; v50 = -1342177264
 ;; @0020                               v28 = load.i64 notrap aligned readonly v0+80
 ;; @0020                               v29 = load.i32 notrap aligned readonly v28
 ;; @0020                               store notrap aligned v29, v24+4
 ;; @0020                               store notrap aligned v16, v9
 ;; @0020                               v32 = call fn0(v0, v2)
-;;                                     v33 = iconst.i64 8
-;; @0020                               v30 = iadd v24, v33  ; v33 = 8
-;; @0020                               store notrap aligned little v32, v30
+;; @0020                               v33 = ireduce.i32 v32
+;;                                     v34 = iconst.i64 8
+;; @0020                               v30 = iadd v24, v34  ; v34 = 8
+;; @0020                               store notrap aligned little v33, v30
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v56 = band.i32 v13, v48  ; v48 = -8
-;; @0023                               return v56
+;;                                     v57 = band.i32 v13, v49  ; v49 = -8
+;; @0023                               return v57
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -14,7 +14,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i64) -> i32 uext tail
+;;     sig0 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u1:28 sig0
 ;;     stack_limit = gv2
 ;;
@@ -23,15 +23,16 @@
 ;; @0022                               v9 = uextend.i64 v2
 ;; @0022                               v10 = iconst.i64 8
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
-;;                                     v18 = iconst.i64 16
-;; @0022                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 16
+;;                                     v19 = iconst.i64 16
+;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 16
 ;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
 ;; @0022                               v17 = call fn0(v0, v3)
+;; @0022                               v18 = ireduce.i32 v17
 ;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               store notrap aligned little v17, v15
+;; @0022                               store notrap aligned little v18, v15
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -16,7 +16,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
@@ -27,41 +27,42 @@
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v13 = load.i64 notrap aligned readonly v0+40
-;; @0021                               v14 = uextend.i64 v11
-;; @0021                               v15 = iadd v13, v14
-;;                                     v46 = iconst.i64 16
-;; @0021                               v16 = iadd v15, v46  ; v46 = 16
-;; @0021                               store notrap aligned little v3, v16  ; v3 = 0.0
-;;                                     v47 = iconst.i64 20
-;; @0021                               v17 = iadd v15, v47  ; v47 = 20
-;; @0021                               istore8 notrap aligned little v4, v17  ; v4 = 0
-;;                                     v57 = iconst.i8 1
-;; @0021                               brif v57, block3, block2  ; v57 = 1
+;; @0021                               v14 = load.i64 notrap aligned readonly v0+40
+;; @0021                               v12 = ireduce.i32 v11
+;; @0021                               v15 = uextend.i64 v12
+;; @0021                               v16 = iadd v14, v15
+;;                                     v47 = iconst.i64 16
+;; @0021                               v17 = iadd v16, v47  ; v47 = 16
+;; @0021                               store notrap aligned little v3, v17  ; v3 = 0.0
+;;                                     v48 = iconst.i64 20
+;; @0021                               v18 = iadd v16, v48  ; v48 = 20
+;; @0021                               istore8 notrap aligned little v4, v18  ; v4 = 0
+;;                                     v58 = iconst.i8 1
+;; @0021                               brif v58, block3, block2  ; v58 = 1
 ;;
 ;;                                 block2:
-;;                                     v64 = iconst.i64 0
-;; @0021                               v27 = iconst.i64 8
-;; @0021                               v28 = uadd_overflow_trap v64, v27, user1  ; v64 = 0, v27 = 8
-;; @0021                               v30 = uadd_overflow_trap v28, v27, user1  ; v27 = 8
-;; @0021                               v25 = load.i64 notrap aligned readonly v0+48
-;; @0021                               v31 = icmp ule v30, v25
-;; @0021                               trapz v31, user1
-;; @0021                               v32 = iadd.i64 v13, v28
-;; @0021                               v33 = load.i64 notrap aligned v32
-;; @0021                               trapz v31, user1
-;;                                     v50 = iconst.i64 1
-;; @0021                               v34 = iadd v33, v50  ; v50 = 1
-;; @0021                               store notrap aligned v34, v32
+;;                                     v65 = iconst.i64 0
+;; @0021                               v28 = iconst.i64 8
+;; @0021                               v29 = uadd_overflow_trap v65, v28, user1  ; v65 = 0, v28 = 8
+;; @0021                               v31 = uadd_overflow_trap v29, v28, user1  ; v28 = 8
+;; @0021                               v26 = load.i64 notrap aligned readonly v0+48
+;; @0021                               v32 = icmp ule v31, v26
+;; @0021                               trapz v32, user1
+;; @0021                               v33 = iadd.i64 v14, v29
+;; @0021                               v34 = load.i64 notrap aligned v33
+;; @0021                               trapz v32, user1
+;;                                     v51 = iconst.i64 1
+;; @0021                               v35 = iadd v34, v51  ; v51 = 1
+;; @0021                               store notrap aligned v35, v33
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v65 = iconst.i32 0
-;;                                     v48 = iconst.i64 24
-;; @0021                               v18 = iadd.i64 v15, v48  ; v48 = 24
-;; @0021                               store notrap aligned little v65, v18  ; v65 = 0
+;;                                     v66 = iconst.i32 0
+;;                                     v49 = iconst.i64 24
+;; @0021                               v19 = iadd.i64 v16, v49  ; v49 = 24
+;; @0021                               store notrap aligned little v66, v19  ; v66 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v11
+;; @0024                               return v12
 ;; }

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -17,62 +17,63 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v50 = stack_addr.i64 ss0
-;;                                     store notrap v4, v50
+;;                                     v51 = stack_addr.i64 ss0
+;;                                     store notrap v4, v51
 ;; @002a                               v8 = iconst.i32 -1342177280
 ;; @002a                               v9 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v13 = load.i64 notrap aligned readonly v0+40
-;; @002a                               v14 = uextend.i64 v11
-;; @002a                               v15 = iadd v13, v14
-;;                                     v51 = iconst.i64 16
-;; @002a                               v16 = iadd v15, v51  ; v51 = 16
-;; @002a                               store notrap aligned little v2, v16
-;;                                     v52 = iconst.i64 20
-;; @002a                               v17 = iadd v15, v52  ; v52 = 20
-;; @002a                               istore8 notrap aligned little v3, v17
-;;                                     v49 = load.i32 notrap v50
-;; @002a                               v19 = iconst.i32 -2
-;; @002a                               v20 = band v49, v19  ; v19 = -2
-;; @002a                               v21 = icmp eq v20, v9  ; v9 = 0
-;; @002a                               brif v21, block3, block2
+;; @002a                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002a                               v12 = ireduce.i32 v11
+;; @002a                               v15 = uextend.i64 v12
+;; @002a                               v16 = iadd v14, v15
+;;                                     v52 = iconst.i64 16
+;; @002a                               v17 = iadd v16, v52  ; v52 = 16
+;; @002a                               store notrap aligned little v2, v17
+;;                                     v53 = iconst.i64 20
+;; @002a                               v18 = iadd v16, v53  ; v53 = 20
+;; @002a                               istore8 notrap aligned little v3, v18
+;;                                     v50 = load.i32 notrap v51
+;; @002a                               v20 = iconst.i32 -2
+;; @002a                               v21 = band v50, v20  ; v20 = -2
+;; @002a                               v22 = icmp eq v21, v9  ; v9 = 0
+;; @002a                               brif v22, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v26 = uextend.i64 v49
-;; @002a                               v27 = iconst.i64 8
-;; @002a                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
-;; @002a                               v30 = uadd_overflow_trap v28, v27, user1  ; v27 = 8
-;; @002a                               v25 = load.i64 notrap aligned readonly v0+48
-;; @002a                               v31 = icmp ule v30, v25
-;; @002a                               trapz v31, user1
-;; @002a                               v32 = iadd.i64 v13, v28
-;; @002a                               v33 = load.i64 notrap aligned v32
-;;                                     v47 = load.i32 notrap v50
-;; @002a                               v39 = uextend.i64 v47
-;; @002a                               v41 = uadd_overflow_trap v39, v27, user1  ; v27 = 8
-;; @002a                               v43 = uadd_overflow_trap v41, v27, user1  ; v27 = 8
-;; @002a                               v44 = icmp ule v43, v25
-;; @002a                               trapz v44, user1
-;;                                     v57 = iconst.i64 1
-;; @002a                               v34 = iadd v33, v57  ; v57 = 1
-;; @002a                               v45 = iadd.i64 v13, v41
-;; @002a                               store notrap aligned v34, v45
+;; @002a                               v27 = uextend.i64 v50
+;; @002a                               v28 = iconst.i64 8
+;; @002a                               v29 = uadd_overflow_trap v27, v28, user1  ; v28 = 8
+;; @002a                               v31 = uadd_overflow_trap v29, v28, user1  ; v28 = 8
+;; @002a                               v26 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v32 = icmp ule v31, v26
+;; @002a                               trapz v32, user1
+;; @002a                               v33 = iadd.i64 v14, v29
+;; @002a                               v34 = load.i64 notrap aligned v33
+;;                                     v48 = load.i32 notrap v51
+;; @002a                               v40 = uextend.i64 v48
+;; @002a                               v42 = uadd_overflow_trap v40, v28, user1  ; v28 = 8
+;; @002a                               v44 = uadd_overflow_trap v42, v28, user1  ; v28 = 8
+;; @002a                               v45 = icmp ule v44, v26
+;; @002a                               trapz v45, user1
+;;                                     v58 = iconst.i64 1
+;; @002a                               v35 = iadd v34, v58  ; v58 = 1
+;; @002a                               v46 = iadd.i64 v14, v42
+;; @002a                               store notrap aligned v35, v46
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v46 = load.i32 notrap v50
-;;                                     v53 = iconst.i64 24
-;; @002a                               v18 = iadd.i64 v15, v53  ; v53 = 24
-;; @002a                               store notrap aligned little v46, v18
+;;                                     v47 = load.i32 notrap v51
+;;                                     v54 = iconst.i64 24
+;; @002a                               v19 = iadd.i64 v16, v54  ; v54 = 24
+;; @002a                               store notrap aligned little v47, v19
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v11
+;; @002d                               return v12
 ;; }

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -20,7 +20,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+104
 ;;     gv5 = load.i64 notrap aligned readonly checked gv3+96
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i32 uext, i32 uext) tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i32 uext, i32 uext) -> i8 tail
 ;;     fn0 = colocated u1:6 sig0
 ;;     stack_limit = gv2
 ;;
@@ -29,7 +29,7 @@
 ;; @003d                               v6 = iconst.i32 0
 ;; @003d                               v7 = global_value.i64 gv3
 ;; @003d                               v8 = uextend.i64 v2
-;; @003d                               call fn0(v7, v5, v6, v8, v3, v4)  ; v5 = 0, v6 = 0
+;; @003d                               v9 = call fn0(v7, v5, v6, v8, v3, v4)  ; v5 = 0, v6 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -20,7 +20,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -67,7 +67,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) -> i8 tail
 ;;     fn0 = colocated u1:1 sig0
 ;;     stack_limit = gv2
 ;;
@@ -78,7 +78,7 @@
 ;; @0090                               v10 = iconst.i32 0
 ;; @0090                               v11 = iconst.i32 1
 ;; @0090                               v12 = global_value.i64 gv3
-;; @0090                               call fn0(v12, v10, v11, v7, v8, v9)  ; v10 = 0, v11 = 1
+;; @0090                               v13 = call fn0(v12, v10, v11, v7, v8, v9)  ; v10 = 0, v11 = 1
 ;; @0094                               jump block1(v2)
 ;;
 ;;                                 block1(v6: i32):
@@ -90,7 +90,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) tail
+;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i64, i64, i64) -> i8 tail
 ;;     fn0 = colocated u1:1 sig0
 ;;     stack_limit = gv2
 ;;
@@ -101,7 +101,7 @@
 ;; @009f                               v10 = iconst.i32 1
 ;; @009f                               v11 = iconst.i32 0
 ;; @009f                               v12 = global_value.i64 gv3
-;; @009f                               call fn0(v12, v10, v11, v7, v8, v9)  ; v10 = 1, v11 = 0
+;; @009f                               v13 = call fn0(v12, v10, v11, v7, v8, v9)  ; v10 = 1, v11 = 0
 ;; @00a3                               jump block1(v2)
 ;;
 ;;                                 block1(v6: i32):

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -22,7 +22,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -112,7 +112,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -22,7 +22,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i32) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;
@@ -114,7 +114,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned gv3+96
-;;     sig0 = (i64 vmctx, i32) -> i32 tail
+;;     sig0 = (i64 vmctx, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -146,7 +146,7 @@
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x9b7
+;;       callq   0x9d0
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -158,7 +158,7 @@
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x9b7
+;;       callq   0x9d0
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9f6
+;;       callq   0xa0f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9f6
+;;       callq   0xa0f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9f6
+;;       callq   0xa0f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x9f6
+;;       callq   0xa0f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9f6
+;;       callq   0xa0f
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -243,7 +243,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0xa38
+;;       callq   0xa6a
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -150,8 +150,8 @@ macro_rules! declare_function_sig {
                 WasmValType::I64
             }
 
-            fn reference(&self) -> WasmValType {
-                self.pointer()
+            fn bool(&self) -> WasmValType {
+                WasmValType::I32
             }
 
             fn over_f64<A: ABI>(&self) -> ABISig {

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -624,4 +624,11 @@ impl<'a> CodeGenContext<'a, Emission> {
         self.stack.push(lo.into());
         self.stack.push(hi.into());
     }
+
+    /// Pops a register from the stack and then immediately frees it. Used to
+    /// discard values from the last operation, for example.
+    pub fn pop_and_free<M: MacroAssembler>(&mut self, masm: &mut M) {
+        let reg = self.pop_to_reg(masm, None);
+        self.free_reg(reg.reg);
+    }
 }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -992,6 +992,7 @@ where
             continuation,
             OperandSize::S64,
         );
+        self.context.free_reg(fuel_var);
         // Out-of-fuel branch.
         FnCall::emit::<M>(
             &mut self.env,
@@ -999,9 +1000,10 @@ where
             &mut self.context,
             Callee::Builtin(out_of_fuel.clone()),
         );
+        self.context.pop_and_free(self.masm);
+
         // Under fuel limits branch.
         self.masm.bind(continuation);
-        self.context.free_reg(fuel_var);
     }
 
     /// Emits a series of instructions that load the `fuel_consumed` field from

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1426,7 +1426,8 @@ where
             self.masm,
             &mut self.context,
             Callee::Builtin(builtin.clone()),
-        )
+        );
+        self.context.pop_and_free(self.masm);
     }
 
     fn visit_table_copy(&mut self, dst: u32, src: u32) {
@@ -1442,7 +1443,8 @@ where
             self.masm,
             &mut self.context,
             Callee::Builtin(builtin),
-        )
+        );
+        self.context.pop_and_free(self.masm);
     }
 
     fn visit_table_get(&mut self, table: u32) {
@@ -1491,7 +1493,7 @@ where
             self.masm,
             &mut self.context,
             Callee::Builtin(builtin.clone()),
-        )
+        );
     }
 
     fn visit_table_size(&mut self, table: u32) {
@@ -1519,7 +1521,8 @@ where
             self.masm,
             &mut self.context,
             Callee::Builtin(builtin.clone()),
-        )
+        );
+        self.context.pop_and_free(self.masm);
     }
 
     fn visit_table_set(&mut self, table: u32) {
@@ -1579,7 +1582,8 @@ where
             self.masm,
             &mut self.context,
             Callee::Builtin(builtin),
-        )
+        );
+        self.context.pop_and_free(self.masm);
     }
 
     fn visit_memory_copy(&mut self, dst_mem: u32, src_mem: u32) {
@@ -1607,7 +1611,8 @@ where
             self.masm,
             &mut self.context,
             Callee::Builtin(builtin),
-        )
+        );
+        self.context.pop_and_free(self.masm);
     }
 
     fn visit_memory_fill(&mut self, mem: u32) {
@@ -1624,7 +1629,8 @@ where
             self.masm,
             &mut self.context,
             Callee::Builtin(builtin),
-        )
+        );
+        self.context.pop_and_free(self.masm);
     }
 
     fn visit_memory_size(&mut self, mem: u32) {


### PR DESCRIPTION
This PR is the equivalent of https://github.com/bytecodealliance/wasmtime/pull/9675 for libcalls used in core wasm and components.
All libcalls now communicate whether or not they trapped through their
return value instead of implicitly calling `longjmp` to exit from the
libcall. This is to make integration with Pulley easier to avoid the
need to `longjmp` over Pulley execution.

Libcall definitions have changed where appropriate and the
`catch_unwind_and_record_trap` function introduced in https://github.com/bytecodealliance/wasmtime/pull/9675 was
refactored to better support multiple types of values being returned
from libcalls (instead of just `Result<()>`).

Note that changes have been made to both the Cranelift translation layer
and the Winch translation layer for this as the ABI of various libcalls
are all changing.