### PR TITLE
Pin some runner images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
   # Note that `wasmtime-platform.h` is excluded here as it's auto-generated.
   clangformat:
     name: Clang format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # FIXME: fails on `ubuntu-24.04` right now
     steps:
     - uses: actions/checkout@v4
       with:
@@ -857,7 +857,7 @@ jobs:
     needs: determine
     if: needs.determine.outputs.run-dwarf
     name: Test DWARF debugging
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-22.04 # FIXME: fails on `ubuntu-24.04` right now
     steps:
     - uses: actions/checkout@v4
       with:

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -4,69 +4,73 @@
 // This is a separate script primarily to write out all the release
 // targets/platforms once and then duplicate them all with a "min" build.
 
+const ubuntu = 'ubuntu-22.04';
+const windows = 'windows-2022';
+const macos = 'macos-14';
+
 const array = [
   {
     // The name of the build which shows up in the name of the artifact for
     // Wasmtime's github releases.
     "build": "x86_64-linux",
     // The GitHub Actions platform that this build runs on
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     // The Rust target that will be used for the build.
     "target": "x86_64-unknown-linux-gnu",
   },
   {
     "build": "aarch64-linux",
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "aarch64-unknown-linux-gnu",
   },
   {
     "build": "s390x-linux",
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "s390x-unknown-linux-gnu",
   },
   {
     "build": "riscv64gc-linux",
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "riscv64gc-unknown-linux-gnu",
   },
   {
     "build": "x86_64-macos",
-    "os": "macos-latest",
+    "os": macos,
     "target": "x86_64-apple-darwin",
   },
   {
     "build": "aarch64-macos",
-    "os": "macos-latest",
+    "os": macos,
     "target": "aarch64-apple-darwin",
   },
   {
     "build": "x86_64-windows",
-    "os": "windows-latest",
+    "os": windows,
     "target": "x86_64-pc-windows-msvc",
   },
   {
     "build": "x86_64-mingw",
-    "os": "windows-latest",
+    "os": windows,
     "target": "x86_64-pc-windows-gnu",
   },
   {
     "build": "aarch64-android",
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "aarch64-linux-android",
   },
   {
     "build": "x86_64-android",
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "x86_64-linux-android",
   },
   {
     "build": "x86_64-musl",
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "x86_64-unknown-linux-musl",
   },
   {
     "build": "aarch64-windows",
-    "os": "windows-latest",
+    "os": windows,
     "target": "aarch64-pc-windows-msvc",
   },
 ];

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -15,11 +15,15 @@ const GENERIC_BUCKETS = 3;
 // compile-and-test crates.
 const SINGLE_CRATE_BUCKETS = ["wasmtime", "wasmtime-cli", "wasmtime-wasi"];
 
+const ubuntu = 'ubuntu-22.04';
+const windows = 'windows-2022';
+const macos = 'macos-14';
+
 // This is the small, fast-to-execute matrix we use for PRs before they enter
 // the merge queue. Same schema as `FULL_MATRIX`.
 const FAST_MATRIX = [
   {
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "name": "Test Linux x86_64",
     "filter": "linux-x64",
     "isa": "x64",
@@ -64,14 +68,14 @@ function supports32Bit(pkg) {
 const FULL_MATRIX = [
   ...FAST_MATRIX,
   {
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "name": "Test MSRV on Linux x86_64",
     "filter": "linux-x64",
     "isa": "x64",
     "rust": "msrv",
   },
   {
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "name": "Test Linux x86_64 with MPK",
     "filter": "linux-x64",
     "isa": "x64"
@@ -82,24 +86,24 @@ const FULL_MATRIX = [
     "filter": "macos-x64",
   },
   {
-    "os": "macos-14",
+    "os": macos,
     "name": "Test macOS arm64",
     "filter": "macos-arm64",
     "target": "aarch64-apple-darwin",
   },
   {
-    "os": "windows-latest",
+    "os": windows,
     "name": "Test Windows MSVC x86_64",
     "filter": "windows-x64",
   },
   {
-    "os": "windows-latest",
+    "os": windows,
     "target": "x86_64-pc-windows-gnu",
     "name": "Test Windows MinGW x86_64",
     "filter": "mingw-x64"
   },
   {
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "aarch64-unknown-linux-gnu",
     "gcc_package": "gcc-aarch64-linux-gnu",
     "gcc": "aarch64-linux-gnu-gcc",
@@ -110,7 +114,7 @@ const FULL_MATRIX = [
     "isa": "aarch64",
   },
   {
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "s390x-unknown-linux-gnu",
     "gcc_package": "gcc-s390x-linux-gnu",
     "gcc": "s390x-linux-gnu-gcc",
@@ -121,7 +125,7 @@ const FULL_MATRIX = [
     "isa": "s390x"
   },
   {
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "riscv64gc-unknown-linux-gnu",
     "gcc_package": "gcc-riscv64-linux-gnu",
     "gcc": "riscv64-linux-gnu-gcc",
@@ -134,7 +138,7 @@ const FULL_MATRIX = [
   {
     "name": "Tests on i686-unknown-linux-gnu",
     "32-bit": true,
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "i686-unknown-linux-gnu",
     "gcc_package": "gcc-i686-linux-gnu",
     "gcc": "i686-linux-gnu-gcc",
@@ -142,7 +146,7 @@ const FULL_MATRIX = [
   {
     "name": "Tests on armv7-unknown-linux-gnueabihf",
     "32-bit": true,
-    "os": "ubuntu-latest",
+    "os": ubuntu,
     "target": "armv7-unknown-linux-gnueabihf",
     "gcc_package": "gcc-arm-linux-gnueabihf",
     "gcc": "arm-linux-gnueabihf-gcc",


### PR DESCRIPTION
For the larger test/build jobs use some variables in the `*.js` files calculating the matrix to pin the images to fixed versions of GitHub actions images. For the `main.yml` file instead of changing everything over to a pin only do the ones that are currently failing on the `ubuntu-24.04` update. The hope is that there's only a few locations to update pinned versions in the future, and we'll need to keep an eye on CI warnings and such to know when to update these pins in the future.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
