### PR TITLE
Add basic pulley disassembly support to `clif-util`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "indicatif",
  "log",
  "pretty_env_logger",
+ "pulley-interpreter",
  "rayon",
  "regalloc2",
  "rustc-hash 2.0.0",

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -52,6 +52,7 @@ rustc-hash = { workspace = true }
 # Note that this just enables `trace-log` for `clif-util` and doesn't turn it on
 # for all of Cranelift, which would be bad.
 regalloc2 = { workspace = true, features = ["trace-log"] }
+pulley-interpreter = { workspace = true, optional = true }
 
 [features]
 default = [
@@ -64,3 +65,4 @@ disas = ["capstone"]
 souper-harvest = ["cranelift-codegen/souper-harvest", "rayon"]
 all-arch = ["cranelift-codegen/all-arch"]
 all-native-arch = ["cranelift-codegen/all-native-arch"]
+pulley = ['cranelift-codegen/pulley', 'dep:pulley-interpreter']

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -39,12 +39,14 @@ pub fn print_traps(traps: &[MachTrap]) -> String {
 cfg_if! {
     if #[cfg(feature = "disas")] {
         pub fn print_disassembly(func: &Function, isa: &dyn TargetIsa, mem: &[u8]) -> Result<()> {
+            #[cfg(feature = "pulley")]
             let is_pulley = match isa.triple().architecture {
                 target_lexicon::Architecture::Pulley32 | target_lexicon::Architecture::Pulley64 => true,
                 _ => false,
             };
             println!("\nDisassembly of {} bytes <{}>:", mem.len(), func.name);
 
+            #[cfg(feature = "pulley")]
             if is_pulley {
                 let mut disas = pulley_interpreter::disas::Disassembler::new(mem);
                 pulley_interpreter::decode::Decoder::decode_all(&mut disas)?;

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -39,9 +39,20 @@ pub fn print_traps(traps: &[MachTrap]) -> String {
 cfg_if! {
     if #[cfg(feature = "disas")] {
         pub fn print_disassembly(func: &Function, isa: &dyn TargetIsa, mem: &[u8]) -> Result<()> {
+            let is_pulley = match isa.triple().architecture {
+                target_lexicon::Architecture::Pulley32 | target_lexicon::Architecture::Pulley64 => true,
+                _ => false,
+            };
+            println!("\nDisassembly of {} bytes <{}>:", mem.len(), func.name);
+
+            if is_pulley {
+                let mut disas = pulley_interpreter::disas::Disassembler::new(mem);
+                pulley_interpreter::decode::Decoder::decode_all(&mut disas)?;
+                println!("{}", disas.disas());
+                return Ok(());
+            }
             let cs = isa.to_capstone().map_err(|e| anyhow::format_err!("{}", e))?;
 
-            println!("\nDisassembly of {} bytes <{}>:", mem.len(), func.name);
             let insns = cs.disasm_all(&mem, 0x0).unwrap();
             for i in insns.iter() {
                 let mut line = String::new();

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -274,7 +274,7 @@ impl<'a> OpVisitor for Disassembler<'a> {
                 write!(&mut self.disas, "{space}{byte:02x}").unwrap();
                 need_space = true;
             }
-            for _ in 0..11_usize.saturating_sub(size) {
+            for _ in 0..12_usize.saturating_sub(size) {
                 write!(&mut self.disas, "   ").unwrap();
             }
         }


### PR DESCRIPTION
Helpful when running `clif-util compile -D --target pulley64` over the input.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
