### PR TITLE
Fix `wasmtime::FieldType::matches` for subtyping and mutability

### DIFF
--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -1235,11 +1235,16 @@ impl TypeRegistry {
     }
 
     /// Is type `sub` a subtype of `sup`?
+    #[inline]
     pub fn is_subtype(&self, sub: VMSharedTypeIndex, sup: VMSharedTypeIndex) -> bool {
         if sub == sup {
             return true;
         }
 
+        self.is_subtype_slow(sub, sup)
+    }
+
+    fn is_subtype_slow(&self, sub: VMSharedTypeIndex, sup: VMSharedTypeIndex) -> bool {
         // Do the O(1) subtype checking trick:
         //
         // In a type system with single inheritance, the subtyping relationships

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1362,7 +1362,14 @@ impl StorageType {
     /// Panics if either type is associated with a different engine from the
     /// other.
     pub fn eq(a: &Self, b: &Self) -> bool {
-        a.matches(b) && b.matches(a)
+        match (a, b) {
+            (StorageType::I8, StorageType::I8) => true,
+            (StorageType::I8, _) => false,
+            (StorageType::I16, StorageType::I16) => true,
+            (StorageType::I16, _) => false,
+            (StorageType::ValType(a), StorageType::ValType(b)) => ValType::eq(a, b),
+            (StorageType::ValType(_), _) => false,
+        }
     }
 
     pub(crate) fn comes_from_same_engine(&self, engine: &Engine) -> bool {
@@ -1457,8 +1464,21 @@ impl FieldType {
     /// Panics if either type is associated with a different engine from the
     /// other.
     pub fn matches(&self, other: &Self) -> bool {
-        (other.mutability == Mutability::Var || self.mutability == Mutability::Const)
-            && self.element_type.matches(&other.element_type)
+        // Our storage type must match `other`'s storage type and either
+        //
+        // 1. Both field types are immutable, or
+        //
+        // 2. Both field types are mutable and `other`'s storage type must match
+        //    ours, i.e. the storage types are exactly the same.
+        use Mutability as M;
+        match (self.mutability, other.mutability) {
+            // Case 1
+            (M::Const, M::Const) => self.element_type.matches(&other.element_type),
+            // Case 2
+            (M::Var, M::Var) => StorageType::eq(&self.element_type, &other.element_type),
+            // Does not match.
+            _ => false,
+        }
     }
 
     /// Is field type `a` precisely equal to field type `b`?
@@ -1676,13 +1696,9 @@ impl StructType {
     pub fn matches(&self, other: &StructType) -> bool {
         assert!(self.comes_from_same_engine(other.engine()));
 
-        // Avoid matching on structure for subtyping checks when we have
-        // precisely the same type.
-        if self.type_index() == other.type_index() {
-            return true;
-        }
-
-        Self::fields_match(self.fields(), other.fields())
+        self.engine()
+            .signatures()
+            .is_subtype(self.type_index(), other.type_index())
     }
 
     fn fields_match(
@@ -1940,13 +1956,9 @@ impl ArrayType {
     pub fn matches(&self, other: &ArrayType) -> bool {
         assert!(self.comes_from_same_engine(other.engine()));
 
-        // Avoid matching on structure for subtyping checks when we have
-        // precisely the same type.
-        if self.type_index() == other.type_index() {
-            return true;
-        }
-
-        self.field_type().matches(&other.field_type())
+        self.engine()
+            .signatures()
+            .is_subtype(self.type_index(), other.type_index())
     }
 
     /// Is array type `a` precisely equal to array type `b`?


### PR DESCRIPTION
Similar to https://github.com/bytecodealliance/wasm-tools/pull/1934 but for `wasmtime::FieldType`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
