### PR TITLE
[s390x] Fix SP unwind rule for the tail-call ABI

### DIFF
--- a/cranelift/codegen/src/isa/unwind.rs
+++ b/cranelift/codegen/src/isa/unwind.rs
@@ -196,6 +196,15 @@ pub enum UnwindInst {
         /// The saved register.
         reg: RealReg,
     },
+    /// Computes the value of the given register in the caller as stack offset.
+    /// Typically used to unwind the stack pointer if the default rule does not apply.
+    /// The `clobber_offset` is computed the same way as for the `SaveReg` rule.
+    RegStackOffset {
+        /// The offset from the start of the clobber area to this register's value.
+        clobber_offset: u32,
+        /// The register whose value is to be set.
+        reg: RealReg,
+    },
     /// Defines if the aarch64-specific pointer authentication available for ARM v8.3+ devices
     /// is enabled for certain pointers or not.
     Aarch64SetPointerAuth {

--- a/cranelift/codegen/src/isa/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/unwind/systemv.rs
@@ -247,6 +247,19 @@ pub(crate) fn create_unwind_info_from_insts<MR: RegisterMapper<Reg>>(
                 let off = (clobber_offset as i32) - (clobber_offset_to_cfa as i32);
                 instructions.push((instruction_offset, CallFrameInstruction::Offset(reg, off)));
             }
+            &UnwindInst::RegStackOffset {
+                clobber_offset,
+                reg,
+            } => {
+                let reg = mr
+                    .map(reg.into())
+                    .map_err(|e| CodegenError::RegisterMappingError(e))?;
+                let off = (clobber_offset as i32) - (clobber_offset_to_cfa as i32);
+                instructions.push((
+                    instruction_offset,
+                    CallFrameInstruction::ValOffset(reg, off),
+                ));
+            }
             &UnwindInst::Aarch64SetPointerAuth { return_addresses } => {
                 instructions.push((
                     instruction_offset,

--- a/cranelift/codegen/src/isa/unwind/winarm64.rs
+++ b/cranelift/codegen/src/isa/unwind/winarm64.rs
@@ -301,6 +301,9 @@ pub(crate) fn create_unwind_info_from_insts(
                     }
                 }
             }
+            &UnwindInst::RegStackOffset { .. } => {
+                unreachable!("only supported with DWARF");
+            }
             &UnwindInst::Aarch64SetPointerAuth { return_addresses } => {
                 assert!(
                     return_addresses,

--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -285,6 +285,9 @@ pub(crate) fn create_unwind_info_from_insts<MR: RegisterMapper<crate::machinst::
                     });
                 }
             },
+            &UnwindInst::RegStackOffset { .. } => {
+                unreachable!("only supported with DWARF");
+            }
             &UnwindInst::Aarch64SetPointerAuth { .. } => {
                 unreachable!("no aarch64 on x64");
             }


### PR DESCRIPTION
On s390x, the unwound SP is always at current CFA - 160.  Therefore, the default rule used on most other platforms (which sets the unwound SP to the current CFA) is incorrect, so we need to provide an explicit DWARF CFI rule to unwind SP.

With the platform ABI, the caller's SP is always stored in the register save area like other call-saved GPRs, so we can simply use a normal DW_CFA_offset rule.  However, with the new tail-call ABI, the value saved in that slot is incorrect - it is not corrected for the incoming tail-call stack arguments that will have been removed as the tail call returns.

To fix this without introducing unnecessary run-time overhead, we can simply use a DW_CFA_val_offset rule that will set the unwound SP to CFA - 160, which is always correct.  However, the current UnwindInst abstraction does not allow any way to generate this DWARF CFI instruction.  Therefore, we introduce a new UnwindInst::RegStackOffset rule for this purpose.

Fixes: https://github.com/bytecodealliance/wasmtime/issues/9719

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
