### PR TITLE
Update clang-format to LLVM 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
   # Note that `wasmtime-platform.h` is excluded here as it's auto-generated.
   clangformat:
     name: Clang format
-    runs-on: ubuntu-22.04 # FIXME: fails on `ubuntu-24.04` right now
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -89,7 +89,7 @@ jobs:
         git ls-files '*.h' '*.c' '*.cpp' | \
           grep -v wasmtime-platform.h | \
           grep -v wasm.h | \
-          xargs clang-format-15 --dry-run --Werror --verbose
+          xargs clang-format-18 --dry-run --Werror --verbose
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/crates/wasmtime/src/runtime/vm/helpers.c
+++ b/crates/wasmtime/src/runtime/vm/helpers.c
@@ -182,7 +182,7 @@ __declspec(dllexport)
 // important.
 __attribute__((weak))
 #endif
-    struct JITDescriptor __jit_debug_descriptor = {1, 0, NULL, NULL};
+struct JITDescriptor __jit_debug_descriptor = {1, 0, NULL, NULL};
 
 struct JITDescriptor *VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)() {
   return &__jit_debug_descriptor;


### PR DESCRIPTION
Update from Ubuntu 22.04 to Ubuntu 24.04, and update the version of clang used accordingly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
