### PR TITLE
pulley: Implement sign-extension cranelift helper

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -178,6 +178,7 @@ where
         from_bits: u8,
         to_bits: u8,
     ) -> Self::I {
+        assert!(from_bits < to_bits);
         let src = XReg::new(src).unwrap();
         let dst = dst.try_into().unwrap();
         match (signed, from_bits) {

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -172,14 +172,23 @@ where
     }
 
     fn gen_extend(
-        _to_reg: Writable<Reg>,
-        _from_reg: Reg,
-        _signed: bool,
+        dst: Writable<Reg>,
+        src: Reg,
+        signed: bool,
         from_bits: u8,
         to_bits: u8,
     ) -> Self::I {
-        assert!(from_bits < to_bits);
-        todo!()
+        let src = XReg::new(src).unwrap();
+        let dst = dst.try_into().unwrap();
+        match (signed, from_bits) {
+            (true, 8) => Inst::Sext8 { dst, src }.into(),
+            (true, 16) => Inst::Sext16 { dst, src }.into(),
+            (true, 32) => Inst::Sext32 { dst, src }.into(),
+            (false, 8) => Inst::Zext8 { dst, src }.into(),
+            (false, 16) => Inst::Zext16 { dst, src }.into(),
+            (false, 32) => Inst::Zext32 { dst, src }.into(),
+            _ => unimplemented!("extend {from_bits} to {to_bits} as signed? {signed}"),
+        }
     }
 
     fn get_ext_mode(

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -126,6 +126,14 @@
     (PopFrame)
     (StackAlloc32 (amt u32))
     (StackFree32 (amt u32))
+
+    ;; Sign extensions.
+    (Zext8 (dst WritableXReg) (src XReg))
+    (Zext16 (dst WritableXReg) (src XReg))
+    (Zext32 (dst WritableXReg) (src XReg))
+    (Sext8 (dst WritableXReg) (src XReg))
+    (Sext16 (dst WritableXReg) (src XReg))
+    (Sext32 (dst WritableXReg) (src XReg))
   )
 )
 
@@ -579,6 +587,42 @@
 (decl gen_br_table (XReg MachLabel BoxVecMachLabel) Unit)
 (rule (gen_br_table idx default labels)
       (emit (MInst.BrTable idx default labels)))
+
+(decl pulley_zext8 (XReg) XReg)
+(rule (pulley_zext8 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Zext8 dst src))))
+        dst))
+
+(decl pulley_zext16 (XReg) XReg)
+(rule (pulley_zext16 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Zext16 dst src))))
+        dst))
+
+(decl pulley_zext32 (XReg) XReg)
+(rule (pulley_zext32 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Zext32 dst src))))
+        dst))
+
+(decl pulley_sext8 (XReg) XReg)
+(rule (pulley_sext8 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Sext8 dst src))))
+        dst))
+
+(decl pulley_sext16 (XReg) XReg)
+(rule (pulley_sext16 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Sext16 dst src))))
+        dst))
+
+(decl pulley_sext32 (XReg) XReg)
+(rule (pulley_sext32 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Sext32 dst src))))
+        dst))
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -553,6 +553,13 @@ fn pulley_emit<P>(
         Inst::PopFrame => enc::pop_frame(sink),
         Inst::StackAlloc32 { amt } => enc::stack_alloc32(sink, *amt),
         Inst::StackFree32 { amt } => enc::stack_free32(sink, *amt),
+
+        Inst::Zext8 { dst, src } => enc::zext8(sink, dst, src),
+        Inst::Zext16 { dst, src } => enc::zext16(sink, dst, src),
+        Inst::Zext32 { dst, src } => enc::zext32(sink, dst, src),
+        Inst::Sext8 { dst, src } => enc::sext8(sink, dst, src),
+        Inst::Sext16 { dst, src } => enc::sext16(sink, dst, src),
+        Inst::Sext32 { dst, src } => enc::sext32(sink, dst, src),
     }
 }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -255,6 +255,16 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
 
         Inst::StackAlloc32 { .. } | Inst::StackFree32 { .. } | Inst::PushFrame | Inst::PopFrame => {
         }
+
+        Inst::Zext8 { dst, src }
+        | Inst::Zext16 { dst, src }
+        | Inst::Zext32 { dst, src }
+        | Inst::Sext8 { dst, src }
+        | Inst::Sext16 { dst, src }
+        | Inst::Sext32 { dst, src } => {
+            collector.reg_use(src);
+            collector.reg_def(dst);
+        }
     }
 }
 
@@ -449,8 +459,8 @@ where
         }
     }
 
-    fn gen_jump(target: MachLabel) -> Self {
-        Inst::Jump { label: target }.into()
+    fn gen_jump(label: MachLabel) -> Self {
+        Inst::Jump { label }.into()
     }
 
     fn worst_case_size() -> CodeOffset {
@@ -874,6 +884,37 @@ impl Inst {
             }
             Inst::PushFrame => format!("push_frame"),
             Inst::PopFrame => format!("pop_frame"),
+
+            Inst::Zext8 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("zext8 {dst}, {src}")
+            }
+            Inst::Zext16 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("zext16 {dst}, {src}")
+            }
+            Inst::Zext32 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("zext32 {dst}, {src}")
+            }
+            Inst::Sext8 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("sext8 {dst}, {src}")
+            }
+            Inst::Sext16 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("sext16 {dst}, {src}")
+            }
+            Inst::Sext32 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("sext32 {dst}, {src}")
+            }
         }
     }
 }

--- a/cranelift/filetests/filetests/isa/pulley32/extend.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/extend.clif
@@ -1,0 +1,172 @@
+test compile precise-output
+target pulley32
+
+function %uext8(i8) {
+    fn0 = colocated %g(i8 uext)
+block0(v0: i8):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   zext8 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; zext8 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %uext16(i16) {
+    fn0 = colocated %g(i16 uext)
+block0(v0: i16):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   zext16 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; zext16 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %uext32(i32) {
+    fn0 = colocated %g(i32 uext)
+block0(v0: i32):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; call 0x0    // target = 0x1
+; pop_frame
+; ret
+
+function %uext64(i64) {
+    fn0 = colocated %g(i64 uext)
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; call 0x0    // target = 0x1
+; pop_frame
+; ret
+
+function %sext8(i8) {
+    fn0 = colocated %g(i8 sext)
+block0(v0: i8):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   sext8 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; sext8 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %sext16(i16) {
+    fn0 = colocated %g(i16 sext)
+block0(v0: i16):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   sext16 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; sext16 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %sext32(i32) {
+    fn0 = colocated %g(i32 sext)
+block0(v0: i32):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; call 0x0    // target = 0x1
+; pop_frame
+; ret
+
+function %sext64(i64) {
+    fn0 = colocated %g(i64 sext)
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; call 0x0    // target = 0x1
+; pop_frame
+; ret
+
+

--- a/cranelift/filetests/filetests/isa/pulley64/extend.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/extend.clif
@@ -1,0 +1,175 @@
+test compile precise-output
+target pulley64
+
+function %uext8(i8) {
+    fn0 = colocated %g(i8 uext)
+block0(v0: i8):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   zext8 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; zext8 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %uext16(i16) {
+    fn0 = colocated %g(i16 uext)
+block0(v0: i16):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   zext16 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; zext16 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %uext32(i32) {
+    fn0 = colocated %g(i32 uext)
+block0(v0: i32):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   zext32 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; zext32 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %uext64(i64) {
+    fn0 = colocated %g(i64 uext)
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; call 0x0    // target = 0x1
+; pop_frame
+; ret
+
+function %sext8(i8) {
+    fn0 = colocated %g(i8 sext)
+block0(v0: i8):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   sext8 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; sext8 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %sext16(i16) {
+    fn0 = colocated %g(i16 sext)
+block0(v0: i16):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   sext16 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; sext16 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %sext32(i32) {
+    fn0 = colocated %g(i32 sext)
+block0(v0: i32):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   sext32 x0, x0
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; sext32 x0, x0
+; call 0x0    // target = 0x4
+; pop_frame
+; ret
+
+function %sext64(i64) {
+    fn0 = colocated %g(i64 sext)
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; call 0x0    // target = 0x1
+; pop_frame
+; ret
+

--- a/pulley/fuzz/src/interp.rs
+++ b/pulley/fuzz/src/interp.rs
@@ -120,6 +120,12 @@ fn op_is_safe_for_fuzzing(op: &Op) -> bool {
         Op::BrTable32(_) => false,
         Op::StackAlloc32(_) => false,
         Op::StackFree32(_) => false,
+        Op::Zext8(Zext8 { dst, .. })
+        | Op::Zext16(Zext16 { dst, .. })
+        | Op::Zext32(Zext32 { dst, .. })
+        | Op::Sext8(Sext8 { dst, .. })
+        | Op::Sext32(Sext32 { dst, .. })
+        | Op::Sext16(Sext16 { dst, .. }) => !dst.is_special(),
     }
 }
 

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1251,6 +1251,42 @@ impl OpVisitor for Interpreter<'_> {
         self.set_sp_unchecked(new_sp);
         ControlFlow::Continue(())
     }
+
+    fn zext8(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_u64() as u8;
+        self.state[dst].set_u64(src.into());
+        ControlFlow::Continue(())
+    }
+
+    fn zext16(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_u64() as u16;
+        self.state[dst].set_u64(src.into());
+        ControlFlow::Continue(())
+    }
+
+    fn zext32(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_u64() as u32;
+        self.state[dst].set_u64(src.into());
+        ControlFlow::Continue(())
+    }
+
+    fn sext8(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_i64() as i8;
+        self.state[dst].set_i64(src.into());
+        ControlFlow::Continue(())
+    }
+
+    fn sext16(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_i64() as i16;
+        self.state[dst].set_i64(src.into());
+        ControlFlow::Continue(())
+    }
+
+    fn sext32(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_i64() as i32;
+        self.state[dst].set_i64(src.into());
+        ControlFlow::Continue(())
+    }
 }
 
 impl ExtendedOpVisitor for Interpreter<'_> {

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -195,6 +195,19 @@ macro_rules! for_each_op {
 
             /// `sp = sp + amt`
             stack_free32 = StackFree32 { amt: u32 };
+
+            /// `dst = zext(low8(src))`
+            zext8 = Zext8 { dst: XReg, src: XReg };
+            /// `dst = zext(low16(src))`
+            zext16 = Zext16 { dst: XReg, src: XReg };
+            /// `dst = zext(low32(src))`
+            zext32 = Zext32 { dst: XReg, src: XReg };
+            /// `dst = sext(low8(src))`
+            sext8 = Sext8 { dst: XReg, src: XReg };
+            /// `dst = sext(low16(src))`
+            sext16 = Sext16 { dst: XReg, src: XReg };
+            /// `dst = sext(low32(src))`
+            sext32 = Sext32 { dst: XReg, src: XReg };
         }
     };
 }


### PR DESCRIPTION
The `uextend` and `sextend` lowerings aren't done yet but this should help fill out ABI bits instead of panicking. Example tests are added showing what support is added here.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
