### PR TITLE
pulley: Track faulting opcode in stack overflow better

### DIFF
--- a/pulley/fuzz/src/roundtrip.rs
+++ b/pulley/fuzz/src/roundtrip.rs
@@ -10,7 +10,10 @@ pub fn roundtrip(ops: Vec<Op>) {
 
     let mut encoded = vec![];
     for op in &ops {
+        let before = encoded.len();
         op.encode(&mut encoded);
+        let size = encoded.len() - before;
+        assert_eq!(size, op.width().into());
     }
     log::trace!("encoded: {encoded:?}");
 

--- a/pulley/src/encode.rs
+++ b/pulley/src/encode.rs
@@ -4,13 +4,20 @@ use crate::imms::*;
 use crate::opcode::{ExtendedOpcode, Opcode};
 use crate::regs::*;
 
-trait Encode {
+/// Helper trait to encode instructions into a "sink".
+pub trait Encode {
+    /// The encoded width of this instruction.
+    const WIDTH: u8;
+
+    /// Encodes this operand or instruction into the provided `sink`.
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>;
 }
 
 impl Encode for u8 {
+    const WIDTH: u8 = 1;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -20,6 +27,8 @@ impl Encode for u8 {
 }
 
 impl Encode for u16 {
+    const WIDTH: u8 = 2;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -29,6 +38,8 @@ impl Encode for u16 {
 }
 
 impl Encode for u32 {
+    const WIDTH: u8 = 4;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -38,6 +49,8 @@ impl Encode for u32 {
 }
 
 impl Encode for u64 {
+    const WIDTH: u8 = 8;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -47,6 +60,8 @@ impl Encode for u64 {
 }
 
 impl Encode for i8 {
+    const WIDTH: u8 = 1;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -56,6 +71,8 @@ impl Encode for i8 {
 }
 
 impl Encode for i16 {
+    const WIDTH: u8 = 2;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -65,6 +82,8 @@ impl Encode for i16 {
 }
 
 impl Encode for i32 {
+    const WIDTH: u8 = 4;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -74,6 +93,8 @@ impl Encode for i32 {
 }
 
 impl Encode for i64 {
+    const WIDTH: u8 = 8;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -83,6 +104,8 @@ impl Encode for i64 {
 }
 
 impl Encode for XReg {
+    const WIDTH: u8 = 1;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -92,6 +115,8 @@ impl Encode for XReg {
 }
 
 impl Encode for FReg {
+    const WIDTH: u8 = 1;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -101,6 +126,8 @@ impl Encode for FReg {
 }
 
 impl Encode for VReg {
+    const WIDTH: u8 = 1;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -110,6 +137,8 @@ impl Encode for VReg {
 }
 
 impl Encode for PcRelOffset {
+    const WIDTH: u8 = 4;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -119,6 +148,8 @@ impl Encode for PcRelOffset {
 }
 
 impl<R: Reg> Encode for BinaryOperands<R> {
+    const WIDTH: u8 = 2;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -128,6 +159,8 @@ impl<R: Reg> Encode for BinaryOperands<R> {
 }
 
 impl<R: Reg + Encode> Encode for RegSet<R> {
+    const WIDTH: u8 = 4;
+
     fn encode<E>(&self, sink: &mut E)
     where
         E: Extend<u8>,
@@ -161,6 +194,18 @@ macro_rules! impl_encoders {
                     )*
                 )?
             }
+
+            impl Encode for crate::op::$name {
+                const WIDTH: u8 = 1 $($( + <$field_ty as Encode>::WIDTH)*)?;
+
+                fn encode<E>(&self, sink: &mut E)
+                where
+                    E: Extend<u8>,
+                {
+                    let Self { $(  $( $field ),* )? } = *self;
+                    $snake_name(sink $( $(, $field)* )?)
+                }
+            }
         )*
     };
 }
@@ -191,6 +236,18 @@ macro_rules! impl_extended_encoders {
                         $field.into().encode(into);
                     )*
                 )?
+            }
+
+            impl Encode for crate::op::$name {
+                const WIDTH: u8 = 3 $($( + <$field_ty as Encode>::WIDTH)*)?;
+
+                fn encode<E>(&self, sink: &mut E)
+                where
+                    E: Extend<u8>,
+                {
+                    let Self { $(  $( $field ),* )? } = *self;
+                    $snake_name(sink $( $(, $field)* )?)
+                }
             }
         )*
     };

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1,6 +1,7 @@
 //! Interpretation of pulley bytecode.
 
 use crate::decode::*;
+use crate::encode::Encode;
 use crate::imms::*;
 use crate::regs::*;
 use crate::ExtendedOpcode;
@@ -600,11 +601,17 @@ impl Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    /// Returns the PC of the current instruction where `I` is the static type
+    /// representing the current instruction.
+    fn current_pc<I: Encode>(&self) -> NonNull<u8> {
+        unsafe { self.pc.offset(-isize::from(I::WIDTH)).as_ptr() }
+    }
+
     /// `sp -= size_of::<T>(); *sp = val;`
     #[must_use]
-    fn push<T>(&mut self, val: T) -> ControlFlow<Done> {
+    fn push<T>(&mut self, val: T, pc: NonNull<u8>) -> ControlFlow<Done> {
         let new_sp = self.state[XReg::sp].get_ptr::<T>().wrapping_sub(1);
-        self.set_sp(new_sp)?;
+        self.set_sp(new_sp, pc)?;
         unsafe {
             new_sp.write_unaligned(val);
         }
@@ -624,11 +631,11 @@ impl Interpreter<'_> {
     /// Returns a trap if this would result in stack overflow, or if `sp` is
     /// beneath the base pointer of `self.state.stack`.
     #[must_use]
-    fn set_sp<T>(&mut self, sp: *mut T) -> ControlFlow<Done> {
+    fn set_sp<T>(&mut self, sp: *mut T, pc: NonNull<u8>) -> ControlFlow<Done> {
         let sp_raw = sp as usize;
         let base_raw = self.state.stack.as_ptr() as usize;
         if sp_raw < base_raw {
-            return ControlFlow::Break(Done::Trap(self.pc.as_ptr()));
+            return ControlFlow::Break(Done::Trap(pc));
         }
         self.set_sp_unchecked(sp);
         ControlFlow::Continue(())
@@ -1138,25 +1145,29 @@ impl OpVisitor for Interpreter<'_> {
     }
 
     fn xpush32(&mut self, src: XReg) -> ControlFlow<Done> {
-        self.push(self.state[src].get_u32())?;
+        let me = self.current_pc::<crate::XPush32>();
+        self.push(self.state[src].get_u32(), me)?;
         ControlFlow::Continue(())
     }
 
     fn xpush32_many(&mut self, srcs: RegSet<XReg>) -> ControlFlow<Done> {
+        let me = self.current_pc::<crate::XPush32Many>();
         for src in srcs {
-            self.xpush32(src)?;
+            self.push(self.state[src].get_u32(), me)?;
         }
         ControlFlow::Continue(())
     }
 
     fn xpush64(&mut self, src: XReg) -> ControlFlow<Done> {
-        self.push(self.state[src].get_u64())?;
+        let me = self.current_pc::<crate::XPush64>();
+        self.push(self.state[src].get_u64(), me)?;
         ControlFlow::Continue(())
     }
 
     fn xpush64_many(&mut self, srcs: RegSet<XReg>) -> ControlFlow<Done> {
+        let me = self.current_pc::<crate::XPush64Many>();
         for src in srcs {
-            self.xpush64(src)?;
+            self.push(self.state[src].get_u64(), me)?;
         }
         ControlFlow::Continue(())
     }
@@ -1190,8 +1201,9 @@ impl OpVisitor for Interpreter<'_> {
     }
 
     fn push_frame(&mut self) -> ControlFlow<Done> {
-        self.push(self.state[XReg::lr].get_ptr::<u8>())?;
-        self.push(self.state[XReg::fp].get_ptr::<u8>())?;
+        let me = self.current_pc::<crate::PushFrame>();
+        self.push(self.state[XReg::lr].get_ptr::<u8>(), me)?;
+        self.push(self.state[XReg::fp].get_ptr::<u8>(), me)?;
         self.state[XReg::fp] = self.state[XReg::sp];
         ControlFlow::Continue(())
     }
@@ -1239,9 +1251,10 @@ impl OpVisitor for Interpreter<'_> {
     }
 
     fn stack_alloc32(&mut self, amt: u32) -> ControlFlow<Done> {
+        let me = self.current_pc::<crate::StackAlloc32>();
         let amt = usize::try_from(amt).unwrap();
         let new_sp = self.state[XReg::sp].get_ptr::<u8>().wrapping_sub(amt);
-        self.set_sp(new_sp)?;
+        self.set_sp(new_sp, me)?;
         ControlFlow::Continue(())
     }
 

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -663,14 +663,15 @@ fn simple_push_pop() {
             // this isn't actually read so just manufacture a dummy one
             pc: UnsafeBytecodeStream::new((&mut 0).into()),
         };
-        assert!(i.push(0_i32).is_continue());
+        let pc = NonNull::from(&0);
+        assert!(i.push(0_i32, pc).is_continue());
         assert_eq!(i.pop::<i32>(), 0_i32);
-        assert!(i.push(1_i32).is_continue());
-        assert!(i.push(2_i32).is_continue());
-        assert!(i.push(3_i32).is_continue());
-        assert!(i.push(4_i32).is_continue());
-        assert!(i.push(5_i32).is_break());
-        assert!(i.push(6_i32).is_break());
+        assert!(i.push(1_i32, pc).is_continue());
+        assert!(i.push(2_i32, pc).is_continue());
+        assert!(i.push(3_i32, pc).is_continue());
+        assert!(i.push(4_i32, pc).is_continue());
+        assert!(i.push(5_i32, pc).is_break());
+        assert!(i.push(6_i32, pc).is_break());
         assert_eq!(i.pop::<i32>(), 4_i32);
         assert_eq!(i.pop::<i32>(), 3_i32);
         assert_eq!(i.pop::<i32>(), 2_i32);

--- a/pulley/src/op.rs
+++ b/pulley/src/op.rs
@@ -1,5 +1,6 @@
 //! Pulley bytecode operations with their operands.
 
+use crate::encode::Encode;
 use crate::imms::*;
 use crate::regs::*;
 
@@ -128,6 +129,16 @@ macro_rules! define_op_encode {
                     Self::ExtendedOp(op) => op.encode(into),
                 }
             }
+
+            /// Returns the encoded size of this op.
+            pub fn width(&self) -> u8 {
+                match self {
+                    $(
+                        Self::$name(_) => <$name as Encode>::WIDTH,
+                    )*
+                    Self::ExtendedOp(op) => op.width(),
+                }
+            }
         }
 
         $(
@@ -165,6 +176,15 @@ macro_rules! define_extended_op_encode {
                 match self {
                     $(
                         Self::$name(op) => op.encode(into),
+                    )*
+                }
+            }
+
+            /// Returns the encoded size of this op.
+            pub fn width(&self) -> u8 {
+                match self {
+                    $(
+                        Self::$name(_) => <$name as Encode>::WIDTH,
                     )*
                 }
             }

--- a/pulley/src/op.rs
+++ b/pulley/src/op.rs
@@ -1,5 +1,6 @@
 //! Pulley bytecode operations with their operands.
 
+#[cfg(feature = "encode")]
 use crate::encode::Encode;
 use crate::imms::*;
 use crate::regs::*;
@@ -131,6 +132,7 @@ macro_rules! define_op_encode {
             }
 
             /// Returns the encoded size of this op.
+            #[cfg(feature = "encode")]
             pub fn width(&self) -> u8 {
                 match self {
                     $(
@@ -181,6 +183,7 @@ macro_rules! define_extended_op_encode {
             }
 
             /// Returns the encoded size of this op.
+            #[cfg(feature = "encode")]
             pub fn width(&self) -> u8 {
                 match self {
                     $(


### PR DESCRIPTION
This commit updates the pulley `Encode` trait to have a `WIDTH` associated with it to be able to calculate the size of an instruction by name rather than hard-coding instruction details in multiple locations. This constant is procedurally generated per-instruction given the definition of the instruction. This for now assumes there are no variable-width instructions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
