### PR TITLE
winch: Epoch-based interruption

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -576,7 +576,6 @@ impl WasmtimeConfig {
             // by Winch.
             self.signals_based_traps = true;
             self.table_lazy_init = true;
-            self.epoch_interruption = false;
             self.debug_info = false;
         }
 

--- a/crates/winch/src/builder.rs
+++ b/crates/winch/src/builder.rs
@@ -65,10 +65,6 @@ impl CompilerBuilder for Builder {
             bail!("Winch requires the signals-based-traps option to be enabled");
         }
 
-        if tunables.epoch_interruption {
-            bail!("Winch does not currently support epoch based interruption");
-        }
-
         if tunables.generate_native_debuginfo {
             bail!("Winch does not currently support generating native debug information");
         }

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -80,7 +80,7 @@ async fn run_and_count_yields_or_trap<F: Fn(Arc<Engine>)>(
     return result.ok().map(|_| (yields, *store));
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_yield_at_func_entry(config: &mut Config) {
     // Should yield at start of call to func $subfunc.
     assert_eq!(
@@ -103,7 +103,7 @@ async fn epoch_yield_at_func_entry(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_yield_at_loop_header(config: &mut Config) {
     // Should yield at top of loop, once per five iters.
     assert_eq!(
@@ -128,7 +128,7 @@ async fn epoch_yield_at_loop_header(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_yield_immediate(config: &mut Config) {
     // We should see one yield immediately when the initial deadline
     // is zero.
@@ -149,7 +149,7 @@ async fn epoch_yield_immediate(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_yield_only_once(config: &mut Config) {
     // We should yield from the subfunction, and then when we return
     // to the outer function and hit another loop header, we should
@@ -180,7 +180,7 @@ async fn epoch_yield_only_once(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_interrupt_infinite_loop(config: &mut Config) {
     assert_eq!(
         None,
@@ -206,7 +206,7 @@ async fn epoch_interrupt_infinite_loop(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_interrupt_function_entries(config: &mut Config) {
     assert_eq!(
         None,
@@ -329,7 +329,7 @@ async fn epoch_interrupt_function_entries(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_callback_continue(config: &mut Config) {
     assert_eq!(
         Some((0, 1)),
@@ -355,7 +355,7 @@ async fn epoch_callback_continue(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_callback_yield(config: &mut Config) {
     assert_eq!(
         Some((1, 1)),
@@ -381,7 +381,7 @@ async fn epoch_callback_yield(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_callback_trap(config: &mut Config) {
     assert_eq!(
         None,
@@ -403,7 +403,7 @@ async fn epoch_callback_trap(config: &mut Config) {
     );
 }
 
-#[wasmtime_test(with = "#[tokio::test]", strategies(not(Winch)))]
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn drop_future_on_epoch_yield(config: &mut Config) {
     let wasm = "
     (module
@@ -457,22 +457,4 @@ async fn drop_future_on_epoch_yield(config: &mut Config) {
     let _ = PollOnce::new(Box::pin(f.call_async(&mut store, &[], &mut []))).await;
 
     assert_eq!(true, alive_flag.load(Ordering::Acquire));
-}
-
-#[wasmtime_test(strategies(not(Cranelift)))]
-#[cfg_attr(miri, ignore)]
-fn ensure_compatibility_between_winch_and_epoch(config: &mut Config) -> Result<()> {
-    config.epoch_interruption(true);
-    let result = Engine::new(&config);
-    match result {
-        Ok(_) => anyhow::bail!("Expected incompatibility between epoch interruption and Winch"),
-        Err(e) => {
-            assert_eq!(
-                e.to_string(),
-                "Winch does not currently support epoch based interruption"
-            );
-        }
-    }
-
-    Ok(())
 }

--- a/tests/disas/winch/x64/epoch/func.wat
+++ b/tests/disas/winch/x64/epoch/func.wat
@@ -1,0 +1,6 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-Wepoch-interruption=y"
+
+(module
+  (func (export "run")))

--- a/tests/disas/winch/x64/epoch/func.wat
+++ b/tests/disas/winch/x64/epoch/func.wat
@@ -4,3 +4,28 @@
 
 (module
   (func (export "run")))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x57
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    0x20(%r14), %rdx
+;;       movq    (%rdx), %rdx
+;;       movq    8(%r14), %rcx
+;;       movq    8(%rcx), %rcx
+;;       cmpq    %rcx, %rdx
+;;       jb      0x51
+;;   44: movq    %r14, %rdi
+;;       callq   0x165
+;;       movq    8(%rsp), %r14
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   57: ud2

--- a/tests/disas/winch/x64/epoch/loop.wat
+++ b/tests/disas/winch/x64/epoch/loop.wat
@@ -1,0 +1,43 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-Wepoch-interruption=y"
+
+(module
+  (func (export "run")
+        (loop $l
+              (br $l))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    (%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x80
+;;   1b: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    0x20(%r14), %rdx
+;;       movq    (%rdx), %rdx
+;;       movq    8(%r14), %rcx
+;;       movq    0x10(%rcx), %rcx
+;;       cmpq    %rcx, %rdx
+;;       jb      0x50
+;;   43: movq    %r14, %rdi
+;;       callq   0x18e
+;;       movq    8(%rsp), %r14
+;;       movq    0x20(%r14), %rdx
+;;       movq    (%rdx), %rdx
+;;       movq    8(%r14), %rcx
+;;       movq    0x10(%rcx), %rcx
+;;       cmpq    %rcx, %rdx
+;;       jb      0x75
+;;   68: movq    %r14, %rdi
+;;       callq   0x18e
+;;       movq    8(%rsp), %r14
+;;       jmp     0x50
+;;   7a: addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   80: ud2

--- a/tests/disas/winch/x64/epoch/loop.wat
+++ b/tests/disas/winch/x64/epoch/loop.wat
@@ -10,34 +10,34 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
-;;       movq    (%r11), %r11
+;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x80
-;;   1b: movq    %rdi, %r14
+;;       ja      0x81
+;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    0x20(%r14), %rdx
 ;;       movq    (%rdx), %rdx
 ;;       movq    8(%r14), %rcx
-;;       movq    0x10(%rcx), %rcx
+;;       movq    8(%rcx), %rcx
 ;;       cmpq    %rcx, %rdx
-;;       jb      0x50
-;;   43: movq    %r14, %rdi
-;;       callq   0x18e
+;;       jb      0x51
+;;   44: movq    %r14, %rdi
+;;       callq   0x18f
 ;;       movq    8(%rsp), %r14
 ;;       movq    0x20(%r14), %rdx
 ;;       movq    (%rdx), %rdx
 ;;       movq    8(%r14), %rcx
-;;       movq    0x10(%rcx), %rcx
+;;       movq    8(%rcx), %rcx
 ;;       cmpq    %rcx, %rdx
-;;       jb      0x75
-;;   68: movq    %r14, %rdi
-;;       callq   0x18e
+;;       jb      0x76
+;;   69: movq    %r14, %rdi
+;;       callq   0x18f
 ;;       movq    8(%rsp), %r14
-;;       jmp     0x50
-;;   7a: addq    $0x10, %rsp
+;;       jmp     0x51
+;;   7b: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   80: ud2
+;;   81: ud2

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -276,6 +276,10 @@ where
             self.emit_fuel_check();
         }
 
+        if self.tunables.epoch_interruption {
+            self.emit_epoch_check();
+        }
+
         // Once we have emitted the epilogue and reserved stack space for the locals, we push the
         // base control flow block.
         self.control_frames.push(ControlStackFrame::block(
@@ -1020,6 +1024,93 @@ where
             self.masm.address_at_reg(fuel_var, u32::from(fuel_offset)),
             writable!(fuel_var),
             // Fuel is an i64.
+            OperandSize::S64,
+        );
+    }
+
+    /// Emit series of instructions that check the current epoch against its
+    /// deadline.
+    pub fn emit_epoch_check(&mut self) {
+        let cont = self.masm.get_label();
+        let new_epoch = self.env.builtins.new_epoch::<M::ABI, M::Ptr>();
+
+        // Checks for runtime limits (e.g., fuel, epoch) are special since they
+        // require inserting abritrary function calls and control flow.
+        // Special care must be taken to ensure that all invariants are met. In
+        // this case, since `new_epoch` takes an argument and returns a value,
+        // we must ensure that any registers used to hold the current epoch
+        // value and deadline are not going to be needed later on by the
+        // function call.
+        let (epoch_deadline_var, epoch_counter_var) = self.context.without::<(Reg, Reg), M, _>(
+            &new_epoch.sig().regs,
+            self.masm,
+            |cx, masm| (cx.any_gpr(masm), cx.any_gpr(masm)),
+        );
+
+        self.emit_load_epoch_deadline_and_counter(epoch_deadline_var, epoch_counter_var);
+
+        // Spill locals and registers to avoid conflicts at the control flow
+        // merge below.
+        self.context.spill(self.masm);
+        self.masm.branch(
+            IntCmpKind::LtU,
+            epoch_counter_var,
+            RegImm::reg(epoch_deadline_var),
+            cont,
+            OperandSize::S64,
+        );
+        // Epoch deadline reached branch.
+        FnCall::emit::<M>(
+            &mut self.env,
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(new_epoch.clone()),
+        );
+        // `new_epoch` returns the new deadline. However we don't
+        // perform any caching, so we simply drop this value.
+        self.visit_drop();
+
+        // Under epoch deadline branch.
+        self.masm.bind(cont);
+
+        self.context.free_reg(epoch_deadline_var);
+        self.context.free_reg(epoch_counter_var);
+    }
+
+    fn emit_load_epoch_deadline_and_counter(
+        &mut self,
+        epoch_deadline_var: Reg,
+        epoch_counter_var: Reg,
+    ) {
+        let epoch_ptr_offset = self.env.vmoffsets.ptr.vmctx_epoch_ptr();
+        let runtime_limits_offset = self.env.vmoffsets.ptr.vmctx_runtime_limits();
+        let epoch_deadline_offset = self.env.vmoffsets.ptr.vmruntime_limits_epoch_deadline();
+
+        // Load the current epoch value into `epoch_counter_var`.
+        self.masm.load_ptr(
+            self.masm.address_at_vmctx(u32::from(epoch_ptr_offset)),
+            writable!(epoch_counter_var),
+        );
+
+        // `epoch_deadline_var` contains the address of the value, so we need
+        // to extract it.
+        self.masm.load(
+            self.masm.address_at_reg(epoch_counter_var, 0),
+            writable!(epoch_counter_var),
+            OperandSize::S64,
+        );
+
+        // Load the `VMRuntimeLimits`.
+        self.masm.load_ptr(
+            self.masm.address_at_vmctx(u32::from(runtime_limits_offset)),
+            writable!(epoch_deadline_var),
+        );
+
+        self.masm.load(
+            self.masm
+                .address_at_reg(epoch_deadline_var, u32::from(epoch_deadline_offset)),
+            writable!(epoch_deadline_var),
+            // The deadline value is a u64.
             OperandSize::S64,
         );
     }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1723,6 +1723,11 @@ where
         if self.tunables.consume_fuel {
             self.emit_fuel_check();
         }
+
+        // Emit epoch check right after binding the loop header.
+        if self.tunables.epoch_interruption {
+            self.emit_epoch_check();
+        }
     }
 
     fn visit_br(&mut self, depth: u32) {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1725,9 +1725,7 @@ where
         }
 
         // Emit epoch check right after binding the loop header.
-        if self.tunables.epoch_interruption {
-            self.emit_epoch_check();
-        }
+        self.maybe_emit_epoch_check();
     }
 
     fn visit_br(&mut self, depth: u32) {


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/8091

This commit introduces support for epoch interruption to Winch. The heuristics around epoch check emission are identical to Cranelift's except for the fact that the current implementation doesn't introduce a local-based cache for the current epoch deadline. This is an intentional decision given Winch's focus on compilation performance. However, if needed in the future, knobs could be introduced to optionally introduce a local cache at the cost of reduced compilation performance.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
