### PR TITLE
Default to Pulley on cranelift/winch-unsupported platforms

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -143,6 +143,9 @@ impl Tunables {
 
     /// Returns the default set of tunables for the given target triple.
     pub fn default_for_target(target: &Triple) -> Result<Self> {
+        if cfg!(miri) {
+            return Ok(Tunables::default_miri());
+        }
         match target
             .pointer_width()
             .map_err(|_| anyhow!("failed to retrieve target pointer width"))?


### PR DESCRIPTION
This commit updates the selection of the default target used by a `Config` to take into account the host architecture and possibly use Pulley instead of the host target itself. The goal here is that when a target isn't explicitly configured then Wasmtime is tasked with picking a reasonable default to execute code with. If neither Winch nor Cranelift has any support then the only way to possibly execute code would be with Pulley, so in these situations pulley becomes the default target.

The goal of this change is to make testing easier on 32-bit platforms where there is no compiler support. This means we won't have to update all tests to explicitly configure pulley on unsupported platforms. Additionally this means that an eventual `wasmtime` executable for 32-bit platforms will use Pulley by default and won't need any extra configuration.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
