### PR TITLE
winch: Minor improvements to fuel check

### DIFF
--- a/tests/disas/winch/x64/fuel/call.wat
+++ b/tests/disas/winch/x64/fuel/call.wat
@@ -1,0 +1,78 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-Wfuel=1"
+(module
+  (import "" "" (func))
+  (func (export "")
+        call 0
+        call $other)
+  (func $other))
+;; wasm[0]::function[1]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x91
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0x4a
+;;   3d: movq    %r14, %rdi
+;;       callq   0x20c
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rax
+;;       movq    (%rax), %r11
+;;       addq    $2, %r11
+;;       movq    %r11, (%rax)
+;;       movq    0x68(%r14), %rcx
+;;       movq    0x58(%r14), %rax
+;;       movq    %rcx, %rdi
+;;       movq    %r14, %rsi
+;;       callq   *%rax
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rax
+;;       movq    (%rax), %r11
+;;       addq    $1, %r11
+;;       movq    %r11, (%rax)
+;;       movq    %r14, %rdi
+;;       movq    %r14, %rsi
+;;       callq   0xa0
+;;       movq    8(%rsp), %r14
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   91: ud2
+;;
+;; wasm[0]::function[2]::other:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0xfe
+;;   bc: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0xea
+;;   dd: movq    %r14, %rdi
+;;       callq   0x20c
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rax
+;;       movq    (%rax), %r11
+;;       addq    $1, %r11
+;;       movq    %r11, (%rax)
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   fe: ud2

--- a/tests/disas/winch/x64/fuel/func.wat
+++ b/tests/disas/winch/x64/fuel/func.wat
@@ -1,0 +1,32 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-Wfuel=1"
+(module
+  (func (export "run")))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x5e
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0x4a
+;;   3d: movq    %r14, %rdi
+;;       callq   0x16c
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rax
+;;       movq    (%rax), %r11
+;;       addq    $1, %r11
+;;       movq    %r11, (%rax)
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   5e: ud2

--- a/tests/disas/winch/x64/fuel/loop.wat
+++ b/tests/disas/winch/x64/fuel/loop.wat
@@ -1,0 +1,46 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-Wfuel=1"
+(module
+  (func (export "run")
+        (loop $l
+              (br $l))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x8f
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0x4a
+;;   3d: movq    %r14, %rdi
+;;       callq   0x19d
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rax
+;;       movq    (%rax), %r11
+;;       addq    $1, %r11
+;;       movq    %r11, (%rax)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0x76
+;;   69: movq    %r14, %rdi
+;;       callq   0x19d
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rax
+;;       movq    (%rax), %r11
+;;       addq    $1, %r11
+;;       movq    %r11, (%rax)
+;;       jmp     0x58
+;;   89: addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   8f: ud2

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1719,13 +1719,8 @@ where
             &mut self.context,
         ));
 
-        // Emit fuel check right after binding the loop header.
-        if self.tunables.consume_fuel {
-            self.emit_fuel_check();
-        }
-
-        // Emit epoch check right after binding the loop header.
         self.maybe_emit_epoch_check();
+        self.maybe_emit_fuel_check();
     }
 
     fn visit_br(&mut self, depth: u32) {


### PR DESCRIPTION
This commits ports the suggestions made in https://github.com/bytecodealliance/wasmtime/pull/9737 to fuel checks.

Namely

* Prefer the usage of `*_reg` over `*_var`
* Add a couple of disassembly tests

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
