### PR TITLE
winch: Implement aarch64 call, trapz, address_at_vmctx

### DIFF
--- a/tests/disas/winch/aarch64/call/params.wat
+++ b/tests/disas/winch/aarch64/call/params.wat
@@ -1,0 +1,166 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+  (func (export "main") (param i32) (param i32) (result i32)
+    (local.get 1)
+    (local.get 0)
+    (i32.add)
+
+    (call $add (i32.const 1) (i32.const 2) (i32.const 3) (i32.const 4) (i32.const 5) (i32.const 6) (i32.const 7) (i32.const 8))
+
+    (local.get 1)
+    (local.get 0)
+    (i32.add)
+
+    (call $add (i32.const 2) (i32.const 3) (i32.const 4) (i32.const 5) (i32.const 6) (i32.const 7) (i32.const 8))
+  )
+
+  (func $add (param i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+    (local.get 0)
+    (local.get 1)
+    (i32.add)
+    (local.get 2)
+    (i32.add)
+    (local.get 3)
+    (i32.add)
+    (local.get 4)
+    (i32.add)
+    (local.get 5)
+    (i32.add)
+    (local.get 6)
+    (i32.add)
+    (local.get 7)
+    (i32.add)
+    (local.get 8)
+    (i32.add)
+  )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28, #4]
+;;       ldur    w1, [x28]
+;;       add     w1, w1, w0, uxtx
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w1, [x28]
+;;       sub     sp, sp, #0x24
+;;       mov     x28, sp
+;;       mov     x0, x9
+;;       mov     x1, x9
+;;       ldur    w2, [x28, #0x24]
+;;       mov     x16, #1
+;;       mov     w3, w16
+;;       mov     x16, #2
+;;       mov     w4, w16
+;;       mov     x16, #3
+;;       mov     w5, w16
+;;       mov     x16, #4
+;;       mov     w6, w16
+;;       mov     x16, #5
+;;       mov     w7, w16
+;;       mov     x16, #6
+;;       mov     w16, w16
+;;       stur    w16, [x28]
+;;       mov     x16, #7
+;;       mov     w16, w16
+;;       stur    w16, [x28, #8]
+;;       mov     x16, #8
+;;       mov     w16, w16
+;;       stur    w16, [x28, #0x10]
+;;       bl      #0x160
+;;   a4: add     sp, sp, #0x24
+;;       mov     x28, sp
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x10]
+;;       ldur    w1, [x28, #4]
+;;       ldur    w2, [x28]
+;;       add     w2, w2, w1, uxtx
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w2, [x28]
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       mov     x0, x9
+;;       mov     x1, x9
+;;       ldur    w2, [x28, #0x24]
+;;       ldur    w3, [x28, #0x20]
+;;       mov     x16, #2
+;;       mov     w4, w16
+;;       mov     x16, #3
+;;       mov     w5, w16
+;;       mov     x16, #4
+;;       mov     w6, w16
+;;       mov     x16, #5
+;;       mov     w7, w16
+;;       mov     x16, #6
+;;       mov     w16, w16
+;;       stur    w16, [x28]
+;;       mov     x16, #7
+;;       mov     w16, w16
+;;       stur    w16, [x28, #8]
+;;       mov     x16, #8
+;;       mov     w16, w16
+;;       stur    w16, [x28, #0x10]
+;;       bl      #0x160
+;;  13c: add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       add     sp, sp, #8
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x10]
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;; 
+;; wasm[0]::function[1]::add:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x28
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x20]
+;;       stur    x1, [x28, #0x18]
+;;       stur    w2, [x28, #0x14]
+;;       stur    w3, [x28, #0x10]
+;;       stur    w4, [x28, #0xc]
+;;       stur    w5, [x28, #8]
+;;       stur    w6, [x28, #4]
+;;       stur    w7, [x28]
+;;       ldur    w0, [x28, #0x10]
+;;       ldur    w1, [x28, #0x14]
+;;       add     w1, w1, w0, uxtx
+;;       ldur    w0, [x28, #0xc]
+;;       add     w1, w1, w0, uxtx
+;;       ldur    w0, [x28, #8]
+;;       add     w1, w1, w0, uxtx
+;;       ldur    w0, [x28, #4]
+;;       add     w1, w1, w0, uxtx
+;;       ldur    w0, [x28]
+;;       add     w1, w1, w0, uxtx
+;;       ldur    w0, [x29, #0x10]
+;;       add     w1, w1, w0, uxtx
+;;       ldur    w0, [x29, #0x18]
+;;       add     w1, w1, w0, uxtx
+;;       ldur    w0, [x29, #0x20]
+;;       add     w1, w1, w0, uxtx
+;;       mov     w0, w1
+;;       add     sp, sp, #0x28
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/call/recursive.wat
+++ b/tests/disas/winch/aarch64/call/recursive.wat
@@ -1,0 +1,84 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+  (func $fibonacci8 (param $n i32) (result i32)
+    (if (result i32) (i32.le_s (local.get $n) (i32.const 1))
+      (then
+        ;; If n <= 1, return n (base case)
+        (local.get $n)
+      )
+      (else
+        ;; Else, return fibonacci(n - 1) + fibonacci(n - 2)
+        (i32.add
+          (call $fibonacci8
+            (i32.sub (local.get $n) (i32.const 1)) ;; Calculate n - 1
+          )
+          (call $fibonacci8
+            (i32.sub (local.get $n) (i32.const 2)) ;; Calculate n - 2
+          )
+        )
+      )
+    )
+  )
+  (export "fib" (func $fibonacci8))
+)
+
+;; wasm[0]::function[0]::fibonacci8:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       ldur    w0, [x28, #4]
+;;       cmp     w0, #1
+;;       cset    x0, le
+;;       tst     w0, w0
+;;       b.eq    #0x44
+;;       b       #0x3c
+;;   3c: ldur    w0, [x28, #4]
+;;       b       #0xd4
+;;   44: ldur    w0, [x28, #4]
+;;       sub     w0, w0, #1
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       mov     x0, x9
+;;       mov     x1, x9
+;;       ldur    w2, [x28, #4]
+;;       bl      #0
+;;   70: add     sp, sp, #4
+;;       mov     x28, sp
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x10]
+;;       ldur    w1, [x28, #4]
+;;       sub     w1, w1, #2
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w1, [x28]
+;;       mov     x0, x9
+;;       mov     x1, x9
+;;       ldur    w2, [x28]
+;;       bl      #0
+;;   b4: add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x14]
+;;       ldur    w1, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       add     w1, w1, w0, uxtx
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/call/reg_on_stack.wat
+++ b/tests/disas/winch/aarch64/call/reg_on_stack.wat
@@ -1,0 +1,68 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+  (func (export "") (param i32) (result i32)
+    local.get 0
+    i32.const 1
+    call 0
+    i32.const 1
+    call 0
+    br_if 0 (;@0;)
+    unreachable
+  )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       ldur    w16, [x28, #4]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x28]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       mov     x0, x9
+;;       mov     x1, x9
+;;       mov     x16, #1
+;;       mov     w2, w16
+;;       bl      #0
+;;   50: add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x14]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       mov     x0, x9
+;;       mov     x1, x9
+;;       mov     x16, #1
+;;       mov     w2, w16
+;;       bl      #0
+;;   7c: ldur    x9, [x28, #0x18]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       ldur    w1, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    w0, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       tst     w1, w1
+;;       b.eq    #0xbc
+;;       b       #0xb0
+;;   b0: add     sp, sp, #4
+;;       mov     x28, sp
+;;       b       #0xc0
+;;   bc: .byte   0x1f, 0xc1, 0x00, 0x00
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/call/simple.wat
+++ b/tests/disas/winch/aarch64/call/simple.wat
@@ -19,7 +19,7 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       ldur    x16, [x2, #8]
-;;       ldur    x16, [x16]
+;;       ldur    x16, [x16, #0x10]
 ;;       add     x16, x16, #0x10
 ;;       cmp     sp, x16
 ;;       b.lo    #0x38

--- a/tests/disas/winch/aarch64/call/simple.wat
+++ b/tests/disas/winch/aarch64/call/simple.wat
@@ -1,5 +1,5 @@
 ;;! target = "aarch64"
-;;! test = "compile"
+;;! test = "winch"
 
 (module
   (func $main (result i32)
@@ -18,23 +18,52 @@
 ;; wasm[0]::function[0]::main:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldur    x16, [x2, #8]
-;;       ldur    x16, [x16, #0x10]
-;;       add     x16, x16, #0x10
-;;       cmp     sp, x16
-;;       b.lo    #0x38
-;;   1c: mov     w4, #0x14
-;;       mov     w5, #0x50
-;;       mov     x3, x2
-;;       bl      #0x40
-;;   2c: add     w2, w2, #2
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       sub     sp, sp, #8
+;;       mov     x28, sp
+;;       mov     x0, x9
+;;       mov     x1, x9
+;;       mov     x16, #0x14
+;;       mov     w2, w16
+;;       mov     x16, #0x50
+;;       mov     w3, w16
+;;       bl      #0x80
+;;   4c: add     sp, sp, #8
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x10]
+;;       mov     x16, #2
+;;       mov     w1, w16
+;;       stur    w1, [x28, #4]
+;;       ldur    w1, [x28, #4]
+;;       add     w0, w0, w1, uxtx
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
 ;; 
 ;; wasm[0]::function[1]::add:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       add     w2, w4, w5
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       add     w1, w1, w0, uxtx
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/simple.wat
+++ b/tests/disas/winch/aarch64/call/simple.wat
@@ -1,0 +1,40 @@
+;;! target = "aarch64"
+;;! test = "compile"
+
+(module
+  (func $main (result i32)
+    (local $var i32)
+    (call $add (i32.const 20) (i32.const 80))
+    (local.set $var (i32.const 2))
+    (local.get $var)
+    (i32.add))
+
+  (func $add (param i32 i32) (result i32)
+    (local.get 0)
+    (local.get 1)
+    (i32.add))
+)
+
+;; wasm[0]::function[0]::main:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       ldur    x16, [x2, #8]
+;;       ldur    x16, [x16]
+;;       add     x16, x16, #0x10
+;;       cmp     sp, x16
+;;       b.lo    #0x38
+;;   1c: mov     w4, #0x14
+;;       mov     w5, #0x50
+;;       mov     x3, x2
+;;       bl      #0x40
+;;   2c: add     w2, w2, #2
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;; 
+;; wasm[0]::function[1]::add:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       add     w2, w4, w5
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -1,0 +1,190 @@
+;;! target="aarch64"
+;;! test = "winch"
+
+(module
+  (type $over-i32 (func (param i32) (result i32)))
+
+  (table funcref
+    (elem
+      $fib-i32
+    )
+  )
+
+  (func $fib-i32 (export "fib-i32") (type $over-i32)
+    (if (result i32) (i32.le_u (local.get 0) (i32.const 1))
+      (then (i32.const 1))
+      (else
+        (i32.add
+          (call_indirect (type $over-i32)
+            (i32.sub (local.get 0) (i32.const 2))
+            (i32.const 0)
+          )
+          (call_indirect (type $over-i32)
+            (i32.sub (local.get 0) (i32.const 1))
+            (i32.const 0)
+          )
+        )
+      )
+    )
+  )
+)
+
+;; wasm[0]::function[0]::fib-i32:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       ldur    w0, [x28, #4]
+;;       cmp     w0, #1
+;;       cset    x0, ls
+;;       tst     w0, w0
+;;       b.eq    #0x48
+;;       b       #0x3c
+;;   3c: mov     x16, #1
+;;       mov     w0, w16
+;;       b       #0x250
+;;   48: ldur    w0, [x28, #4]
+;;       sub     w0, w0, #2
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       mov     x2, x9
+;;       ldur    x3, [x2, #0x60]
+;;       cmp     x1, x3, uxtx
+;;       b.hs    #0x260
+;;   74: mov     x16, x1
+;;       mov     x16, #8
+;;       mul     x16, x16, x16
+;;       ldur    x2, [x2, #0x58]
+;;       mov     x4, x2
+;;       add     x2, x2, x16, uxtx
+;;       cmp     w1, w3, uxtx
+;;       csel    x2, x4, x4, hs
+;;       ldur    x0, [x2]
+;;       tst     x0, x0
+;;       b.ne    #0xd4
+;;       b       #0xa4
+;;   a4: sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w1, [x28]
+;;       mov     x0, x9
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       ldur    w2, [x28]
+;;       bl      #0x3b4
+;;   c4: add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x14]
+;;       b       #0xd8
+;;   d4: and     x0, x0, #0xfffffffffffffffe
+;;       cbz     x0, #0x264
+;;   dc: ldur    x16, [x9, #0x50]
+;;       ldur    w1, [x16]
+;;       ldur    w2, [x0, #0x10]
+;;       cmp     w1, w2, uxtx
+;;       b.ne    #0x268
+;;   f0: sub     sp, sp, #8
+;;       mov     x28, sp
+;;       stur    x0, [x28]
+;;       ldur    x3, [x28]
+;;       add     sp, sp, #8
+;;       mov     x28, sp
+;;       ldur    x5, [x3, #0x18]
+;;       ldur    x4, [x3, #8]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       mov     x0, x5
+;;       mov     x1, x9
+;;       ldur    w2, [x28, #4]
+;;       blr     x4
+;;  128: add     sp, sp, #4
+;;       mov     x28, sp
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x10]
+;;       ldur    w1, [x28, #4]
+;;       sub     w1, w1, #1
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w0, [x28]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w1, [x28]
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       mov     x2, x9
+;;       ldur    x3, [x2, #0x60]
+;;       cmp     x1, x3, uxtx
+;;       b.hs    #0x26c
+;;  174: mov     x16, x1
+;;       mov     x16, #8
+;;       mul     x16, x16, x16
+;;       ldur    x2, [x2, #0x58]
+;;       mov     x4, x2
+;;       add     x2, x2, x16, uxtx
+;;       cmp     w1, w3, uxtx
+;;       csel    x2, x4, x4, hs
+;;       ldur    x0, [x2]
+;;       tst     x0, x0
+;;       b.ne    #0x1e4
+;;       b       #0x1a4
+;;  1a4: sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w1, [x28]
+;;       sub     sp, sp, #0xc
+;;       mov     x28, sp
+;;       mov     x0, x9
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       ldur    w2, [x28, #0xc]
+;;       bl      #0x3b4
+;;  1cc: add     sp, sp, #0xc
+;;       mov     x28, sp
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x18]
+;;       b       #0x1e8
+;;  1e4: and     x0, x0, #0xfffffffffffffffe
+;;       cbz     x0, #0x270
+;;  1ec: ldur    x16, [x9, #0x50]
+;;       ldur    w1, [x16]
+;;       ldur    w2, [x0, #0x10]
+;;       cmp     w1, w2, uxtx
+;;       b.ne    #0x274
+;;  200: sub     sp, sp, #8
+;;       mov     x28, sp
+;;       stur    x0, [x28]
+;;       ldur    x3, [x28]
+;;       add     sp, sp, #8
+;;       mov     x28, sp
+;;       ldur    x5, [x3, #0x18]
+;;       ldur    x4, [x3, #8]
+;;       mov     x0, x5
+;;       mov     x1, x9
+;;       ldur    w2, [x28]
+;;       blr     x4
+;;  230: add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x14]
+;;       ldur    w1, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       add     w1, w1, w0, uxtx
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;  260: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  264: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  268: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  26c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  270: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  274: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -1,0 +1,112 @@
+;;! target="aarch64"
+;;! test = "winch"
+
+(module
+    (type $param-i32 (func (param i32)))
+
+    (func $param-i32 (type $param-i32))
+    (func (export "")
+        (local i32)
+        local.get 0
+        (call_indirect (type $param-i32) (i32.const 0))
+    )
+
+    (table funcref
+      (elem
+        $param-i32)
+    )
+)
+
+;; wasm[0]::function[0]::param-i32:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;; 
+;; wasm[0]::function[1]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       ldur    w16, [x28, #4]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x28]
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       mov     x2, x9
+;;       ldur    x3, [x2, #0x60]
+;;       cmp     x1, x3, uxtx
+;;       b.hs    #0x168
+;;   90: mov     x16, x1
+;;       mov     x16, #8
+;;       mul     x16, x16, x16
+;;       ldur    x2, [x2, #0x58]
+;;       mov     x4, x2
+;;       add     x2, x2, x16, uxtx
+;;       cmp     w1, w3, uxtx
+;;       csel    x2, x4, x4, hs
+;;       ldur    x0, [x2]
+;;       tst     x0, x0
+;;       b.ne    #0xf0
+;;       b       #0xc0
+;;   c0: sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w1, [x28]
+;;       mov     x0, x9
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       ldur    w2, [x28]
+;;       bl      #0x3a4
+;;   e0: add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x14]
+;;       b       #0xf4
+;;   f0: and     x0, x0, #0xfffffffffffffffe
+;;       cbz     x0, #0x16c
+;;   f8: ldur    x16, [x9, #0x50]
+;;       ldur    w1, [x16]
+;;       ldur    w2, [x0, #0x10]
+;;       cmp     w1, w2, uxtx
+;;       b.ne    #0x170
+;;  10c: sub     sp, sp, #8
+;;       mov     x28, sp
+;;       stur    x0, [x28]
+;;       ldur    x3, [x28]
+;;       add     sp, sp, #8
+;;       mov     x28, sp
+;;       ldur    x5, [x3, #0x18]
+;;       ldur    x4, [x3, #8]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       mov     x0, x5
+;;       mov     x1, x9
+;;       ldur    w2, [x28, #4]
+;;       blr     x4
+;;  144: add     sp, sp, #4
+;;       mov     x28, sp
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0x10]
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;  168: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  16c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  170: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -927,4 +927,14 @@ impl Assembler {
             )),
         })
     }
+
+    pub fn call_with_lib(&mut self, lib: LibCall, dst: Reg) {
+        let name = ExternalName::LibCall(lib);
+        self.emit(Inst::LoadExtName {
+            rd: writable!(dst.into()),
+            name: name.into(),
+            offset: 0,
+        });
+        self.call_with_reg(dst)
+    }
 }

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -724,6 +724,14 @@ impl Assembler {
         });
     }
 
+    /// Trap if rn is 0
+    pub fn trapz(&mut self, rn: Reg, code: TrapCode) {
+        self.emit(Inst::TrapIf {
+            kind: CondBrKind::Zero(rn.into()),
+            trap_code: code,
+        });
+    }
+
     // Helpers for ALU operations.
 
     fn emit_alu_rri(&mut self, op: ALUOp, imm: Imm12, rn: Reg, rd: WritableReg, size: OperandSize) {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -6,19 +6,18 @@ use crate::{
     masm::OperandSize,
     reg::{writable, Reg, WritableReg},
 };
-use cranelift_codegen::ir::TrapCode;
-use cranelift_codegen::isa::aarch64::inst::{
-    BitOp, BranchTarget, Cond, CondBrKind, FPULeftShiftImm, FPUOp1, FPUOp2,
-    FPUOpRI::{self, UShr32, UShr64},
-    FPUOpRIMod, FPURightShiftImm, FpuRoundMode, ImmLogic, ImmShift, ScalarSize,
-};
 use cranelift_codegen::{
-    ir::{MemFlags, SourceLoc},
+    ir::{ExternalName, LibCall, MemFlags, SourceLoc, TrapCode, UserExternalNameRef},
     isa::aarch64::inst::{
         self,
         emit::{EmitInfo, EmitState},
-        ALUOp, ALUOp3, AMode, ExtendOp, Imm12, Inst, PairAMode, VecLanesOp, VecMisc2, VectorSize,
+        ALUOp, ALUOp3, AMode, BitOp, BranchTarget, Cond, CondBrKind, ExtendOp, FPULeftShiftImm,
+        FPUOp1, FPUOp2,
+        FPUOpRI::{self, UShr32, UShr64},
+        FPUOpRIMod, FPURightShiftImm, FpuRoundMode, Imm12, ImmLogic, ImmShift, Inst, PairAMode,
+        ScalarSize, VecLanesOp, VecMisc2, VectorSize,
     },
+    isa::CallConv,
     settings, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit, MachInstEmitState,
     MachLabel, Writable,
 };

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -909,7 +909,7 @@ impl Assembler {
         &self.buffer
     }
 
-    /// Emits a direct call to a function defined locally and
+    /// Emit a direct call to a function defined locally and
     /// referenced to by `name`.
     pub fn call_with_name(&mut self, name: UserExternalNameRef, call_conv: CallingConvention) {
         self.emit(Inst::Call {
@@ -920,7 +920,7 @@ impl Assembler {
         })
     }
 
-    /// Emits an indirect call to a function whose address is
+    /// Emit an indirect call to a function whose address is
     /// stored the `callee` register.
     pub fn call_with_reg(&mut self, callee: Reg, call_conv: CallingConvention) {
         self.emit(Inst::CallInd {
@@ -932,7 +932,7 @@ impl Assembler {
     }
 
     /// Emit a call to a well-known libcall.
-    /// `dst` is used as a scratch register to hold the address of the libcall function
+    /// `dst` is used as a scratch register to hold the address of the libcall function.
     pub fn call_with_lib(&mut self, lib: LibCall, dst: Reg, call_conv: CallingConvention) {
         let name = ExternalName::LibCall(lib);
         self.emit(Inst::LoadExtName {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -723,7 +723,7 @@ impl Assembler {
         });
     }
 
-    /// Trap if rn is 0
+    /// Trap if `rn` is zero.
     pub fn trapz(&mut self, rn: Reg, code: TrapCode) {
         self.emit(Inst::TrapIf {
             kind: CondBrKind::Zero(rn.into()),
@@ -909,6 +909,8 @@ impl Assembler {
         &self.buffer
     }
 
+    /// Emits a direct call to a function defined locally and
+    /// referenced to by `name`.
     pub fn call_with_name(&mut self, name: UserExternalNameRef) {
         self.emit(Inst::Call {
             info: Box::new(cranelift_codegen::CallInfo::empty(
@@ -918,6 +920,8 @@ impl Assembler {
         })
     }
 
+    /// Emits an indirect call to a function whose address is 
+    /// stored the `callee` register.
     pub fn call_with_reg(&mut self, callee: Reg) {
         self.emit(Inst::CallInd {
             info: Box::new(cranelift_codegen::CallInfo::empty(
@@ -927,6 +931,8 @@ impl Assembler {
         })
     }
 
+    /// Emit a call to a well-known libcall.
+    /// `dst` is used as a scratch register to hold the address of the libcall function
     pub fn call_with_lib(&mut self, lib: LibCall, dst: Reg) {
         let name = ExternalName::LibCall(lib);
         self.emit(Inst::LoadExtName {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -918,4 +918,13 @@ impl Assembler {
             )),
         })
     }
+
+    pub fn call_with_reg(&mut self, callee: Reg) {
+        self.emit(Inst::CallInd {
+            info: Box::new(cranelift_codegen::CallInfo::empty(
+                callee.into(),
+                CallConv::SystemV,
+            )),
+        })
+    }
 }

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -909,4 +909,13 @@ impl Assembler {
     pub fn buffer(&self) -> &MachBuffer<Inst> {
         &self.buffer
     }
+
+    pub fn call_with_name(&mut self, name: UserExternalNameRef) {
+        self.emit(Inst::Call {
+            info: Box::new(cranelift_codegen::CallInfo::empty(
+                ExternalName::user(name),
+                CallConv::SystemV,
+            )),
+        })
+    }
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -179,11 +179,11 @@ impl Masm for MacroAssembler {
         let aligned_args_size = align_to(stack_args_size, alignment);
         let total_stack = delta + aligned_args_size;
         self.reserve_stack(total_stack);
-        let callee = load_callee(self);
+        let (callee, call_conv) = load_callee(self);
         match callee {
-            CalleeKind::Indirect(reg) => self.asm.call_with_reg(reg),
-            CalleeKind::Direct(idx) => self.asm.call_with_name(idx),
-            CalleeKind::LibCall(lib) => self.asm.call_with_lib(lib, scratch()),
+            CalleeKind::Indirect(reg) => self.asm.call_with_reg(reg, call_conv),
+            CalleeKind::Direct(idx) => self.asm.call_with_name(idx, call_conv),
+            CalleeKind::LibCall(lib) => self.asm.call_with_lib(lib, scratch(), call_conv),
         }
 
         total_stack

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1,6 +1,11 @@
-use super::{abi::Aarch64ABI, address::Address, asm::Assembler, regs};
+use super::{
+    abi::Aarch64ABI,
+    address::Address,
+    asm::Assembler,
+    regs::{self, scratch},
+};
 use crate::{
-    abi::local::LocalSlot,
+    abi::{self, align_to, calculate_frame_adjustment, local::LocalSlot, vmctx,},
     codegen::{ptr_type_from_ptr_size, CodeGenContext, Emission, FuncEnv},
     isa::{
         reg::{writable, Reg, WritableReg},

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -126,8 +126,8 @@ impl Masm for MacroAssembler {
         Address::from_shadow_sp(offset.as_u32() as i64)
     }
 
-    fn address_at_vmctx(&self, _offset: u32) -> Self::Address {
-        todo!()
+    fn address_at_vmctx(&self, offset: u32) -> Self::Address {
+        Address::offset(vmctx!(Self), offset as i64)
     }
 
     fn store_ptr(&mut self, src: Reg, dst: Self::Address) {
@@ -165,10 +165,23 @@ impl Masm for MacroAssembler {
 
     fn call(
         &mut self,
-        _stack_args_size: u32,
-        _load_callee: impl FnMut(&mut Self) -> (CalleeKind, CallingConvention),
+        stack_args_size: u32,
+        mut load_callee: impl FnMut(&mut Self) -> (CalleeKind, CallingConvention),
     ) -> u32 {
-        todo!()
+        let alignment: u32 = <Self::ABI as abi::ABI>::call_stack_align().into();
+        let addend: u32 = <Self::ABI as abi::ABI>::arg_base_offset().into();
+        let delta = calculate_frame_adjustment(self.sp_offset().as_u32(), addend, alignment);
+        let aligned_args_size = align_to(stack_args_size, alignment);
+        let total_stack = delta + aligned_args_size;
+        self.reserve_stack(total_stack);
+        let callee = load_callee(self);
+        match callee {
+            CalleeKind::Indirect(reg) => self.asm.call_with_reg(reg),
+            CalleeKind::Direct(idx) => self.asm.call_with_name(idx),
+            CalleeKind::LibCall(lib) => self.asm.call_with_lib(lib, scratch()),
+        }
+
+        total_stack
     }
 
     fn load(&mut self, src: Address, dst: WritableReg, size: OperandSize) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -5,7 +5,7 @@ use super::{
     regs::{self, scratch},
 };
 use crate::{
-    abi::{self, align_to, calculate_frame_adjustment, local::LocalSlot, vmctx,},
+    abi::{self, align_to, calculate_frame_adjustment, local::LocalSlot, vmctx},
     codegen::{ptr_type_from_ptr_size, CodeGenContext, Emission, FuncEnv},
     isa::{
         reg::{writable, Reg, WritableReg},

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -662,8 +662,8 @@ impl Masm for MacroAssembler {
         self.asm.udf(code);
     }
 
-    fn trapz(&mut self, _src: Reg, _code: TrapCode) {
-        todo!()
+    fn trapz(&mut self, src: Reg, code: TrapCode) {
+        self.asm.trapz(src, code);
     }
 
     fn trapif(&mut self, cc: IntCmpKind, code: TrapCode) {


### PR DESCRIPTION
Implement the following MASM instruction for the aarch64 platform:
- call
- address_at_vmctx
- trapz

I initially planned to only implement call, but implementing the tests uncovered the necessity to implement the other two as prerequisite for indirect calls.

Right now the calling convention is hardcoded to SystemV, but maybe we also want to support AppleAarch64?

#8321

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
