### PR TITLE
Use `runner.os` in CI configuration more

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -639,7 +639,7 @@ jobs:
   # Perform all tests of the c-api
   test_capi:
     needs: determine
-    name: Test C-API ${{ runner.os }}
+    name: Test C-API ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     if: needs.determine.outputs.test-capi
 
@@ -805,7 +805,7 @@ jobs:
         include:
           - os: windows-latest
             feature: winml
-    name: Test wasi-nn (${{ matrix.feature }}, ${{ runner.os }})
+    name: Test wasi-nn (${{ matrix.feature }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: determine
     if: needs.determine.outputs.run-full

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -639,7 +639,7 @@ jobs:
   # Perform all tests of the c-api
   test_capi:
     needs: determine
-    name: Test C-API ${{ matrix.os }}
+    name: Test C-API ${{ runner.os }}
     runs-on: ${{ matrix.os }}
     if: needs.determine.outputs.test-capi
 
@@ -660,9 +660,9 @@ jobs:
     - run: cmake -Sexamples -Bexamples/build -DBUILD_SHARED_LIBS=OFF
     - run: cmake --build examples/build --config Debug
     - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target RUN_TESTS
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
     - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target test
-      if: matrix.os != 'windows-latest'
+      if: runner.os != 'Windows'
 
   # Perform all tests (debug mode) for `wasmtime`.
   #
@@ -760,14 +760,14 @@ jobs:
     # to CPU-specific features.
     - name: CPU information
       run: lscpu
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
     - name: CPU information
       run: sysctl hw
-      if: contains(matrix.os, 'macos')
+      if: runner.os == 'macOS'
     - name: CPU information
       run: wmic cpu list /format:list
       shell: pwsh
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
 
     # Since MPK (PKU) is not present on some GitHub runners, we check if it is
     # available before force-enabling it. This occasional testing is better than
@@ -805,7 +805,7 @@ jobs:
         include:
           - os: windows-latest
             feature: winml
-    name: Test wasi-nn (${{ matrix.feature }}, ${{ matrix.os }})
+    name: Test wasi-nn (${{ matrix.feature }}, ${{ runner.os }})
     runs-on: ${{ matrix.os }}
     needs: determine
     if: needs.determine.outputs.run-full
@@ -824,9 +824,9 @@ jobs:
     # GitHub Actions Window Server image doesn't have desktop experience
     # enabled, so we download the standalone library from ONNX Runtime project.
     - uses: nuget/setup-nuget@v2
-      if: (matrix.os == 'windows-latest') && (matrix.feature == 'winml')
+      if: (runner.os == 'Windows') && (matrix.feature == 'winml')
     - run: nuget install Microsoft.AI.MachineLearning
-      if: (matrix.os == 'windows-latest') && (matrix.feature == 'winml')
+      if: (runner.os == 'Windows') && (matrix.feature == 'winml')
 
     # Install Rust targets.
     - run: rustup target add wasm32-wasip1


### PR DESCRIPTION
Instead of using `matrix.os` which can change over time as images change instead use `runner.os` to both name jobs and have conditions on jobs. This couples it more closely to what's intended, the choice of OS, rather than image version.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
