### PR TITLE
cpp demangling check for demangling error

### DIFF
--- a/crates/environ/src/demangling.rs
+++ b/crates/environ/src/demangling.rs
@@ -7,8 +7,11 @@ pub fn demangle_function_name(writer: &mut impl core::fmt::Write, name: &str) ->
     #[cfg(feature = "demangle")]
     if let Ok(demangled) = rustc_demangle::try_demangle(name) {
         return write!(writer, "{demangled}");
-    } else if let Ok(demangled) = cpp_demangle::Symbol::new(name) {
-        return write!(writer, "{demangled}");
+    } else if let Ok(symbol) = cpp_demangle::Symbol::new(name) {
+        let options = cpp_demangle::DemangleOptions::default();
+        if let Ok(demangled) = symbol.demangle(&options) {
+            return write!(writer, "{demangled}");
+        }
     }
 
     write!(writer, "{name}")


### PR DESCRIPTION
The use of cpp_demangle in `crates/environ/src/demangling.rs` missed a check if demangling would actually succeed.

This PR's wraps the use of cpp_demangle with an explicitly call of [demangle](https://docs.rs/cpp_demangle/latest/cpp_demangle/struct.Symbol.html#method.demangle) and can therefore check its Result.  
The current implicit demangle call did not check this result. In some cases this lead to failed unwrapping in [instantiate.rs](https://github.com/bytecodealliance/wasmtime/blob/66989d9d6cfabb4c0781134b8d78bcbd81c6e511/crates/wasmtime/src/runtime/instantiate.rs#L73).

Closes #9753 
