### PR TITLE
winch: Track the callee calling convention

### DIFF
--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -567,7 +567,7 @@ impl ABIParams {
 }
 
 /// An ABI-specific representation of a function signature.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct ABISig {
     /// Function parameters.
     pub params: ABIParams,
@@ -575,11 +575,24 @@ pub(crate) struct ABISig {
     pub results: ABIResults,
     /// A unique set of registers used in the entire [`ABISig`].
     pub regs: HashSet<Reg>,
+    /// Calling convention used.
+    pub call_conv: CallingConvention,
+}
+
+impl Default for ABISig {
+    fn default() -> Self {
+        Self {
+            params: Default::default(),
+            results: Default::default(),
+            regs: Default::default(),
+            call_conv: CallingConvention::Default,
+        }
+    }
 }
 
 impl ABISig {
     /// Create a new ABI signature.
-    pub fn new(params: ABIParams, results: ABIResults) -> Self {
+    pub fn new(cc: CallingConvention, params: ABIParams, results: ABIResults) -> Self {
         let regs = params
             .operands
             .regs
@@ -590,6 +603,7 @@ impl ABISig {
             params,
             results,
             regs,
+            call_conv: cc,
         }
     }
 

--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -96,7 +96,7 @@ impl FnCall {
         let arg_stack_space = sig.params_stack_size();
         let reserved_stack = masm.call(arg_stack_space, |masm| {
             Self::assign(sig, &callee_context, ret_area.as_ref(), context, masm);
-            kind
+            (kind, sig.call_conv)
         });
 
         Self::cleanup(

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -48,7 +48,7 @@ impl ABI for Aarch64ABI {
                 )
             });
 
-        ABISig::new(params, results)
+        ABISig::new(call_conv.clone(), params, results)
     }
 
     fn abi_results(returns: &[WasmValType], call_conv: &CallingConvention) -> ABIResults {

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -48,7 +48,7 @@ impl ABI for Aarch64ABI {
                 )
             });
 
-        ABISig::new(call_conv.clone(), params, results)
+        ABISig::new(*call_conv, params, results)
     }
 
     fn abi_results(returns: &[WasmValType], call_conv: &CallingConvention) -> ABIResults {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -2,7 +2,10 @@ use super::{abi::Aarch64ABI, address::Address, asm::Assembler, regs};
 use crate::{
     abi::local::LocalSlot,
     codegen::{ptr_type_from_ptr_size, CodeGenContext, Emission, FuncEnv},
-    isa::reg::{writable, Reg, WritableReg},
+    isa::{
+        reg::{writable, Reg, WritableReg},
+        CallingConvention,
+    },
     masm::{
         CalleeKind, DivKind, ExtendKind, FloatCmpKind, Imm as I, IntCmpKind,
         MacroAssembler as Masm, MulWideKind, OperandSize, RegImm, RemKind, RoundingMode, SPOffset,
@@ -163,7 +166,7 @@ impl Masm for MacroAssembler {
     fn call(
         &mut self,
         _stack_args_size: u32,
-        _load_callee: impl FnMut(&mut Self) -> CalleeKind,
+        _load_callee: impl FnMut(&mut Self) -> (CalleeKind, CallingConvention),
     ) -> u32 {
         todo!()
     }

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -134,6 +134,17 @@ impl CallingConvention {
     }
 }
 
+impl From<CallingConvention> for CallConv {
+    fn from(value: CallingConvention) -> Self {
+        match value {
+            CallingConvention::SystemV => Self::SystemV,
+            CallingConvention::AppleAarch64 => Self::AppleAarch64,
+            CallingConvention::Default => Self::Winch,
+            CallingConvention::WindowsFastcall => Self::WindowsFastcall,
+        }
+    }
+}
+
 /// A trait representing commonalities between the supported
 /// instruction set architectures.
 pub trait TargetIsa: Send + Sync {

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -68,7 +68,7 @@ impl ABI for X64ABI {
             },
         );
 
-        ABISig::new(params, results)
+        ABISig::new(call_conv.clone(), params, results)
     }
 
     fn abi_results(returns: &[WasmValType], call_conv: &CallingConvention) -> ABIResults {

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -68,7 +68,7 @@ impl ABI for X64ABI {
             },
         );
 
-        ABISig::new(call_conv.clone(), params, results)
+        ABISig::new(*call_conv, params, results)
     }
 
     fn abi_results(returns: &[WasmValType], call_conv: &CallingConvention) -> ABIResults {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1,6 +1,9 @@
 use crate::abi::{self, align_to, scratch, LocalSlot};
 use crate::codegen::{CodeGenContext, Emission, FuncEnv};
-use crate::isa::reg::{writable, Reg, WritableReg};
+use crate::isa::{
+    reg::{writable, Reg, WritableReg},
+    CallingConvention,
+};
 use cranelift_codegen::{
     binemit::CodeOffset,
     ir::{Endianness, LibCall, MemFlags, RelSourceLoc, SourceLoc, UserExternalNameRef},
@@ -584,7 +587,11 @@ pub(crate) trait MacroAssembler {
     fn address_at_reg(&self, reg: Reg, offset: u32) -> Self::Address;
 
     /// Emit a function call to either a local or external function.
-    fn call(&mut self, stack_args_size: u32, f: impl FnMut(&mut Self) -> CalleeKind) -> u32;
+    fn call(
+        &mut self,
+        stack_args_size: u32,
+        f: impl FnMut(&mut Self) -> (CalleeKind, CallingConvention),
+    ) -> u32;
 
     /// Get stack pointer offset.
     fn sp_offset(&self) -> SPOffset;


### PR DESCRIPTION
This commit aims to improve the consistency of call emission in Winch.

Prior to this commit, the calling convention at Winch's assembler layer was hardcoded. Even though the calling convention invariants are correctly handled early on in the code generation process and this has no effect on the generated code, it could lead to subtle bugs if Cranelift's emission infrastructure changes. It could also be confusing when trying to implement call instrutions for other backends.

This change is motivated by some of the questions in https://github.com/bytecodealliance/wasmtime/pull/9751

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
