### PR TITLE
Implement custom stack unwinding for Pulley

### DIFF
--- a/crates/wasmtime/src/runtime/profiling.rs
+++ b/crates/wasmtime/src/runtime/profiling.rs
@@ -137,7 +137,7 @@ impl GuestProfiler {
         let now = Timestamp::from_nanos_since_reference(
             self.start.elapsed().as_nanos().try_into().unwrap(),
         );
-        let backtrace = Backtrace::new(store.as_context().0.vmruntime_limits());
+        let backtrace = Backtrace::new(store.as_context().0);
         let frames = lookup_frames(&self.modules, &backtrace);
         self.profile
             .add_sample(self.thread, now, frames, delta.into(), 1);
@@ -154,7 +154,7 @@ impl GuestProfiler {
         match kind {
             CallHook::CallingWasm | CallHook::ReturningFromWasm => {}
             CallHook::CallingHost => {
-                let backtrace = Backtrace::new(store.as_context().0.vmruntime_limits());
+                let backtrace = Backtrace::new(store.as_context().0);
                 let frames = lookup_frames(&self.modules, &backtrace);
                 self.profile.add_marker_with_stack(
                     self.thread,

--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -257,11 +257,7 @@ impl WasmBacktrace {
     /// always captures a backtrace.
     pub fn force_capture(store: impl AsContext) -> WasmBacktrace {
         let store = store.as_context();
-        Self::from_captured(
-            store.0,
-            crate::runtime::vm::Backtrace::new(store.0.runtime_limits()),
-            None,
-        )
+        Self::from_captured(store.0, crate::runtime::vm::Backtrace::new(store.0), None)
     }
 
     fn from_captured(

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -35,6 +35,7 @@ mod store_box;
 mod sys;
 mod table;
 mod traphandlers;
+mod unwind;
 mod vmcontext;
 
 #[cfg(feature = "threads")]
@@ -82,6 +83,7 @@ pub use crate::runtime::vm::sys::mmap::open_file_for_mmap;
 pub use crate::runtime::vm::sys::unwind::UnwindRegistration;
 pub use crate::runtime::vm::table::{Table, TableElement};
 pub use crate::runtime::vm::traphandlers::*;
+pub use crate::runtime::vm::unwind::*;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,

--- a/crates/wasmtime/src/runtime/vm/traphandlers/coredump_enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/coredump_enabled.rs
@@ -31,7 +31,8 @@ impl CallThreadState {
         if !self.capture_coredump {
             return None;
         }
-        let bt = unsafe { Backtrace::new_with_trap_state(limits, self, trap_pc_and_fp) };
+        let bt =
+            unsafe { Backtrace::new_with_trap_state(limits, self.unwinder, self, trap_pc_and_fp) };
 
         Some(CoreDumpStack {
             bt,

--- a/crates/wasmtime/src/runtime/vm/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/unwind.rs
@@ -46,6 +46,11 @@ unsafe impl Unwind for UnwindPulley {
         *(fp as *mut usize).offset(1)
     }
     fn assert_fp_is_aligned(&self, fp: usize) {
-        assert_eq!(fp % 16, 0, "stack should always be aligned to 16");
+        let expected = if cfg!(target_pointer_width = "32") {
+            8
+        } else {
+            16
+        };
+        assert_eq!(fp % expected, 0, "stack should always be aligned");
     }
 }

--- a/crates/wasmtime/src/runtime/vm/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/unwind.rs
@@ -1,0 +1,51 @@
+//! Support for low-level primitives of unwinding the stack.
+
+use crate::runtime::vm::arch;
+
+/// Implementation necessary to unwind the stack, used by `Backtrace`.
+pub unsafe trait Unwind {
+    /// Returns the offset, from the current frame pointer, of where to get to
+    /// the previous frame pointer on the stack.
+    fn next_older_fp_from_fp_offset(&self) -> usize;
+
+    /// Load the return address of a frame given the frame pointer for that
+    /// frame.
+    unsafe fn get_next_older_pc_from_fp(&self, fp: usize) -> usize;
+
+    /// Debug assertion that the frame pointer is aligned.
+    fn assert_fp_is_aligned(&self, fp: usize);
+}
+
+/// A host-backed implementation of unwinding, using the native platform ABI
+/// that Cranelift has.
+pub struct UnwindHost;
+
+unsafe impl Unwind for UnwindHost {
+    fn next_older_fp_from_fp_offset(&self) -> usize {
+        arch::NEXT_OLDER_FP_FROM_FP_OFFSET
+    }
+    unsafe fn get_next_older_pc_from_fp(&self, fp: usize) -> usize {
+        arch::get_next_older_pc_from_fp(fp)
+    }
+    fn assert_fp_is_aligned(&self, fp: usize) {
+        arch::assert_fp_is_aligned(fp)
+    }
+}
+
+/// An implementation specifically designed for unwinding Pulley's runtime stack
+/// (which might not match the native host).
+pub struct UnwindPulley;
+
+unsafe impl Unwind for UnwindPulley {
+    fn next_older_fp_from_fp_offset(&self) -> usize {
+        0
+    }
+    unsafe fn get_next_older_pc_from_fp(&self, fp: usize) -> usize {
+        // The calling convention always pushes the return pointer (aka the PC
+        // of the next older frame) just before this frame.
+        *(fp as *mut usize).offset(1)
+    }
+    fn assert_fp_is_aligned(&self, fp: usize) {
+        assert_eq!(fp % 16, 0, "stack should always be aligned to 16");
+    }
+}


### PR DESCRIPTION
The pulley calling convention may not match the native calling convention, which is the case for s390x, so the unwinding that Wasmtime does needs to be parameterized over what's being unwound. This commit adds a new `Unwind` trait with various methods behind it that the backtrace implementation is then updated to use.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
