### PR TITLE
pulley: Support big-endian targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,9 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "env_logger 0.11.5",
+ "target-lexicon",
  "wasmtime",
+ "wasmtime-environ",
  "wasmtime-wast-util",
 ]
 

--- a/cranelift/codegen/meta/src/isa/pulley.rs
+++ b/cranelift/codegen/meta/src/isa/pulley.rs
@@ -10,5 +10,11 @@ pub(crate) fn define() -> TargetIsa {
          * 'pointer64'\n",
         vec!["pointer32", "pointer64"],
     );
+    settings.add_bool(
+        "big_endian",
+        "Whether this is a big-endian target",
+        "Whether this is a big-endian target",
+        false,
+    );
     TargetIsa::new("pulley", settings.build())
 }

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -112,8 +112,12 @@ pub fn lookup(triple: Triple) -> Result<Builder, LookupError> {
         Architecture::Aarch64 { .. } => isa_builder!(aarch64, (feature = "arm64"), triple),
         Architecture::S390x { .. } => isa_builder!(s390x, (feature = "s390x"), triple),
         Architecture::Riscv64 { .. } => isa_builder!(riscv64, (feature = "riscv64"), triple),
-        Architecture::Pulley32 => isa_builder!(pulley32, (feature = "pulley"), triple),
-        Architecture::Pulley64 => isa_builder!(pulley64, (feature = "pulley"), triple),
+        Architecture::Pulley32 | Architecture::Pulley32be => {
+            isa_builder!(pulley32, (feature = "pulley"), triple)
+        }
+        Architecture::Pulley64 | Architecture::Pulley64be => {
+            isa_builder!(pulley64, (feature = "pulley"), triple)
+        }
         _ => Err(LookupError::Unsupported),
     }
 }

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -134,6 +134,10 @@
     (Sext8 (dst WritableXReg) (src XReg))
     (Sext16 (dst WritableXReg) (src XReg))
     (Sext32 (dst WritableXReg) (src XReg))
+
+    ;; Byte swaps.
+    (Bswap32 (dst WritableXReg) (src XReg))
+    (Bswap64 (dst WritableXReg) (src XReg))
   )
 )
 
@@ -622,6 +626,18 @@
 (rule (pulley_sext32 src)
       (let ((dst WritableXReg (temp_writable_xreg))
             (_ Unit (emit (MInst.Sext32 dst src))))
+        dst))
+
+(decl pulley_bswap32 (XReg) XReg)
+(rule (pulley_bswap32 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Bswap32 dst src))))
+        dst))
+
+(decl pulley_bswap64 (XReg) XReg)
+(rule (pulley_bswap64 src)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Bswap64 dst src))))
         dst))
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -566,6 +566,8 @@ fn pulley_emit<P>(
         Inst::Sext8 { dst, src } => enc::sext8(sink, dst, src),
         Inst::Sext16 { dst, src } => enc::sext16(sink, dst, src),
         Inst::Sext32 { dst, src } => enc::sext32(sink, dst, src),
+        Inst::Bswap32 { dst, src } => enc::bswap32(sink, dst, src),
+        Inst::Bswap64 { dst, src } => enc::bswap64(sink, dst, src),
     }
 }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -261,7 +261,9 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         | Inst::Zext32 { dst, src }
         | Inst::Sext8 { dst, src }
         | Inst::Sext16 { dst, src }
-        | Inst::Sext32 { dst, src } => {
+        | Inst::Sext32 { dst, src }
+        | Inst::Bswap32 { dst, src }
+        | Inst::Bswap64 { dst, src } => {
             collector.reg_use(src);
             collector.reg_def(dst);
         }
@@ -914,6 +916,16 @@ impl Inst {
                 let dst = format_reg(*dst.to_reg());
                 let src = format_reg(**src);
                 format!("sext32 {dst}, {src}")
+            }
+            Inst::Bswap32 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("bswap32 {dst}, {src}")
+            }
+            Inst::Bswap64 { dst, src } => {
+                let dst = format_reg(*dst.to_reg());
+                let src = format_reg(**src);
+                format!("bswap64 {dst}, {src}")
             }
         }
     }

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -235,11 +235,9 @@
 
 ;;;; Rules for `store` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl littleendian () MemFlags)
-(extern extractor littleendian littleendian)
-
-(decl bigendian () MemFlags)
-(extern extractor bigendian bigendian)
+(type Endianness extern (enum Big Little))
+(decl pure endianness (MemFlags) Endianness)
+(extern constructor endianness endianness)
 
 (rule (lower (store flags src @ (value_type ty) addr (offset32 offset)))
       (side_effect (pulley_store (Amode.RegOffset addr (i32_as_i64 offset))
@@ -248,9 +246,15 @@
                                  flags)))
 
 (decl xswap_if_be (XReg Type MemFlags) XReg)
-(rule 0 (xswap_if_be val _ty (littleendian)) val)
-(rule 1 (xswap_if_be val $I32 (bigendian)) (pulley_bswap32 val))
-(rule 1 (xswap_if_be val $I64 (bigendian)) (pulley_bswap64 val))
+(rule (xswap_if_be val _ty flags)
+  (if-let (Endianness.Little) (endianness flags))
+  val)
+(rule (xswap_if_be val $I32 flags)
+  (if-let (Endianness.Big) (endianness flags))
+  (pulley_bswap32 val))
+(rule (xswap_if_be val $I64 flags)
+  (if-let (Endianness.Big) (endianness flags))
+  (pulley_bswap64 val))
 
 ;;;; Rules for `stack_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -226,18 +226,31 @@
 ;;;; Rules for `load` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (load flags addr (offset32 offset))))
-      (pulley_load (Amode.RegOffset addr (i32_as_i64 offset))
-                   ty
-                   flags
-                   (ExtKind.Zero)))
+    (let ((le Reg (pulley_load (Amode.RegOffset addr (i32_as_i64 offset))
+                               ty
+                               flags
+                               (ExtKind.Zero))))
+      (xswap_if_be le ty flags)))
+
 
 ;;;; Rules for `store` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(decl littleendian () MemFlags)
+(extern extractor littleendian littleendian)
+
+(decl bigendian () MemFlags)
+(extern extractor bigendian bigendian)
+
 (rule (lower (store flags src @ (value_type ty) addr (offset32 offset)))
       (side_effect (pulley_store (Amode.RegOffset addr (i32_as_i64 offset))
-                                 src
+                                 (xswap_if_be src ty flags)
                                  ty
                                  flags)))
+
+(decl xswap_if_be (XReg Type MemFlags) XReg)
+(rule 0 (xswap_if_be val _ty (littleendian)) val)
+(rule 1 (xswap_if_be val $I32 (bigendian)) (pulley_bswap32 val))
+(rule 1 (xswap_if_be val $I64 (bigendian)) (pulley_bswap64 val))
 
 ;;;; Rules for `stack_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -114,6 +114,24 @@ where
     fn lr_reg(&mut self) -> XReg {
         XReg::new(regs::lr_reg()).unwrap()
     }
+
+    fn littleendian(&mut self, flags: MemFlags) -> Option<()> {
+        let endianness = flags.endianness(self.backend.target_endianness());
+        if endianness == Endianness::Little {
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn bigendian(&mut self, flags: MemFlags) -> Option<()> {
+        let endianness = flags.endianness(self.backend.target_endianness());
+        if endianness == Endianness::Big {
+            Some(())
+        } else {
+            None
+        }
+    }
 }
 
 /// The main entry point for lowering with ISLE.

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -115,22 +115,8 @@ where
         XReg::new(regs::lr_reg()).unwrap()
     }
 
-    fn littleendian(&mut self, flags: MemFlags) -> Option<()> {
-        let endianness = flags.endianness(self.backend.target_endianness());
-        if endianness == Endianness::Little {
-            Some(())
-        } else {
-            None
-        }
-    }
-
-    fn bigendian(&mut self, flags: MemFlags) -> Option<()> {
-        let endianness = flags.endianness(self.backend.target_endianness());
-        if endianness == Endianness::Big {
-            Some(())
-        } else {
-            None
-        }
+    fn endianness(&mut self, flags: MemFlags) -> Endianness {
+        flags.endianness(self.backend.target_endianness())
     }
 }
 

--- a/cranelift/filetests/filetests/isa/pulley64/loadbe.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/loadbe.clif
@@ -1,0 +1,71 @@
+test compile precise-output
+target pulley64 big_endian
+
+function %load_i32(i64) -> i32 {
+block0(v0: i64):
+    v1 = load.i32 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   x2 = load32_u x0+0 // flags =
+;   bswap32 x0, x2
+;   ret
+;
+; Disassembled:
+; load32_u x2, x0
+; bswap32 x0, x2
+; ret
+
+function %load_i64(i64) -> i64 {
+block0(v0: i64):
+    v1 = load.i64 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   x2 = load64_u x0+0 // flags =
+;   bswap64 x0, x2
+;   ret
+;
+; Disassembled:
+; load64 x2, x0
+; bswap64 x0, x2
+; ret
+
+function %load_i32_with_offset(i64) -> i32 {
+block0(v0: i64):
+    v1 = load.i32 v0+4
+    return v1
+}
+
+; VCode:
+; block0:
+;   x2 = load32_u x0+4 // flags =
+;   bswap32 x0, x2
+;   ret
+;
+; Disassembled:
+; load32_u_offset8 x2, x0, 4
+; bswap32 x0, x2
+; ret
+
+function %load_i64_with_offset(i64) -> i64 {
+block0(v0: i64):
+    v1 = load.i64 v0+8
+    return v1
+}
+
+; VCode:
+; block0:
+;   x2 = load64_u x0+8 // flags =
+;   bswap64 x0, x2
+;   ret
+;
+; Disassembled:
+; load64_offset8 x2, x0, 8
+; bswap64 x0, x2
+; ret
+

--- a/cranelift/filetests/filetests/isa/pulley64/storebe.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/storebe.clif
@@ -1,0 +1,71 @@
+test compile precise-output
+target pulley64 big_endian
+
+function %store_i32(i32, i64) {
+block0(v0: i32, v1: i64):
+    store v0, v1
+    return
+}
+
+; VCode:
+; block0:
+;   bswap32 x3, x0
+;   store32 x1+0, x3 // flags = 
+;   ret
+;
+; Disassembled:
+; bswap32 x3, x0
+; store32 x1, x3
+; ret
+
+function %store_i64(i64, i64) {
+block0(v0: i64, v1: i64):
+    store v0, v1
+    return
+}
+
+; VCode:
+; block0:
+;   bswap64 x3, x0
+;   store64 x1+0, x3 // flags = 
+;   ret
+;
+; Disassembled:
+; bswap64 x3, x0
+; store64 x1, x3
+; ret
+
+function %store_i32_with_offset(i32, i64) {
+block0(v0: i32, v1: i64):
+    store v0, v1+4
+    return
+}
+
+; VCode:
+; block0:
+;   bswap32 x3, x0
+;   store32 x1+4, x3 // flags = 
+;   ret
+;
+; Disassembled:
+; bswap32 x3, x0
+; store32_offset8 x1, 4, x3
+; ret
+
+function %store_i64_with_offset(i64, i64) {
+block0(v0: i64, v1: i64):
+    store v0, v1+8
+    return
+}
+
+; VCode:
+; block0:
+;   bswap64 x3, x0
+;   store64 x1+8, x3 // flags = 
+;   ret
+;
+; Disassembled:
+; bswap64 x3, x0
+; store64_offset8 x1, 8, x3
+; ret
+

--- a/crates/environ/src/ext.rs
+++ b/crates/environ/src/ext.rs
@@ -5,14 +5,36 @@ pub trait TripleExt {
     /// Helper for returning whether this target is for pulley, wasmtime's
     /// interpreter.
     fn is_pulley(&self) -> bool;
+
+    /// Returns the target triple for pulley to run on this host.
+    fn pulley_host() -> Self;
 }
 
 impl TripleExt for Triple {
     fn is_pulley(&self) -> bool {
         match self.architecture {
-            Architecture::Pulley32 => true,
-            Architecture::Pulley64 => true,
+            Architecture::Pulley32 | Architecture::Pulley32be => true,
+            Architecture::Pulley64 | Architecture::Pulley64be => true,
             _ => false,
         }
+    }
+
+    fn pulley_host() -> Self {
+        if cfg!(target_endian = "little") {
+            if cfg!(target_pointer_width = "32") {
+                return "pulley32".parse().unwrap();
+            } else if cfg!(target_pointer_width = "64") {
+                return "pulley64".parse().unwrap();
+            }
+        }
+        if cfg!(target_endian = "big") {
+            if cfg!(target_pointer_width = "32") {
+                return "pulley32be".parse().unwrap();
+            } else if cfg!(target_pointer_width = "64") {
+                return "pulley64be".parse().unwrap();
+            }
+        }
+
+        unreachable!()
     }
 }

--- a/crates/misc/component-test-util/Cargo.toml
+++ b/crates/misc/component-test-util/Cargo.toml
@@ -12,4 +12,6 @@ env_logger = { workspace = true }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
 wasmtime = { workspace = true, features = ["component-model", "async"] }
+wasmtime-environ = { workspace = true }
 wasmtime-wast-util = { path = '../../wast-util' }
+target-lexicon = { workspace = true }

--- a/crates/misc/component-test-util/src/lib.rs
+++ b/crates/misc/component-test-util/src/lib.rs
@@ -132,6 +132,7 @@ forward_impls! {
 
 /// Helper method to apply `wast_config` to `config`.
 pub fn apply_wast_config(config: &mut Config, wast_config: &wasmtime_wast_util::WastConfig) {
+    use wasmtime_environ::TripleExt;
     use wasmtime_wast_util::{Collector, Compiler};
 
     config.strategy(match wast_config.compiler {
@@ -139,11 +140,9 @@ pub fn apply_wast_config(config: &mut Config, wast_config: &wasmtime_wast_util::
         Compiler::Winch => wasmtime::Strategy::Winch,
     });
     if let Compiler::CraneliftPulley = wast_config.compiler {
-        if cfg!(target_pointer_width = "32") {
-            config.target("pulley32").unwrap();
-        } else {
-            config.target("pulley64").unwrap();
-        }
+        config
+            .target(&target_lexicon::Triple::pulley_host().to_string())
+            .unwrap();
     }
     config.collector(match wast_config.collector {
         Collector::Auto => wasmtime::Collector::Auto,

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -486,6 +486,12 @@ impl Engine {
             "has_avx512vbmi" => "avx512vbmi",
             "has_lzcnt" => "lzcnt",
 
+            // pulley features
+            "big_endian" if cfg!(target_endian = "big") => return Ok(()),
+            "big_endian" if cfg!(target_endian = "little") => {
+                return Err("wrong host endianness".to_string())
+            }
+
             _ => {
                 // FIXME: should enumerate risc-v features and plumb them
                 // through to the `detect_host_feature` function.

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -335,11 +335,7 @@ impl Compiler {
             Compiler::Winch => {
                 cfg!(target_arch = "x86_64")
             }
-            Compiler::CraneliftPulley => {
-                // FIXME(#9747) pulley needs more refactoring to support a
-                // big-endian host.
-                cfg!(target_endian = "little")
-            }
+            Compiler::CraneliftPulley => true,
         }
     }
 }

--- a/pulley/fuzz/src/interp.rs
+++ b/pulley/fuzz/src/interp.rs
@@ -127,6 +127,7 @@ fn op_is_safe_for_fuzzing(op: &Op) -> bool {
         | Op::Sext8(Sext8 { dst, .. })
         | Op::Sext32(Sext32 { dst, .. })
         | Op::Sext16(Sext16 { dst, .. }) => !dst.is_special(),
+        Op::Bswap32(Bswap32 { dst, .. }) | Op::Bswap64(Bswap64 { dst, .. }) => !dst.is_special(),
     }
 }
 

--- a/pulley/fuzz/src/interp.rs
+++ b/pulley/fuzz/src/interp.rs
@@ -127,7 +127,6 @@ fn op_is_safe_for_fuzzing(op: &Op) -> bool {
         | Op::Sext8(Sext8 { dst, .. })
         | Op::Sext32(Sext32 { dst, .. })
         | Op::Sext16(Sext16 { dst, .. }) => !dst.is_special(),
-        Op::Bswap32(Bswap32 { dst, .. }) | Op::Bswap64(Bswap64 { dst, .. }) => !dst.is_special(),
     }
 }
 
@@ -136,5 +135,8 @@ fn extended_op_is_safe_for_fuzzing(op: &ExtendedOp) -> bool {
         ExtendedOp::Trap(_) => true,
         ExtendedOp::Nop(_) => true,
         ExtendedOp::CallIndirectHost(_) => false,
+        ExtendedOp::Bswap32(Bswap32 { dst, .. }) | ExtendedOp::Bswap64(Bswap64 { dst, .. }) => {
+            !dst.is_special()
+        }
     }
 }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1123,31 +1123,33 @@ impl OpVisitor for Interpreter<'_> {
 
     fn load32_u(&mut self, dst: XReg, ptr: XReg) -> ControlFlow<Done> {
         let ptr = self.state[ptr].get_ptr::<u32>();
-        let val = unsafe { ptr::read_unaligned(ptr) };
+        let val = unsafe { u32::from_le(ptr::read_unaligned(ptr)) };
         self.state[dst].set_u64(u64::from(val));
         ControlFlow::Continue(())
     }
 
     fn load32_s(&mut self, dst: XReg, ptr: XReg) -> ControlFlow<Done> {
         let ptr = self.state[ptr].get_ptr::<i32>();
-        let val = unsafe { ptr::read_unaligned(ptr) };
+        let val = unsafe { i32::from_le(ptr::read_unaligned(ptr)) };
         self.state[dst].set_i64(i64::from(val));
         ControlFlow::Continue(())
     }
 
     fn load64(&mut self, dst: XReg, ptr: XReg) -> ControlFlow<Done> {
         let ptr = self.state[ptr].get_ptr::<u64>();
-        let val = unsafe { ptr::read_unaligned(ptr) };
+        let val = unsafe { u64::from_le(ptr::read_unaligned(ptr)) };
         self.state[dst].set_u64(val);
         ControlFlow::Continue(())
     }
 
     fn load32_u_offset8(&mut self, dst: XReg, ptr: XReg, offset: i8) -> ControlFlow<Done> {
         let val = unsafe {
-            self.state[ptr]
-                .get_ptr::<u32>()
-                .byte_offset(offset.into())
-                .read_unaligned()
+            u32::from_le(
+                self.state[ptr]
+                    .get_ptr::<u32>()
+                    .byte_offset(offset.into())
+                    .read_unaligned(),
+            )
         };
         self.state[dst].set_u64(u64::from(val));
         ControlFlow::Continue(())
@@ -1155,10 +1157,12 @@ impl OpVisitor for Interpreter<'_> {
 
     fn load32_s_offset8(&mut self, dst: XReg, ptr: XReg, offset: i8) -> ControlFlow<Done> {
         let val = unsafe {
-            self.state[ptr]
-                .get_ptr::<i32>()
-                .byte_offset(offset.into())
-                .read_unaligned()
+            i32::from_le(
+                self.state[ptr]
+                    .get_ptr::<i32>()
+                    .byte_offset(offset.into())
+                    .read_unaligned(),
+            )
         };
         self.state[dst].set_i64(i64::from(val));
         ControlFlow::Continue(())
@@ -1166,10 +1170,12 @@ impl OpVisitor for Interpreter<'_> {
 
     fn load32_u_offset64(&mut self, dst: XReg, ptr: XReg, offset: i64) -> ControlFlow<Done> {
         let val = unsafe {
-            self.state[ptr]
-                .get_ptr::<u32>()
-                .byte_offset(offset as isize)
-                .read_unaligned()
+            u32::from_le(
+                self.state[ptr]
+                    .get_ptr::<u32>()
+                    .byte_offset(offset as isize)
+                    .read_unaligned(),
+            )
         };
         self.state[dst].set_u64(u64::from(val));
         ControlFlow::Continue(())
@@ -1177,10 +1183,12 @@ impl OpVisitor for Interpreter<'_> {
 
     fn load32_s_offset64(&mut self, dst: XReg, ptr: XReg, offset: i64) -> ControlFlow<Done> {
         let val = unsafe {
-            self.state[ptr]
-                .get_ptr::<i32>()
-                .byte_offset(offset as isize)
-                .read_unaligned()
+            i32::from_le(
+                self.state[ptr]
+                    .get_ptr::<i32>()
+                    .byte_offset(offset as isize)
+                    .read_unaligned(),
+            )
         };
         self.state[dst].set_i64(i64::from(val));
         ControlFlow::Continue(())
@@ -1188,10 +1196,12 @@ impl OpVisitor for Interpreter<'_> {
 
     fn load64_offset8(&mut self, dst: XReg, ptr: XReg, offset: i8) -> ControlFlow<Done> {
         let val = unsafe {
-            self.state[ptr]
-                .get_ptr::<u64>()
-                .byte_offset(offset.into())
-                .read_unaligned()
+            u64::from_le(
+                self.state[ptr]
+                    .get_ptr::<u64>()
+                    .byte_offset(offset.into())
+                    .read_unaligned(),
+            )
         };
         self.state[dst].set_u64(val);
         ControlFlow::Continue(())
@@ -1199,10 +1209,12 @@ impl OpVisitor for Interpreter<'_> {
 
     fn load64_offset64(&mut self, dst: XReg, ptr: XReg, offset: i64) -> ControlFlow<Done> {
         let val = unsafe {
-            self.state[ptr]
-                .get_ptr::<u64>()
-                .byte_offset(offset as isize)
-                .read_unaligned()
+            u64::from_le(
+                self.state[ptr]
+                    .get_ptr::<u64>()
+                    .byte_offset(offset as isize)
+                    .read_unaligned(),
+            )
         };
         self.state[dst].set_u64(val);
         ControlFlow::Continue(())
@@ -1212,7 +1224,7 @@ impl OpVisitor for Interpreter<'_> {
         let ptr = self.state[ptr].get_ptr::<u32>();
         let val = self.state[src].get_u32();
         unsafe {
-            ptr::write_unaligned(ptr, val);
+            ptr::write_unaligned(ptr, val.to_le());
         }
         ControlFlow::Continue(())
     }
@@ -1221,7 +1233,7 @@ impl OpVisitor for Interpreter<'_> {
         let ptr = self.state[ptr].get_ptr::<u64>();
         let val = self.state[src].get_u64();
         unsafe {
-            ptr::write_unaligned(ptr, val);
+            ptr::write_unaligned(ptr, val.to_le());
         }
         ControlFlow::Continue(())
     }
@@ -1232,7 +1244,7 @@ impl OpVisitor for Interpreter<'_> {
             self.state[ptr]
                 .get_ptr::<u32>()
                 .byte_offset(offset.into())
-                .write_unaligned(val);
+                .write_unaligned(val.to_le());
         }
         ControlFlow::Continue(())
     }
@@ -1243,7 +1255,7 @@ impl OpVisitor for Interpreter<'_> {
             self.state[ptr]
                 .get_ptr::<u64>()
                 .byte_offset(offset.into())
-                .write_unaligned(val);
+                .write_unaligned(val.to_le());
         }
         ControlFlow::Continue(())
     }
@@ -1254,7 +1266,7 @@ impl OpVisitor for Interpreter<'_> {
             self.state[ptr]
                 .get_ptr::<u32>()
                 .byte_offset(offset as isize)
-                .write_unaligned(val);
+                .write_unaligned(val.to_le());
         }
         ControlFlow::Continue(())
     }
@@ -1265,7 +1277,7 @@ impl OpVisitor for Interpreter<'_> {
             self.state[ptr]
                 .get_ptr::<u64>()
                 .byte_offset(offset as isize)
-                .write_unaligned(val);
+                .write_unaligned(val.to_le());
         }
         ControlFlow::Continue(())
     }
@@ -1425,6 +1437,18 @@ impl OpVisitor for Interpreter<'_> {
     fn sext32(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
         let src = self.state[src].get_i64() as i32;
         self.state[dst].set_i64(src.into());
+        ControlFlow::Continue(())
+    }
+
+    fn bswap32(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_u32();
+        self.state[dst].set_u32(src.swap_bytes());
+        ControlFlow::Continue(())
+    }
+
+    fn bswap64(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_u64();
+        self.state[dst].set_u64(src.swap_bytes());
         ControlFlow::Continue(())
     }
 }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1439,18 +1439,6 @@ impl OpVisitor for Interpreter<'_> {
         self.state[dst].set_i64(src.into());
         ControlFlow::Continue(())
     }
-
-    fn bswap32(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
-        let src = self.state[src].get_u32();
-        self.state[dst].set_u32(src.swap_bytes());
-        ControlFlow::Continue(())
-    }
-
-    fn bswap64(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
-        let src = self.state[src].get_u64();
-        self.state[dst].set_u64(src.swap_bytes());
-        ControlFlow::Continue(())
-    }
 }
 
 impl ExtendedOpVisitor for Interpreter<'_> {
@@ -1465,5 +1453,17 @@ impl ExtendedOpVisitor for Interpreter<'_> {
 
     fn call_indirect_host(&mut self, id: u8) -> ControlFlow<Done> {
         ControlFlow::Break(self.done_call_indirect_host(id))
+    }
+
+    fn bswap32(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_u32();
+        self.state[dst].set_u32(src.swap_bytes());
+        ControlFlow::Continue(())
+    }
+
+    fn bswap64(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let src = self.state[src].get_u64();
+        self.state[dst].set_u64(src.swap_bytes());
+        ControlFlow::Continue(())
     }
 }

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -208,11 +208,6 @@ macro_rules! for_each_op {
             sext16 = Sext16 { dst: XReg, src: XReg };
             /// `dst = sext(low32(src))`
             sext32 = Sext32 { dst: XReg, src: XReg };
-
-            /// `dst = byteswap(low32(src))`
-            bswap32 = Bswap32 { dst: XReg, src: XReg };
-            /// `dst = byteswap(src)`
-            bswap64 = Bswap64 { dst: XReg, src: XReg };
         }
     };
 }
@@ -246,6 +241,11 @@ macro_rules! for_each_extended_op {
             /// is resolved at link-time when raw bytecode from Cranelift is
             /// assembled into the final object that Wasmtime will interpret.
             call_indirect_host = CallIndirectHost { id: u8 };
+
+            /// `dst = byteswap(low32(src))`
+            bswap32 = Bswap32 { dst: XReg, src: XReg };
+            /// `dst = byteswap(src)`
+            bswap64 = Bswap64 { dst: XReg, src: XReg };
         }
     };
 }

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -122,40 +122,40 @@ macro_rules! for_each_op {
             /// 32-bit unsigned less-than-equal.
             xulteq32 = Xulteq32 { operands: BinaryOperands<XReg> };
 
-            /// `dst = zero_extend(load32(ptr))`
+            /// `dst = zero_extend(load32_le(ptr))`
             load32_u = Load32U { dst: XReg, ptr: XReg };
-            /// `dst = sign_extend(load32(ptr))`
+            /// `dst = sign_extend(load32_le(ptr))`
             load32_s = Load32S { dst: XReg, ptr: XReg };
-            /// `dst = load64(ptr)`
+            /// `dst = load64_le(ptr)`
             load64 = Load64 { dst: XReg, ptr: XReg };
 
-            /// `dst = zero_extend(load32(ptr + offset8))`
+            /// `dst = zero_extend(load32_le(ptr + offset8))`
             load32_u_offset8 = Load32UOffset8 { dst: XReg, ptr: XReg, offset: i8 };
-            /// `dst = sign_extend(load32(ptr + offset8))`
+            /// `dst = sign_extend(load32_le(ptr + offset8))`
             load32_s_offset8 = Load32SOffset8 { dst: XReg, ptr: XReg, offset: i8 };
-            /// `dst = load64(ptr + offset8)`
+            /// `dst = load64_le(ptr + offset8)`
             load64_offset8 = Load64Offset8 { dst: XReg, ptr: XReg, offset: i8 };
 
-            /// `dst = zero_extend(load32(ptr + offset64))`
+            /// `dst = zero_extend(load32_le(ptr + offset64))`
             load32_u_offset64 = Load32UOffset64 { dst: XReg, ptr: XReg, offset: i64 };
-            /// `dst = sign_extend(load32(ptr + offset64))`
+            /// `dst = sign_extend(load32_le(ptr + offset64))`
             load32_s_offset64 = Load32SOffset64 { dst: XReg, ptr: XReg, offset: i64 };
-            /// `dst = load64(ptr + offset64)`
+            /// `dst = load64_le(ptr + offset64)`
             load64_offset64 = Load64Offset64 { dst: XReg, ptr: XReg, offset: i64 };
 
-            /// `*ptr = low32(src)`
+            /// `*ptr = low32(src.to_le())`
             store32 = Store32 { ptr: XReg, src: XReg };
-            /// `*ptr = src`
+            /// `*ptr = src.to_le()`
             store64 = Store64 { ptr: XReg, src: XReg };
 
-            /// `*(ptr + sign_extend(offset8)) = low32(src)`
+            /// `*(ptr + sign_extend(offset8)) = low32(src).to_le()`
             store32_offset8 = Store32SOffset8 { ptr: XReg, offset: i8, src: XReg };
-            /// `*(ptr + sign_extend(offset8)) = src`
+            /// `*(ptr + sign_extend(offset8)) = src.to_le()`
             store64_offset8 = Store64Offset8 { ptr: XReg, offset: i8, src: XReg };
 
-            /// `*(ptr + sign_extend(offset64)) = low32(src)`
+            /// `*(ptr + sign_extend(offset64)) = low32(src).to_le()`
             store32_offset64 = Store32SOffset64 { ptr: XReg, offset: i64, src: XReg };
-            /// `*(ptr + sign_extend(offset64)) = src`
+            /// `*(ptr + sign_extend(offset64)) = src.to_le()`
             store64_offset64 = Store64Offset64 { ptr: XReg, offset: i64, src: XReg };
 
             /// `push lr; push fp; fp = sp`
@@ -208,6 +208,11 @@ macro_rules! for_each_op {
             sext16 = Sext16 { dst: XReg, src: XReg };
             /// `dst = sext(low32(src))`
             sext32 = Sext32 { dst: XReg, src: XReg };
+
+            /// `dst = byteswap(low32(src))`
+            bswap32 = Bswap32 { dst: XReg, src: XReg };
+            /// `dst = byteswap(src)`
+            bswap64 = Bswap64 { dst: XReg, src: XReg };
         }
     };
 }

--- a/pulley/tests/all/interp.rs
+++ b/pulley/tests/all/interp.rs
@@ -526,10 +526,10 @@ fn xulteq32() {
 
 #[test]
 fn load32_u() {
-    let a = UnsafeCell::new(11u32);
-    let b = UnsafeCell::new(22u32);
-    let c = UnsafeCell::new(33u32);
-    let d = UnsafeCell::new(i32::MIN as u32);
+    let a = UnsafeCell::new(11u32.to_le());
+    let b = UnsafeCell::new(22u32.to_le());
+    let c = UnsafeCell::new(33u32.to_le());
+    let d = UnsafeCell::new((i32::MIN as u32).to_le());
 
     for (expected, addr) in [
         (11, a.get()),
@@ -556,10 +556,10 @@ fn load32_u() {
 
 #[test]
 fn load32_s() {
-    let a = UnsafeCell::new(11u32);
-    let b = UnsafeCell::new(22u32);
-    let c = UnsafeCell::new(33u32);
-    let d = UnsafeCell::new(-1i32 as u32);
+    let a = UnsafeCell::new(11u32.to_le());
+    let b = UnsafeCell::new(22u32.to_le());
+    let c = UnsafeCell::new(33u32.to_le());
+    let d = UnsafeCell::new((-1i32 as u32).to_le());
 
     for (expected, addr) in [
         (11, a.get()),
@@ -586,10 +586,10 @@ fn load32_s() {
 
 #[test]
 fn load64() {
-    let a = UnsafeCell::new(11u64);
-    let b = UnsafeCell::new(22u64);
-    let c = UnsafeCell::new(33u64);
-    let d = UnsafeCell::new(-1i64 as u64);
+    let a = UnsafeCell::new(11u64.to_le());
+    let b = UnsafeCell::new(22u64.to_le());
+    let c = UnsafeCell::new(33u64.to_le());
+    let d = UnsafeCell::new((-1i64 as u64).to_le());
 
     for (expected, addr) in [
         (11, a.get()),
@@ -616,10 +616,10 @@ fn load64() {
 
 #[test]
 fn load32_u_offset8() {
-    let a = UnsafeCell::new([11u32, 22]);
-    let b = UnsafeCell::new([33u32, 44]);
-    let c = UnsafeCell::new([55u32, 66]);
-    let d = UnsafeCell::new([i32::MIN as u32, i32::MAX as u32]);
+    let a = UnsafeCell::new([11u32.to_le(), 22u32.to_le()]);
+    let b = UnsafeCell::new([33u32.to_le(), 44u32.to_le()]);
+    let c = UnsafeCell::new([55u32.to_le(), 66u32.to_le()]);
+    let d = UnsafeCell::new([(i32::MIN as u32).to_le(), (i32::MAX as u32).to_le()]);
 
     for (expected, addr, offset) in [
         (11, a.get(), 0),
@@ -651,10 +651,10 @@ fn load32_u_offset8() {
 
 #[test]
 fn load32_s_offset8() {
-    let a = UnsafeCell::new([11u32, 22]);
-    let b = UnsafeCell::new([33u32, 44]);
-    let c = UnsafeCell::new([55u32, 66]);
-    let d = UnsafeCell::new([-1i32 as u32, i32::MAX as u32]);
+    let a = UnsafeCell::new([11u32.to_le(), 22u32.to_le()]);
+    let b = UnsafeCell::new([33u32.to_le(), 44u32.to_le()]);
+    let c = UnsafeCell::new([55u32.to_le(), 66u32.to_le()]);
+    let d = UnsafeCell::new([(-1i32 as u32).to_le(), (i32::MAX as u32).to_le()]);
 
     for (expected, addr, offset) in [
         (11, a.get(), 0),
@@ -687,10 +687,10 @@ fn load32_s_offset8() {
 
 #[test]
 fn load64_offset8() {
-    let a = UnsafeCell::new([11u64, 22]);
-    let b = UnsafeCell::new([33u64, 44]);
-    let c = UnsafeCell::new([55u64, 66]);
-    let d = UnsafeCell::new([-1i64 as u64, i64::MAX as u64]);
+    let a = UnsafeCell::new([11u64.to_le(), 22u64.to_le()]);
+    let b = UnsafeCell::new([33u64.to_le(), 44u64.to_le()]);
+    let c = UnsafeCell::new([55u64.to_le(), 66u64.to_le()]);
+    let d = UnsafeCell::new([(-1i64 as u64).to_le(), (i64::MAX as u64).to_le()]);
 
     for (expected, addr, offset) in [
         (11, a.get(), 0),
@@ -722,10 +722,10 @@ fn load64_offset8() {
 
 #[test]
 fn load32_u_offset64() {
-    let a = UnsafeCell::new([11u32, 22]);
-    let b = UnsafeCell::new([33u32, 44]);
-    let c = UnsafeCell::new([55u32, 66]);
-    let d = UnsafeCell::new([i32::MIN as u32, i32::MAX as u32]);
+    let a = UnsafeCell::new([11u32.to_le(), 22u32.to_le()]);
+    let b = UnsafeCell::new([33u32.to_le(), 44u32.to_le()]);
+    let c = UnsafeCell::new([55u32.to_le(), 66u32.to_le()]);
+    let d = UnsafeCell::new([(i32::MIN as u32).to_le(), (i32::MAX as u32).to_le()]);
 
     for (expected, addr, offset) in [
         (11, a.get(), 0),
@@ -757,10 +757,10 @@ fn load32_u_offset64() {
 
 #[test]
 fn load32_s_offset64() {
-    let a = UnsafeCell::new([11u32, 22]);
-    let b = UnsafeCell::new([33u32, 44]);
-    let c = UnsafeCell::new([55u32, 66]);
-    let d = UnsafeCell::new([-1i32 as u32, i32::MAX as u32]);
+    let a = UnsafeCell::new([11u32.to_le(), 22u32.to_le()]);
+    let b = UnsafeCell::new([33u32.to_le(), 44u32.to_le()]);
+    let c = UnsafeCell::new([55u32.to_le(), 66u32.to_le()]);
+    let d = UnsafeCell::new([(-1i32 as u32).to_le(), (i32::MAX as u32).to_le()]);
 
     for (expected, addr, offset) in [
         (11, a.get(), 0),
@@ -793,10 +793,10 @@ fn load32_s_offset64() {
 
 #[test]
 fn load64_offset64() {
-    let a = UnsafeCell::new([11u64, 22]);
-    let b = UnsafeCell::new([33u64, 44]);
-    let c = UnsafeCell::new([55u64, 66]);
-    let d = UnsafeCell::new([-1i64 as u64, i64::MAX as u64]);
+    let a = UnsafeCell::new([11u64.to_le(), 22u64.to_le()]);
+    let b = UnsafeCell::new([33u64.to_le(), 44u64.to_le()]);
+    let c = UnsafeCell::new([55u64.to_le(), 66u64.to_le()]);
+    let d = UnsafeCell::new([(-1i64 as u64).to_le(), (i64::MAX as u64).to_le()]);
 
     for (expected, addr, offset) in [
         (11, a.get(), 0),

--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -54,6 +54,7 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use wasmtime::{Engine, OptLevel, Strategy};
 use wasmtime_cli_flags::CommonOptions;
+use wasmtime_environ::TripleExt;
 
 fn main() -> Result<()> {
     if cfg!(miri) {
@@ -347,10 +348,7 @@ fn assert_output(
                     .collect::<Vec<_>>())
             })?,
             Err(_) => {
-                assert!(matches!(
-                    isa.triple().architecture,
-                    target_lexicon::Architecture::Pulley32 | target_lexicon::Architecture::Pulley64
-                ));
+                assert!(isa.triple().is_pulley());
                 disas_insts(&mut actual, &bytes, |bytes, _addr| {
                     let mut result = vec![];
 


### PR DESCRIPTION
This commit fixes the Pulley interpreter and Cranelift backend to properly support big-endian targets. The problem beforehand was that loads/stores in Pulley were defined as the native endianness which means that big and little-endian platforms differed. Additionally the previously set of understood pulley targets were implicitly always little-endian which was not appropriate for a big-endian host where JIT data structures are stored in big-endian format.

This commit fixes all of these issues with a few changes:

* Pulley loads/stores are always little-endian now.
* Pulley now has bswap32/bswap64 instructions.
* Wasmtime/Cranelift now understand big-endian pulley targets (e.g. `pulley32be`).
* CLIF translation of loads/stores now properly handles the endianness flags on `MemFlags`.

In the future if necessary we could natively add a macro-op for big-endian loads/stores to Pulley but for now it's more minimal to just have `bswap32` and `bswap64`.

The result of this commit is that Pulley tests are now run and executed on s390x like all other platforms.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
