### PR TITLE
Procedurally generate Pulley Cranelift boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ name = "cranelift-codegen-meta"
 version = "0.116.0"
 dependencies = [
  "cranelift-codegen-shared",
+ "pulley-interpreter",
 ]
 
 [[package]]

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -86,7 +86,12 @@ x86 = []
 arm64 = []
 s390x = []
 riscv64 = []
-pulley = ["dep:pulley-interpreter", "pulley-interpreter/encode", "pulley-interpreter/disas"]
+pulley = [
+  "dep:pulley-interpreter",
+  "pulley-interpreter/encode",
+  "pulley-interpreter/disas",
+  "cranelift-codegen-meta/pulley",
+]
 # Enable the ISA target for the host machine
 host-arch = []
 

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -17,3 +17,7 @@ rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
 cranelift-codegen-shared = { path = "../shared", version = "0.116.0" }
+pulley-interpreter = { workspace = true, optional = true }
+
+[features]
+pulley = ['dep:pulley-interpreter']

--- a/cranelift/codegen/meta/src/isle.rs
+++ b/cranelift/codegen/meta/src/isle.rs
@@ -64,6 +64,8 @@ pub fn get_isle_compilations(
     let prelude_isle = codegen_crate_dir.join("src").join("prelude.isle");
     let prelude_opt_isle = codegen_crate_dir.join("src").join("prelude_opt.isle");
     let prelude_lower_isle = codegen_crate_dir.join("src").join("prelude_lower.isle");
+    #[cfg(feature = "pulley")]
+    let pulley_gen = gen_dir.join("pulley_gen.isle");
 
     // Directory for mid-end optimizations.
     let src_opts = codegen_crate_dir.join("src").join("opts");
@@ -73,6 +75,7 @@ pub fn get_isle_compilations(
     let src_isa_aarch64 = codegen_crate_dir.join("src").join("isa").join("aarch64");
     let src_isa_s390x = codegen_crate_dir.join("src").join("isa").join("s390x");
     let src_isa_risc_v = codegen_crate_dir.join("src").join("isa").join("riscv64");
+    #[cfg(feature = "pulley")]
     let src_isa_pulley_shared = codegen_crate_dir
         .join("src")
         .join("isa")
@@ -166,6 +169,7 @@ pub fn get_isle_compilations(
                 untracked_inputs: vec![clif_lower_isle.clone()],
             },
             // The Pulley instruction selector.
+            #[cfg(feature = "pulley")]
             IsleCompilation {
                 name: "pulley".to_string(),
                 output: gen_dir.join("isle_pulley_shared.rs"),
@@ -175,7 +179,7 @@ pub fn get_isle_compilations(
                     src_isa_pulley_shared.join("inst.isle"),
                     src_isa_pulley_shared.join("lower.isle"),
                 ],
-                untracked_inputs: vec![clif_lower_isle.clone()],
+                untracked_inputs: vec![pulley_gen.clone(), clif_lower_isle.clone()],
             },
         ],
     }

--- a/cranelift/codegen/meta/src/lib.rs
+++ b/cranelift/codegen/meta/src/lib.rs
@@ -75,14 +75,13 @@ fn generate_rust_for_shared_defs(
 }
 
 /// Generates all the ISLE source files used in Cranelift from the meta-language.
-pub fn generate_isle(isas: &[isa::Isa], isle_dir: &std::path::Path) -> Result<(), error::Error> {
+pub fn generate_isle(isle_dir: &std::path::Path) -> Result<(), error::Error> {
     let shared_defs = shared::define();
-    generate_isle_for_shared_defs(&shared_defs, isas, isle_dir)
+    generate_isle_for_shared_defs(&shared_defs, isle_dir)
 }
 
 fn generate_isle_for_shared_defs(
     shared_defs: &Definitions,
-    isas: &[isa::Isa],
     isle_dir: &std::path::Path,
 ) -> Result<(), error::Error> {
     gen_isle::generate(
@@ -94,11 +93,7 @@ fn generate_isle_for_shared_defs(
     )?;
 
     #[cfg(feature = "pulley")]
-    if isas.contains(&isa::Isa::Pulley32) || isas.contains(&isa::Isa::Pulley64) {
-        pulley::generate_isle("pulley_gen.isle", isle_dir)?;
-    }
-
-    let _ = isas;
+    pulley::generate_isle("pulley_gen.isle", isle_dir)?;
 
     Ok(())
 }
@@ -111,6 +106,6 @@ pub fn generate(
 ) -> Result<(), error::Error> {
     let shared_defs = shared::define();
     generate_rust_for_shared_defs(&shared_defs, isas, out_dir)?;
-    generate_isle_for_shared_defs(&shared_defs, isas, isle_dir)?;
+    generate_isle_for_shared_defs(&shared_defs, isle_dir)?;
     Ok(())
 }

--- a/cranelift/codegen/meta/src/pulley.rs
+++ b/cranelift/codegen/meta/src/pulley.rs
@@ -1,0 +1,331 @@
+use crate::error::Error;
+use std::path::Path;
+
+struct Inst<'a> {
+    snake_name: &'a str,
+    name: &'a str,
+    fields: &'a [(&'a str, &'a str)],
+}
+
+macro_rules! define {
+    (
+        $(
+            $( #[$attr:meta] )*
+            $snake_name:ident = $name:ident $( { $( $field:ident : $field_ty:ty ),* } )? ;
+        )*
+    ) => {
+        &[$(Inst {
+            snake_name: stringify!($snake_name),
+            name: stringify!($name),
+            fields: &[$($( (stringify!($field), stringify!($field_ty)), )*)?],
+        }),*]
+        // helpers.push_str(concat!("(define pulley_", stringify!($snake_name), " ("));
+    };
+}
+
+const OPS: &[Inst<'_>] = pulley_interpreter::for_each_op!(define);
+const EXTENDED_OPS: &[Inst<'_>] = pulley_interpreter::for_each_extended_op!(define);
+
+enum Operand<'a> {
+    Normal { name: &'a str, ty: &'a str },
+    Writable { name: &'a str, ty: &'a str },
+    Binop { reg: &'a str },
+}
+
+impl Inst<'_> {
+    fn operands(&self) -> impl Iterator<Item = Operand<'_>> {
+        self.fields.iter().map(|(name, ty)| match (*name, *ty) {
+            ("operands", "BinaryOperands < XReg >") => Operand::Binop { reg: "XReg" },
+            (name, "RegSet < XReg >") => Operand::Normal {
+                name,
+                ty: "VecXReg",
+            },
+            ("dst", ty) => Operand::Writable { name, ty },
+            (name, ty) => Operand::Normal { name, ty },
+        })
+    }
+
+    fn skip(&self) -> bool {
+        match self.name {
+            // Skip instructions related to control-flow as those require
+            // special handling with `MachBuffer`.
+            "Jump" | "Call" | "CallIndirect" => true,
+
+            // Skip special instructions not used in Cranelift.
+            "XPush32Many" | "XPush64Many" | "XPop32Many" | "XPop64Many" => true,
+
+            // The pulley backend has its own trap-with-trap-code.
+            "Trap" => true,
+
+            // Skip more branching-related instructions.
+            n => n.starts_with("Br"),
+        }
+    }
+}
+
+pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
+    let mut rust = String::new();
+
+    // Generate a pretty-printing method for debugging.
+    rust.push_str("pub fn print(inst: &RawInst) -> String {\n");
+    rust.push_str("match inst {\n");
+    for inst @ Inst { name, .. } in OPS.iter().chain(EXTENDED_OPS) {
+        if inst.skip() {
+            continue;
+        }
+
+        let mut pat = String::new();
+        let mut locals = String::new();
+        let mut format_string = String::new();
+        format_string.push_str(inst.snake_name);
+        for (i, op) in inst.operands().enumerate() {
+            match op {
+                Operand::Normal { name, ty } | Operand::Writable { name, ty } => {
+                    pat.push_str(name);
+                    pat.push_str(",");
+
+                    if i > 0 {
+                        format_string.push_str(",");
+                    }
+                    format_string.push_str(" {");
+                    format_string.push_str(name);
+                    format_string.push_str("}");
+
+                    if ty.contains("Reg") {
+                        if name == "dst" {
+                            locals.push_str(&format!("let {name} = reg_name(*{name}.to_reg());\n"));
+                        } else {
+                            locals.push_str(&format!("let {name} = reg_name(**{name});\n"));
+                        }
+                    }
+                }
+                Operand::Binop { reg: _ } => {
+                    pat.push_str("dst, src1, src2,");
+                    format_string.push_str(" {dst}, {src1}, {src2}");
+                    locals.push_str(&format!("let dst = reg_name(*dst.to_reg());\n"));
+                    locals.push_str(&format!("let src1 = reg_name(**src1);\n"));
+                    locals.push_str(&format!("let src2 = reg_name(**src2);\n"));
+                }
+            }
+        }
+
+        rust.push_str(&format!(
+            "
+        RawInst::{name} {{ {pat} }} => {{
+            {locals}
+            format!(\"{format_string}\")
+        }}
+        "
+        ));
+    }
+    rust.push_str("}\n");
+    rust.push_str("}\n");
+
+    // Generate `get_operands` to feed information to regalloc
+    rust.push_str(
+        "pub fn get_operands(inst: &mut RawInst, collector: &mut impl OperandVisitor) {\n",
+    );
+    rust.push_str("match inst {\n");
+    for inst @ Inst { name, .. } in OPS.iter().chain(EXTENDED_OPS) {
+        if inst.skip() {
+            continue;
+        }
+
+        let mut pat = String::new();
+        let mut uses = Vec::new();
+        let mut defs = Vec::new();
+        for op in inst.operands() {
+            match op {
+                Operand::Normal { name, ty } => {
+                    if ty.contains("Reg") {
+                        uses.push(name);
+                        pat.push_str(name);
+                        pat.push_str(",");
+                    }
+                }
+                Operand::Writable { name, ty } => {
+                    if ty.contains("Reg") {
+                        defs.push(name);
+                        pat.push_str(name);
+                        pat.push_str(",");
+                    }
+                }
+                Operand::Binop { reg: _ } => {
+                    pat.push_str("dst, src1, src2,");
+                    uses.push("src1");
+                    uses.push("src2");
+                    defs.push("dst");
+                }
+            }
+        }
+
+        let uses = uses
+            .iter()
+            .map(|u| format!("collector.reg_use({u});\n"))
+            .collect::<String>();
+        let defs = defs
+            .iter()
+            .map(|u| format!("collector.reg_def({u});\n"))
+            .collect::<String>();
+
+        rust.push_str(&format!(
+            "
+        RawInst::{name} {{ {pat} .. }} => {{
+            {uses}
+            {defs}
+        }}
+        "
+        ));
+    }
+    rust.push_str("}\n");
+    rust.push_str("}\n");
+
+    // Generate an emission method
+    rust.push_str("pub fn emit<P>(inst: &RawInst, sink: &mut MachBuffer<InstAndKind<P>>)\n");
+    rust.push_str("  where P: PulleyTargetKind,\n");
+    rust.push_str("{\n");
+    rust.push_str("match *inst {\n");
+    for inst @ Inst {
+        name, snake_name, ..
+    } in OPS.iter().chain(EXTENDED_OPS)
+    {
+        if inst.skip() {
+            continue;
+        }
+
+        let mut pat = String::new();
+        let mut args = String::new();
+        for op in inst.operands() {
+            match op {
+                Operand::Normal { name, ty: _ } | Operand::Writable { name, ty: _ } => {
+                    pat.push_str(name);
+                    pat.push_str(",");
+
+                    args.push_str(name);
+                    args.push_str(",");
+                }
+                Operand::Binop { reg: _ } => {
+                    pat.push_str("dst, src1, src2,");
+                    args.push_str(
+                        "pulley_interpreter::regs::BinaryOperands::new(dst, src1, src2),",
+                    );
+                }
+            }
+        }
+
+        rust.push_str(&format!(
+            "
+        RawInst::{name} {{ {pat} }} => {{
+            pulley_interpreter::encode::{snake_name}(sink, {args})
+        }}
+        "
+        ));
+    }
+    rust.push_str("}\n");
+    rust.push_str("}\n");
+
+    std::fs::write(out_dir.join(filename), rust)?;
+    Ok(())
+}
+
+pub fn generate_isle(filename: &str, out_dir: &Path) -> Result<(), Error> {
+    let mut isle = String::new();
+
+    // Generate the `RawInst` enum
+    isle.push_str("(type RawInst (enum\n");
+    for inst in OPS.iter().chain(EXTENDED_OPS) {
+        if inst.skip() {
+            continue;
+        }
+        isle.push_str("  (");
+        isle.push_str(inst.name);
+        for op in inst.operands() {
+            match op {
+                Operand::Normal { name, ty } => {
+                    isle.push_str(&format!("\n    ({name} {ty})"));
+                }
+                Operand::Writable { name, ty } => {
+                    isle.push_str(&format!("\n    ({name} Writable{ty})"));
+                }
+                Operand::Binop { reg } => {
+                    isle.push_str(&format!("\n    (dst Writable{reg})"));
+                    isle.push_str(&format!("\n    (src1 {reg})"));
+                    isle.push_str(&format!("\n    (src2 {reg})"));
+                }
+            }
+        }
+        isle.push_str(")\n");
+    }
+    isle.push_str("))\n");
+
+    // Generate the `pulley_*` constructors with a `decl` and a `rule`.
+    for inst @ Inst {
+        name, snake_name, ..
+    } in OPS.iter().chain(EXTENDED_OPS)
+    {
+        if inst.skip() {
+            continue;
+        }
+        // generate `decl` and `rule` at the same time, placing the `rule` in
+        // temporary storage on the side. Makes generation a bit easier to read
+        // as opposed to doing the decl first then the rule.
+        let mut rule = String::new();
+        isle.push_str(&format!("(decl pulley_{snake_name} ("));
+        rule.push_str(&format!("(rule (pulley_{snake_name} "));
+        let mut result = None;
+        let mut ops = Vec::new();
+        for op in inst.operands() {
+            match op {
+                Operand::Normal { name, ty } => {
+                    isle.push_str(ty);
+                    rule.push_str(name);
+                    ops.push(name);
+                }
+                Operand::Writable { name: _, ty } => {
+                    assert!(result.is_none(), "{} has >1 result", inst.snake_name);
+                    result = Some(ty);
+                }
+                Operand::Binop { reg } => {
+                    isle.push_str(&format!("{reg} {reg}"));
+                    rule.push_str("src1 src2");
+                    ops.push("src1");
+                    ops.push("src2");
+                    assert!(result.is_none(), "{} has >1 result", inst.snake_name);
+                    result = Some(reg);
+                }
+            }
+            isle.push_str(" ");
+            rule.push_str(" ");
+        }
+        isle.push_str(") ");
+        rule.push_str(")");
+        let ops = ops.join(" ");
+        match result {
+            Some(result) => {
+                isle.push_str(result);
+                rule.push_str(&format!(
+                    "
+  (let (
+      (dst Writable{result} (temp_writable_{}))
+      (_ Unit (emit (RawInst.{name} dst {ops})))
+    )
+    dst))\
+\n",
+                    result.to_lowercase()
+                ));
+            }
+            None => {
+                isle.push_str("SideEffectNoResult");
+                rule.push_str(&format!(
+                    "  (SideEffectNoResult.Inst (RawInst.{name} {ops})))\n",
+                ));
+            }
+        }
+        isle.push_str(")\n");
+
+        isle.push_str(&rule);
+    }
+
+    std::fs::write(out_dir.join(filename), isle)?;
+    Ok(())
+}

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -182,12 +182,12 @@ where
         let src = XReg::new(src).unwrap();
         let dst = dst.try_into().unwrap();
         match (signed, from_bits) {
-            (true, 8) => Inst::Sext8 { dst, src }.into(),
-            (true, 16) => Inst::Sext16 { dst, src }.into(),
-            (true, 32) => Inst::Sext32 { dst, src }.into(),
-            (false, 8) => Inst::Zext8 { dst, src }.into(),
-            (false, 16) => Inst::Zext16 { dst, src }.into(),
-            (false, 32) => Inst::Zext32 { dst, src }.into(),
+            (true, 8) => RawInst::Sext8 { dst, src }.into(),
+            (true, 16) => RawInst::Sext16 { dst, src }.into(),
+            (true, 32) => RawInst::Sext32 { dst, src }.into(),
+            (false, 8) => RawInst::Zext8 { dst, src }.into(),
+            (false, 16) => RawInst::Zext16 { dst, src }.into(),
+            (false, 32) => RawInst::Zext32 { dst, src }.into(),
             _ => unimplemented!("extend {from_bits} to {to_bits} as signed? {signed}"),
         }
     }
@@ -220,8 +220,8 @@ where
         let dst = into_reg.try_into().unwrap();
         let imm = imm as i32;
         smallvec![
-            Inst::Xconst32 { dst, imm }.into(),
-            Inst::Xadd32 {
+            RawInst::Xconst32 { dst, imm }.into(),
+            RawInst::Xadd32 {
                 dst,
                 src1: from_reg.try_into().unwrap(),
                 src2: dst.to_reg(),
@@ -261,13 +261,13 @@ where
         let inst = if amount < 0 {
             let amount = amount.checked_neg().unwrap();
             if let Ok(amt) = u32::try_from(amount) {
-                Inst::StackAlloc32 { amt }
+                RawInst::StackAlloc32 { amt }
             } else {
                 unreachable!()
             }
         } else {
             if let Ok(amt) = u32::try_from(amount) {
-                Inst::StackFree32 { amt }
+                RawInst::StackFree32 { amt }
             } else {
                 unreachable!()
             }
@@ -284,7 +284,7 @@ where
         let mut insts = SmallVec::new();
 
         if frame_layout.setup_area_size > 0 {
-            insts.push(Inst::PushFrame.into());
+            insts.push(RawInst::PushFrame.into());
             if flags.unwind_info() {
                 insts.push(
                     Inst::Unwind {
@@ -310,7 +310,7 @@ where
         let mut insts = SmallVec::new();
 
         if frame_layout.setup_area_size > 0 {
-            insts.push(Inst::PopFrame.into());
+            insts.push(RawInst::PopFrame.into());
         }
 
         if frame_layout.tail_args_size > 0 {
@@ -327,7 +327,7 @@ where
         _isa_flags: &PulleyFlags,
         _frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
-        smallvec![Inst::Ret {}.into()]
+        smallvec![RawInst::Ret {}.into()]
     }
 
     fn gen_probestack(_insts: &mut SmallInstVec<Self::I>, _frame_size: u32) {

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -83,7 +83,10 @@
     ;; Stores.
     (Store (mem Amode) (src Reg) (ty Type) (flags MemFlags))
 
-    ;; TODO
+    ;; A raw pulley instruction generated at compile-time via Pulley's
+    ;; `for_each_op!` macro. This variant has `pulley_*` constructors to
+    ;; emit this instruction and auto-generated methods for other various
+    ;; bits and pieces of boilerplate in the backend.
     (Raw (raw RawInst))
   )
 )

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -45,9 +45,6 @@
       (dst WritableXReg)
       (reg XReg))
 
-    ;; Return.
-    (Ret)
-
     ;; Load an external symbol's address into a register.
     (LoadExtName (dst WritableXReg)
                  (name BoxExternalName)
@@ -77,35 +74,6 @@
     (BrIfXult32 (src1 XReg) (src2 XReg) (taken MachLabel) (not_taken MachLabel))
     (BrIfXulteq32 (src1 XReg) (src2 XReg) (taken MachLabel) (not_taken MachLabel))
 
-    ;; Register-to-register moves.
-    (Xmov (dst WritableXReg) (src XReg))
-    (Fmov (dst WritableFReg) (src FReg))
-    (Vmov (dst WritableVReg) (src VReg))
-
-    ;; Integer constants, zero-extended to 64 bits.
-    (Xconst8 (dst WritableXReg) (imm i8))
-    (Xconst16 (dst WritableXReg) (imm i16))
-    (Xconst32 (dst WritableXReg) (imm i32))
-    (Xconst64 (dst WritableXReg) (imm i64))
-
-    ;; Integer arithmetic.
-    (Xadd32 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xadd64 (dst WritableXReg) (src1 XReg) (src2 XReg))
-
-    ;; Comparisons.
-    (Xeq64 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xneq64 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xslt64 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xslteq64 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xult64 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xulteq64 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xeq32 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xneq32 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xslt32 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xslteq32 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xult32 (dst WritableXReg) (src1 XReg) (src2 XReg))
-    (Xulteq32 (dst WritableXReg) (src1 XReg) (src2 XReg))
-
     ;; Load the memory address referenced by `mem` into `dst`.
     (LoadAddr (dst WritableXReg) (mem Amode))
 
@@ -115,31 +83,14 @@
     ;; Stores.
     (Store (mem Amode) (src Reg) (ty Type) (flags MemFlags))
 
-    ;; Bitcasts.
-    (BitcastIntFromFloat32 (dst WritableXReg) (src FReg))
-    (BitcastIntFromFloat64 (dst WritableXReg) (src FReg))
-    (BitcastFloatFromInt32 (dst WritableFReg) (src XReg))
-    (BitcastFloatFromInt64 (dst WritableFReg) (src XReg))
-
-    ;; Stack manipulations
-    (PushFrame)
-    (PopFrame)
-    (StackAlloc32 (amt u32))
-    (StackFree32 (amt u32))
-
-    ;; Sign extensions.
-    (Zext8 (dst WritableXReg) (src XReg))
-    (Zext16 (dst WritableXReg) (src XReg))
-    (Zext32 (dst WritableXReg) (src XReg))
-    (Sext8 (dst WritableXReg) (src XReg))
-    (Sext16 (dst WritableXReg) (src XReg))
-    (Sext32 (dst WritableXReg) (src XReg))
-
-    ;; Byte swaps.
-    (Bswap32 (dst WritableXReg) (src XReg))
-    (Bswap64 (dst WritableXReg) (src XReg))
+    ;; TODO
+    (Raw (raw RawInst))
   )
 )
+
+(decl raw_inst_to_inst (RawInst) MInst)
+(rule (raw_inst_to_inst inst) (MInst.Raw inst))
+(convert RawInst MInst raw_inst_to_inst)
 
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
@@ -414,30 +365,6 @@
             (_ Unit (emit (MInst.GetSpecial dst reg))))
         dst))
 
-(decl pulley_xconst8 (i8) XReg)
-(rule (pulley_xconst8 x)
-      (let ((reg WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xconst8 reg x))))
-        reg))
-
-(decl pulley_xconst16 (i16) XReg)
-(rule (pulley_xconst16 x)
-      (let ((reg WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xconst16 reg x))))
-        reg))
-
-(decl pulley_xconst32 (i32) XReg)
-(rule (pulley_xconst32 x)
-      (let ((reg WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xconst32 reg x))))
-        reg))
-
-(decl pulley_xconst64 (i64) XReg)
-(rule (pulley_xconst64 x)
-      (let ((reg WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xconst64 reg x))))
-        reg))
-
 (decl pulley_jump (MachLabel) SideEffectNoResult)
 (rule (pulley_jump label)
       (SideEffectNoResult.Inst (MInst.Jump label)))
@@ -470,90 +397,6 @@
 (rule (pulley_br_if_xulteq32 a b taken not_taken)
       (SideEffectNoResult.Inst (MInst.BrIfXulteq32 a b taken not_taken)))
 
-(decl pulley_xadd32 (XReg XReg) XReg)
-(rule (pulley_xadd32 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xadd32 dst a b))))
-        dst))
-
-(decl pulley_xadd64 (XReg XReg) XReg)
-(rule (pulley_xadd64 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xadd64 dst a b))))
-        dst))
-
-(decl pulley_xeq64 (XReg XReg) XReg)
-(rule (pulley_xeq64 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xeq64 dst a b))))
-        dst))
-
-(decl pulley_xneq64 (XReg XReg) XReg)
-(rule (pulley_xneq64 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xneq64 dst a b))))
-        dst))
-
-(decl pulley_xslt64 (XReg XReg) XReg)
-(rule (pulley_xslt64 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xslt64 dst a b))))
-        dst))
-
-(decl pulley_xslteq64 (XReg XReg) XReg)
-(rule (pulley_xslteq64 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xslteq64 dst a b))))
-        dst))
-
-(decl pulley_xult64 (XReg XReg) XReg)
-(rule (pulley_xult64 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xult64 dst a b))))
-        dst))
-
-(decl pulley_xulteq64 (XReg XReg) XReg)
-(rule (pulley_xulteq64 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xulteq64 dst a b))))
-        dst))
-
-(decl pulley_xeq32 (XReg XReg) XReg)
-(rule (pulley_xeq32 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xeq32 dst a b))))
-        dst))
-
-(decl pulley_xneq32 (XReg XReg) XReg)
-(rule (pulley_xneq32 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xneq32 dst a b))))
-        dst))
-
-(decl pulley_xslt32 (XReg XReg) XReg)
-(rule (pulley_xslt32 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xslt32 dst a b))))
-        dst))
-
-(decl pulley_xslteq32 (XReg XReg) XReg)
-(rule (pulley_xslteq32 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xslteq32 dst a b))))
-        dst))
-
-(decl pulley_xult32 (XReg XReg) XReg)
-(rule (pulley_xult32 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xult32 dst a b))))
-        dst))
-
-(decl pulley_xulteq32 (XReg XReg) XReg)
-(rule (pulley_xulteq32 a b)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Xulteq32 dst a b))))
-        dst))
-
 (decl pulley_load (Amode Type MemFlags ExtKind) Reg)
 (rule (pulley_load amode ty flags ext)
       (let ((dst WritableReg (temp_writable_reg ty))
@@ -564,81 +407,9 @@
 (rule (pulley_store amode src ty flags)
       (SideEffectNoResult.Inst (MInst.Store amode src ty flags)))
 
-(decl pulley_bitcast_float_from_int_32 (XReg) FReg)
-(rule (pulley_bitcast_float_from_int_32 src)
-      (let ((dst WritableFReg (temp_writable_freg))
-            (_ Unit (emit (MInst.BitcastFloatFromInt32 dst src))))
-        dst))
-
-(decl pulley_bitcast_float_from_int_64 (XReg) FReg)
-(rule (pulley_bitcast_float_from_int_64 src)
-      (let ((dst WritableFReg (temp_writable_freg))
-            (_ Unit (emit (MInst.BitcastFloatFromInt64 dst src))))
-        dst))
-
-(decl pulley_bitcast_int_from_float_32 (FReg) XReg)
-(rule (pulley_bitcast_int_from_float_32 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.BitcastIntFromFloat32 dst src))))
-        dst))
-
-(decl pulley_bitcast_int_from_float_64 (FReg) XReg)
-(rule (pulley_bitcast_int_from_float_64 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.BitcastIntFromFloat64 dst src))))
-        dst))
-
 (decl gen_br_table (XReg MachLabel BoxVecMachLabel) Unit)
 (rule (gen_br_table idx default labels)
       (emit (MInst.BrTable idx default labels)))
-
-(decl pulley_zext8 (XReg) XReg)
-(rule (pulley_zext8 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Zext8 dst src))))
-        dst))
-
-(decl pulley_zext16 (XReg) XReg)
-(rule (pulley_zext16 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Zext16 dst src))))
-        dst))
-
-(decl pulley_zext32 (XReg) XReg)
-(rule (pulley_zext32 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Zext32 dst src))))
-        dst))
-
-(decl pulley_sext8 (XReg) XReg)
-(rule (pulley_sext8 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Sext8 dst src))))
-        dst))
-
-(decl pulley_sext16 (XReg) XReg)
-(rule (pulley_sext16 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Sext16 dst src))))
-        dst))
-
-(decl pulley_sext32 (XReg) XReg)
-(rule (pulley_sext32 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Sext32 dst src))))
-        dst))
-
-(decl pulley_bswap32 (XReg) XReg)
-(rule (pulley_bswap32 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Bswap32 dst src))))
-        dst))
-
-(decl pulley_bswap64 (XReg) XReg)
-(rule (pulley_bswap64 src)
-      (let ((dst WritableXReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.Bswap64 dst src))))
-        dst))
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -24,8 +24,22 @@ pub use self::emit::*;
 // Instructions (top level): definition
 
 pub use crate::isa::pulley_shared::lower::isle::generated_code::MInst as Inst;
+pub use crate::isa::pulley_shared::lower::isle::generated_code::RawInst;
+
+impl From<RawInst> for Inst {
+    fn from(raw: RawInst) -> Inst {
+        Inst::Raw { raw }
+    }
+}
 
 use super::PulleyTargetKind;
+
+mod generated {
+    use super::*;
+    use crate::isa::pulley_shared::lower::isle::generated_code::RawInst;
+
+    include!(concat!(env!("OUT_DIR"), "/pulley_inst_gen.rs"));
+}
 
 impl Inst {
     /// Generic constructor for a load (zero-extending where appropriate).
@@ -61,9 +75,6 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             for RetPair { vreg, preg } in rets {
                 collector.reg_fixed_use(vreg, *preg);
             }
-        }
-        Inst::Ret => {
-            unreachable!("`ret` is only added after regalloc")
         }
 
         Inst::Unwind { .. } | Inst::Trap { .. } | Inst::Nop => {}
@@ -167,45 +178,6 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_use(src2);
         }
 
-        Inst::Xmov { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
-        Inst::Fmov { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
-        Inst::Vmov { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
-
-        Inst::Xconst8 { dst, imm: _ }
-        | Inst::Xconst16 { dst, imm: _ }
-        | Inst::Xconst32 { dst, imm: _ }
-        | Inst::Xconst64 { dst, imm: _ } => {
-            collector.reg_def(dst);
-        }
-
-        Inst::Xadd32 { dst, src1, src2 }
-        | Inst::Xadd64 { dst, src1, src2 }
-        | Inst::Xeq64 { dst, src1, src2 }
-        | Inst::Xneq64 { dst, src1, src2 }
-        | Inst::Xslt64 { dst, src1, src2 }
-        | Inst::Xslteq64 { dst, src1, src2 }
-        | Inst::Xult64 { dst, src1, src2 }
-        | Inst::Xulteq64 { dst, src1, src2 }
-        | Inst::Xeq32 { dst, src1, src2 }
-        | Inst::Xneq32 { dst, src1, src2 }
-        | Inst::Xslt32 { dst, src1, src2 }
-        | Inst::Xslteq32 { dst, src1, src2 }
-        | Inst::Xult32 { dst, src1, src2 }
-        | Inst::Xulteq32 { dst, src1, src2 } => {
-            collector.reg_use(src1);
-            collector.reg_use(src2);
-            collector.reg_def(dst);
-        }
-
         Inst::LoadAddr { dst, mem } => {
             collector.reg_def(dst);
             mem.get_operands(collector);
@@ -232,41 +204,11 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_use(src);
         }
 
-        Inst::BitcastIntFromFloat32 { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
-        Inst::BitcastIntFromFloat64 { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
-        Inst::BitcastFloatFromInt32 { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
-        Inst::BitcastFloatFromInt64 { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
-
         Inst::BrTable { idx, .. } => {
             collector.reg_use(idx);
         }
 
-        Inst::StackAlloc32 { .. } | Inst::StackFree32 { .. } | Inst::PushFrame | Inst::PopFrame => {
-        }
-
-        Inst::Zext8 { dst, src }
-        | Inst::Zext16 { dst, src }
-        | Inst::Zext32 { dst, src }
-        | Inst::Sext8 { dst, src }
-        | Inst::Sext16 { dst, src }
-        | Inst::Sext32 { dst, src }
-        | Inst::Bswap32 { dst, src }
-        | Inst::Bswap64 { dst, src } => {
-            collector.reg_use(src);
-            collector.reg_def(dst);
-        }
+        Inst::Raw { raw } => generated::get_operands(raw, collector),
     }
 }
 
@@ -291,6 +233,18 @@ where
     fn from(inst: Inst) -> Self {
         Self {
             inst,
+            kind: PhantomData,
+        }
+    }
+}
+
+impl<P> From<RawInst> for InstAndKind<P>
+where
+    P: PulleyTargetKind,
+{
+    fn from(inst: RawInst) -> Self {
+        Self {
+            inst: inst.into(),
             kind: PhantomData,
         }
     }
@@ -359,7 +313,9 @@ where
 
     fn is_move(&self) -> Option<(Writable<Reg>, Reg)> {
         match self.inst {
-            Inst::Xmov { dst, src } => Some((Writable::from_reg(*dst.to_reg()), *src)),
+            Inst::Raw {
+                raw: RawInst::Xmov { dst, src },
+            } => Some((Writable::from_reg(*dst.to_reg()), *src)),
             _ => None,
         }
     }
@@ -384,7 +340,10 @@ where
 
     fn is_term(&self) -> MachTerminator {
         match self.inst {
-            Inst::Ret { .. } | Inst::Rets { .. } => MachTerminator::Ret,
+            Inst::Raw {
+                raw: RawInst::Ret { .. },
+            }
+            | Inst::Rets { .. } => MachTerminator::Ret,
             Inst::Jump { .. } => MachTerminator::Uncond,
             Inst::BrIf { .. }
             | Inst::BrIfXeq32 { .. }
@@ -404,17 +363,17 @@ where
 
     fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Self {
         match ty {
-            ir::types::I8 | ir::types::I16 | ir::types::I32 | ir::types::I64 => Inst::Xmov {
+            ir::types::I8 | ir::types::I16 | ir::types::I32 | ir::types::I64 => RawInst::Xmov {
                 dst: WritableXReg::try_from(to_reg).unwrap(),
                 src: XReg::new(from_reg).unwrap(),
             }
             .into(),
-            ir::types::F32 | ir::types::F64 => Inst::Fmov {
+            ir::types::F32 | ir::types::F64 => RawInst::Fmov {
                 dst: WritableFReg::try_from(to_reg).unwrap(),
                 src: FReg::new(from_reg).unwrap(),
             }
             .into(),
-            _ if ty.is_vector() => Inst::Vmov {
+            _ if ty.is_vector() => RawInst::Vmov {
                 dst: WritableVReg::try_from(to_reg).unwrap(),
                 src: VReg::new(from_reg).unwrap(),
             }
@@ -585,8 +544,6 @@ impl Inst {
 
             Inst::Nop => format!("nop"),
 
-            Inst::Ret => format!("ret"),
-
             Inst::GetSpecial { dst, reg } => {
                 let dst = format_reg(*dst.to_reg());
                 let reg = format_reg(**reg);
@@ -697,125 +654,6 @@ impl Inst {
                 format!("br_if_xulteq32 {src1}, {src2}, {taken}; jump {not_taken}")
             }
 
-            Inst::Xmov { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("{dst} = xmov {src}")
-            }
-            Inst::Fmov { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("{dst} = fmov {src}")
-            }
-            Inst::Vmov { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("{dst} = vmov {src}")
-            }
-
-            Inst::Xconst8 { dst, imm } => {
-                let dst = format_reg(*dst.to_reg());
-                format!("{dst} = xconst8 {imm}")
-            }
-            Inst::Xconst16 { dst, imm } => {
-                let dst = format_reg(*dst.to_reg());
-                format!("{dst} = xconst16 {imm}")
-            }
-            Inst::Xconst32 { dst, imm } => {
-                let dst = format_reg(*dst.to_reg());
-                format!("{dst} = xconst32 {imm}")
-            }
-            Inst::Xconst64 { dst, imm } => {
-                let dst = format_reg(*dst.to_reg());
-                format!("{dst} = xconst64 {imm}")
-            }
-
-            Inst::Xadd32 { dst, src1, src2 } => format!(
-                "{} = xadd32 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xadd64 { dst, src1, src2 } => format!(
-                "{} = xadd64 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-
-            Inst::Xeq64 { dst, src1, src2 } => format!(
-                "{} = xeq64 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xneq64 { dst, src1, src2 } => format!(
-                "{} = xneq64 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xslt64 { dst, src1, src2 } => format!(
-                "{} = xslt64 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xslteq64 { dst, src1, src2 } => format!(
-                "{} = xslteq64 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xult64 { dst, src1, src2 } => format!(
-                "{} = xult64 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xulteq64 { dst, src1, src2 } => format!(
-                "{} = xulteq64 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xeq32 { dst, src1, src2 } => format!(
-                "{} = xeq32 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xneq32 { dst, src1, src2 } => format!(
-                "{} = xneq32 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xslt32 { dst, src1, src2 } => format!(
-                "{} = xslt32 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xslteq32 { dst, src1, src2 } => format!(
-                "{} = xslteq32 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xult32 { dst, src1, src2 } => format!(
-                "{} = xult32 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-            Inst::Xulteq32 { dst, src1, src2 } => format!(
-                "{} = xulteq32 {}, {}",
-                format_reg(*dst.to_reg()),
-                format_reg(**src1),
-                format_reg(**src2)
-            ),
-
             Inst::LoadAddr { dst, mem } => {
                 let dst = format_reg(*dst.to_reg());
                 let mem = mem.to_string();
@@ -848,27 +686,6 @@ impl Inst {
                 format!("store{ty} {mem}, {src} // flags = {flags}")
             }
 
-            Inst::BitcastIntFromFloat32 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("{dst} = bitcast_int_from_float32 {src}")
-            }
-            Inst::BitcastIntFromFloat64 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("{dst} = bitcast_int_from_float64 {src}")
-            }
-            Inst::BitcastFloatFromInt32 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("{dst} = bitcast_float_from_int32 {src}")
-            }
-            Inst::BitcastFloatFromInt64 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("{dst} = bitcast_float_from_int64 {src}")
-            }
-
             Inst::BrTable {
                 idx,
                 default,
@@ -877,56 +694,7 @@ impl Inst {
                 let idx = format_reg(**idx);
                 format!("br_table {idx} {default:?} {targets:?}")
             }
-
-            Inst::StackAlloc32 { amt } => {
-                format!("stack_alloc32 {amt:#x}")
-            }
-            Inst::StackFree32 { amt } => {
-                format!("stack_free32 {amt:#x}")
-            }
-            Inst::PushFrame => format!("push_frame"),
-            Inst::PopFrame => format!("pop_frame"),
-
-            Inst::Zext8 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("zext8 {dst}, {src}")
-            }
-            Inst::Zext16 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("zext16 {dst}, {src}")
-            }
-            Inst::Zext32 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("zext32 {dst}, {src}")
-            }
-            Inst::Sext8 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("sext8 {dst}, {src}")
-            }
-            Inst::Sext16 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("sext16 {dst}, {src}")
-            }
-            Inst::Sext32 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("sext32 {dst}, {src}")
-            }
-            Inst::Bswap32 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("bswap32 {dst}, {src}")
-            }
-            Inst::Bswap64 { dst, src } => {
-                let dst = format_reg(*dst.to_reg());
-                let src = format_reg(**src);
-                format!("bswap64 {dst}, {src}")
-            }
+            Inst::Raw { raw } => generated::print(raw),
         }
     }
 }

--- a/cranelift/filetests/filetests/isa/pulley32/br_table.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/br_table.clif
@@ -34,19 +34,19 @@ block5(v5: i32):
 ; block2:
 ;   jump label4
 ; block3:
-;   x5 = xconst8 3
+;   xconst8 x5, 3
 ;   jump label7
 ; block4:
-;   x5 = xconst8 2
+;   xconst8 x5, 2
 ;   jump label7
 ; block5:
-;   x5 = xconst8 1
+;   xconst8 x5, 1
 ;   jump label7
 ; block6:
-;   x5 = xconst8 4
+;   xconst8 x5, 4
 ;   jump label7
 ; block7:
-;   x0 = xadd32 x0, x5
+;   xadd32 x0, x0, x5
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley32/brif-icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif-icmp.clif
@@ -19,10 +19,10 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -50,10 +50,10 @@ block2:
 ; block0:
 ;   br_if_xneq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -81,10 +81,10 @@ block2:
 ; block0:
 ;   br_if_xult32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -112,10 +112,10 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -143,10 +143,10 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -174,10 +174,10 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -205,10 +205,10 @@ block2:
 ; block0:
 ;   br_if_xult32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -236,10 +236,10 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -267,10 +267,10 @@ block2:
 ; block0:
 ;   br_if_xslt32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -298,10 +298,10 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -330,10 +330,10 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley32/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif.clif
@@ -18,10 +18,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -48,10 +48,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -78,10 +78,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -108,10 +108,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -137,13 +137,13 @@ block2:
 
 ; VCode:
 ; block0:
-;   x5 = xeq32 x0, x1
+;   xeq32 x5, x0, x1
 ;   br_if x5, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -170,13 +170,13 @@ block2:
 
 ; VCode:
 ; block0:
-;   x5 = xneq32 x0, x1
+;   xneq32 x5, x0, x1
 ;   br_if x5, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -205,10 +205,10 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -234,13 +234,13 @@ block2:
 
 ; VCode:
 ; block0:
-;   x5 = xulteq64 x1, x0
+;   xulteq64 x5, x1, x0
 ;   br_if x5, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -15,9 +15,9 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   pop_frame
 ;   ret
 ;
@@ -42,9 +42,9 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   pop_frame
 ;   ret
 ;
@@ -71,10 +71,10 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   x0 = xconst8 0
-;   x1 = xconst8 1
-;   x2 = xconst8 2
-;   x3 = xconst8 3
+;   xconst8 x0, 0
+;   xconst8 x1, 1
+;   xconst8 x2, 2
+;   xconst8 x3, 3
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   pop_frame
 ;   ret
@@ -104,9 +104,9 @@ block0:
 ;   push_frame
 ; block0:
 ;   call CallInfo { dest: TestCase(%g), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x4 = xadd64 x0, x2
-;   x3 = xadd64 x1, x3
-;   x0 = xadd64 x4, x3
+;   xadd64 x4, x0, x2
+;   xadd64 x3, x1, x3
+;   xadd64 x0, x4, x3
 ;   pop_frame
 ;   ret
 ;
@@ -130,32 +130,32 @@ block0:
 
 ; VCode:
 ;   push_frame
-;   stack_alloc32 0x30
+;   stack_alloc32 48
 ; block0:
-;   x15 = xconst8 0
+;   xconst8 x15, 0
 ;   store64 OutgoingArg(0), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(8), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(16), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(24), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(32), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(40), x15 // flags =  notrap aligned
-;   x0 = xmov x15
-;   x1 = xmov x15
-;   x2 = xmov x15
-;   x3 = xmov x15
-;   x4 = xmov x15
-;   x5 = xmov x15
-;   x6 = xmov x15
-;   x7 = xmov x15
-;   x8 = xmov x15
-;   x9 = xmov x15
-;   x10 = xmov x15
-;   x11 = xmov x15
-;   x12 = xmov x15
-;   x13 = xmov x15
-;   x14 = xmov x15
+;   xmov x0, x15
+;   xmov x1, x15
+;   xmov x2, x15
+;   xmov x3, x15
+;   xmov x4, x15
+;   xmov x5, x15
+;   xmov x6, x15
+;   xmov x7, x15
+;   xmov x8, x15
+;   xmov x9, x15
+;   xmov x10, x15
+;   xmov x11, x15
+;   xmov x12, x15
+;   xmov x13, x15
+;   xmov x14, x15
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   stack_free32 0x30
+;   stack_free32 48
 ;   pop_frame
 ;   ret
 ;
@@ -227,47 +227,47 @@ block0:
 
 ; VCode:
 ;   push_frame
-;   stack_alloc32 0x40
+;   stack_alloc32 64
 ;   store64 sp+56, x18 // flags =  notrap aligned
 ;   store64 sp+48, x20 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x18 = xmov x13
-;   x20 = xmov x11
+;   xmov x18, x13
+;   xmov x20, x11
 ;   x24 = load64_u OutgoingArg(0) // flags = notrap aligned
 ;   x11 = load64_u OutgoingArg(8) // flags = notrap aligned
 ;   x13 = load64_u OutgoingArg(16) // flags = notrap aligned
 ;   x19 = load64_u OutgoingArg(24) // flags = notrap aligned
 ;   x21 = load64_u OutgoingArg(32) // flags = notrap aligned
-;   x25 = xadd64 x0, x1
-;   x23 = xadd64 x2, x3
-;   x5 = xadd64 x4, x5
-;   x6 = xadd64 x6, x7
-;   x7 = xadd64 x8, x9
-;   x0 = xmov x20
-;   x4 = xadd64 x10, x0
-;   x10 = xmov x18
-;   x8 = xadd64 x12, x10
-;   x14 = xadd64 x14, x15
-;   x15 = xadd64 x24, x11
-;   x13 = xadd64 x11, x13
-;   x0 = xadd64 x19, x21
-;   x1 = xadd64 x25, x23
-;   x2 = xadd64 x5, x6
-;   x3 = xadd64 x7, x4
-;   x14 = xadd64 x8, x14
-;   x13 = xadd64 x15, x13
-;   x15 = xadd64 x0, x0
-;   x0 = xadd64 x1, x2
-;   x14 = xadd64 x3, x14
-;   x13 = xadd64 x13, x15
-;   x14 = xadd64 x0, x14
-;   x13 = xadd64 x13, x13
-;   x0 = xadd64 x14, x13
+;   xadd64 x25, x0, x1
+;   xadd64 x23, x2, x3
+;   xadd64 x5, x4, x5
+;   xadd64 x6, x6, x7
+;   xadd64 x7, x8, x9
+;   xmov x0, x20
+;   xadd64 x4, x10, x0
+;   xmov x10, x18
+;   xadd64 x8, x12, x10
+;   xadd64 x14, x14, x15
+;   xadd64 x15, x24, x11
+;   xadd64 x13, x11, x13
+;   xadd64 x0, x19, x21
+;   xadd64 x1, x25, x23
+;   xadd64 x2, x5, x6
+;   xadd64 x3, x7, x4
+;   xadd64 x14, x8, x14
+;   xadd64 x13, x15, x13
+;   xadd64 x15, x0, x0
+;   xadd64 x0, x1, x2
+;   xadd64 x14, x3, x14
+;   xadd64 x13, x13, x15
+;   xadd64 x14, x0, x14
+;   xadd64 x13, x13, x13
+;   xadd64 x0, x14, x13
 ;   x18 = load64_u sp+56 // flags = notrap aligned
 ;   x20 = load64_u sp+48 // flags = notrap aligned
-;   stack_free32 0x40
+;   stack_free32 64
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley32/iadd.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/iadd.clif
@@ -9,7 +9,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xadd32 x0, x1
+;   xadd32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -24,7 +24,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xadd32 x0, x1
+;   xadd32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -39,7 +39,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xadd32 x0, x1
+;   xadd32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -54,7 +54,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xadd64 x0, x1
+;   xadd64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley32/icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/icmp.clif
@@ -9,7 +9,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xeq32 x0, x1
+;   xeq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -24,7 +24,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xeq32 x0, x1
+;   xeq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -39,7 +39,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xeq32 x0, x1
+;   xeq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -54,7 +54,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xeq64 x0, x1
+;   xeq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -69,7 +69,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xneq32 x0, x1
+;   xneq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -84,7 +84,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xneq32 x0, x1
+;   xneq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -99,7 +99,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xneq32 x0, x1
+;   xneq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -114,7 +114,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xneq64 x0, x1
+;   xneq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -129,7 +129,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x0, x1
+;   xult32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -144,7 +144,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x0, x1
+;   xult32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -159,7 +159,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x0, x1
+;   xult32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -174,7 +174,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xult64 x0, x1
+;   xult64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -189,7 +189,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x0, x1
+;   xulteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -204,7 +204,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x0, x1
+;   xulteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -219,7 +219,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x0, x1
+;   xulteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -234,7 +234,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq64 x0, x1
+;   xulteq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -249,7 +249,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x0, x1
+;   xslt32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -264,7 +264,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x0, x1
+;   xslt32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -279,7 +279,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x0, x1
+;   xslt32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -294,7 +294,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslt64 x0, x1
+;   xslt64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -309,7 +309,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x0, x1
+;   xslteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -324,7 +324,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x0, x1
+;   xslteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -339,7 +339,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x0, x1
+;   xslteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -354,7 +354,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq64 x0, x1
+;   xslteq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -369,7 +369,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x1, x0
+;   xult32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -384,7 +384,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x1, x0
+;   xult32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -399,7 +399,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x1, x0
+;   xult32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -414,7 +414,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xult64 x1, x0
+;   xult64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -429,7 +429,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x1, x0
+;   xslt32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -444,7 +444,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x1, x0
+;   xslt32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -459,7 +459,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x1, x0
+;   xslt32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -474,7 +474,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslt64 x1, x0
+;   xslt64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -489,7 +489,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x1, x0
+;   xulteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -504,7 +504,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x1, x0
+;   xulteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -519,7 +519,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x1, x0
+;   xulteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -534,7 +534,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq64 x1, x0
+;   xulteq64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -549,7 +549,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x1, x0
+;   xslteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -564,7 +564,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x1, x0
+;   xslteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -579,7 +579,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x1, x0
+;   xslteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -594,7 +594,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq64 x1, x0
+;   xslteq64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley32/iconst.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/iconst.clif
@@ -9,7 +9,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst16 255
+;   xconst16 x0, 255
 ;   ret
 ;
 ; Disassembled:
@@ -24,7 +24,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst32 65535
+;   xconst32 x0, 65535
 ;   ret
 ;
 ; Disassembled:
@@ -39,7 +39,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst32 -1
+;   xconst32 x0, -1
 ;   ret
 ;
 ; Disassembled:
@@ -54,7 +54,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst64 -1
+;   xconst64 x0, -1
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley32/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/jump.clif
@@ -21,10 +21,10 @@ block3(v3: i8):
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   jump label3
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   jump label3
 ; block3:
 ;   ret

--- a/cranelift/filetests/filetests/isa/pulley32/stack_addr.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/stack_addr.clif
@@ -10,10 +10,10 @@ block0():
 
 ; VCode:
 ;   push_frame
-;   stack_alloc32 0x10
+;   stack_alloc32 16
 ; block0:
 ;   x0 = load_addr Slot(0)
-;   stack_free32 0x10
+;   stack_free32 16
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley32/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/trap.clif
@@ -23,7 +23,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if eq, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -43,7 +43,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if ne, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -63,7 +63,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if eq, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -83,7 +83,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if ne, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -114,8 +114,8 @@ block2:
 ; block1:
 ;   ret
 ; block2:
-;   x5 = xconst8 42
-;   x6 = xconst8 0
+;   xconst8 x5, 42
+;   xconst8 x6, 0
 ;   trap_if ne, Size64, x5, x6 // code = TrapCode(1)
 ;   ret
 ;
@@ -147,8 +147,8 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x4 = xconst8 0
-;   x5 = xconst8 0
+;   xconst8 x4, 0
+;   xconst8 x5, 0
 ;   trap_if eq, Size64, x4, x5 // code = TrapCode(1)
 ;   ret
 ; block2:

--- a/cranelift/filetests/filetests/isa/pulley64/br_table.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/br_table.clif
@@ -34,19 +34,19 @@ block5(v5: i32):
 ; block2:
 ;   jump label4
 ; block3:
-;   x5 = xconst8 3
+;   xconst8 x5, 3
 ;   jump label7
 ; block4:
-;   x5 = xconst8 2
+;   xconst8 x5, 2
 ;   jump label7
 ; block5:
-;   x5 = xconst8 1
+;   xconst8 x5, 1
 ;   jump label7
 ; block6:
-;   x5 = xconst8 4
+;   xconst8 x5, 4
 ;   jump label7
 ; block7:
-;   x0 = xadd32 x0, x5
+;   xadd32 x0, x0, x5
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley64/brif-icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif-icmp.clif
@@ -19,10 +19,10 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -50,10 +50,10 @@ block2:
 ; block0:
 ;   br_if_xneq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -81,10 +81,10 @@ block2:
 ; block0:
 ;   br_if_xult32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -112,10 +112,10 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -143,10 +143,10 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -174,10 +174,10 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -205,10 +205,10 @@ block2:
 ; block0:
 ;   br_if_xult32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -236,10 +236,10 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -267,10 +267,10 @@ block2:
 ; block0:
 ;   br_if_xslt32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -298,10 +298,10 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x1, x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
@@ -330,10 +330,10 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ; block2:
-;   x0 = xconst8 2
+;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley64/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif.clif
@@ -18,10 +18,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -48,10 +48,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -78,10 +78,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -108,10 +108,10 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -137,13 +137,13 @@ block2:
 
 ; VCode:
 ; block0:
-;   x5 = xeq32 x0, x1
+;   xeq32 x5, x0, x1
 ;   br_if x5, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -170,13 +170,13 @@ block2:
 
 ; VCode:
 ; block0:
-;   x5 = xneq32 x0, x1
+;   xneq32 x5, x0, x1
 ;   br_if x5, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -205,10 +205,10 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:
@@ -234,13 +234,13 @@ block2:
 
 ; VCode:
 ; block0:
-;   x5 = xulteq64 x1, x0
+;   xulteq64 x5, x1, x0
 ;   br_if x5, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   ret
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -15,9 +15,9 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   pop_frame
 ;   ret
 ;
@@ -42,9 +42,9 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   pop_frame
 ;   ret
 ;
@@ -71,10 +71,10 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   x0 = xconst8 0
-;   x1 = xconst8 1
-;   x2 = xconst8 2
-;   x3 = xconst8 3
+;   xconst8 x0, 0
+;   xconst8 x1, 1
+;   xconst8 x2, 2
+;   xconst8 x3, 3
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
 ;   pop_frame
 ;   ret
@@ -104,9 +104,9 @@ block0:
 ;   push_frame
 ; block0:
 ;   call CallInfo { dest: TestCase(%g), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }], clobbers: PRegSet { bits: [65520, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x4 = xadd64 x0, x2
-;   x3 = xadd64 x1, x3
-;   x0 = xadd64 x4, x3
+;   xadd64 x4, x0, x2
+;   xadd64 x3, x1, x3
+;   xadd64 x0, x4, x3
 ;   pop_frame
 ;   ret
 ;
@@ -130,32 +130,32 @@ block0:
 
 ; VCode:
 ;   push_frame
-;   stack_alloc32 0x30
+;   stack_alloc32 48
 ; block0:
-;   x15 = xconst8 0
+;   xconst8 x15, 0
 ;   store64 OutgoingArg(0), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(8), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(16), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(24), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(32), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(40), x15 // flags =  notrap aligned
-;   x0 = xmov x15
-;   x1 = xmov x15
-;   x2 = xmov x15
-;   x3 = xmov x15
-;   x4 = xmov x15
-;   x5 = xmov x15
-;   x6 = xmov x15
-;   x7 = xmov x15
-;   x8 = xmov x15
-;   x9 = xmov x15
-;   x10 = xmov x15
-;   x11 = xmov x15
-;   x12 = xmov x15
-;   x13 = xmov x15
-;   x14 = xmov x15
+;   xmov x0, x15
+;   xmov x1, x15
+;   xmov x2, x15
+;   xmov x3, x15
+;   xmov x4, x15
+;   xmov x5, x15
+;   xmov x6, x15
+;   xmov x7, x15
+;   xmov x8, x15
+;   xmov x9, x15
+;   xmov x10, x15
+;   xmov x11, x15
+;   xmov x12, x15
+;   xmov x13, x15
+;   xmov x14, x15
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   stack_free32 0x30
+;   stack_free32 48
 ;   pop_frame
 ;   ret
 ;
@@ -227,47 +227,47 @@ block0:
 
 ; VCode:
 ;   push_frame
-;   stack_alloc32 0x40
+;   stack_alloc32 64
 ;   store64 sp+56, x18 // flags =  notrap aligned
 ;   store64 sp+48, x20 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   x18 = xmov x13
-;   x20 = xmov x11
+;   xmov x18, x13
+;   xmov x20, x11
 ;   x24 = load64_u OutgoingArg(0) // flags = notrap aligned
 ;   x11 = load64_u OutgoingArg(8) // flags = notrap aligned
 ;   x13 = load64_u OutgoingArg(16) // flags = notrap aligned
 ;   x19 = load64_u OutgoingArg(24) // flags = notrap aligned
 ;   x21 = load64_u OutgoingArg(32) // flags = notrap aligned
-;   x25 = xadd64 x0, x1
-;   x23 = xadd64 x2, x3
-;   x5 = xadd64 x4, x5
-;   x6 = xadd64 x6, x7
-;   x7 = xadd64 x8, x9
-;   x0 = xmov x20
-;   x4 = xadd64 x10, x0
-;   x10 = xmov x18
-;   x8 = xadd64 x12, x10
-;   x14 = xadd64 x14, x15
-;   x15 = xadd64 x24, x11
-;   x13 = xadd64 x11, x13
-;   x0 = xadd64 x19, x21
-;   x1 = xadd64 x25, x23
-;   x2 = xadd64 x5, x6
-;   x3 = xadd64 x7, x4
-;   x14 = xadd64 x8, x14
-;   x13 = xadd64 x15, x13
-;   x15 = xadd64 x0, x0
-;   x0 = xadd64 x1, x2
-;   x14 = xadd64 x3, x14
-;   x13 = xadd64 x13, x15
-;   x14 = xadd64 x0, x14
-;   x13 = xadd64 x13, x13
-;   x0 = xadd64 x14, x13
+;   xadd64 x25, x0, x1
+;   xadd64 x23, x2, x3
+;   xadd64 x5, x4, x5
+;   xadd64 x6, x6, x7
+;   xadd64 x7, x8, x9
+;   xmov x0, x20
+;   xadd64 x4, x10, x0
+;   xmov x10, x18
+;   xadd64 x8, x12, x10
+;   xadd64 x14, x14, x15
+;   xadd64 x15, x24, x11
+;   xadd64 x13, x11, x13
+;   xadd64 x0, x19, x21
+;   xadd64 x1, x25, x23
+;   xadd64 x2, x5, x6
+;   xadd64 x3, x7, x4
+;   xadd64 x14, x8, x14
+;   xadd64 x13, x15, x13
+;   xadd64 x15, x0, x0
+;   xadd64 x0, x1, x2
+;   xadd64 x14, x3, x14
+;   xadd64 x13, x13, x15
+;   xadd64 x14, x0, x14
+;   xadd64 x13, x13, x13
+;   xadd64 x0, x14, x13
 ;   x18 = load64_u sp+56 // flags = notrap aligned
 ;   x20 = load64_u sp+48 // flags = notrap aligned
-;   stack_free32 0x40
+;   stack_free32 64
 ;   pop_frame
 ;   ret
 ;
@@ -356,9 +356,9 @@ block0:
 
 ; VCode:
 ;   push_frame
-;   stack_alloc32 0x40
+;   stack_alloc32 64
 ; block0:
-;   x15 = xconst8 0
+;   xconst8 x15, 0
 ;   store64 OutgoingArg(0), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(8), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(16), x15 // flags =  notrap aligned
@@ -367,23 +367,23 @@ block0:
 ;   store64 OutgoingArg(40), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(48), x15 // flags =  notrap aligned
 ;   store64 OutgoingArg(56), x15 // flags =  notrap aligned
-;   x0 = xmov x15
-;   x1 = xmov x15
-;   x2 = xmov x15
-;   x3 = xmov x15
-;   x4 = xmov x15
-;   x5 = xmov x15
-;   x6 = xmov x15
-;   x7 = xmov x15
-;   x8 = xmov x15
-;   x9 = xmov x15
-;   x10 = xmov x15
-;   x11 = xmov x15
-;   x12 = xmov x15
-;   x13 = xmov x15
-;   x14 = xmov x15
+;   xmov x0, x15
+;   xmov x1, x15
+;   xmov x2, x15
+;   xmov x3, x15
+;   xmov x4, x15
+;   xmov x5, x15
+;   xmov x6, x15
+;   xmov x7, x15
+;   xmov x8, x15
+;   xmov x9, x15
+;   xmov x10, x15
+;   xmov x11, x15
+;   xmov x12, x15
+;   xmov x13, x15
+;   xmov x14, x15
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   stack_free32 0x40
+;   stack_free32 64
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley64/iadd.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/iadd.clif
@@ -9,7 +9,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xadd32 x0, x1
+;   xadd32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -24,7 +24,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xadd32 x0, x1
+;   xadd32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -39,7 +39,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xadd32 x0, x1
+;   xadd32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -54,7 +54,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xadd64 x0, x1
+;   xadd64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley64/icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/icmp.clif
@@ -9,7 +9,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xeq32 x0, x1
+;   xeq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -24,7 +24,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xeq32 x0, x1
+;   xeq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -39,7 +39,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xeq32 x0, x1
+;   xeq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -54,7 +54,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xeq64 x0, x1
+;   xeq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -69,7 +69,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xneq32 x0, x1
+;   xneq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -84,7 +84,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xneq32 x0, x1
+;   xneq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -99,7 +99,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xneq32 x0, x1
+;   xneq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -114,7 +114,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xneq64 x0, x1
+;   xneq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -129,7 +129,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x0, x1
+;   xult32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -144,7 +144,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x0, x1
+;   xult32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -159,7 +159,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x0, x1
+;   xult32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -174,7 +174,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xult64 x0, x1
+;   xult64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -189,7 +189,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x0, x1
+;   xulteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -204,7 +204,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x0, x1
+;   xulteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -219,7 +219,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x0, x1
+;   xulteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -234,7 +234,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq64 x0, x1
+;   xulteq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -249,7 +249,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x0, x1
+;   xslt32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -264,7 +264,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x0, x1
+;   xslt32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -279,7 +279,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x0, x1
+;   xslt32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -294,7 +294,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslt64 x0, x1
+;   xslt64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -309,7 +309,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x0, x1
+;   xslteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -324,7 +324,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x0, x1
+;   xslteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -339,7 +339,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x0, x1
+;   xslteq32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -354,7 +354,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq64 x0, x1
+;   xslteq64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -369,7 +369,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x1, x0
+;   xult32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -384,7 +384,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x1, x0
+;   xult32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -399,7 +399,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xult32 x1, x0
+;   xult32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -414,7 +414,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xult64 x1, x0
+;   xult64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -429,7 +429,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x1, x0
+;   xslt32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -444,7 +444,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x1, x0
+;   xslt32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -459,7 +459,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslt32 x1, x0
+;   xslt32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -474,7 +474,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslt64 x1, x0
+;   xslt64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -489,7 +489,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x1, x0
+;   xulteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -504,7 +504,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x1, x0
+;   xulteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -519,7 +519,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq32 x1, x0
+;   xulteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -534,7 +534,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xulteq64 x1, x0
+;   xulteq64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -549,7 +549,7 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x1, x0
+;   xslteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -564,7 +564,7 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x1, x0
+;   xslteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -579,7 +579,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq32 x1, x0
+;   xslteq32 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:
@@ -594,7 +594,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   x0 = xslteq64 x1, x0
+;   xslteq64 x0, x1, x0
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley64/iconst.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/iconst.clif
@@ -9,7 +9,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst16 255
+;   xconst16 x0, 255
 ;   ret
 ;
 ; Disassembled:
@@ -24,7 +24,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst32 65535
+;   xconst32 x0, 65535
 ;   ret
 ;
 ; Disassembled:
@@ -39,7 +39,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst32 -1
+;   xconst32 x0, -1
 ;   ret
 ;
 ; Disassembled:
@@ -54,7 +54,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   x0 = xconst64 -1
+;   xconst64 x0, -1
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/pulley64/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/jump.clif
@@ -21,10 +21,10 @@ block3(v3: i8):
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x0 = xconst8 0
+;   xconst8 x0, 0
 ;   jump label3
 ; block2:
-;   x0 = xconst8 1
+;   xconst8 x0, 1
 ;   jump label3
 ; block3:
 ;   ret

--- a/cranelift/filetests/filetests/isa/pulley64/stack_addr.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/stack_addr.clif
@@ -10,10 +10,10 @@ block0():
 
 ; VCode:
 ;   push_frame
-;   stack_alloc32 0x10
+;   stack_alloc32 16
 ; block0:
 ;   x0 = load_addr Slot(0)
-;   stack_free32 0x10
+;   stack_free32 16
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley64/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/trap.clif
@@ -23,7 +23,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if eq, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -43,7 +43,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if ne, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -63,7 +63,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if eq, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -83,7 +83,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   x2 = xconst8 42
+;   xconst8 x2, 42
 ;   trap_if ne, Size64, x0, x2 // code = TrapCode(1)
 ;   ret
 ;
@@ -114,8 +114,8 @@ block2:
 ; block1:
 ;   ret
 ; block2:
-;   x5 = xconst8 42
-;   x6 = xconst8 0
+;   xconst8 x5, 42
+;   xconst8 x6, 0
 ;   trap_if ne, Size64, x5, x6 // code = TrapCode(1)
 ;   ret
 ;
@@ -147,8 +147,8 @@ block2:
 ; block0:
 ;   br_if x0, label2; jump label1
 ; block1:
-;   x4 = xconst8 0
-;   x5 = xconst8 0
+;   xconst8 x4, 0
+;   xconst8 x5, 0
 ;   trap_if eq, Size64, x4, x5 // code = TrapCode(1)
 ;   ret
 ; block2:

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -15,6 +15,7 @@ extern crate std;
 extern crate alloc;
 
 /// Calls the given macro with each opcode.
+#[macro_export]
 macro_rules! for_each_op {
     ( $macro:ident ) => {
         $macro! {
@@ -213,6 +214,7 @@ macro_rules! for_each_op {
 }
 
 /// Calls the given macro with each extended opcode.
+#[macro_export]
 macro_rules! for_each_extended_op {
     ( $macro:ident ) => {
         $macro! {


### PR DESCRIPTION
This commit is an integration of the `for_each_op!` macro (and extended ops) for Cranelift. This procedurally generates a few new items for Cranelift's Pulley backend to use:

* `RawInst` - a raw enumeration of instructions as-is.
* ISLE constructors (e.g. `pulley_*` ctors) - generated for all of the `RawInst` variants.
* Register allocation methods for `RawInst`
* Pretty printing methods for `RawInst`
* Emission methods for `RawInst`

The `Inst` enum now has a `Raw` variant which contains a `RawInst`. In this manner the main `Inst` enum can still have pseudo-insts like `Call`, polymorphic instructions like loads/stores (probably gonna get refactored in the future though), and slightly different representations such as `Inst::Trap` having a `TrapCode` and `RawInst::Trap` wouldn't.

The goal of this commit is to lower the amount of effort to quickly add and experiment with new instructions in Pulley. Ideally it's now just (a) define them in the pulley macro, (b) implement a direct lowering rule, and (c) implement it in the interpreter. Ideally no need to implement anything else inside of Cranelift as everything should be auto-generated.

Many existing `Inst` variants have been deleted in favor of their equivalents in `RawInst` now. This undeniably increases the complexity of the Pulley backend but at least for me I find it well worth it to have all this boilerplate generated automatically.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
