### PR TITLE
Fix some off-by-one comparisons in assertions

### DIFF
--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -135,7 +135,7 @@ impl Mmap<AlignedLength> {
 
     /// Return a struct representing a page-aligned offset into the mmap.
     ///
-    /// Returns an error if `offset >= self.len_aligned()`.
+    /// Returns an error if `offset > self.len_aligned()`.
     pub fn offset(self: &Arc<Self>, offset: HostAlignedByteCount) -> Result<MmapOffset> {
         if offset > self.len_aligned() {
             bail!(
@@ -359,9 +359,6 @@ pub struct MmapOffset {
 impl MmapOffset {
     #[inline]
     fn new(mmap: Arc<Mmap<AlignedLength>>, offset: HostAlignedByteCount) -> Self {
-        // Note < rather than <=. This currently cannot represent the logical
-        // end of the mmap. We may need to change this if that becomes
-        // necessary.
         assert!(
             offset <= mmap.len_aligned(),
             "offset {} is in bounds (< {})",

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -137,7 +137,7 @@ impl Mmap<AlignedLength> {
     ///
     /// Returns an error if `offset >= self.len_aligned()`.
     pub fn offset(self: &Arc<Self>, offset: HostAlignedByteCount) -> Result<MmapOffset> {
-        if offset >= self.len_aligned() {
+        if offset > self.len_aligned() {
             bail!(
                 "offset {} is not in bounds for mmap: {}",
                 offset,
@@ -363,7 +363,7 @@ impl MmapOffset {
         // end of the mmap. We may need to change this if that becomes
         // necessary.
         assert!(
-            offset < mmap.len_aligned(),
+            offset <= mmap.len_aligned(),
             "offset {} is in bounds (< {})",
             offset,
             mmap.len_aligned(),

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -734,3 +734,19 @@ fn get_memory_type_with_custom_page_size_from_wasm(config: &mut Config) -> Resul
 
     Ok(())
 }
+
+#[wasmtime_test]
+fn configure_zero(config: &mut Config) -> Result<()> {
+    config.guard_before_linear_memory(false);
+    config.memory_guard_size(0);
+    config.memory_reservation(0);
+    config.memory_reservation_for_growth(0);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let ty = MemoryType::new(0, None);
+    let memory = Memory::new(&mut store, ty)?;
+    assert_eq!(memory.data_size(&store), 0);
+
+    Ok(())
+}


### PR DESCRIPTION
Fuzzing found a small issue with #9687 and this commit relaxes a few off-by-one checks to allow addressing one-byte-beyond-the-end of a linear memory.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
