### PR TITLE
Fix minor wast fuzzing issues

### DIFF
--- a/crates/fuzzing/build.rs
+++ b/crates/fuzzing/build.rs
@@ -15,7 +15,8 @@ fn main() {
     root.pop(); // chop off 'fuzzing'
     root.pop(); // chop off 'crates'
 
-    let tests = wasmtime_wast_util::find_tests(&root).unwrap();
+    let mut tests = wasmtime_wast_util::find_tests(&root).unwrap();
+    tests.sort_by_key(|test| test.path.clone());
 
     let mut code = format!("static FILES: &[fn() -> wasmtime_wast_util::WastTest] = &[\n");
 

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -624,7 +624,7 @@ fn is_matching_assert_invalid_error_message(test: &str, expected: &str, actual: 
     // and another asserts a different error message). Overall we didn't benefit
     // a whole lot from trying to match errors so just assume the error is
     // roughly the same and otherwise don't try to match it.
-    if Path::new(test).starts_with("./tests/spec_testsuite") {
+    if test.contains("spec_testsuite") {
         return true;
     }
 


### PR DESCRIPTION
* Sort tests by name to ensure that a reproduction on one machine works on another.
* Relax the error message matching to be a bit more lenient with paths.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
