### PR TITLE
winch Aarch64: reinterpret_float_as_int, reinterpret_int_as_float

### DIFF
--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f32)
+        (i32.const 1)
+        (f32.reinterpret_i32)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       scvtf   s0, w0
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f32)
+        (local i32)  
+
+        (local.get 0)
+        (f32.reinterpret_i32)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       ldur    w0, [x28, #4]
+;;       scvtf   s0, w0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (result f32)
+        (local.get 0)
+        (f32.reinterpret_i32)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       ldur    w0, [x28, #4]
+;;       scvtf   s0, w0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        i32.const 1
+        f32.reinterpret_i32
+        drop
+        i32.const 1
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       scvtf   s0, w0
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f32)
+        i32.const 1
+        f32.reinterpret_i32
+        block
+        end
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     w0, w16
+;;       scvtf   s0, w0
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    s0, [x28]
+;;       ldur    s0, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f64)
+        (i64.const 1)
+        (f64.reinterpret_i64)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       scvtf   d0, x0
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f64)
+        (local i64)  
+
+        (local.get 0)
+        (f64.reinterpret_i64)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       ldur    x0, [x28]
+;;       scvtf   d0, x0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (result f64)
+        (local.get 0)
+        (f64.reinterpret_i64)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    x2, [x28]
+;;       ldur    x0, [x28]
+;;       scvtf   d0, x0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        i64.const 1
+        f64.reinterpret_i64
+        drop
+        i64.const 1
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       scvtf   d0, x0
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f64)
+        i64.const 1
+        f64.reinterpret_i64
+        block
+        end
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #1
+;;       mov     x0, x16
+;;       scvtf   d0, x0
+;;       sub     sp, sp, #8
+;;       mov     x28, sp
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       add     sp, sp, #8
+;;       mov     x28, sp
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (f32.const 1.0)
+        (i32.reinterpret_f32)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x3f800000
+;;       fmov    s0, w16
+;;       fcvtzs  w0, s0
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+        (local f32)  
+
+        (local.get 0)
+        (i32.reinterpret_f32)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       ldur    s0, [x28, #4]
+;;       fcvtzs  w0, s0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f32) (result i32)
+        (local.get 0)
+        (i32.reinterpret_f32)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    s0, [x28, #4]
+;;       ldur    s0, [x28, #4]
+;;       fcvtzs  w0, s0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f32)
+        f32.const 1.0
+        i32.reinterpret_f32
+        drop
+        f32.const 1.0
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x3f800000
+;;       fmov    s0, w16
+;;       fcvtzs  w0, s0
+;;       mov     x16, #0x3f800000
+;;       fmov    s0, w16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (f64.const 1.0)
+        (i64.reinterpret_f64)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x3ff0000000000000
+;;       fmov    d0, x16
+;;       fcvtzs  x0, d0
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
@@ -1,0 +1,28 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+        (local f64)  
+
+        (local.get 0)
+        (i64.reinterpret_f64)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       mov     x16, #0
+;;       stur    x16, [x28]
+;;       ldur    d0, [x28]
+;;       fcvtzs  x0, d0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
@@ -1,0 +1,25 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param f64) (result i64)
+        (local.get 0)
+        (i64.reinterpret_f64)
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    d0, [x28]
+;;       ldur    d0, [x28]
+;;       fcvtzs  x0, d0
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
@@ -1,0 +1,29 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result f64)
+        f64.const 1.0
+        i64.reinterpret_f64
+        drop
+        f64.const 1.0
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0x3ff0000000000000
+;;       fmov    d0, x16
+;;       fcvtzs  x0, d0
+;;       mov     x16, #0x3ff0000000000000
+;;       fmov    d0, x16
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -537,12 +537,12 @@ impl Masm for MacroAssembler {
         todo!()
     }
 
-    fn reinterpret_float_as_int(&mut self, _dst: WritableReg, _src: Reg, _size: OperandSize) {
-        todo!()
+    fn reinterpret_float_as_int(&mut self, dst: WritableReg, src: Reg, size: OperandSize) {
+        self.asm.fpu_to_int(src, dst, size);
     }
 
-    fn reinterpret_int_as_float(&mut self, _dst: WritableReg, _src: Reg, _size: OperandSize) {
-        todo!()
+    fn reinterpret_int_as_float(&mut self, dst: WritableReg, src: Reg, size: OperandSize) {
+        self.asm.int_to_fpu(src, dst, size);
     }
 
     fn demote(&mut self, dst: WritableReg, src: Reg) {


### PR DESCRIPTION
Implement the following MASM instructions for the Aarch64 platform (#8321):

- `reinterpret_float_as_int`
- `reinterpret_int_as_float`