### PR TITLE
Add `-Wextended-const` CLI flag

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -351,6 +351,8 @@ wasmtime_option_group! {
         pub custom_page_sizes: Option<bool>,
         /// Configure support for the wide-arithmetic proposal.
         pub wide_arithmetic: Option<bool>,
+        /// Configure support for the extended-const proposal.
+        pub extended_const: Option<bool>,
     }
 
     enum Wasm {
@@ -885,6 +887,9 @@ impl CommonOptions {
         }
         if let Some(enable) = self.wasm.wide_arithmetic.or(all) {
             config.wasm_wide_arithmetic(enable);
+        }
+        if let Some(enable) = self.wasm.extended_const.or(all) {
+            config.wasm_extended_const(enable);
         }
 
         macro_rules! handle_conditionally_compiled {


### PR DESCRIPTION
Adds a flag that can be used to control the `extended-const` proposal on the CLI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
