### PR TITLE
Winch: Implement rem for aarch64

### DIFF
--- a/tests/disas/winch/aarch64/i32_rems/const.wat
+++ b/tests/disas/winch/aarch64/i32_rems/const.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const 7)
+	(i32.const 5)
+	(i32.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #5
+;;       mov     w0, w16
+;;       mov     x16, #7
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/one_zero.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const 1)
+	(i32.const 0)
+	(i32.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       mov     x16, #1
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_rems/overflow.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const 0x80000000)
+	(i32.const -1)
+	(i32.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0xffffffff
+;;       mov     w0, w16
+;;       mov     x16, #0x80000000
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/params.wat
+++ b/tests/disas/winch/aarch64/i32_rems/params.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+	(local.get 0)
+	(local.get 1)
+	(i32.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const 0)
+	(i32.const 0)
+	(i32.rem_s)
+    )
+) 
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/const.wat
+++ b/tests/disas/winch/aarch64/i32_remu/const.wat
@@ -23,8 +23,8 @@
 ;;       mov     x16, #7
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x58
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/const.wat
+++ b/tests/disas/winch/aarch64/i32_remu/const.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const 7)
+	(i32.const 5)
+	(i32.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #5
+;;       mov     w0, w16
+;;       mov     x16, #7
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/one_zero.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const 1)
+	(i32.const 0)
+	(i32.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       mov     x16, #1
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/one_zero.wat
@@ -23,8 +23,8 @@
 ;;       mov     x16, #1
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x58
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/params.wat
+++ b/tests/disas/winch/aarch64/i32_remu/params.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i32) (param i32) (result i32)
+	(local.get 0)
+	(local.get 1)
+	(i32.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       stur    w3, [x28]
+;;       ldur    w0, [x28]
+;;       ldur    w1, [x28, #4]
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/params.wat
+++ b/tests/disas/winch/aarch64/i32_remu/params.wat
@@ -23,8 +23,8 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       cbz     x0, #0x58
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_remu/signed.wat
@@ -23,8 +23,8 @@
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x58
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_remu/signed.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const -1)
+	(i32.const -1)
+	(i32.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       orr     x16, xzr, #0xffffffff
+;;       mov     w0, w16
+;;       orr     x16, xzr, #0xffffffff
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
@@ -1,0 +1,35 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i32)
+	(i32.const 0)
+	(i32.const 0)
+	(i32.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     w0, w16
+;;       mov     x16, #0
+;;       mov     w1, w16
+;;       cbz     x0, #0x58
+;;   34: sxtw    x0, w0
+;;       sxtw    x1, w1
+;;       udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     w0, w1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
@@ -23,8 +23,8 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x58
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i64_rems/const.wat
+++ b/tests/disas/winch/aarch64/i64_rems/const.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const 7)
+	(i64.const 5)
+	(i64.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #5
+;;       mov     x0, x16
+;;       mov     x16, #7
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/one_zero.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const 1)
+	(i64.const 0)
+	(i64.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     x0, x16
+;;       mov     x16, #1
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i64_rems/overflow.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const 0x8000000000000000)
+	(i64.const -1)
+	(i64.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-1
+;;       mov     x0, x16
+;;       mov     x16, #-0x8000000000000000
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/params.wat
+++ b/tests/disas/winch/aarch64/i64_rems/params.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+	(local.get 0)
+	(local.get 1)
+	(i64.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cbz     x0, #0x50
+;;   34: sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const 0)
+	(i64.const 0)
+	(i64.rem_s)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     x0, x16
+;;       mov     x16, #0
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: sdiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/const.wat
+++ b/tests/disas/winch/aarch64/i64_remu/const.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const 7)
+	(i64.const 5)
+	(i64.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #5
+;;       mov     x0, x16
+;;       mov     x16, #7
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/one_zero.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const 1)
+	(i64.const 0)
+	(i64.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     x0, x16
+;;       mov     x16, #1
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/params.wat
+++ b/tests/disas/winch/aarch64/i64_remu/params.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (param i64) (param i64) (result i64)
+	(local.get 0)
+	(local.get 1)
+	(i64.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x20
+;;       mov     x28, sp
+;;       stur    x0, [x28, #0x18]
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x3, [x28]
+;;       ldur    x0, [x28]
+;;       ldur    x1, [x28, #8]
+;;       cbz     x0, #0x50
+;;   34: udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x20
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i64_remu/signed.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const -1)
+	(i64.const -1)
+	(i64.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #-1
+;;       mov     x0, x16
+;;       mov     x16, #-1
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
@@ -1,0 +1,33 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+    (func (result i64)
+	(i64.const 0)
+	(i64.const 0)
+	(i64.rem_u)
+    )
+)
+
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x16, #0
+;;       mov     x0, x16
+;;       mov     x16, #0
+;;       mov     x1, x16
+;;       cbz     x0, #0x50
+;;   34: udiv    x16, x1, x0
+;;       msub    x1, x0, x16, x1
+;;       mov     x0, x1
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -2,7 +2,9 @@
 
 use super::{address::Address, regs};
 use crate::aarch64::regs::zero;
-use crate::masm::{DivKind, ExtendKind, FloatCmpKind, IntCmpKind, RemKind, RoundingMode, ShiftKind};
+use crate::masm::{
+    DivKind, ExtendKind, FloatCmpKind, IntCmpKind, RemKind, RoundingMode, ShiftKind,
+};
 use crate::CallingConvention;
 use crate::{
     masm::OperandSize,
@@ -463,7 +465,14 @@ impl Assembler {
     }
 
     /// Signed/unsigned remainder operation with three registers.
-    pub fn rem_rrr(&mut self, divisor: Reg, dividend: Reg, dest: Writable<Reg>, kind: RemKind, size: OperandSize) {
+    pub fn rem_rrr(
+        &mut self,
+        divisor: Reg,
+        dividend: Reg,
+        dest: Writable<Reg>,
+        kind: RemKind,
+        size: OperandSize,
+    ) {
         // Check for division by 0
         self.emit(Inst::TrapIf {
             kind: CondBrKind::Zero(divisor.into()),
@@ -506,7 +515,14 @@ impl Assembler {
             OperandSize::S64,
         );
 
-        self.emit_alu_rrrr(ALUOp3::MSub, scratch, divisor, dest.map(Into::into), dividend, OperandSize::S64);
+        self.emit_alu_rrrr(
+            ALUOp3::MSub,
+            scratch,
+            divisor,
+            dest.map(Into::into),
+            dividend,
+            OperandSize::S64,
+        );
     }
 
     /// And with three registers.

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -483,8 +483,16 @@ impl Masm for MacroAssembler {
         })
     }
 
-    fn rem(&mut self, _context: &mut CodeGenContext<Emission>, _kind: RemKind, _size: OperandSize) {
-        todo!()
+    fn rem(&mut self, context: &mut CodeGenContext<Emission>, kind: RemKind, size: OperandSize) {
+        context.binop(self, size, |this, dividend, divisor, size| {
+            this.asm
+                .rem_rrr(divisor, dividend, writable!(dividend), kind, size);
+            match size {
+                OperandSize::S32 => TypedReg::new(WasmValType::I32, dividend),
+                OperandSize::S64 => TypedReg::new(WasmValType::I64, dividend),
+                s => unreachable!("invalid size for remainder: {s:?}"),
+            }
+        })
     }
 
     fn zero(&mut self, reg: WritableReg) {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -23,6 +23,7 @@ pub(crate) enum DivKind {
 }
 
 /// Remainder kind.
+#[derive(Copy, Clone)]
 pub(crate) enum RemKind {
     /// Signed remainder.
     Signed,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -31,6 +31,12 @@ pub(crate) enum RemKind {
     Unsigned,
 }
 
+impl RemKind {
+    pub fn is_signed(&self) -> bool {
+        matches!(self, Self::Signed)
+    }
+}
+
 #[derive(Eq, PartialEq)]
 pub(crate) enum MulWideKind {
     Signed,


### PR DESCRIPTION
Implement remainder operation for `aarch64` in winch.

one more step in the #8321 series
