### PR TITLE
winch(aarch64): Handle division signedness

### DIFF
--- a/tests/disas/winch/aarch64/i32_divu/const.wat
+++ b/tests/disas/winch/aarch64/i32_divu/const.wat
@@ -23,8 +23,8 @@
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x54
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/tests/disas/winch/aarch64/i32_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/one_zero.wat
@@ -23,8 +23,8 @@
 ;;       mov     x16, #1
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x54
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/tests/disas/winch/aarch64/i32_divu/params.wat
+++ b/tests/disas/winch/aarch64/i32_divu/params.wat
@@ -23,8 +23,8 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       cbz     x0, #0x54
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/i32_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_divu/signed.wat
@@ -23,8 +23,8 @@
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x54
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
@@ -23,8 +23,8 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       cbz     x0, #0x54
-;;   34: sxtw    x0, w0
-;;       sxtw    x1, w1
+;;   34: mov     w0, w0
+;;       mov     w1, w1
 ;;       udiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -163,6 +163,7 @@ pub(crate) enum ShiftKind {
 /// Kinds of extends in WebAssembly. Each MacroAssembler implementation
 /// is responsible for emitting the correct sequence of instructions when
 /// lowering to machine code.
+#[derive(Copy, Clone)]
 pub(crate) enum ExtendKind {
     /// Sign extends i32 to i64.
     I64ExtendI32S,


### PR DESCRIPTION
This commit fixes how signedness division is hanlded in aarch64. Prior to this commit, sign-extension was emitted unconditionally.

This commit ensures that the correct extension is emitted depending on the division kind.

Additionally this commit prefers making use of existing assembler helpers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
