### PR TITLE
winch(aarch64): Implement `load_addr`

### DIFF
--- a/tests/disas/winch/aarch64/call/multi.wat
+++ b/tests/disas/winch/aarch64/call/multi.wat
@@ -1,0 +1,64 @@
+;;! target = "aarch64"
+;;! test = "winch"
+(module
+  (func $multi (result i32 i32)
+        i32.const 1
+        i32.const 2)
+
+  (func $start
+        call $multi
+        drop
+        drop)
+)
+;; wasm[0]::function[0]::multi:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x1
+;;       sub     sp, sp, #0x18
+;;       mov     x28, sp
+;;       stur    x1, [x28, #0x10]
+;;       stur    x2, [x28, #8]
+;;       stur    x0, [x28]
+;;       mov     x16, #2
+;;       mov     w0, w16
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       mov     x16, #1
+;;       stur    w16, [x28]
+;;       ldur    x1, [x28, #4]
+;;       ldur    w16, [x28]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       stur    w16, [x1]
+;;       add     sp, sp, #0x18
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;
+;; wasm[0]::function[1]::start:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       mov     x28, sp
+;;       mov     x9, x0
+;;       sub     sp, sp, #0x10
+;;       mov     x28, sp
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       sub     sp, sp, #4
+;;       mov     x28, sp
+;;       sub     sp, sp, #0xc
+;;       mov     x28, sp
+;;       mov     x1, x9
+;;       mov     x2, x9
+;;       ldur    x0, [x28, #0xc]
+;;       bl      #0
+;;   a0: add     sp, sp, #0xc
+;;       mov     x28, sp
+;;       ldur    x9, [x28, #0xc]
+;;       add     sp, sp, #4
+;;       mov     x28, sp
+;;       add     sp, sp, #0x10
+;;       mov     x28, sp
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/winch/x64/call/multi.wat
+++ b/tests/disas/winch/x64/call/multi.wat
@@ -1,0 +1,62 @@
+;;! target = "x86_64"
+;;! test = "winch"
+(module
+  (func $multi (result i32 i32)
+        i32.const 1
+        i32.const 2)
+
+  (func $start
+        call $multi
+        drop
+        drop)
+)
+;; wasm[0]::function[0]::multi:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rsi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x24, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x58
+;;   1c: movq    %rsi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rsi, 0x18(%rsp)
+;;       movq    %rdx, 0x10(%rsp)
+;;       movq    %rdi, 8(%rsp)
+;;       movl    $2, %eax
+;;       subq    $4, %rsp
+;;       movl    $1, (%rsp)
+;;       movq    0xc(%rsp), %rcx
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, (%rcx)
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   58: ud2
+;;
+;; wasm[0]::function[1]::start:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0xb7
+;;   7c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       subq    $4, %rsp
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    0xc(%rsp), %rdi
+;;       callq   0
+;;       addq    $0xc, %rsp
+;;       movq    0xc(%rsp), %r14
+;;       addq    $4, %rsp
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   b7: ud2

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -202,7 +202,7 @@ impl Assembler {
         self.ldr(addr, rd, size, false);
     }
 
-    /// Load a register.
+    /// Load address into a register.
     fn ldr(&mut self, addr: Address, rd: WritableReg, size: OperandSize, signed: bool) {
         use OperandSize::*;
         let writable_reg = rd.map(Into::into);

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -214,8 +214,8 @@ impl Masm for MacroAssembler {
         }
     }
 
-    fn load_addr(&mut self, _src: Self::Address, _dst: WritableReg, _size: OperandSize) {
-        todo!()
+    fn load_addr(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize) {
+        self.asm.uload(src, dst, size);
     }
 
     fn pop(&mut self, dst: WritableReg, size: OperandSize) {


### PR DESCRIPTION
This commit fills in the `load_addr` Masm implementation. `load_addr` is mostly used for multi-value. This commit introduces some disas tests as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
