### PR TITLE
pulley: Flesh out conditional registers 

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -532,16 +532,15 @@ where
         _isa_flags: &PulleyFlags,
     ) -> u32 {
         match rc {
-            // Spilling an integer register requires spilling 8 bytes, and spill
-            // slots are defined in terms of "word bytes" or the size of a
-            // pointer. That means on 32-bit pulley we need to take up two spill
-            // slots for integers where on 64-bit pulley we need to only take up
-            // one spill slot for integers.
-            RegClass::Int => match P::pointer_width() {
+            // Spilling an integer or float register requires spilling 8 bytes,
+            // and spill slots are defined in terms of "word bytes" or the size
+            // of a pointer. That means on 32-bit pulley we need to take up two
+            // spill slots where on 64-bit pulley we need to only take up one
+            // spill slot for integers.
+            RegClass::Int | RegClass::Float => match P::pointer_width() {
                 PointerWidth::PointerWidth32 => 2,
                 PointerWidth::PointerWidth64 => 1,
             },
-            RegClass::Float => todo!(),
             RegClass::Vector => unreachable!(),
         }
     }

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -61,7 +61,7 @@
     (Jump (label MachLabel))
 
     ;; Jump to `then` if `c` is nonzero, otherwise to `else`.
-    (BrIf (c XReg) (taken MachLabel) (not_taken MachLabel))
+    (BrIf32 (c XReg) (taken MachLabel) (not_taken MachLabel))
 
     ;; Compare-and-branch macro ops.
     (BrIfXeq32 (src1 XReg) (src2 XReg) (taken MachLabel) (not_taken MachLabel))
@@ -372,9 +372,9 @@
 (rule (pulley_jump label)
       (SideEffectNoResult.Inst (MInst.Jump label)))
 
-(decl pulley_br_if (XReg MachLabel MachLabel) SideEffectNoResult)
-(rule (pulley_br_if c taken not_taken)
-      (SideEffectNoResult.Inst (MInst.BrIf c taken not_taken)))
+(decl pulley_br_if32 (XReg MachLabel MachLabel) SideEffectNoResult)
+(rule (pulley_br_if32 c taken not_taken)
+      (SideEffectNoResult.Inst (MInst.BrIf32 c taken not_taken)))
 
 (decl pulley_br_if_xeq32 (XReg XReg MachLabel MachLabel) SideEffectNoResult)
 (rule (pulley_br_if_xeq32 a b taken not_taken)
@@ -431,11 +431,3 @@
 
 (decl gen_call_indirect (SigRef Value ValueSlice) InstOutput)
 (extern constructor gen_call_indirect gen_call_indirect)
-
-;;;; Helpers for Sign/Zero extension ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl zext (Value) XReg)
-(rule (zext val @ (value_type $I64)) val)
-(rule (zext val @ (value_type $I32)) (pulley_zext32 val))
-(rule (zext val @ (value_type $I16)) (pulley_zext16 val))
-(rule (zext val @ (value_type $I8)) (pulley_zext8 val))

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -247,7 +247,7 @@ fn pulley_emit<P>(
             enc::jump(sink, 0x00000000);
         }
 
-        Inst::BrIf {
+        Inst::BrIf32 {
             c,
             taken,
             not_taken,
@@ -258,14 +258,14 @@ fn pulley_emit<P>(
 
             sink.use_label_at_offset(taken_start, *taken, LabelUse::Jump(2));
             let mut inverted = SmallVec::<[u8; 16]>::new();
-            enc::br_if_not(&mut inverted, c, 0x00000000);
+            enc::br_if_not32(&mut inverted, c, 0x00000000);
             debug_assert_eq!(
                 inverted.len(),
                 usize::try_from(taken_end - *start_offset).unwrap()
             );
 
             sink.add_cond_branch(*start_offset, taken_end, *taken, &inverted);
-            enc::br_if(sink, c, 0x00000000);
+            enc::br_if32(sink, c, 0x00000000);
             debug_assert_eq!(sink.cur_offset(), taken_end);
 
             // If not taken.

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -164,7 +164,7 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
 
         Inst::Jump { .. } => {}
 
-        Inst::BrIf {
+        Inst::BrIf32 {
             c,
             taken: _,
             not_taken: _,
@@ -426,7 +426,7 @@ where
             }
             | Inst::Rets { .. } => MachTerminator::Ret,
             Inst::Jump { .. } => MachTerminator::Uncond,
-            Inst::BrIf { .. }
+            Inst::BrIf32 { .. }
             | Inst::BrIfXeq32 { .. }
             | Inst::BrIfXneq32 { .. }
             | Inst::BrIfXslt32 { .. }
@@ -651,7 +651,7 @@ impl Inst {
 
             Inst::Jump { label } => format!("jump {}", label.to_string()),
 
-            Inst::BrIf {
+            Inst::BrIf32 {
                 c,
                 taken,
                 not_taken,
@@ -659,7 +659,7 @@ impl Inst {
                 let c = format_reg(**c);
                 let taken = taken.to_string();
                 let not_taken = not_taken.to_string();
-                format!("br_if {c}, {taken}; jump {not_taken}")
+                format!("br_if32 {c}, {taken}; jump {not_taken}")
             }
 
             Inst::BrIfXeq32 {

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -6,6 +6,20 @@
 
 ;;;; Rules for Control Flow ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; Helper to place a conditional `Value` provided into a register. Pulley
+;; conditional values occupy the full low 32-bits of a register and so this
+;; needs to handle situations such as when the `Value` is 64-bits an explicit
+;; comparison must be made. Additionally if `Value` is smaller than 32-bits
+;; then it must be sign-extended up to at least 32 bits.
+(decl lower_cond (Value) XReg)
+(rule (lower_cond val @ (value_type $I64)) (pulley_xneq64 val (pulley_xconst8 0)))
+(rule (lower_cond val @ (value_type $I32)) val)
+(rule (lower_cond val @ (value_type $I16)) (pulley_zext16 val))
+(rule (lower_cond val @ (value_type $I8)) (pulley_zext8 val))
+
+;; Peel away explicit `uextend` values to take a look at the inner value.
+(rule 1 (lower_cond (uextend val)) (lower_cond val))
+
 ;; The main control-flow-lowering term: takes a control-flow instruction and
 ;; target(s) and emits the necessary instructions.
 (decl partial lower_branch (Inst MachLabelSlice) Unit)
@@ -15,8 +29,8 @@
       (emit_side_effect (pulley_jump label)))
 
 ;; Generic case for conditional branches.
-(rule -1 (lower_branch (brif (maybe_uextend c) _ _) (two_targets then else))
-      (emit_side_effect (pulley_br_if (zext c) then else)))
+(rule -1 (lower_branch (brif c _ _) (two_targets then else))
+      (emit_side_effect (pulley_br_if32 (lower_cond c) then else)))
 
 ;; Conditional branches on `icmp`s.
 (rule (lower_branch (brif (maybe_uextend (icmp cc a b @ (value_type $I32))) _ _)
@@ -420,8 +434,14 @@
 
 ;;;; Rules for `uextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type (fits_in_64 _) (uextend val)))
-  (zext val))
+(rule (lower (has_type (fits_in_64 _) (uextend val @ (value_type $I32))))
+  (pulley_zext32 val))
+
+(rule (lower (has_type (fits_in_64 _) (uextend val @ (value_type $I16))))
+  (pulley_zext16 val))
+
+(rule (lower (has_type (fits_in_64 _) (uextend val @ (value_type $I8))))
+  (pulley_zext8 val))
 
 ;;;; Rules for `sextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -446,3 +466,17 @@
 
 (rule (lower (has_type $I64 (uadd_overflow_trap a b tc)))
   (pulley_xadd64_uoverflow_trap a b tc))
+
+;;;; Rules for `select` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 0 (lower (has_type (ty_int (fits_in_32 _)) (select c a b)))
+  (pulley_xselect32 (lower_cond c) a b))
+
+(rule 1 (lower (has_type $I64 (select c a b)))
+  (pulley_xselect64 (lower_cond c) a b))
+
+(rule 1 (lower (has_type $F32 (select c a b)))
+  (pulley_fselect32 (lower_cond c) a b))
+
+(rule 1 (lower (has_type $F64 (select c a b)))
+  (pulley_fselect64 (lower_cond c) a b))

--- a/cranelift/filetests/filetests/isa/pulley32/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif.clif
@@ -17,7 +17,7 @@ block2:
 ; VCode:
 ; block0:
 ;   zext8 x4, x0
-;   br_if x4, label2; jump label1
+;   br_if32 x4, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -27,7 +27,7 @@ block2:
 ;
 ; Disassembled:
 ; zext8 x4, x0
-; br_if x4, 0xa    // target = 0xd
+; br_if32 x4, 0xa    // target = 0xd
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -49,7 +49,7 @@ block2:
 ; VCode:
 ; block0:
 ;   zext16 x4, x0
-;   br_if x4, label2; jump label1
+;   br_if32 x4, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -59,7 +59,7 @@ block2:
 ;
 ; Disassembled:
 ; zext16 x4, x0
-; br_if x4, 0xa    // target = 0xd
+; br_if32 x4, 0xa    // target = 0xd
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -80,8 +80,7 @@ block2:
 
 ; VCode:
 ; block0:
-;   zext32 x4, x0
-;   br_if x4, label2; jump label1
+;   br_if32 x0, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -90,8 +89,7 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; zext32 x4, x0
-; br_if x4, 0xa    // target = 0xd
+; br_if32 x0, 0xa    // target = 0xa
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -112,7 +110,9 @@ block2:
 
 ; VCode:
 ; block0:
-;   br_if x0, label2; jump label1
+;   xconst8 x4, 0
+;   xneq64 x6, x0, x4
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -121,7 +121,9 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if x0, 0xa    // target = 0xa
+; xconst8 x4, 0
+; xneq64 x6, x0, x4
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -145,7 +147,7 @@ block2:
 ; block0:
 ;   xeq32 x6, x0, x1
 ;   zext8 x6, x6
-;   br_if x6, label2; jump label1
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -156,7 +158,7 @@ block2:
 ; Disassembled:
 ; xeq32 x6, x0, x1
 ; zext8 x6, x6
-; br_if x6, 0xa    // target = 0x10
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -180,7 +182,7 @@ block2:
 ; block0:
 ;   xneq32 x6, x0, x1
 ;   zext8 x6, x6
-;   br_if x6, label2; jump label1
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -191,7 +193,7 @@ block2:
 ; Disassembled:
 ; xneq32 x6, x0, x1
 ; zext8 x6, x6
-; br_if x6, 0xa    // target = 0x10
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -246,7 +248,7 @@ block2:
 ; block0:
 ;   xulteq64 x6, x1, x0
 ;   zext8 x6, x6
-;   br_if x6, label2; jump label1
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -257,7 +259,7 @@ block2:
 ; Disassembled:
 ; xulteq64 x6, x1, x0
 ; zext8 x6, x6
-; br_if x6, 0xa    // target = 0x10
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1

--- a/cranelift/filetests/filetests/isa/pulley32/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/jump.clif
@@ -20,7 +20,7 @@ block3(v3: i8):
 ; VCode:
 ; block0:
 ;   zext8 x5, x0
-;   br_if x5, label2; jump label1
+;   br_if32 x5, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   jump label3
@@ -32,7 +32,7 @@ block3(v3: i8):
 ;
 ; Disassembled:
 ; zext8 x5, x0
-; br_if x5, 0xe    // target = 0x11
+; br_if32 x5, 0xe    // target = 0x11
 ; xconst8 x0, 0
 ; jump 0x8    // target = 0x14
 ; xconst8 x0, 1

--- a/cranelift/filetests/filetests/isa/pulley32/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/trap.clif
@@ -110,21 +110,25 @@ block2:
 
 ; VCode:
 ; block0:
-;   br_if x0, label2; jump label1
+;   xconst8 x4, 0
+;   xneq64 x6, x0, x4
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   ret
 ; block2:
-;   xconst8 x5, 42
-;   xconst8 x6, 0
-;   trap_if ne, Size64, x5, x6 // code = TrapCode(1)
+;   xconst8 x7, 42
+;   xconst8 x8, 0
+;   trap_if ne, Size64, x7, x8 // code = TrapCode(1)
 ;   ret
 ;
 ; Disassembled:
-; br_if x0, 0x7    // target = 0x7
+; xconst8 x4, 0
+; xneq64 x6, x0, x4
+; br_if32 x6, 0x7    // target = 0xd
 ; ret
-; xconst8 x5, 42
-; xconst8 x6, 0
-; br_if_xneq64 x5, x6, 0x8    // target = 0x15
+; xconst8 x7, 42
+; xconst8 x8, 0
+; br_if_xneq64 x7, x8, 0x8    // target = 0x1b
 ; ret
 ; trap
 
@@ -145,20 +149,24 @@ block2:
 
 ; VCode:
 ; block0:
-;   br_if x0, label2; jump label1
-; block1:
 ;   xconst8 x4, 0
-;   xconst8 x5, 0
-;   trap_if eq, Size64, x4, x5 // code = TrapCode(1)
+;   xneq64 x6, x0, x4
+;   br_if32 x6, label2; jump label1
+; block1:
+;   xconst8 x6, 0
+;   xconst8 x7, 0
+;   trap_if eq, Size64, x6, x7 // code = TrapCode(1)
 ;   ret
 ; block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if x0, 0x14    // target = 0x14
 ; xconst8 x4, 0
-; xconst8 x5, 0
-; br_if_xeq64 x4, x5, 0x9    // target = 0x15
+; xneq64 x6, x0, x4
+; br_if32 x6, 0x14    // target = 0x1a
+; xconst8 x6, 0
+; xconst8 x7, 0
+; br_if_xeq64 x6, x7, 0x9    // target = 0x1b
 ; ret
 ; ret
 ; trap

--- a/cranelift/filetests/filetests/isa/pulley64/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif.clif
@@ -17,7 +17,7 @@ block2:
 ; VCode:
 ; block0:
 ;   zext8 x4, x0
-;   br_if x4, label2; jump label1
+;   br_if32 x4, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -27,7 +27,7 @@ block2:
 ;
 ; Disassembled:
 ; zext8 x4, x0
-; br_if x4, 0xa    // target = 0xd
+; br_if32 x4, 0xa    // target = 0xd
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -49,7 +49,7 @@ block2:
 ; VCode:
 ; block0:
 ;   zext16 x4, x0
-;   br_if x4, label2; jump label1
+;   br_if32 x4, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -59,7 +59,7 @@ block2:
 ;
 ; Disassembled:
 ; zext16 x4, x0
-; br_if x4, 0xa    // target = 0xd
+; br_if32 x4, 0xa    // target = 0xd
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -80,8 +80,7 @@ block2:
 
 ; VCode:
 ; block0:
-;   zext32 x4, x0
-;   br_if x4, label2; jump label1
+;   br_if32 x0, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -90,8 +89,7 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; zext32 x4, x0
-; br_if x4, 0xa    // target = 0xd
+; br_if32 x0, 0xa    // target = 0xa
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -112,7 +110,9 @@ block2:
 
 ; VCode:
 ; block0:
-;   br_if x0, label2; jump label1
+;   xconst8 x4, 0
+;   xneq64 x6, x0, x4
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -121,7 +121,9 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if x0, 0xa    // target = 0xa
+; xconst8 x4, 0
+; xneq64 x6, x0, x4
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -145,7 +147,7 @@ block2:
 ; block0:
 ;   xeq32 x6, x0, x1
 ;   zext8 x6, x6
-;   br_if x6, label2; jump label1
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -156,7 +158,7 @@ block2:
 ; Disassembled:
 ; xeq32 x6, x0, x1
 ; zext8 x6, x6
-; br_if x6, 0xa    // target = 0x10
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -180,7 +182,7 @@ block2:
 ; block0:
 ;   xneq32 x6, x0, x1
 ;   zext8 x6, x6
-;   br_if x6, label2; jump label1
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -191,7 +193,7 @@ block2:
 ; Disassembled:
 ; xneq32 x6, x0, x1
 ; zext8 x6, x6
-; br_if x6, 0xa    // target = 0x10
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1
@@ -246,7 +248,7 @@ block2:
 ; block0:
 ;   xulteq64 x6, x1, x0
 ;   zext8 x6, x6
-;   br_if x6, label2; jump label1
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   ret
@@ -257,7 +259,7 @@ block2:
 ; Disassembled:
 ; xulteq64 x6, x1, x0
 ; zext8 x6, x6
-; br_if x6, 0xa    // target = 0x10
+; br_if32 x6, 0xa    // target = 0x10
 ; xconst8 x0, 0
 ; ret
 ; xconst8 x0, 1

--- a/cranelift/filetests/filetests/isa/pulley64/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/jump.clif
@@ -20,7 +20,7 @@ block3(v3: i8):
 ; VCode:
 ; block0:
 ;   zext8 x5, x0
-;   br_if x5, label2; jump label1
+;   br_if32 x5, label2; jump label1
 ; block1:
 ;   xconst8 x0, 0
 ;   jump label3
@@ -32,7 +32,7 @@ block3(v3: i8):
 ;
 ; Disassembled:
 ; zext8 x5, x0
-; br_if x5, 0xe    // target = 0x11
+; br_if32 x5, 0xe    // target = 0x11
 ; xconst8 x0, 0
 ; jump 0x8    // target = 0x14
 ; xconst8 x0, 1

--- a/cranelift/filetests/filetests/isa/pulley64/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/trap.clif
@@ -110,21 +110,25 @@ block2:
 
 ; VCode:
 ; block0:
-;   br_if x0, label2; jump label1
+;   xconst8 x4, 0
+;   xneq64 x6, x0, x4
+;   br_if32 x6, label2; jump label1
 ; block1:
 ;   ret
 ; block2:
-;   xconst8 x5, 42
-;   xconst8 x6, 0
-;   trap_if ne, Size64, x5, x6 // code = TrapCode(1)
+;   xconst8 x7, 42
+;   xconst8 x8, 0
+;   trap_if ne, Size64, x7, x8 // code = TrapCode(1)
 ;   ret
 ;
 ; Disassembled:
-; br_if x0, 0x7    // target = 0x7
+; xconst8 x4, 0
+; xneq64 x6, x0, x4
+; br_if32 x6, 0x7    // target = 0xd
 ; ret
-; xconst8 x5, 42
-; xconst8 x6, 0
-; br_if_xneq64 x5, x6, 0x8    // target = 0x15
+; xconst8 x7, 42
+; xconst8 x8, 0
+; br_if_xneq64 x7, x8, 0x8    // target = 0x1b
 ; ret
 ; trap
 
@@ -145,20 +149,24 @@ block2:
 
 ; VCode:
 ; block0:
-;   br_if x0, label2; jump label1
-; block1:
 ;   xconst8 x4, 0
-;   xconst8 x5, 0
-;   trap_if eq, Size64, x4, x5 // code = TrapCode(1)
+;   xneq64 x6, x0, x4
+;   br_if32 x6, label2; jump label1
+; block1:
+;   xconst8 x6, 0
+;   xconst8 x7, 0
+;   trap_if eq, Size64, x6, x7 // code = TrapCode(1)
 ;   ret
 ; block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if x0, 0x14    // target = 0x14
 ; xconst8 x4, 0
-; xconst8 x5, 0
-; br_if_xeq64 x4, x5, 0x9    // target = 0x15
+; xneq64 x6, x0, x4
+; br_if32 x6, 0x14    // target = 0x1a
+; xconst8 x6, 0
+; xconst8 x7, 0
+; br_if_xeq64 x6, x7, 0x9    // target = 0x1b
 ; ret
 ; ret
 ; trap

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -395,7 +395,6 @@ impl WastTest {
         // features in Pulley are implemented.
         if config.compiler == Compiler::CraneliftPulley {
             let unsupported = [
-                "misc_testsuite/br-table-fuzzbug.wast",
                 "misc_testsuite/call_indirect.wast",
                 "misc_testsuite/component-model/fused.wast",
                 "misc_testsuite/component-model/strings.wast",
@@ -413,7 +412,6 @@ impl WastTest {
                 "misc_testsuite/gc/anyref_that_is_i31_barriers.wast",
                 "misc_testsuite/gc/i31ref-of-global-initializers.wast",
                 "misc_testsuite/gc/i31ref-tables.wast",
-                "misc_testsuite/gc/ref-test.wast",
                 "misc_testsuite/int-to-float-splat.wast",
                 "misc_testsuite/issue1809.wast",
                 "misc_testsuite/issue4840.wast",
@@ -440,7 +438,6 @@ impl WastTest {
                 "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
                 "misc_testsuite/simd/unaligned-load.wast",
                 "misc_testsuite/simd/v128-select.wast",
-                "misc_testsuite/sink-float-but-dont-trap.wast",
                 "misc_testsuite/table_copy.wast",
                 "misc_testsuite/table_copy_on_imported_tables.wast",
                 "misc_testsuite/threads/LB_atomic.wast",
@@ -458,7 +455,6 @@ impl WastTest {
                 "misc_testsuite/winch/table_fill.wast",
                 "misc_testsuite/winch/table_get.wast",
                 "misc_testsuite/winch/table_set.wast",
-                "spec_testsuite/br_if.wast",
                 "spec_testsuite/bulk.wast",
                 "spec_testsuite/call.wast",
                 "spec_testsuite/call_indirect.wast",

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -903,8 +903,8 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
-    fn br_if(&mut self, cond: XReg, offset: PcRelOffset) -> ControlFlow<Done> {
-        let cond = self.state[cond].get_u64();
+    fn br_if32(&mut self, cond: XReg, offset: PcRelOffset) -> ControlFlow<Done> {
+        let cond = self.state[cond].get_u32();
         if cond != 0 {
             self.pc_rel_jump::<crate::BrIf>(offset)
         } else {
@@ -912,8 +912,8 @@ impl OpVisitor for Interpreter<'_> {
         }
     }
 
-    fn br_if_not(&mut self, cond: XReg, offset: PcRelOffset) -> ControlFlow<Done> {
-        let cond = self.state[cond].get_u64();
+    fn br_if_not32(&mut self, cond: XReg, offset: PcRelOffset) -> ControlFlow<Done> {
+        let cond = self.state[cond].get_u32();
         if cond == 0 {
             self.pc_rel_jump::<crate::BrIfNot>(offset)
         } else {
@@ -1176,84 +1176,84 @@ impl OpVisitor for Interpreter<'_> {
     fn xeq64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
-        self.state[operands.dst].set_u64(u64::from(a == b));
+        self.state[operands.dst].set_u32(u32::from(a == b));
         ControlFlow::Continue(())
     }
 
     fn xneq64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
-        self.state[operands.dst].set_u64(u64::from(a != b));
+        self.state[operands.dst].set_u32(u32::from(a != b));
         ControlFlow::Continue(())
     }
 
     fn xslt64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64();
         let b = self.state[operands.src2].get_i64();
-        self.state[operands.dst].set_u64(u64::from(a < b));
+        self.state[operands.dst].set_u32(u32::from(a < b));
         ControlFlow::Continue(())
     }
 
     fn xslteq64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64();
         let b = self.state[operands.src2].get_i64();
-        self.state[operands.dst].set_u64(u64::from(a <= b));
+        self.state[operands.dst].set_u32(u32::from(a <= b));
         ControlFlow::Continue(())
     }
 
     fn xult64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
-        self.state[operands.dst].set_u64(u64::from(a < b));
+        self.state[operands.dst].set_u32(u32::from(a < b));
         ControlFlow::Continue(())
     }
 
     fn xulteq64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
-        self.state[operands.dst].set_u64(u64::from(a <= b));
+        self.state[operands.dst].set_u32(u32::from(a <= b));
         ControlFlow::Continue(())
     }
 
     fn xeq32(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32();
         let b = self.state[operands.src2].get_u32();
-        self.state[operands.dst].set_u64(u64::from(a == b));
+        self.state[operands.dst].set_u32(u32::from(a == b));
         ControlFlow::Continue(())
     }
 
     fn xneq32(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32();
         let b = self.state[operands.src2].get_u32();
-        self.state[operands.dst].set_u64(u64::from(a != b));
+        self.state[operands.dst].set_u32(u32::from(a != b));
         ControlFlow::Continue(())
     }
 
     fn xslt32(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32();
         let b = self.state[operands.src2].get_i32();
-        self.state[operands.dst].set_u64(u64::from(a < b));
+        self.state[operands.dst].set_u32(u32::from(a < b));
         ControlFlow::Continue(())
     }
 
     fn xslteq32(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32();
         let b = self.state[operands.src2].get_i32();
-        self.state[operands.dst].set_u64(u64::from(a <= b));
+        self.state[operands.dst].set_u32(u32::from(a <= b));
         ControlFlow::Continue(())
     }
 
     fn xult32(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32();
         let b = self.state[operands.src2].get_u32();
-        self.state[operands.dst].set_u64(u64::from(a < b));
+        self.state[operands.dst].set_u32(u32::from(a < b));
         ControlFlow::Continue(())
     }
 
     fn xulteq32(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32();
         let b = self.state[operands.src2].get_u32();
-        self.state[operands.dst].set_u64(u64::from(a <= b));
+        self.state[operands.dst].set_u32(u32::from(a <= b));
         ControlFlow::Continue(())
     }
 
@@ -1771,6 +1771,70 @@ impl OpVisitor for Interpreter<'_> {
     fn xclz64(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u64();
         self.state[dst].set_u64(a.leading_zeros().into());
+        ControlFlow::Continue(())
+    }
+
+    fn xselect32(
+        &mut self,
+        dst: XReg,
+        cond: XReg,
+        if_nonzero: XReg,
+        if_zero: XReg,
+    ) -> ControlFlow<Done> {
+        let result = if self.state[cond].get_u32() != 0 {
+            self.state[if_nonzero].get_u32()
+        } else {
+            self.state[if_zero].get_u32()
+        };
+        self.state[dst].set_u32(result);
+        ControlFlow::Continue(())
+    }
+
+    fn xselect64(
+        &mut self,
+        dst: XReg,
+        cond: XReg,
+        if_nonzero: XReg,
+        if_zero: XReg,
+    ) -> ControlFlow<Done> {
+        let result = if self.state[cond].get_u32() != 0 {
+            self.state[if_nonzero].get_u64()
+        } else {
+            self.state[if_zero].get_u64()
+        };
+        self.state[dst].set_u64(result);
+        ControlFlow::Continue(())
+    }
+
+    fn fselect32(
+        &mut self,
+        dst: FReg,
+        cond: XReg,
+        if_nonzero: FReg,
+        if_zero: FReg,
+    ) -> ControlFlow<Done> {
+        let result = if self.state[cond].get_u32() != 0 {
+            self.state[if_nonzero].get_f32()
+        } else {
+            self.state[if_zero].get_f32()
+        };
+        self.state[dst].set_f32(result);
+        ControlFlow::Continue(())
+    }
+
+    fn fselect64(
+        &mut self,
+        dst: FReg,
+        cond: XReg,
+        if_nonzero: FReg,
+        if_zero: FReg,
+    ) -> ControlFlow<Done> {
+        let result = if self.state[cond].get_u32() != 0 {
+            self.state[if_nonzero].get_f64()
+        } else {
+            self.state[if_zero].get_f64()
+        };
+        self.state[dst].set_f64(result);
         ControlFlow::Continue(())
     }
 }

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -101,13 +101,13 @@ macro_rules! for_each_op {
             /// Unconditionally transfer control to the PC at the given offset.
             jump = Jump { offset: PcRelOffset };
 
-            /// Conditionally transfer control to the given PC offset if `cond`
-            /// contains a non-zero value.
-            br_if = BrIf { cond: XReg, offset: PcRelOffset };
+            /// Conditionally transfer control to the given PC offset if
+            /// `low32(cond)` contains a non-zero value.
+            br_if32 = BrIf { cond: XReg, offset: PcRelOffset };
 
-            /// Conditionally transfer control to the given PC offset if `cond`
-            /// contains a zero value.
-            br_if_not = BrIfNot { cond: XReg, offset: PcRelOffset };
+            /// Conditionally transfer control to the given PC offset if
+            /// `low32(cond)` contains a zero value.
+            br_if_not32 = BrIfNot { cond: XReg, offset: PcRelOffset };
 
             /// Branch if `a == b`.
             br_if_xeq32 = BrIfXeq32 { a: XReg, b: XReg, offset: PcRelOffset };
@@ -134,7 +134,7 @@ macro_rules! for_each_op {
             /// Branch if unsigned `a <= b`.
             br_if_xulteq64 = BrIfXulteq64 { a: XReg, b: XReg, offset: PcRelOffset };
 
-            /// Branch to the label indicated by `idx`.
+            /// Branch to the label indicated by `low32(idx)`.
             ///
             /// After this instruction are `amt` instances of `PcRelOffset`
             /// and the `idx` selects which one will be branched to. The value
@@ -207,29 +207,29 @@ macro_rules! for_each_op {
             /// `dst = src1 >> low6(src2)`
             xshr64_u = Xshr64U { operands: BinaryOperands<XReg> };
 
-            /// 64-bit equality.
+            /// `low32(dst) = src1 == src2`
             xeq64 = Xeq64 { operands: BinaryOperands<XReg> };
-            /// 64-bit inequality.
+            /// `low32(dst) = src1 != src2`
             xneq64 = Xneq64 { operands: BinaryOperands<XReg> };
-            /// 64-bit signed less-than.
+            /// `low32(dst) = src1 < src2` (signed)
             xslt64 = Xslt64 { operands: BinaryOperands<XReg> };
-            /// 64-bit signed less-than-equal.
+            /// `low32(dst) = src1 <= src2` (signed)
             xslteq64 = Xslteq64 { operands: BinaryOperands<XReg> };
-            /// 64-bit unsigned less-than.
+            /// `low32(dst) = src1 < src2` (unsigned)
             xult64 = Xult64 { operands: BinaryOperands<XReg> };
-            /// 64-bit unsigned less-than-equal.
+            /// `low32(dst) = src1 <= src2` (unsigned)
             xulteq64 = Xulteq64 { operands: BinaryOperands<XReg> };
-            /// 32-bit equality.
+            /// `low32(dst) = low32(src1) == low32(src2)`
             xeq32 = Xeq32 { operands: BinaryOperands<XReg> };
-            /// 32-bit inequality.
+            /// `low32(dst) = low32(src1) != low32(src2)`
             xneq32 = Xneq32 { operands: BinaryOperands<XReg> };
-            /// 32-bit signed less-than.
+            /// `low32(dst) = low32(src1) < low32(src2)` (signed)
             xslt32 = Xslt32 { operands: BinaryOperands<XReg> };
-            /// 32-bit signed less-than-equal.
+            /// `low32(dst) = low32(src1) <= low32(src2)` (signed)
             xslteq32 = Xslteq32 { operands: BinaryOperands<XReg> };
-            /// 32-bit unsigned less-than.
+            /// `low32(dst) = low32(src1) < low32(src2)` (unsigned)
             xult32 = Xult32 { operands: BinaryOperands<XReg> };
-            /// 32-bit unsigned less-than-equal.
+            /// `low32(dst) = low32(src1) <= low32(src2)` (unsigned)
             xulteq32 = Xulteq32 { operands: BinaryOperands<XReg> };
 
             /// `low32(dst) = zext(*(ptr + offset))`
@@ -386,6 +386,15 @@ macro_rules! for_each_op {
             flt64 = Flt64 { dst: XReg, src1: FReg, src2: FReg };
             /// `low32(dst) = zext(src1 <= src2)`
             flteq64 = Flteq64 { dst: XReg, src1: FReg, src2: FReg };
+
+            /// `low32(dst) = low32(cond) ? low32(if_nonzero) : low32(if_zero)`
+            xselect32 = XSelect32 { dst: XReg, cond: XReg, if_nonzero: XReg, if_zero: XReg };
+            /// `dst = low32(cond) ? if_nonzero : if_zero`
+            xselect64 = XSelect64 { dst: XReg, cond: XReg, if_nonzero: XReg, if_zero: XReg };
+            /// `low32(dst) = low32(cond) ? low32(if_nonzero) : low32(if_zero)`
+            fselect32 = FSelect32 { dst: FReg, cond: XReg, if_nonzero: FReg, if_zero: FReg };
+            /// `dst = low32(cond) ? if_nonzero : if_zero`
+            fselect64 = FSelect64 { dst: FReg, cond: XReg, if_nonzero: FReg, if_zero: FReg };
         }
     };
 }

--- a/pulley/tests/all/interp.rs
+++ b/pulley/tests/all/interp.rs
@@ -194,7 +194,7 @@ fn xeq64() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -219,7 +219,7 @@ fn xneq64() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -251,7 +251,7 @@ fn xslt64() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -283,7 +283,7 @@ fn xslteq64() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -312,7 +312,7 @@ fn xult64() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -341,7 +341,7 @@ fn xulteq64() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -370,7 +370,7 @@ fn xeq32() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -396,7 +396,7 @@ fn xneq32() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -430,7 +430,7 @@ fn xslt32() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -462,7 +462,7 @@ fn xslteq32() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -490,7 +490,7 @@ fn xult32() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }
@@ -518,7 +518,7 @@ fn xulteq32() {
                     },
                 },
                 x(0),
-                expected,
+                expected | 0x1234567800000000,
             );
         }
     }

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -13,7 +13,7 @@
 ;;       xload64le_offset32 x8, x8, 8
 ;;       xulteq64 x8, x8, x9
 ;;       zext8 x8, x8
-;;       br_if x8, 0x8    // target = 0x2b
+;;       br_if32 x8, 0x8    // target = 0x2b
 ;;   29: pop_frame
 ;;       ret
 ;;   2b: call 0xa2    // target = 0xcd


### PR DESCRIPTION
This commit redefines previous Pulley instructions working with
conditional values and results to always operate on the low 32-bits of a
register rather than the full 64-bit width of integer registers. This
should help 32-bit platforms work with just a word and avoid an
extraneous load of top bits that are likely always zero.

The previous `br_if` and `br_if_not` instructions now have a "32" suffix
to make it clear that they're only operating on 32-bit register widths.
Additionally the `xeq32` family of instructions (compare-and-set) now
all only define the low 32-bits of the destination register.

Finally, lowerings of `select` in CLIF were added for integer and
floating-point registers.

cc https://github.com/bytecodealliance/wasmtime/issues/9783