### PR TITLE
pulley: Support `runtests` in Cranelift filetests

### DIFF
--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -37,4 +37,4 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 cranelift.workspace = true
 smallvec = { workspace = true }
-pulley-interpreter = { workspace = true, features = ["disas", "std"] }
+pulley-interpreter = { workspace = true, features = ["disas", "std", "interp"] }

--- a/cranelift/filetests/filetests/runtests/br.clif
+++ b/cranelift/filetests/filetests/runtests/br.clif
@@ -5,6 +5,10 @@ target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %jump() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/runtests/brif.clif
+++ b/cranelift/filetests/filetests/runtests/brif.clif
@@ -5,6 +5,10 @@ target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %brif_value(i8) -> i64 {
 block0(v0: i8):


### PR DESCRIPTION
This'll help when adding unit tests for Pulley and/or might be useful when debugging various lowerings and such in the future. I hope to enable more tests in the future once more pulley lowerings are available.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
