### PR TITLE
aarch64: support udiv for 32bit integers

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -488,6 +488,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             // Here `Lo` == "less than" when interpreting the two
             // operands as unsigned integers.
             kind: CondBrKind::Cond(Cond::Lo),
+            size: OperandSize::Size64,
         });
         insts
     }

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -488,7 +488,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
             // Here `Lo` == "less than" when interpreting the two
             // operands as unsigned integers.
             kind: CondBrKind::Cond(Cond::Lo),
-            size: OperandSize::Size64,
         });
         insts
     }

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -870,7 +870,6 @@
        ;; *execute* the embedded `Inst`. (In the emitted code, we use the inverse
        ;; of this condition in a branch that skips the trap instruction.)
        (TrapIf
-        (size OperandSize)
         (kind CondBrKind)
         (trap_code TrapCode))
 
@@ -1993,10 +1992,10 @@
 (decl nzcv (bool bool bool bool) NZCV)
 (extern constructor nzcv nzcv)
 
-(decl cond_br_zero (Reg) CondBrKind)
+(decl cond_br_zero (Reg OperandSize) CondBrKind)
 (extern constructor cond_br_zero cond_br_zero)
 
-(decl cond_br_not_zero (Reg) CondBrKind)
+(decl cond_br_not_zero (Reg OperandSize) CondBrKind)
 (extern constructor cond_br_not_zero cond_br_not_zero)
 
 (decl cond_br_cond (Cond) CondBrKind)
@@ -3507,7 +3506,7 @@
       (side_effect
        (with_flags_side_effect flags
         (ConsumesFlags.ConsumesFlagsSideEffect
-         (MInst.TrapIf (operand_size $I64) (cond_br_cond cond) trap_code)))))
+         (MInst.TrapIf (cond_br_cond cond) trap_code)))))
 
 ;; Helpers for lowering `trapz` and `trapnz`.
 (type ZeroCond
@@ -3515,19 +3514,19 @@
        Zero
        NonZero))
 
-(decl zero_cond_to_cond_br (ZeroCond Reg) CondBrKind)
-(rule (zero_cond_to_cond_br (ZeroCond.Zero) reg)
-      (cond_br_zero reg))
+(decl zero_cond_to_cond_br (ZeroCond Reg OperandSize) CondBrKind)
+(rule (zero_cond_to_cond_br (ZeroCond.Zero) reg size)
+      (cond_br_zero reg size))
 
-(rule (zero_cond_to_cond_br (ZeroCond.NonZero) reg)
-      (cond_br_not_zero reg))
+(rule (zero_cond_to_cond_br (ZeroCond.NonZero) reg size)
+      (cond_br_not_zero reg size))
 
 (decl trap_if_val (ZeroCond Value TrapCode) InstOutput)
 (rule (trap_if_val zero_cond val @ (value_type (fits_in_64 _)) trap_code)
       (let ((reg Reg (put_in_reg_zext64 val)))
       (side_effect
        (SideEffectNoResult.Inst
-        (MInst.TrapIf (operand_size $I64) (zero_cond_to_cond_br zero_cond reg) trap_code)))))
+        (MInst.TrapIf (zero_cond_to_cond_br zero_cond reg (operand_size $I64)) trap_code)))))
 
 (rule -1 (trap_if_val zero_cond val @ (value_type $I128) trap_code)
   (let ((c ValueRegs (put_in_regs val))
@@ -3536,7 +3535,7 @@
         (c_test Reg (orr $I64 c_lo c_hi)))
       (side_effect
        (SideEffectNoResult.Inst
-        (MInst.TrapIf (operand_size $I64) (zero_cond_to_cond_br zero_cond c_test) trap_code)))))
+        (MInst.TrapIf (zero_cond_to_cond_br zero_cond c_test (operand_size $I64)) trap_code)))))
 
 ;; Immediate value helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3662,7 +3661,7 @@
 
 (decl trap_if_zero_divisor (Reg OperandSize) Reg)
 (rule (trap_if_zero_divisor reg size)
-      (let ((_ Unit (emit (MInst.TrapIf size (cond_br_zero reg) (trap_code_division_by_zero)))))
+      (let ((_ Unit (emit (MInst.TrapIf (cond_br_zero reg size ) (trap_code_division_by_zero)))))
         reg))
 
 (decl size_from_ty (Type) OperandSize)
@@ -3686,7 +3685,7 @@
                                        (u8_into_uimm5 1)
                                        (nzcv false false false false)
                                        (Cond.Eq))))
-          (_ Unit (emit (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Vs))
+          (_ Unit (emit (MInst.TrapIf (cond_br_cond (Cond.Vs))
                                       (trap_code_integer_overflow))))
         )
         x))
@@ -3710,7 +3709,7 @@
       (with_flags_reg
         producer
         (ConsumesFlags.ConsumesFlagsSideEffect
-          (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Hs)) tc))))
+          (MInst.TrapIf (cond_br_cond (Cond.Hs)) tc))))
 
 (decl sink_atomic_load (Inst) Reg)
 (rule (sink_atomic_load x @ (atomic_load _ addr))
@@ -4273,7 +4272,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp size src src)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Vs))
+                    (MInst.TrapIf (cond_br_cond (Cond.Vs))
                         (trap_code_bad_conversion_to_integer))
                     src))))
        (value_regs_get r 0)))
@@ -4286,7 +4285,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (ScalarSize.Size32) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Le))
+                    (MInst.TrapIf (cond_br_cond (Cond.Le))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4294,7 +4293,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (ScalarSize.Size64) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Le))
+                    (MInst.TrapIf (cond_br_cond (Cond.Le))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4302,7 +4301,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (scalar_size in_ty) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Lt))
+                    (MInst.TrapIf (cond_br_cond (Cond.Lt))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4310,7 +4309,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (scalar_size in_ty) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Le))
+                    (MInst.TrapIf (cond_br_cond (Cond.Le))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4320,7 +4319,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp size src max)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Ge))
+                    (MInst.TrapIf (cond_br_cond (Cond.Ge))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -870,6 +870,7 @@
        ;; *execute* the embedded `Inst`. (In the emitted code, we use the inverse
        ;; of this condition in a branch that skips the trap instruction.)
        (TrapIf
+        (size OperandSize)
         (kind CondBrKind)
         (trap_code TrapCode))
 
@@ -3506,7 +3507,7 @@
       (side_effect
        (with_flags_side_effect flags
         (ConsumesFlags.ConsumesFlagsSideEffect
-         (MInst.TrapIf (cond_br_cond cond) trap_code)))))
+         (MInst.TrapIf (operand_size $I64) (cond_br_cond cond) trap_code)))))
 
 ;; Helpers for lowering `trapz` and `trapnz`.
 (type ZeroCond
@@ -3526,7 +3527,7 @@
       (let ((reg Reg (put_in_reg_zext64 val)))
       (side_effect
        (SideEffectNoResult.Inst
-        (MInst.TrapIf (zero_cond_to_cond_br zero_cond reg) trap_code)))))
+        (MInst.TrapIf (operand_size $I64) (zero_cond_to_cond_br zero_cond reg) trap_code)))))
 
 (rule -1 (trap_if_val zero_cond val @ (value_type $I128) trap_code)
   (let ((c ValueRegs (put_in_regs val))
@@ -3535,7 +3536,7 @@
         (c_test Reg (orr $I64 c_lo c_hi)))
       (side_effect
        (SideEffectNoResult.Inst
-        (MInst.TrapIf (zero_cond_to_cond_br zero_cond c_test) trap_code)))))
+        (MInst.TrapIf (operand_size $I64) (zero_cond_to_cond_br zero_cond c_test) trap_code)))))
 
 ;; Immediate value helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3659,9 +3660,9 @@
 
 ;; Misc instruction helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl trap_if_zero_divisor (Reg) Reg)
-(rule (trap_if_zero_divisor reg)
-      (let ((_ Unit (emit (MInst.TrapIf (cond_br_zero reg) (trap_code_division_by_zero)))))
+(decl trap_if_zero_divisor (Reg OperandSize) Reg)
+(rule (trap_if_zero_divisor reg size)
+      (let ((_ Unit (emit (MInst.TrapIf size (cond_br_zero reg) (trap_code_division_by_zero)))))
         reg))
 
 (decl size_from_ty (Type) OperandSize)
@@ -3685,7 +3686,7 @@
                                        (u8_into_uimm5 1)
                                        (nzcv false false false false)
                                        (Cond.Eq))))
-          (_ Unit (emit (MInst.TrapIf (cond_br_cond (Cond.Vs))
+          (_ Unit (emit (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Vs))
                                       (trap_code_integer_overflow))))
         )
         x))
@@ -3709,7 +3710,7 @@
       (with_flags_reg
         producer
         (ConsumesFlags.ConsumesFlagsSideEffect
-          (MInst.TrapIf (cond_br_cond (Cond.Hs)) tc))))
+          (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Hs)) tc))))
 
 (decl sink_atomic_load (Inst) Reg)
 (rule (sink_atomic_load x @ (atomic_load _ addr))
@@ -4272,7 +4273,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp size src src)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (cond_br_cond (Cond.Vs))
+                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Vs))
                         (trap_code_bad_conversion_to_integer))
                     src))))
        (value_regs_get r 0)))
@@ -4285,7 +4286,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (ScalarSize.Size32) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (cond_br_cond (Cond.Le))
+                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Le))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4293,7 +4294,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (ScalarSize.Size64) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (cond_br_cond (Cond.Le))
+                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Le))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4301,7 +4302,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (scalar_size in_ty) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (cond_br_cond (Cond.Lt))
+                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Lt))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4309,7 +4310,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp (scalar_size in_ty) src min)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (cond_br_cond (Cond.Le))
+                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Le))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))
@@ -4319,7 +4320,7 @@
       (let ((r ValueRegs
                   (with_flags (fpu_cmp size src max)
                    (ConsumesFlags.ConsumesFlagsReturnsReg
-                    (MInst.TrapIf (cond_br_cond (Cond.Ge))
+                    (MInst.TrapIf (operand_size $I64) (cond_br_cond (Cond.Ge))
                         (trap_code_integer_overflow))
                     src))))
        (value_regs_get r 0)))

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -233,9 +233,9 @@ impl Cond {
 #[derive(Clone, Copy, Debug)]
 pub enum CondBrKind {
     /// Condition: given register is zero.
-    Zero(Reg),
+    Zero(Reg, OperandSize),
     /// Condition: given register is nonzero.
-    NotZero(Reg),
+    NotZero(Reg, OperandSize),
     /// Condition: the given condition-code test is true.
     Cond(Cond),
 }
@@ -244,8 +244,8 @@ impl CondBrKind {
     /// Return the inverted branch condition.
     pub fn invert(self) -> CondBrKind {
         match self {
-            CondBrKind::Zero(reg) => CondBrKind::NotZero(reg),
-            CondBrKind::NotZero(reg) => CondBrKind::Zero(reg),
+            CondBrKind::Zero(reg, size) => CondBrKind::NotZero(reg, size),
+            CondBrKind::NotZero(reg, size) => CondBrKind::Zero(reg, size),
             CondBrKind::Cond(c) => CondBrKind::Cond(c.invert()),
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -770,9 +770,7 @@ impl MachInstEmit for Inst {
                 // indication that something is wrong.
                 debug_assert_ne!(stack_reg(), rn);
                 debug_assert_ne!(stack_reg(), rm);
-                let inst = enc_arith_rrr(top11, bit15_10, rd, rn, rm);
-                println!("inst {alu_op:?}: {inst:b}");
-                sink.put4(inst);
+                sink.put4(enc_arith_rrr(top11, bit15_10, rd, rn, rm));
             }
             &Inst::AluRRRR {
                 alu_op,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -755,8 +755,7 @@ impl MachInstEmit for Inst {
                     ALUOp::UMulH => 0b10011011_110,
                 };
 
-                dbg!(alu_op);
-                let top11 = top11 | dbg!(size.sf_bit()) << 10;
+                let top11 = top11 | size.sf_bit() << 10;
                 let bit15_10 = match alu_op {
                     ALUOp::SDiv => 0b000011,
                     ALUOp::UDiv => 0b000010,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -728,8 +728,7 @@ impl MachInstEmit for Inst {
                 rm,
             } => {
                 debug_assert!(match alu_op {
-                    ALUOp::SMulH | ALUOp::UMulH =>
-                        size == OperandSize::Size64,
+                    ALUOp::SMulH | ALUOp::UMulH => size == OperandSize::Size64,
                     _ => true,
                 });
                 let top11 = match alu_op {
@@ -771,7 +770,7 @@ impl MachInstEmit for Inst {
                 // indication that something is wrong.
                 debug_assert_ne!(stack_reg(), rn);
                 debug_assert_ne!(stack_reg(), rm);
-                let inst =enc_arith_rrr(top11, bit15_10, rd, rn, rm);
+                let inst = enc_arith_rrr(top11, bit15_10, rd, rn, rm);
                 println!("inst {alu_op:?}: {inst:b}");
                 sink.put4(inst);
             }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -728,7 +728,7 @@ impl MachInstEmit for Inst {
                 rm,
             } => {
                 debug_assert!(match alu_op {
-                    ALUOp::SDiv | ALUOp::UDiv | ALUOp::SMulH | ALUOp::UMulH =>
+                    ALUOp::SMulH | ALUOp::UMulH =>
                         size == OperandSize::Size64,
                     _ => true,
                 });
@@ -749,12 +749,14 @@ impl MachInstEmit for Inst {
                     ALUOp::AddS => 0b00101011_000,
                     ALUOp::SubS => 0b01101011_000,
                     ALUOp::SDiv => 0b10011010_110,
-                    ALUOp::UDiv => 0b10011010_110,
+                    ALUOp::UDiv => 0b00011010_110,
                     ALUOp::RotR | ALUOp::Lsr | ALUOp::Asr | ALUOp::Lsl => 0b00011010_110,
                     ALUOp::SMulH => 0b10011011_010,
                     ALUOp::UMulH => 0b10011011_110,
                 };
-                let top11 = top11 | size.sf_bit() << 10;
+
+                dbg!(alu_op);
+                let top11 = top11 | dbg!(size.sf_bit()) << 10;
                 let bit15_10 = match alu_op {
                     ALUOp::SDiv => 0b000011,
                     ALUOp::UDiv => 0b000010,
@@ -770,7 +772,9 @@ impl MachInstEmit for Inst {
                 // indication that something is wrong.
                 debug_assert_ne!(stack_reg(), rn);
                 debug_assert_ne!(stack_reg(), rm);
-                sink.put4(enc_arith_rrr(top11, bit15_10, rd, rn, rm));
+                let inst =enc_arith_rrr(top11, bit15_10, rd, rn, rm);
+                println!("inst {alu_op:?}: {inst:b}");
+                sink.put4(inst);
             }
             &Inst::AluRRRR {
                 alu_op,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -5901,25 +5901,22 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
-            kind: CondBrKind::NotZero(xreg(8)),
+            kind: CondBrKind::NotZero(xreg(8), OperandSize::Size64),
         },
         "280000B51FC10000",
         "cbnz x8, #trap=stk_ovf",
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
-            kind: CondBrKind::Zero(xreg(8)),
+            kind: CondBrKind::Zero(xreg(8), OperandSize::Size64),
         },
         "280000B41FC10000",
         "cbz x8, #trap=stk_ovf",
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Ne),
         },
@@ -5928,7 +5925,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Eq),
         },
@@ -5937,7 +5933,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Lo),
         },
@@ -5946,7 +5941,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Hs),
         },
@@ -5955,7 +5949,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Pl),
         },
@@ -5964,7 +5957,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Mi),
         },
@@ -5973,7 +5965,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Vc),
         },
@@ -5982,7 +5973,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Vs),
         },
@@ -5991,7 +5981,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Ls),
         },
@@ -6000,7 +5989,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Hi),
         },
@@ -6009,7 +5997,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Lt),
         },
@@ -6018,7 +6005,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Ge),
         },
@@ -6027,7 +6013,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Le),
         },
@@ -6036,7 +6021,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Gt),
         },
@@ -6045,7 +6029,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Nv),
         },
@@ -6054,7 +6037,6 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
-            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Al),
         },

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -5901,6 +5901,7 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::NotZero(xreg(8)),
         },
@@ -5909,6 +5910,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Zero(xreg(8)),
         },
@@ -5917,6 +5919,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Ne),
         },
@@ -5925,6 +5928,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Eq),
         },
@@ -5933,6 +5937,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Lo),
         },
@@ -5941,6 +5946,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Hs),
         },
@@ -5949,6 +5955,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Pl),
         },
@@ -5957,6 +5964,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Mi),
         },
@@ -5965,6 +5973,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Vc),
         },
@@ -5973,6 +5982,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Vs),
         },
@@ -5981,6 +5991,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Ls),
         },
@@ -5989,6 +6000,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Hi),
         },
@@ -5997,6 +6009,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Lt),
         },
@@ -6005,6 +6018,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Ge),
         },
@@ -6013,6 +6027,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Le),
         },
@@ -6021,6 +6036,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Gt),
         },
@@ -6029,6 +6045,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Nv),
         },
@@ -6037,6 +6054,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::TrapIf {
+            size: OperandSize::Size64,
             trap_code: TrapCode::STACK_OVERFLOW,
             kind: CondBrKind::Cond(Cond::Al),
         },

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1234,6 +1234,7 @@ impl Inst {
                 rn,
                 rm,
             } => {
+                dbg!(alu_op, size);
                 let op = op_name(alu_op);
                 let rd = pretty_print_ireg(rd.to_reg(), size);
                 let rn = pretty_print_ireg(rn, size);

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -873,7 +873,7 @@ fn aarch64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             }
         }
         Inst::CondBr { kind, .. } => match kind {
-            CondBrKind::Zero(rt) | CondBrKind::NotZero(rt) => collector.reg_use(rt),
+            CondBrKind::Zero(rt, _) | CondBrKind::NotZero(rt, _) => collector.reg_use(rt),
             CondBrKind::Cond(_) => {}
         },
         Inst::TestBitAndBranch { rn, .. } => {
@@ -886,7 +886,7 @@ fn aarch64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         Inst::Brk => {}
         Inst::Udf { .. } => {}
         Inst::TrapIf { kind, .. } => match kind {
-            CondBrKind::Zero(rt) | CondBrKind::NotZero(rt) => collector.reg_use(rt),
+            CondBrKind::Zero(rt, _) | CondBrKind::NotZero(rt, _) => collector.reg_use(rt),
             CondBrKind::Cond(_) => {}
         },
         Inst::Adr { rd, .. } | Inst::Adrp { rd, .. } => {
@@ -2632,12 +2632,12 @@ impl Inst {
                 let taken = taken.pretty_print(0);
                 let not_taken = not_taken.pretty_print(0);
                 match kind {
-                    &CondBrKind::Zero(reg) => {
-                        let reg = pretty_print_reg(reg);
+                    &CondBrKind::Zero(reg, size) => {
+                        let reg = pretty_print_reg_sized(reg, size);
                         format!("cbz {reg}, {taken} ; b {not_taken}")
                     }
-                    &CondBrKind::NotZero(reg) => {
-                        let reg = pretty_print_reg(reg);
+                    &CondBrKind::NotZero(reg, size) => {
+                        let reg = pretty_print_reg_sized(reg, size);
                         format!("cbnz {reg}, {taken} ; b {not_taken}")
                     }
                     &CondBrKind::Cond(c) => {
@@ -2669,15 +2669,14 @@ impl Inst {
             &Inst::Brk => "brk #0".to_string(),
             &Inst::Udf { .. } => "udf #0xc11f".to_string(),
             &Inst::TrapIf {
-                size,
                 ref kind,
                 trap_code,
             } => match kind {
-                &CondBrKind::Zero(reg) => {
+                &CondBrKind::Zero(reg, size) => {
                     let reg = pretty_print_reg_sized(reg, size);
                     format!("cbz {reg}, #trap={trap_code}")
                 }
-                &CondBrKind::NotZero(reg) => {
+                &CondBrKind::NotZero(reg, size) => {
                     let reg = pretty_print_reg_sized(reg, size);
                     format!("cbnz {reg}, #trap={trap_code}")
                 }

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1234,7 +1234,6 @@ impl Inst {
                 rn,
                 rm,
             } => {
-                dbg!(alu_op, size);
                 let op = op_name(alu_op);
                 let rd = pretty_print_ireg(rd.to_reg(), size);
                 let rn = pretty_print_ireg(rn, size);

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2669,15 +2669,16 @@ impl Inst {
             &Inst::Brk => "brk #0".to_string(),
             &Inst::Udf { .. } => "udf #0xc11f".to_string(),
             &Inst::TrapIf {
+                size,
                 ref kind,
                 trap_code,
             } => match kind {
                 &CondBrKind::Zero(reg) => {
-                    let reg = pretty_print_reg(reg);
+                    let reg = pretty_print_reg_sized(reg, size);
                     format!("cbz {reg}, #trap={trap_code}")
                 }
                 &CondBrKind::NotZero(reg) => {
-                    let reg = pretty_print_reg(reg);
+                    let reg = pretty_print_reg_sized(reg, size);
                     format!("cbnz {reg}, #trap={trap_code}")
                 }
                 &CondBrKind::Cond(c) => {

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -179,6 +179,18 @@ pub fn pretty_print_reg(reg: Reg) -> String {
     show_reg(reg)
 }
 
+fn show_reg_sized(reg: Reg, size: OperandSize) -> String {
+    match reg.class() {
+        RegClass::Int => show_ireg_sized(reg, size),
+        RegClass::Float => todo!(),
+        RegClass::Vector => unreachable!(),
+    }
+}
+
+pub fn pretty_print_reg_sized(reg: Reg, size: OperandSize) -> String {
+    show_reg_sized(reg, size)
+}
+
 /// If `ireg` denotes an Int-classed reg, make a best-effort attempt to show
 /// its name at the 32-bit size.
 pub fn show_ireg_sized(reg: Reg, size: OperandSize) -> String {

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -182,7 +182,7 @@ pub fn pretty_print_reg(reg: Reg) -> String {
 fn show_reg_sized(reg: Reg, size: OperandSize) -> String {
     match reg.class() {
         RegClass::Int => show_ireg_sized(reg, size),
-        RegClass::Float => todo!(),
+        RegClass::Float => show_reg(reg),
         RegClass::Vector => unreachable!(),
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1031,7 +1031,7 @@
 ;; Note that aarch64's `udiv` doesn't trap so to respect the semantics of
 ;; CLIF's `udiv` the check for zero needs to be manually performed.
 (rule udiv 1 (lower (has_type $I64 (udiv x y)))
-        (a64_udiv $I64 (put_in_reg x) (trap_if_zero_divisor (put_in_reg y))))
+      (a64_udiv $I64 (put_in_reg x) (trap_if_zero_divisor (put_in_reg y))))
 
 (rule udiv (lower (has_type (fits_in_32 ty) (udiv x y)))
       (a64_udiv $I32 (put_in_reg x) (put_nonzero_in_reg y)))

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -3095,14 +3095,14 @@
             (rt Reg (orr $I64 c_lo c_hi)))
        (emit_side_effect
         (with_flags_side_effect flags
-         (cond_br taken not_taken (cond_br_not_zero rt))))))
+         (cond_br taken not_taken (cond_br_not_zero rt (operand_size $I64)))))))
 (rule -2 (lower_branch (brif c @ (value_type ty) _ _) (two_targets taken not_taken))
       (if (ty_int_ref_scalar_64 ty))
       (let ((flags ProducesFlags (flags_to_producesflags c))
             (rt Reg (put_in_reg_zext64 c)))
        (emit_side_effect
         (with_flags_side_effect flags
-         (cond_br taken not_taken (cond_br_not_zero rt))))))
+         (cond_br taken not_taken (cond_br_not_zero rt (operand_size $I64)))))))
 
 ;; Special lowerings for `tbnz` - "Test bit and Branch if Nonzero"
 (rule 1 (lower_branch (brif (band x @ (value_type ty) (u64_from_iconst n)) _ _)

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1030,33 +1030,35 @@
 
 ;; Note that aarch64's `udiv` doesn't trap so to respect the semantics of
 ;; CLIF's `udiv` the check for zero needs to be manually performed.
+
 (rule udiv 1 (lower (has_type $I64 (udiv x y)))
-      (a64_udiv $I64 (put_in_reg x) (trap_if_zero_divisor (put_in_reg y))))
+      (a64_udiv $I64 (put_in_reg x) (put_nonzero_in_reg y)))
 
 (rule udiv (lower (has_type (fits_in_32 ty) (udiv x y)))
-      (a64_udiv $I32 (put_in_reg x) (put_nonzero_in_reg y)))
+      (a64_udiv $I32 (put_in_reg_zext32 x) (put_nonzero_in_reg y)))
 
+;; helpers for udiv:
 ;; Helper for placing a `Value` into a `Reg` and validating that it's nonzero.
-(spec (put_nonzero_in_reg x)
-      (provide (= result (zero_ext 64 x)))
-      (require (not (= result #x0000000000000000))))
 (decl put_nonzero_in_reg (Value) Reg)
-(rule -1 (put_nonzero_in_reg val)
-      (trap_if_zero_divisor (put_in_reg val)))
 
 ;; Special case where if a `Value` is known to be nonzero we can trivially
 ;; move it into a register.
-(rule (put_nonzero_in_reg (and (value_type ty)
-                                      (iconst (nonzero_u64_from_imm64 n))))
+(rule (put_nonzero_in_reg (and (value_type ty) (iconst (nonzero_u64_from_imm64 n))))
       (imm ty (ImmExtend.Zero) n))
 
-;; Helper for placing a `Value` into a `Reg` and validating that it's nonzero.
+(rule -1 (put_nonzero_in_reg (and (value_type $I64) val))
+      (trap_if_zero_divisor (put_in_reg val) (operand_size $I64)))
+
+(rule -2 (put_nonzero_in_reg (and (value_type (fits_in_32 _)) val))
+      (trap_if_zero_divisor (put_in_reg_zext32 val) (operand_size $I32)))
+
+;; Helper for placing a `Value` into a `Reg` and validating that it's nonzero and extending it to 64 bits.
 (spec (put_nonzero_in_reg_zext64 x)
       (provide (= result (zero_ext 64 x)))
       (require (not (= result #x0000000000000000))))
 (decl put_nonzero_in_reg_zext64 (Value) Reg)
-(rule -1 (put_nonzero_in_reg_zext64 val)
-      (trap_if_zero_divisor (put_in_reg_zext64 val)))
+(rule -1 (put_nonzero_in_reg_zext64 (and (value_type ty) val))
+      (trap_if_zero_divisor (put_in_reg_zext64 val) (operand_size ty)))
 
 ;; Special case where if a `Value` is known to be nonzero we can trivially
 ;; move it into a register.
@@ -1106,7 +1108,7 @@
        (require (not (= #x0000000000000000 result))))
 (decl put_nonzero_in_reg_sext64 (Value) Reg)
 (rule -1 (put_nonzero_in_reg_sext64 val)
-      (trap_if_zero_divisor (put_in_reg_sext64 val)))
+      (trap_if_zero_divisor (put_in_reg_sext64 val) (operand_size $I64)))
 
 ;; Note that this has a special case where if the `Value` is a constant that's
 ;; not zero we can skip the zero check.

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1028,13 +1028,27 @@
 
 ;;;; Rules for `udiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: Add UDiv32 to implement 32-bit directly, rather
-;; than extending the input.
-;;
 ;; Note that aarch64's `udiv` doesn't trap so to respect the semantics of
 ;; CLIF's `udiv` the check for zero needs to be manually performed.
-(rule udiv (lower (has_type (fits_in_64 ty) (udiv x y)))
-      (a64_udiv $I64 (put_in_reg_zext64 x) (put_nonzero_in_reg_zext64 y)))
+(rule udiv 1 (lower (has_type $I64 (udiv x y)))
+        (a64_udiv $I64 (put_in_reg x) (trap_if_zero_divisor (put_in_reg y))))
+
+(rule udiv (lower (has_type (fits_in_32 ty) (udiv x y)))
+      (a64_udiv $I32 (put_in_reg x) (put_nonzero_in_reg y)))
+
+;; Helper for placing a `Value` into a `Reg` and validating that it's nonzero.
+(spec (put_nonzero_in_reg x)
+      (provide (= result (zero_ext 64 x)))
+      (require (not (= result #x0000000000000000))))
+(decl put_nonzero_in_reg (Value) Reg)
+(rule -1 (put_nonzero_in_reg val)
+      (trap_if_zero_divisor (put_in_reg val)))
+
+;; Special case where if a `Value` is known to be nonzero we can trivially
+;; move it into a register.
+(rule (put_nonzero_in_reg (and (value_type ty)
+                                      (iconst (nonzero_u64_from_imm64 n))))
+      (imm ty (ImmExtend.Zero) n))
 
 ;; Helper for placing a `Value` into a `Reg` and validating that it's nonzero.
 (spec (put_nonzero_in_reg_zext64 x)

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -354,12 +354,12 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
         self.lower_ctx.emit(inst.clone());
     }
 
-    fn cond_br_zero(&mut self, reg: Reg) -> CondBrKind {
-        CondBrKind::Zero(reg)
+    fn cond_br_zero(&mut self, reg: Reg, size: &OperandSize) -> CondBrKind {
+        CondBrKind::Zero(reg, *size)
     }
 
-    fn cond_br_not_zero(&mut self, reg: Reg) -> CondBrKind {
-        CondBrKind::NotZero(reg)
+    fn cond_br_not_zero(&mut self, reg: Reg, size: &OperandSize) -> CondBrKind {
+        CondBrKind::NotZero(reg, *size)
     }
 
     fn cond_br_cond(&mut self, cond: &Cond) -> CondBrKind {

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -2061,7 +2061,7 @@ mod test {
 
     use super::*;
     use crate::ir::UserExternalNameRef;
-    use crate::isa::aarch64::inst::xreg;
+    use crate::isa::aarch64::inst::{xreg, OperandSize};
     use crate::isa::aarch64::inst::{BranchTarget, CondBrKind, EmitInfo, Inst};
     use crate::machinst::{MachInstEmit, MachInstEmitState};
     use crate::settings;
@@ -2100,7 +2100,7 @@ mod test {
 
         buf.bind_label(label(0), state.ctrl_plane_mut());
         let inst = Inst::CondBr {
-            kind: CondBrKind::NotZero(xreg(0)),
+            kind: CondBrKind::NotZero(xreg(0), OperandSize::Size64),
             taken: target(1),
             not_taken: target(2),
         };
@@ -2131,7 +2131,7 @@ mod test {
 
         buf.bind_label(label(0), state.ctrl_plane_mut());
         let inst = Inst::CondBr {
-            kind: CondBrKind::Zero(xreg(0)),
+            kind: CondBrKind::Zero(xreg(0), OperandSize::Size64),
             taken: target(1),
             not_taken: target(2),
         };
@@ -2154,8 +2154,7 @@ mod test {
         let mut buf2 = MachBuffer::new();
         let mut state = Default::default();
         let inst = Inst::TrapIf {
-            size: crate::isa::aarch64::inst::OperandSize::Size64,
-            kind: CondBrKind::NotZero(xreg(0)),
+            kind: CondBrKind::NotZero(xreg(0), OperandSize::Size64),
             trap_code: TrapCode::STACK_OVERFLOW,
         };
         inst.emit(&mut buf2, &info, &mut state);
@@ -2178,7 +2177,7 @@ mod test {
 
         buf.bind_label(label(0), state.ctrl_plane_mut());
         let inst = Inst::CondBr {
-            kind: CondBrKind::NotZero(xreg(0)),
+            kind: CondBrKind::NotZero(xreg(0), OperandSize::Size64),
             taken: target(2),
             not_taken: target(3),
         };
@@ -2208,7 +2207,7 @@ mod test {
         let mut buf2 = MachBuffer::new();
         let mut state = Default::default();
         let inst = Inst::CondBr {
-            kind: CondBrKind::NotZero(xreg(0)),
+            kind: CondBrKind::NotZero(xreg(0), OperandSize::Size64),
 
             // This conditionally taken branch has a 19-bit constant, shifted
             // to the left by two, giving us a 21-bit range in total. Half of
@@ -2261,7 +2260,7 @@ mod test {
 
         buf.bind_label(label(3), state.ctrl_plane_mut());
         let inst = Inst::CondBr {
-            kind: CondBrKind::NotZero(xreg(0)),
+            kind: CondBrKind::NotZero(xreg(0), OperandSize::Size64),
             taken: target(0),
             not_taken: target(1),
         };
@@ -2274,7 +2273,7 @@ mod test {
         let mut buf2 = MachBuffer::new();
         let mut state = Default::default();
         let inst = Inst::CondBr {
-            kind: CondBrKind::NotZero(xreg(0)),
+            kind: CondBrKind::NotZero(xreg(0), OperandSize::Size64),
             taken: BranchTarget::ResolvedOffset(8),
             not_taken: BranchTarget::ResolvedOffset(4 - (2000000 + 4)),
         };
@@ -2333,7 +2332,7 @@ mod test {
 
         buf.bind_label(label(0), state.ctrl_plane_mut());
         let inst = Inst::CondBr {
-            kind: CondBrKind::Zero(xreg(0)),
+            kind: CondBrKind::Zero(xreg(0), OperandSize::Size64),
             taken: target(1),
             not_taken: target(2),
         };

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -2154,6 +2154,7 @@ mod test {
         let mut buf2 = MachBuffer::new();
         let mut state = Default::default();
         let inst = Inst::TrapIf {
+            size: crate::isa::aarch64::inst::OperandSize::Size64,
             kind: CondBrKind::NotZero(xreg(0)),
             trap_code: TrapCode::STACK_OVERFLOW,
         };

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -266,18 +266,14 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   mov w3, w0
-;   mov w5, w1
-;   cbz x5, #trap=int_divz
-;   udiv x0, x3, x5
+;   cbz w1, #trap=int_divz
+;   udiv w0, w0, w1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w3, w0
-;   mov w5, w1
-;   cbz x5, #0x14
-;   udiv x0, x3, x5
+;   cbz w1, #0xc
+;   udiv w0, w0, w1
 ;   ret
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
 
@@ -290,16 +286,14 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   mov w2, w0
-;   movz w4, #2
-;   udiv x0, x2, x4
+;   movz w2, #2
+;   udiv w0, w0, w2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w2, w0
-;   mov w4, #2
-;   udiv x0, x2, x4
+;   mov w2, #2
+;   udiv w0, w0, w2
 ;   ret
 
 function %f16(i32, i32) -> i32 {
@@ -337,7 +331,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   mov w3, w0
 ;   mov w5, w1
-;   cbz x5, #trap=int_divz
+;   cbz w5, #trap=int_divz
 ;   udiv x8, x3, x5
 ;   msub x0, x8, x5, x3
 ;   ret
@@ -346,7 +340,7 @@ block0(v0: i32, v1: i32):
 ; block0: ; offset 0x0
 ;   mov w3, w0
 ;   mov w5, w1
-;   cbz x5, #0x18
+;   cbz w5, #0x18
 ;   udiv x8, x3, x5
 ;   msub x0, x8, x5, x3
 ;   ret

--- a/tests/disas/winch/aarch64/i32_divs/const.wat
+++ b/tests/disas/winch/aarch64/i32_divs/const.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
-;;       cbz     x0, #0x60
+;;       cbz     w0, #0x60
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
 ;;       b.vs    #0x64

--- a/tests/disas/winch/aarch64/i32_divs/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/one_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     x0, #0x60
+;;       cbz     w0, #0x60
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
 ;;       b.vs    #0x64

--- a/tests/disas/winch/aarch64/i32_divs/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_divs/overflow.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x80000000
 ;;       mov     w1, w16
-;;       cbz     x0, #0x60
+;;       cbz     w0, #0x60
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
 ;;       b.vs    #0x64

--- a/tests/disas/winch/aarch64/i32_divs/params.wat
+++ b/tests/disas/winch/aarch64/i32_divs/params.wat
@@ -22,7 +22,7 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     x0, #0x60
+;;       cbz     w0, #0x60
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
 ;;       b.vs    #0x64

--- a/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     x0, #0x60
+;;       cbz     w0, #0x60
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
 ;;       b.vs    #0x64

--- a/tests/disas/winch/aarch64/i32_divu/const.wat
+++ b/tests/disas/winch/aarch64/i32_divu/const.wat
@@ -22,13 +22,11 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
-;;       cbz     x0, #0x54
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x1, x1, x0
+;;       cbz     x0, #0x4c
+;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/const.wat
+++ b/tests/disas/winch/aarch64/i32_divu/const.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
-;;       cbz     x0, #0x4c
+;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/tests/disas/winch/aarch64/i32_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/one_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     x0, #0x4c
+;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/tests/disas/winch/aarch64/i32_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/one_zero.wat
@@ -22,13 +22,11 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     x0, #0x54
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x1, x1, x0
+;;       cbz     x0, #0x4c
+;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/params.wat
+++ b/tests/disas/winch/aarch64/i32_divu/params.wat
@@ -22,13 +22,11 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     x0, #0x54
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x1, x1, x0
+;;       cbz     x0, #0x4c
+;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/params.wat
+++ b/tests/disas/winch/aarch64/i32_divu/params.wat
@@ -22,7 +22,7 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     x0, #0x4c
+;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x18

--- a/tests/disas/winch/aarch64/i32_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_divu/signed.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     x0, #0x4c
+;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/tests/disas/winch/aarch64/i32_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_divu/signed.wat
@@ -22,13 +22,11 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     x0, #0x54
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x1, x1, x0
+;;       cbz     x0, #0x4c
+;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
@@ -22,13 +22,11 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     x0, #0x54
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x1, x1, x0
+;;       cbz     x0, #0x4c
+;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     x0, #0x4c
+;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10

--- a/tests/disas/winch/aarch64/i32_rems/const.wat
+++ b/tests/disas/winch/aarch64/i32_rems/const.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #7
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
+;;       cbz     w0, #0x58
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0

--- a/tests/disas/winch/aarch64/i32_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/one_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
+;;       cbz     w0, #0x58
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0

--- a/tests/disas/winch/aarch64/i32_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_rems/overflow.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x80000000
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
+;;       cbz     w0, #0x58
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0

--- a/tests/disas/winch/aarch64/i32_rems/params.wat
+++ b/tests/disas/winch/aarch64/i32_rems/params.wat
@@ -22,7 +22,7 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     x0, #0x58
+;;       cbz     w0, #0x58
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0

--- a/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
+;;       cbz     w0, #0x58
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0

--- a/tests/disas/winch/aarch64/i32_remu/const.wat
+++ b/tests/disas/winch/aarch64/i32_remu/const.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #7
 ;;       mov     w1, w16
-;;       cbz     x0, #0x50
+;;       cbz     w0, #0x50
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/const.wat
+++ b/tests/disas/winch/aarch64/i32_remu/const.wat
@@ -22,14 +22,12 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #7
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x16, x1, x0
-;;       msub    x1, x0, x16, x1
+;;       cbz     x0, #0x50
+;;   34: udiv    w16, w1, w0
+;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/one_zero.wat
@@ -22,14 +22,12 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x16, x1, x0
-;;       msub    x1, x0, x16, x1
+;;       cbz     x0, #0x50
+;;   34: udiv    w16, w1, w0
+;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/one_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     x0, #0x50
+;;       cbz     w0, #0x50
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/params.wat
+++ b/tests/disas/winch/aarch64/i32_remu/params.wat
@@ -22,14 +22,12 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     x0, #0x58
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x16, x1, x0
-;;       msub    x1, x0, x16, x1
+;;       cbz     x0, #0x50
+;;   34: udiv    w16, w1, w0
+;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/params.wat
+++ b/tests/disas/winch/aarch64/i32_remu/params.wat
@@ -22,7 +22,7 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     x0, #0x50
+;;       cbz     w0, #0x50
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_remu/signed.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     x0, #0x50
+;;       cbz     w0, #0x50
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_remu/signed.wat
@@ -22,14 +22,12 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x16, x1, x0
-;;       msub    x1, x0, x16, x1
+;;       cbz     x0, #0x50
+;;   34: udiv    w16, w1, w0
+;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     x0, #0x50
+;;       cbz     w0, #0x50
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1

--- a/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
@@ -22,14 +22,12 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     x0, #0x58
-;;   34: mov     w0, w0
-;;       mov     w1, w1
-;;       udiv    x16, x1, x0
-;;       msub    x1, x0, x16, x1
+;;       cbz     x0, #0x50
+;;   34: udiv    w16, w1, w0
+;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -447,19 +447,12 @@ impl Assembler {
             size
         };
 
-
         let op = match kind {
             DivKind::Signed => ALUOp::SDiv,
             DivKind::Unsigned => ALUOp::UDiv,
         };
 
-        self.emit_alu_rrr(
-            op,
-            divisor,
-            dividend,
-            dest.map(Into::into),
-            size,
-        );
+        self.emit_alu_rrr(op, divisor, dividend, dest.map(Into::into), size);
     }
 
     /// Signed/unsigned remainder operation with three registers.
@@ -491,13 +484,7 @@ impl Assembler {
         };
 
         let scratch = regs::scratch();
-        self.emit_alu_rrr(
-            op,
-            divisor,
-            dividend,
-            writable!(scratch.into()),
-            size,
-        );
+        self.emit_alu_rrr(op, divisor, dividend, writable!(scratch.into()), size);
 
         self.emit_alu_rrrr(
             ALUOp3::MSub,

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -410,7 +410,7 @@ impl Assembler {
         size: OperandSize,
     ) {
         // Check for division by 0.
-        self.trapz(divisor, TrapCode::INTEGER_DIVISION_BY_ZERO);
+        self.trapz(divisor, TrapCode::INTEGER_DIVISION_BY_ZERO, size);
 
         // check for overflow
         if kind == DivKind::Signed {
@@ -465,7 +465,7 @@ impl Assembler {
         size: OperandSize,
     ) {
         // Check for division by 0
-        self.trapz(divisor, TrapCode::INTEGER_DIVISION_BY_ZERO);
+        self.trapz(divisor, TrapCode::INTEGER_DIVISION_BY_ZERO, size);
 
         // `cranelift-codegen` doesn't support emitting sdiv for anything but I64,
         // we therefore sign-extend the operand.
@@ -864,14 +864,16 @@ impl Assembler {
     /// Conditional trap.
     pub fn trapif(&mut self, cc: Cond, code: TrapCode) {
         self.emit(Inst::TrapIf {
+            size: OperandSize::S64.into(),
             kind: CondBrKind::Cond(cc),
             trap_code: code,
         });
     }
 
     /// Trap if `rn` is zero.
-    pub fn trapz(&mut self, rn: Reg, code: TrapCode) {
+    pub fn trapz(&mut self, rn: Reg, code: TrapCode, size: OperandSize) {
         self.emit(Inst::TrapIf {
+            size: size.into(),
             kind: CondBrKind::Zero(rn.into()),
             trap_code: code,
         });

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -10,6 +10,7 @@ use crate::{
     masm::OperandSize,
     reg::{writable, Reg, WritableReg},
 };
+
 use cranelift_codegen::isa::aarch64::inst::{UImm5, NZCV};
 use cranelift_codegen::{
     ir::{ExternalName, LibCall, MemFlags, SourceLoc, TrapCode, UserExternalNameRef},
@@ -864,7 +865,6 @@ impl Assembler {
     /// Conditional trap.
     pub fn trapif(&mut self, cc: Cond, code: TrapCode) {
         self.emit(Inst::TrapIf {
-            size: OperandSize::S64.into(),
             kind: CondBrKind::Cond(cc),
             trap_code: code,
         });
@@ -873,8 +873,7 @@ impl Assembler {
     /// Trap if `rn` is zero.
     pub fn trapz(&mut self, rn: Reg, code: TrapCode, size: OperandSize) {
         self.emit(Inst::TrapIf {
-            size: size.into(),
-            kind: CondBrKind::Zero(rn.into()),
+            kind: CondBrKind::Zero(rn.into(), size.into()),
             trap_code: code,
         });
     }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -698,7 +698,7 @@ impl Masm for MacroAssembler {
     }
 
     fn trapz(&mut self, src: Reg, code: TrapCode) {
-        self.asm.trapz(src, code);
+        self.asm.trapz(src, code, OperandSize::S64);
     }
 
     fn trapif(&mut self, cc: IntCmpKind, code: TrapCode) {


### PR DESCRIPTION
This PR takes first steps towards completing #9766, by implementing support for 32bit unsigned division in cranelift and winch.
we had to take the following steps to enable that:

-  extend the ISLE lowering rules in cranelift to properly handle 32bits udiv, by have a rule that matches 64bit division, and another for anything else that fits 32bit. The 32 bits basically is the old 64bits rule but for 32bits.
- stop extending registers to 64bits in the ISLE rules.
- patch the emit code to emit the correct instruction for 32bits division.
- in winch: stop emitting extend operations for urem and udiv.
- Make `trap_if` size aware: this avoids having to perform extensions before `cbz`, shaving more instructions. This is reflected in the lowering rules for checking division by zero for udiv.