### PR TITLE
cli: add http outgoing body options

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -375,6 +375,13 @@ wasmtime_option_group! {
         pub threads: Option<bool>,
         /// Enable support for WASI HTTP imports
         pub http: Option<bool>,
+        /// Number of distinct write calls to the outgoing body's output-stream
+        /// that the implementation will buffer.
+        /// Default: 1.
+        pub http_outgoing_body_buffer_chunks: Option<usize>,
+        /// Maximum size allowed in a write call to the outgoing body's output-stream.
+        /// Default: 1024 * 1024.
+        pub http_outgoing_body_chunk_size: Option<usize>,
         /// Enable support for WASI config imports (experimental)
         pub config: Option<bool>,
         /// Enable support for WASI key-value imports (experimental)

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -232,7 +232,10 @@ pub use crate::error::{
     http_request_error, hyper_request_error, hyper_response_error, HttpError, HttpResult,
 };
 #[doc(inline)]
-pub use crate::types::{WasiHttpCtx, WasiHttpImpl, WasiHttpView};
+pub use crate::types::{
+    WasiHttpCtx, WasiHttpImpl, WasiHttpView, DEFAULT_OUTGOING_BODY_BUFFER_CHUNKS,
+    DEFAULT_OUTGOING_BODY_CHUNK_SIZE,
+};
 
 /// Add all of the `wasi:http/proxy` world's interfaces to a [`wasmtime::component::Linker`].
 ///

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -130,15 +130,20 @@ pub trait WasiHttpView: Send {
     /// that the implementation will buffer.
     /// Default: 1.
     fn outgoing_body_buffer_chunks(&mut self) -> usize {
-        1
+        DEFAULT_OUTGOING_BODY_BUFFER_CHUNKS
     }
 
     /// Maximum size allowed in a write call to the outgoing body's output-stream.
     /// Default: 1024 * 1024.
     fn outgoing_body_chunk_size(&mut self) -> usize {
-        1024 * 1024
+        DEFAULT_OUTGOING_BODY_CHUNK_SIZE
     }
 }
+
+/// The default value configured for [`WasiHttpView::outgoing_body_buffer_chunks`] in [`WasiHttpView`].
+pub const DEFAULT_OUTGOING_BODY_BUFFER_CHUNKS: usize = 1;
+/// The default value configured for [`WasiHttpView::outgoing_body_chunk_size`] in [`WasiHttpView`].
+pub const DEFAULT_OUTGOING_BODY_CHUNK_SIZE: usize = 1024 * 1024;
 
 impl<T: ?Sized + WasiHttpView> WasiHttpView for &mut T {
     fn ctx(&mut self) -> &mut WasiHttpCtx {

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1714,6 +1714,30 @@ mod test_programs {
     }
 
     #[tokio::test]
+    async fn cli_serve_outgoing_body_config() -> Result<()> {
+        let server = WasmtimeServe::new(CLI_SERVE_ECHO_ENV_COMPONENT, |cmd| {
+            cmd.arg("-Scli");
+            cmd.arg("-Shttp-outgoing-body-buffer-chunks=2");
+            cmd.arg("-Shttp-outgoing-body-chunk-size=1024");
+        })?;
+
+        let resp = server
+            .send_request(
+                hyper::Request::builder()
+                    .uri("http://localhost/")
+                    .header("env", "FOO")
+                    .body(String::new())
+                    .context("failed to make request")?,
+            )
+            .await?;
+
+        assert!(resp.status().is_success());
+
+        server.finish()?;
+        Ok(())
+    }
+
+    #[tokio::test]
     #[ignore] // TODO: printing stderr in the child and killing the child at the
               // end of this test race so the stderr may be present or not. Need
               // to implement a more graceful shutdown routine for `wasmtime


### PR DESCRIPTION
Continue #9670, add support for configuring `outgoing_body_buffer_chunks` and `outgoing_body_chunk_size` in the wasmtime CLI.

cc @alexcrichton 