### PR TITLE
pulley: Move `fp`/`lr` out of `XReg` set

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -380,12 +380,6 @@
 (decl sp_reg () XReg)
 (extern constructor sp_reg sp_reg)
 
-(decl fp_reg () XReg)
-(extern constructor fp_reg fp_reg)
-
-(decl lr_reg () XReg)
-(extern constructor lr_reg lr_reg)
-
 (decl pulley_get_special (XReg) XReg)
 (rule (pulley_get_special reg)
       (let ((dst WritableXReg (temp_writable_xreg))

--- a/cranelift/codegen/src/isa/pulley_shared/inst/regs.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/regs.rs
@@ -89,10 +89,10 @@ define_registers! {
     x_reg(24) => x24, writable_x24;
     x_reg(25) => x25, writable_x25;
     x_reg(26) => x26, writable_x26;
+    x_reg(27) => x27, writable_x27;
+    x_reg(28) => x28, writable_x28;
 
-    x_reg(27) => stack_reg, writable_stack_reg;
-    x_reg(28) => lr_reg, writable_lr_reg;
-    x_reg(29) => fp_reg, writable_fp_reg;
+    x_reg(29) => stack_reg, writable_stack_reg;
     x_reg(30) => spilltmp_reg, writable_spilltmp_reg;
     x_reg(31) => spilltmp2_reg, writable_spilltmp2_reg;
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/regs.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/regs.rs
@@ -91,10 +91,10 @@ define_registers! {
     x_reg(26) => x26, writable_x26;
     x_reg(27) => x27, writable_x27;
     x_reg(28) => x28, writable_x28;
+    x_reg(29) => x29, writable_x29;
 
-    x_reg(29) => stack_reg, writable_stack_reg;
-    x_reg(30) => spilltmp_reg, writable_spilltmp_reg;
-    x_reg(31) => spilltmp2_reg, writable_spilltmp2_reg;
+    x_reg(30) => stack_reg, writable_stack_reg;
+    x_reg(31) => spilltmp_reg, writable_spilltmp_reg;
 
     f_reg(0) => f0, writable_f0;
     f_reg(1) => f1, writable_f1;

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -86,13 +86,11 @@
 
 ;;;; Rules for `get_frame_pointer` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (get_frame_pointer))
-      (pulley_get_special (fp_reg)))
+(rule (lower (get_frame_pointer)) (pulley_xmov_fp))
 
 ;;;; Rules for `get_return_address` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (get_return_address))
-      (pulley_get_special (lr_reg)))
+(rule (lower (get_return_address)) (pulley_xmov_lr))
 
 ;;;; Rules for `return` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -107,14 +107,6 @@ where
         XReg::new(regs::stack_reg()).unwrap()
     }
 
-    fn fp_reg(&mut self) -> XReg {
-        XReg::new(regs::fp_reg()).unwrap()
-    }
-
-    fn lr_reg(&mut self) -> XReg {
-        XReg::new(regs::lr_reg()).unwrap()
-    }
-
     fn cond_invert(&mut self, cond: &Cond) -> Cond {
         cond.invert()
     }

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -228,37 +228,37 @@ block0:
 ; VCode:
 ;   push_frame
 ;   stack_alloc32 112
-;   xstore64 sp+104, x18 // flags =  notrap aligned
-;   xstore64 sp+96, x19 // flags =  notrap aligned
+;   xstore64 sp+104, x17 // flags =  notrap aligned
+;   xstore64 sp+96, x18 // flags =  notrap aligned
 ;   xstore64 sp+88, x20 // flags =  notrap aligned
-;   xstore64 sp+80, x23 // flags =  notrap aligned
-;   xstore64 sp+72, x24 // flags =  notrap aligned
-;   xstore64 sp+64, x25 // flags =  notrap aligned
-;   xstore64 sp+56, x26 // flags =  notrap aligned
+;   xstore64 sp+80, x21 // flags =  notrap aligned
+;   xstore64 sp+72, x22 // flags =  notrap aligned
+;   xstore64 sp+64, x23 // flags =  notrap aligned
+;   xstore64 sp+56, x29 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xmov x23, x13
-;   xmov x25, x11
-;   x18 = xload64 OutgoingArg(0) // flags = notrap aligned
+;   xmov x20, x13
+;   xmov x22, x11
+;   x29 = xload64 OutgoingArg(0) // flags = notrap aligned
 ;   x11 = xload64 OutgoingArg(8) // flags = notrap aligned
 ;   x13 = xload64 OutgoingArg(16) // flags = notrap aligned
-;   x24 = xload64 OutgoingArg(24) // flags = notrap aligned
-;   x26 = xload64 OutgoingArg(32) // flags = notrap aligned
-;   xadd64 x20, x0, x1
-;   xadd64 x19, x2, x3
+;   x21 = xload64 OutgoingArg(24) // flags = notrap aligned
+;   x23 = xload64 OutgoingArg(32) // flags = notrap aligned
+;   xadd64 x18, x0, x1
+;   xadd64 x17, x2, x3
 ;   xadd64 x5, x4, x5
 ;   xadd64 x6, x6, x7
 ;   xadd64 x7, x8, x9
-;   xmov x0, x25
+;   xmov x0, x22
 ;   xadd64 x4, x10, x0
-;   xmov x10, x23
+;   xmov x10, x20
 ;   xadd64 x8, x12, x10
 ;   xadd64 x14, x14, x15
-;   xadd64 x15, x18, x11
+;   xadd64 x15, x29, x11
 ;   xadd64 x13, x11, x13
-;   xadd64 x0, x24, x26
-;   xadd64 x1, x20, x19
+;   xadd64 x0, x21, x23
+;   xadd64 x1, x18, x17
 ;   xadd64 x2, x5, x6
 ;   xadd64 x3, x7, x4
 ;   xadd64 x14, x8, x14
@@ -270,13 +270,13 @@ block0:
 ;   xadd64 x14, x0, x14
 ;   xadd64 x13, x13, x13
 ;   xadd64 x0, x14, x13
-;   x18 = xload64 sp+104 // flags = notrap aligned
-;   x19 = xload64 sp+96 // flags = notrap aligned
+;   x17 = xload64 sp+104 // flags = notrap aligned
+;   x18 = xload64 sp+96 // flags = notrap aligned
 ;   x20 = xload64 sp+88 // flags = notrap aligned
-;   x23 = xload64 sp+80 // flags = notrap aligned
-;   x24 = xload64 sp+72 // flags = notrap aligned
-;   x25 = xload64 sp+64 // flags = notrap aligned
-;   x26 = xload64 sp+56 // flags = notrap aligned
+;   x21 = xload64 sp+80 // flags = notrap aligned
+;   x22 = xload64 sp+72 // flags = notrap aligned
+;   x23 = xload64 sp+64 // flags = notrap aligned
+;   x29 = xload64 sp+56 // flags = notrap aligned
 ;   stack_free32 112
 ;   pop_frame
 ;   ret
@@ -284,36 +284,36 @@ block0:
 ; Disassembled:
 ; push_frame
 ; stack_alloc32 112
-; xstore64le_offset32 sp, 104, x18
-; xstore64le_offset32 sp, 96, x19
+; xstore64le_offset32 sp, 104, x17
+; xstore64le_offset32 sp, 96, x18
 ; xstore64le_offset32 sp, 88, x20
-; xstore64le_offset32 sp, 80, x23
-; xstore64le_offset32 sp, 72, x24
-; xstore64le_offset32 sp, 64, x25
-; xstore64le_offset32 sp, 56, x26
+; xstore64le_offset32 sp, 80, x21
+; xstore64le_offset32 sp, 72, x22
+; xstore64le_offset32 sp, 64, x23
+; xstore64le_offset32 sp, 56, x29
 ; xmov x0, sp
 ; call 0x0    // target = 0x3a
-; xmov x23, x13
-; xmov x25, x11
-; xload64le_offset32 x18, sp, 0
+; xmov x20, x13
+; xmov x22, x11
+; xload64le_offset32 x29, sp, 0
 ; xload64le_offset32 x11, sp, 8
 ; xload64le_offset32 x13, sp, 16
-; xload64le_offset32 x24, sp, 24
-; xload64le_offset32 x26, sp, 32
-; xadd64 x20, x0, x1
-; xadd64 x19, x2, x3
+; xload64le_offset32 x21, sp, 24
+; xload64le_offset32 x23, sp, 32
+; xadd64 x18, x0, x1
+; xadd64 x17, x2, x3
 ; xadd64 x5, x4, x5
 ; xadd64 x6, x6, x7
 ; xadd64 x7, x8, x9
-; xmov x0, x25
+; xmov x0, x22
 ; xadd64 x4, x10, x0
-; xmov x10, x23
+; xmov x10, x20
 ; xadd64 x8, x12, x10
 ; xadd64 x14, x14, x15
-; xadd64 x15, x18, x11
+; xadd64 x15, x29, x11
 ; xadd64 x13, x11, x13
-; xadd64 x0, x24, x26
-; xadd64 x1, x20, x19
+; xadd64 x0, x21, x23
+; xadd64 x1, x18, x17
 ; xadd64 x2, x5, x6
 ; xadd64 x3, x7, x4
 ; xadd64 x14, x8, x14
@@ -325,13 +325,13 @@ block0:
 ; xadd64 x14, x0, x14
 ; xadd64 x13, x13, x13
 ; xadd64 x0, x14, x13
-; xload64le_offset32 x18, sp, 104
-; xload64le_offset32 x19, sp, 96
+; xload64le_offset32 x17, sp, 104
+; xload64le_offset32 x18, sp, 96
 ; xload64le_offset32 x20, sp, 88
-; xload64le_offset32 x23, sp, 80
-; xload64le_offset32 x24, sp, 72
-; xload64le_offset32 x25, sp, 64
-; xload64le_offset32 x26, sp, 56
+; xload64le_offset32 x21, sp, 80
+; xload64le_offset32 x22, sp, 72
+; xload64le_offset32 x23, sp, 64
+; xload64le_offset32 x29, sp, 56
 ; stack_free32 112
 ; pop_frame
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -231,34 +231,34 @@ block0:
 ;   xstore64 sp+104, x18 // flags =  notrap aligned
 ;   xstore64 sp+96, x19 // flags =  notrap aligned
 ;   xstore64 sp+88, x20 // flags =  notrap aligned
-;   xstore64 sp+80, x21 // flags =  notrap aligned
-;   xstore64 sp+72, x23 // flags =  notrap aligned
-;   xstore64 sp+64, x24 // flags =  notrap aligned
-;   xstore64 sp+56, x25 // flags =  notrap aligned
+;   xstore64 sp+80, x23 // flags =  notrap aligned
+;   xstore64 sp+72, x24 // flags =  notrap aligned
+;   xstore64 sp+64, x25 // flags =  notrap aligned
+;   xstore64 sp+56, x26 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xmov x18, x13
-;   xmov x20, x11
-;   x24 = xload64 OutgoingArg(0) // flags = notrap aligned
+;   xmov x23, x13
+;   xmov x25, x11
+;   x18 = xload64 OutgoingArg(0) // flags = notrap aligned
 ;   x11 = xload64 OutgoingArg(8) // flags = notrap aligned
 ;   x13 = xload64 OutgoingArg(16) // flags = notrap aligned
-;   x19 = xload64 OutgoingArg(24) // flags = notrap aligned
-;   x21 = xload64 OutgoingArg(32) // flags = notrap aligned
-;   xadd64 x25, x0, x1
-;   xadd64 x23, x2, x3
+;   x24 = xload64 OutgoingArg(24) // flags = notrap aligned
+;   x26 = xload64 OutgoingArg(32) // flags = notrap aligned
+;   xadd64 x20, x0, x1
+;   xadd64 x19, x2, x3
 ;   xadd64 x5, x4, x5
 ;   xadd64 x6, x6, x7
 ;   xadd64 x7, x8, x9
-;   xmov x0, x20
+;   xmov x0, x25
 ;   xadd64 x4, x10, x0
-;   xmov x10, x18
+;   xmov x10, x23
 ;   xadd64 x8, x12, x10
 ;   xadd64 x14, x14, x15
-;   xadd64 x15, x24, x11
+;   xadd64 x15, x18, x11
 ;   xadd64 x13, x11, x13
-;   xadd64 x0, x19, x21
-;   xadd64 x1, x25, x23
+;   xadd64 x0, x24, x26
+;   xadd64 x1, x20, x19
 ;   xadd64 x2, x5, x6
 ;   xadd64 x3, x7, x4
 ;   xadd64 x14, x8, x14
@@ -273,10 +273,10 @@ block0:
 ;   x18 = xload64 sp+104 // flags = notrap aligned
 ;   x19 = xload64 sp+96 // flags = notrap aligned
 ;   x20 = xload64 sp+88 // flags = notrap aligned
-;   x21 = xload64 sp+80 // flags = notrap aligned
-;   x23 = xload64 sp+72 // flags = notrap aligned
-;   x24 = xload64 sp+64 // flags = notrap aligned
-;   x25 = xload64 sp+56 // flags = notrap aligned
+;   x23 = xload64 sp+80 // flags = notrap aligned
+;   x24 = xload64 sp+72 // flags = notrap aligned
+;   x25 = xload64 sp+64 // flags = notrap aligned
+;   x26 = xload64 sp+56 // flags = notrap aligned
 ;   stack_free32 112
 ;   pop_frame
 ;   ret
@@ -287,33 +287,33 @@ block0:
 ; xstore64le_offset32 sp, 104, x18
 ; xstore64le_offset32 sp, 96, x19
 ; xstore64le_offset32 sp, 88, x20
-; xstore64le_offset32 sp, 80, x21
-; xstore64le_offset32 sp, 72, x23
-; xstore64le_offset32 sp, 64, x24
-; xstore64le_offset32 sp, 56, x25
+; xstore64le_offset32 sp, 80, x23
+; xstore64le_offset32 sp, 72, x24
+; xstore64le_offset32 sp, 64, x25
+; xstore64le_offset32 sp, 56, x26
 ; xmov x0, sp
 ; call 0x0    // target = 0x3a
-; xmov x18, x13
-; xmov x20, x11
-; xload64le_offset32 x24, sp, 0
+; xmov x23, x13
+; xmov x25, x11
+; xload64le_offset32 x18, sp, 0
 ; xload64le_offset32 x11, sp, 8
 ; xload64le_offset32 x13, sp, 16
-; xload64le_offset32 x19, sp, 24
-; xload64le_offset32 x21, sp, 32
-; xadd64 x25, x0, x1
-; xadd64 x23, x2, x3
+; xload64le_offset32 x24, sp, 24
+; xload64le_offset32 x26, sp, 32
+; xadd64 x20, x0, x1
+; xadd64 x19, x2, x3
 ; xadd64 x5, x4, x5
 ; xadd64 x6, x6, x7
 ; xadd64 x7, x8, x9
-; xmov x0, x20
+; xmov x0, x25
 ; xadd64 x4, x10, x0
-; xmov x10, x18
+; xmov x10, x23
 ; xadd64 x8, x12, x10
 ; xadd64 x14, x14, x15
-; xadd64 x15, x24, x11
+; xadd64 x15, x18, x11
 ; xadd64 x13, x11, x13
-; xadd64 x0, x19, x21
-; xadd64 x1, x25, x23
+; xadd64 x0, x24, x26
+; xadd64 x1, x20, x19
 ; xadd64 x2, x5, x6
 ; xadd64 x3, x7, x4
 ; xadd64 x14, x8, x14
@@ -328,10 +328,10 @@ block0:
 ; xload64le_offset32 x18, sp, 104
 ; xload64le_offset32 x19, sp, 96
 ; xload64le_offset32 x20, sp, 88
-; xload64le_offset32 x21, sp, 80
-; xload64le_offset32 x23, sp, 72
-; xload64le_offset32 x24, sp, 64
-; xload64le_offset32 x25, sp, 56
+; xload64le_offset32 x23, sp, 80
+; xload64le_offset32 x24, sp, 72
+; xload64le_offset32 x25, sp, 64
+; xload64le_offset32 x26, sp, 56
 ; stack_free32 112
 ; pop_frame
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley32/special_regs.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/special_regs.clif
@@ -11,7 +11,7 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x29
+;   xmov x0, x30
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley32/special_regs.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/special_regs.clif
@@ -11,7 +11,7 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x27
+;   xmov x0, x29
 ;   pop_frame
 ;   ret
 ;
@@ -30,13 +30,13 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x29
+;   xmov_fp x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xmov x0, fp
+; xmov_fp x0
 ; pop_frame
 ; ret
 
@@ -49,13 +49,13 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x28
+;   xmov_lr x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xmov x0, lr
+; xmov_lr x0
 ; pop_frame
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -228,37 +228,37 @@ block0:
 ; VCode:
 ;   push_frame
 ;   stack_alloc32 112
-;   xstore64 sp+104, x18 // flags =  notrap aligned
-;   xstore64 sp+96, x19 // flags =  notrap aligned
+;   xstore64 sp+104, x17 // flags =  notrap aligned
+;   xstore64 sp+96, x18 // flags =  notrap aligned
 ;   xstore64 sp+88, x20 // flags =  notrap aligned
-;   xstore64 sp+80, x23 // flags =  notrap aligned
-;   xstore64 sp+72, x24 // flags =  notrap aligned
-;   xstore64 sp+64, x25 // flags =  notrap aligned
-;   xstore64 sp+56, x26 // flags =  notrap aligned
+;   xstore64 sp+80, x21 // flags =  notrap aligned
+;   xstore64 sp+72, x22 // flags =  notrap aligned
+;   xstore64 sp+64, x23 // flags =  notrap aligned
+;   xstore64 sp+56, x29 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xmov x23, x13
-;   xmov x25, x11
-;   x18 = xload64 OutgoingArg(0) // flags = notrap aligned
+;   xmov x20, x13
+;   xmov x22, x11
+;   x29 = xload64 OutgoingArg(0) // flags = notrap aligned
 ;   x11 = xload64 OutgoingArg(8) // flags = notrap aligned
 ;   x13 = xload64 OutgoingArg(16) // flags = notrap aligned
-;   x24 = xload64 OutgoingArg(24) // flags = notrap aligned
-;   x26 = xload64 OutgoingArg(32) // flags = notrap aligned
-;   xadd64 x20, x0, x1
-;   xadd64 x19, x2, x3
+;   x21 = xload64 OutgoingArg(24) // flags = notrap aligned
+;   x23 = xload64 OutgoingArg(32) // flags = notrap aligned
+;   xadd64 x18, x0, x1
+;   xadd64 x17, x2, x3
 ;   xadd64 x5, x4, x5
 ;   xadd64 x6, x6, x7
 ;   xadd64 x7, x8, x9
-;   xmov x0, x25
+;   xmov x0, x22
 ;   xadd64 x4, x10, x0
-;   xmov x10, x23
+;   xmov x10, x20
 ;   xadd64 x8, x12, x10
 ;   xadd64 x14, x14, x15
-;   xadd64 x15, x18, x11
+;   xadd64 x15, x29, x11
 ;   xadd64 x13, x11, x13
-;   xadd64 x0, x24, x26
-;   xadd64 x1, x20, x19
+;   xadd64 x0, x21, x23
+;   xadd64 x1, x18, x17
 ;   xadd64 x2, x5, x6
 ;   xadd64 x3, x7, x4
 ;   xadd64 x14, x8, x14
@@ -270,13 +270,13 @@ block0:
 ;   xadd64 x14, x0, x14
 ;   xadd64 x13, x13, x13
 ;   xadd64 x0, x14, x13
-;   x18 = xload64 sp+104 // flags = notrap aligned
-;   x19 = xload64 sp+96 // flags = notrap aligned
+;   x17 = xload64 sp+104 // flags = notrap aligned
+;   x18 = xload64 sp+96 // flags = notrap aligned
 ;   x20 = xload64 sp+88 // flags = notrap aligned
-;   x23 = xload64 sp+80 // flags = notrap aligned
-;   x24 = xload64 sp+72 // flags = notrap aligned
-;   x25 = xload64 sp+64 // flags = notrap aligned
-;   x26 = xload64 sp+56 // flags = notrap aligned
+;   x21 = xload64 sp+80 // flags = notrap aligned
+;   x22 = xload64 sp+72 // flags = notrap aligned
+;   x23 = xload64 sp+64 // flags = notrap aligned
+;   x29 = xload64 sp+56 // flags = notrap aligned
 ;   stack_free32 112
 ;   pop_frame
 ;   ret
@@ -284,36 +284,36 @@ block0:
 ; Disassembled:
 ; push_frame
 ; stack_alloc32 112
-; xstore64le_offset32 sp, 104, x18
-; xstore64le_offset32 sp, 96, x19
+; xstore64le_offset32 sp, 104, x17
+; xstore64le_offset32 sp, 96, x18
 ; xstore64le_offset32 sp, 88, x20
-; xstore64le_offset32 sp, 80, x23
-; xstore64le_offset32 sp, 72, x24
-; xstore64le_offset32 sp, 64, x25
-; xstore64le_offset32 sp, 56, x26
+; xstore64le_offset32 sp, 80, x21
+; xstore64le_offset32 sp, 72, x22
+; xstore64le_offset32 sp, 64, x23
+; xstore64le_offset32 sp, 56, x29
 ; xmov x0, sp
 ; call 0x0    // target = 0x3a
-; xmov x23, x13
-; xmov x25, x11
-; xload64le_offset32 x18, sp, 0
+; xmov x20, x13
+; xmov x22, x11
+; xload64le_offset32 x29, sp, 0
 ; xload64le_offset32 x11, sp, 8
 ; xload64le_offset32 x13, sp, 16
-; xload64le_offset32 x24, sp, 24
-; xload64le_offset32 x26, sp, 32
-; xadd64 x20, x0, x1
-; xadd64 x19, x2, x3
+; xload64le_offset32 x21, sp, 24
+; xload64le_offset32 x23, sp, 32
+; xadd64 x18, x0, x1
+; xadd64 x17, x2, x3
 ; xadd64 x5, x4, x5
 ; xadd64 x6, x6, x7
 ; xadd64 x7, x8, x9
-; xmov x0, x25
+; xmov x0, x22
 ; xadd64 x4, x10, x0
-; xmov x10, x23
+; xmov x10, x20
 ; xadd64 x8, x12, x10
 ; xadd64 x14, x14, x15
-; xadd64 x15, x18, x11
+; xadd64 x15, x29, x11
 ; xadd64 x13, x11, x13
-; xadd64 x0, x24, x26
-; xadd64 x1, x20, x19
+; xadd64 x0, x21, x23
+; xadd64 x1, x18, x17
 ; xadd64 x2, x5, x6
 ; xadd64 x3, x7, x4
 ; xadd64 x14, x8, x14
@@ -325,13 +325,13 @@ block0:
 ; xadd64 x14, x0, x14
 ; xadd64 x13, x13, x13
 ; xadd64 x0, x14, x13
-; xload64le_offset32 x18, sp, 104
-; xload64le_offset32 x19, sp, 96
+; xload64le_offset32 x17, sp, 104
+; xload64le_offset32 x18, sp, 96
 ; xload64le_offset32 x20, sp, 88
-; xload64le_offset32 x23, sp, 80
-; xload64le_offset32 x24, sp, 72
-; xload64le_offset32 x25, sp, 64
-; xload64le_offset32 x26, sp, 56
+; xload64le_offset32 x21, sp, 80
+; xload64le_offset32 x22, sp, 72
+; xload64le_offset32 x23, sp, 64
+; xload64le_offset32 x29, sp, 56
 ; stack_free32 112
 ; pop_frame
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -231,34 +231,34 @@ block0:
 ;   xstore64 sp+104, x18 // flags =  notrap aligned
 ;   xstore64 sp+96, x19 // flags =  notrap aligned
 ;   xstore64 sp+88, x20 // flags =  notrap aligned
-;   xstore64 sp+80, x21 // flags =  notrap aligned
-;   xstore64 sp+72, x23 // flags =  notrap aligned
-;   xstore64 sp+64, x24 // flags =  notrap aligned
-;   xstore64 sp+56, x25 // flags =  notrap aligned
+;   xstore64 sp+80, x23 // flags =  notrap aligned
+;   xstore64 sp+72, x24 // flags =  notrap aligned
+;   xstore64 sp+64, x25 // flags =  notrap aligned
+;   xstore64 sp+56, x26 // flags =  notrap aligned
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65279, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xmov x18, x13
-;   xmov x20, x11
-;   x24 = xload64 OutgoingArg(0) // flags = notrap aligned
+;   xmov x23, x13
+;   xmov x25, x11
+;   x18 = xload64 OutgoingArg(0) // flags = notrap aligned
 ;   x11 = xload64 OutgoingArg(8) // flags = notrap aligned
 ;   x13 = xload64 OutgoingArg(16) // flags = notrap aligned
-;   x19 = xload64 OutgoingArg(24) // flags = notrap aligned
-;   x21 = xload64 OutgoingArg(32) // flags = notrap aligned
-;   xadd64 x25, x0, x1
-;   xadd64 x23, x2, x3
+;   x24 = xload64 OutgoingArg(24) // flags = notrap aligned
+;   x26 = xload64 OutgoingArg(32) // flags = notrap aligned
+;   xadd64 x20, x0, x1
+;   xadd64 x19, x2, x3
 ;   xadd64 x5, x4, x5
 ;   xadd64 x6, x6, x7
 ;   xadd64 x7, x8, x9
-;   xmov x0, x20
+;   xmov x0, x25
 ;   xadd64 x4, x10, x0
-;   xmov x10, x18
+;   xmov x10, x23
 ;   xadd64 x8, x12, x10
 ;   xadd64 x14, x14, x15
-;   xadd64 x15, x24, x11
+;   xadd64 x15, x18, x11
 ;   xadd64 x13, x11, x13
-;   xadd64 x0, x19, x21
-;   xadd64 x1, x25, x23
+;   xadd64 x0, x24, x26
+;   xadd64 x1, x20, x19
 ;   xadd64 x2, x5, x6
 ;   xadd64 x3, x7, x4
 ;   xadd64 x14, x8, x14
@@ -273,10 +273,10 @@ block0:
 ;   x18 = xload64 sp+104 // flags = notrap aligned
 ;   x19 = xload64 sp+96 // flags = notrap aligned
 ;   x20 = xload64 sp+88 // flags = notrap aligned
-;   x21 = xload64 sp+80 // flags = notrap aligned
-;   x23 = xload64 sp+72 // flags = notrap aligned
-;   x24 = xload64 sp+64 // flags = notrap aligned
-;   x25 = xload64 sp+56 // flags = notrap aligned
+;   x23 = xload64 sp+80 // flags = notrap aligned
+;   x24 = xload64 sp+72 // flags = notrap aligned
+;   x25 = xload64 sp+64 // flags = notrap aligned
+;   x26 = xload64 sp+56 // flags = notrap aligned
 ;   stack_free32 112
 ;   pop_frame
 ;   ret
@@ -287,33 +287,33 @@ block0:
 ; xstore64le_offset32 sp, 104, x18
 ; xstore64le_offset32 sp, 96, x19
 ; xstore64le_offset32 sp, 88, x20
-; xstore64le_offset32 sp, 80, x21
-; xstore64le_offset32 sp, 72, x23
-; xstore64le_offset32 sp, 64, x24
-; xstore64le_offset32 sp, 56, x25
+; xstore64le_offset32 sp, 80, x23
+; xstore64le_offset32 sp, 72, x24
+; xstore64le_offset32 sp, 64, x25
+; xstore64le_offset32 sp, 56, x26
 ; xmov x0, sp
 ; call 0x0    // target = 0x3a
-; xmov x18, x13
-; xmov x20, x11
-; xload64le_offset32 x24, sp, 0
+; xmov x23, x13
+; xmov x25, x11
+; xload64le_offset32 x18, sp, 0
 ; xload64le_offset32 x11, sp, 8
 ; xload64le_offset32 x13, sp, 16
-; xload64le_offset32 x19, sp, 24
-; xload64le_offset32 x21, sp, 32
-; xadd64 x25, x0, x1
-; xadd64 x23, x2, x3
+; xload64le_offset32 x24, sp, 24
+; xload64le_offset32 x26, sp, 32
+; xadd64 x20, x0, x1
+; xadd64 x19, x2, x3
 ; xadd64 x5, x4, x5
 ; xadd64 x6, x6, x7
 ; xadd64 x7, x8, x9
-; xmov x0, x20
+; xmov x0, x25
 ; xadd64 x4, x10, x0
-; xmov x10, x18
+; xmov x10, x23
 ; xadd64 x8, x12, x10
 ; xadd64 x14, x14, x15
-; xadd64 x15, x24, x11
+; xadd64 x15, x18, x11
 ; xadd64 x13, x11, x13
-; xadd64 x0, x19, x21
-; xadd64 x1, x25, x23
+; xadd64 x0, x24, x26
+; xadd64 x1, x20, x19
 ; xadd64 x2, x5, x6
 ; xadd64 x3, x7, x4
 ; xadd64 x14, x8, x14
@@ -328,10 +328,10 @@ block0:
 ; xload64le_offset32 x18, sp, 104
 ; xload64le_offset32 x19, sp, 96
 ; xload64le_offset32 x20, sp, 88
-; xload64le_offset32 x21, sp, 80
-; xload64le_offset32 x23, sp, 72
-; xload64le_offset32 x24, sp, 64
-; xload64le_offset32 x25, sp, 56
+; xload64le_offset32 x23, sp, 80
+; xload64le_offset32 x24, sp, 72
+; xload64le_offset32 x25, sp, 64
+; xload64le_offset32 x26, sp, 56
 ; stack_free32 112
 ; pop_frame
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley64/special_regs.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/special_regs.clif
@@ -11,7 +11,7 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x29
+;   xmov x0, x30
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley64/special_regs.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/special_regs.clif
@@ -11,7 +11,7 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x27
+;   xmov x0, x29
 ;   pop_frame
 ;   ret
 ;
@@ -30,13 +30,13 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x29
+;   xmov_fp x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xmov x0, fp
+; xmov_fp x0
 ; pop_frame
 ; ret
 
@@ -49,13 +49,13 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xmov x0, x28
+;   xmov_lr x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xmov x0, lr
+; xmov_lr x0
 ; pop_frame
 ; ret
 

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -512,6 +512,12 @@ macro_rules! for_each_extended_op {
             /// assembled into the final object that Wasmtime will interpret.
             call_indirect_host = CallIndirectHost { id: u8 };
 
+            /// Gets the special "fp" register and moves it into `dst`.
+            xmov_fp = XmovFp { dst: XReg };
+
+            /// Gets the special "lr" register and moves it into `dst`.
+            xmov_lr = XmovLr { dst: XReg };
+
             /// `dst = byteswap(low32(src))`
             bswap32 = Bswap32 { dst: XReg, src: XReg };
             /// `dst = byteswap(src)`

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -301,8 +301,6 @@ mod tests {
     #[test]
     fn special_x_regs() {
         assert!(XReg::sp.is_special());
-        assert!(XReg::lr.is_special());
-        assert!(XReg::fp.is_special());
         assert!(XReg::spilltmp0.is_special());
         assert!(XReg::spilltmp1.is_special());
     }

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -69,16 +69,10 @@ macro_rules! impl_reg {
 pub enum XReg {
     x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,  x8,  x9,
     x10, x11, x12, x13, x14, x15, x16, x17, x18, x19,
-    x20, x21, x22, x23, x24, x25, x26,
+    x20, x21, x22, x23, x24, x25, x26, x27, x28,
 
     /// The special `sp` stack pointer register.
     sp,
-
-    /// The special `lr` link register.
-    lr,
-
-    /// The special `fp` frame pointer register.
-    fp,
 
     /// The special `spilltmp0` scratch register.
     spilltmp0,
@@ -93,10 +87,7 @@ impl XReg {
 
     /// Is this `x` register a special register?
     pub fn is_special(self) -> bool {
-        matches!(
-            self,
-            Self::sp | Self::lr | Self::fp | Self::spilltmp0 | Self::spilltmp1
-        )
+        matches!(self, Self::sp | Self::spilltmp0 | Self::spilltmp1)
     }
 }
 

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -69,7 +69,7 @@ macro_rules! impl_reg {
 pub enum XReg {
     x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,  x8,  x9,
     x10, x11, x12, x13, x14, x15, x16, x17, x18, x19,
-    x20, x21, x22, x23, x24, x25, x26, x27, x28,
+    x20, x21, x22, x23, x24, x25, x26, x27, x28, x29,
 
     /// The special `sp` stack pointer register.
     sp,
@@ -77,8 +77,6 @@ pub enum XReg {
     /// The special `spilltmp0` scratch register.
     spilltmp0,
 
-    /// The special `spilltmp1` scratch register.
-    spilltmp1,
 }
 
 impl XReg {
@@ -87,7 +85,7 @@ impl XReg {
 
     /// Is this `x` register a special register?
     pub fn is_special(self) -> bool {
-        matches!(self, Self::sp | Self::spilltmp0 | Self::spilltmp1)
+        matches!(self, Self::sp | Self::spilltmp0)
     }
 }
 
@@ -302,7 +300,6 @@ mod tests {
     fn special_x_regs() {
         assert!(XReg::sp.is_special());
         assert!(XReg::spilltmp0.is_special());
-        assert!(XReg::spilltmp1.is_special());
     }
 
     #[test]

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -14,5 +14,5 @@
 ;;       br_if_xulteq64 x6, x7, 0x9    // target = 0x26
 ;;   24: pop_frame
 ;;       ret
-;;   26: call 0xbd    // target = 0xe3
+;;   26: call 0xbf    // target = 0xe5
 ;;   2b: jump 0xfffffffffffffff9    // target = 0x24


### PR DESCRIPTION
This commit moves the `fp` and `lr` registers out of the `XReg` register set and into the `MachineState` per-VM. These are automatically modified and read with `push_frame` and `pop_frame`. Dedicated `xmov_{fp,lr}` instructions were added for use in Wasmtime's trampolines which directly read these registers.

cc #9747