### PR TITLE
 pulley: Get switch.wast spec test passing 

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -650,6 +650,11 @@
 (rule (lower (has_type $F32 (fneg a))) (pulley_fneg32 a))
 (rule (lower (has_type $F64 (fneg a))) (pulley_fneg64 a))
 
+;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type $I32 (ineg a))) (pulley_xneg32 a))
+(rule (lower (has_type $I64 (ineg a))) (pulley_xneg64 a))
+
 ;;;; Rules for `fabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fabs a))) (pulley_fabs32 a))

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -494,7 +494,6 @@ impl WastTest {
                 "spec_testsuite/simd_store32_lane.wast",
                 "spec_testsuite/simd_store64_lane.wast",
                 "spec_testsuite/simd_store8_lane.wast",
-                "spec_testsuite/switch.wast",
             ];
 
             if unsupported.iter().any(|part| self.path.ends_with(part)) {

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1241,6 +1241,18 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xneg32(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let a = self.state[src].get_i32();
+        self.state[dst].set_i32(a.wrapping_neg());
+        ControlFlow::Continue(())
+    }
+
+    fn xneg64(&mut self, dst: XReg, src: XReg) -> ControlFlow<Done> {
+        let a = self.state[src].get_i64();
+        self.state[dst].set_i64(a.wrapping_neg());
+        ControlFlow::Continue(())
+    }
+
     fn xeq64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -228,6 +228,11 @@ macro_rules! for_each_op {
             /// `dst = src1 >> low6(src2)`
             xshr64_u = Xshr64U { operands: BinaryOperands<XReg> };
 
+            /// `low32(dst) = -low32(src)`
+            xneg32 = Xneg32 { dst: XReg, src: XReg };
+            /// `dst = -src`
+            xneg64 = Xneg64 { dst: XReg, src: XReg };
+
             /// `low32(dst) = src1 == src2`
             xeq64 = Xeq64 { operands: BinaryOperands<XReg> };
             /// `low32(dst) = src1 != src2`


### PR DESCRIPTION
Fill out a lowering for CLIF's `ineg` instruction.

cc https://github.com/bytecodealliance/wasmtime/issues/9783