### PR TITLE
Exclude Pulley from MIRI testing on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,6 @@ jobs:
           fi
           if grep -q pulley names.log; then
             echo test-nightly=true >> $GITHUB_OUTPUT
-            echo test-miri=true >> $GITHUB_OUTPUT
           fi
         fi
         matrix="$(node ./ci/build-test-matrix.js ./commits.log ./names.log $run_full)"


### PR DESCRIPTION
This hasn't actually turned up anything in quite some time and MIRI testing is relatively slow so by default don't test MIRI on Pulley PRs (it's of course still tested on the merge queue though)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
