### PR TITLE
pulley: Disable the WebAssembly `threads` proposal

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1960,12 +1960,15 @@ impl Config {
         #[cfg(any(feature = "cranelift", feature = "winch"))]
         match self.compiler_config.strategy {
             None | Some(Strategy::Cranelift) => {
-                // Pulley is just starting and most errors are because of
-                // unsupported lowerings which is a first-class error. Some
-                // errors are panics though due to unimplemented bits in ABI
-                // code and those causes are listed here.
+                // Pulley at this time fundamentally doesn't support the
+                // `threads` proposal, notably shared memory, because Rust can't
+                // safely implement loads/stores in the face of shared memory.
+                //
+                // Additionally pulley currently panics on tail-call generation
+                // in Cranelift ABI call which will get implemented in the
+                // future but is listed here for now as unsupported.
                 if self.compiler_target().is_pulley() {
-                    return WasmFeatures::TAIL_CALL;
+                    return WasmFeatures::TAIL_CALL | WasmFeatures::THREADS;
                 }
 
                 // Other Cranelift backends are either 100% missing or complete

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -298,6 +298,12 @@ impl Compiler {
             }
 
             Compiler::CraneliftPulley => {
+                // Pulley at this time fundamentally does not support threads
+                // due to being unable to implement non-atomic loads/stores
+                // safely.
+                if config.threads() {
+                    return true;
+                }
                 // Unsupported proposals. Note that other proposals have partial
                 // support at this time (pulley is a work-in-progress) and so
                 // individual tests are listed below as "should fail" even if
@@ -397,9 +403,7 @@ impl WastTest {
             let unsupported = [
                 "misc_testsuite/int-to-float-splat.wast",
                 "misc_testsuite/issue6562.wast",
-                "misc_testsuite/memory-combos.wast",
                 "misc_testsuite/memory64/simd.wast",
-                "misc_testsuite/memory64/threads.wast",
                 "misc_testsuite/simd/almost-extmul.wast",
                 "misc_testsuite/simd/canonicalize-nan.wast",
                 "misc_testsuite/simd/cvt-from-uint.wast",
@@ -413,11 +417,6 @@ impl WastTest {
                 "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
                 "misc_testsuite/simd/unaligned-load.wast",
                 "misc_testsuite/simd/v128-select.wast",
-                "misc_testsuite/threads/LB_atomic.wast",
-                "misc_testsuite/threads/MP_atomic.wast",
-                "misc_testsuite/threads/MP_wait.wast",
-                "misc_testsuite/threads/SB_atomic.wast",
-                "misc_testsuite/threads/load-store-alignment.wast",
                 "misc_testsuite/winch/_simd_address.wast",
                 "misc_testsuite/winch/_simd_const.wast",
                 "misc_testsuite/winch/_simd_load.wast",
@@ -432,7 +431,6 @@ impl WastTest {
                 "spec_testsuite/proposals/relaxed-simd/relaxed_laneselect.wast",
                 "spec_testsuite/proposals/relaxed-simd/relaxed_madd_nmadd.wast",
                 "spec_testsuite/proposals/relaxed-simd/relaxed_min_max.wast",
-                "spec_testsuite/proposals/threads/atomic.wast",
                 "spec_testsuite/simd_address.wast",
                 "spec_testsuite/simd_align.wast",
                 "spec_testsuite/simd_bit_shift.wast",


### PR DESCRIPTION
Forcibly disable the `threads` proposal for Pulley. This is done because I don't believe there's any way that we can, in Rust, implement non-atomic loads and stores in a manner that isn't undefined behavior. Until this is available leave this proposal as flagged as unsupported.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
