### PR TITLE
allow customizing log prefixes for wasmtime serve command

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1913,8 +1913,7 @@ stderr [1] :: after empty
     async fn cli_serve_with_print_no_prefix() -> Result<()> {
         let server = WasmtimeServe::new(CLI_SERVE_WITH_PRINT_COMPONENT, |cmd| {
             cmd.arg("-Scli");
-            cmd.arg("--logging-prefix-stdout=");
-            cmd.arg("--logging-prefix-stderr=");
+            cmd.arg("--no-logging-prefix");
         })?;
 
         for _ in 0..2 {


### PR DESCRIPTION
### What

As discussed in feature request: https://github.com/bytecodealliance/wasmtime/issues/9799, `wasmtime serve` command always prefixes stdout and stderr logs of wasi-http handler with hardcoded format. This prevents user to implement consistent logging formats like json logging.

This PR adds an optional flags, `--no-logging-prefix`, to stop adding log prefixes. When the new flags are not provided, existing hehaviour is preserved.

### Test

- Added test case to cover new flags
- [Existing test case](https://github.com/bytecodealliance/wasmtime/blob/da93f647974518e111561b3b451ef8c4a576bf20/tests/all/cli_tests.rs#L1868) covers the existing behaviour when flags are absent.

### Alternatives

I know adding flags to CLI creates long term promise, so I'm trying to be careful here and have considered a few alternatives.

#### boolean flags vs string


(original implementation in this PR) To allow better flexibility and future proof, we could add two string flags, `--logging-prefix-stdout` and `--logging-prefix-stderr`, which allows users to customize the prefix, and possibly removing the prefix by providing empty strings. This enables future possibilities like allow users to specify log prefixes with templates, as the `{ req_id }` could be useful. __this is replaced with simple boolean flag of `--no-logging-prefix` to avoid over engineering.__

#### Debug options 

The existing `DebugOptions` already contains some customization about logging
https://github.com/bytecodealliance/wasmtime/blob/da93f647974518e111561b3b451ef8c4a576bf20/crates/cli-flags/src/lib.rs#L241-L244

While we could add the flags there, I feel the new flags in this PR are specific to `wasmtime serve` command. So adding them to the common flags might confuse people for other commands.
