### PR TITLE
docs: remove old features flag from bindgen documentation

### DIFF
--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -373,13 +373,6 @@ pub(crate) use self::store::ComponentStoreData;
 ///         serde::Serialize,
 ///     ],
 ///
-///     // A list of WIT "features" to enable when parsing the WIT document that
-///     // this bindgen macro matches. WIT features are all disabled by default
-///     // and must be opted-in-to if source level features are used.
-///     //
-///     // This option defaults to an empty array.
-///     features: ["foo", "bar", "baz"],
-///
 ///     // An niche configuration option to require that the `T` in `Store<T>`
 ///     // is always `Send` in the generated bindings. Typically not needed
 ///     // but if synchronous bindings depend on asynchronous bindings using


### PR DESCRIPTION
It seems that this was removed in https://github.com/bytecodealliance/wasmtime/pull/9381

The new method is really nice for controlling this at runtime, however the docs still mentioned the old behavior.
