### PR TITLE
pulley: Implement `return_call` instructions

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -53,6 +53,12 @@
     ;; An indirect call to an unknown callee.
     (IndirectCall (info BoxCallIndInfo))
 
+    ;; A direct return-call macro instruction.
+    (ReturnCall (info BoxReturnCallInfo))
+
+    ;; An indirect return-call macro instruction.
+    (ReturnIndirectCall (info BoxReturnCallIndInfo))
+
     ;; An indirect call out to a host-defined function. The host function
     ;; pointer is the first "argument" of this function call.
     (IndirectCallHost (info BoxCallInfo))
@@ -125,6 +131,8 @@
 
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
+(type BoxReturnCallInfo (primitive BoxReturnCallInfo))
+(type BoxReturnCallIndInfo (primitive BoxReturnCallIndInfo))
 
 ;;;; Address Modes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -9,7 +9,9 @@ use inst::InstAndKind;
 use crate::ir::{condcodes::*, immediates::*, types::*, *};
 use crate::isa::pulley_shared::{
     abi::*,
-    inst::{FReg, OperandSize, VReg, WritableFReg, WritableVReg, WritableXReg, XReg},
+    inst::{
+        FReg, OperandSize, ReturnCallInfo, VReg, WritableFReg, WritableVReg, WritableXReg, XReg,
+    },
     lower::{regs, Cond},
     *,
 };
@@ -25,6 +27,8 @@ type VecArgPair = Vec<ArgPair>;
 type VecRetPair = Vec<RetPair>;
 type BoxCallInfo = Box<CallInfo<ExternalName>>;
 type BoxCallIndInfo = Box<CallInfo<XReg>>;
+type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
+type BoxReturnCallIndInfo = Box<ReturnCallInfo<XReg>>;
 type BoxExternalName = Box<ExternalName>;
 
 pub(crate) struct PulleyIsleContext<'a, 'b, I, B>

--- a/crates/cranelift/src/translate/table.rs
+++ b/crates/cranelift/src/translate/table.rs
@@ -82,8 +82,10 @@ impl TableData {
         }
 
         // Convert `index` to `addr_ty`.
-        if index_ty != addr_ty {
+        if addr_ty.bytes() > index_ty.bytes() {
             index = pos.ins().uextend(addr_ty, index);
+        } else if addr_ty.bytes() < index_ty.bytes() {
+            index = pos.ins().ireduce(addr_ty, index);
         }
 
         // Add the table base address base

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1963,12 +1963,8 @@ impl Config {
                 // Pulley at this time fundamentally doesn't support the
                 // `threads` proposal, notably shared memory, because Rust can't
                 // safely implement loads/stores in the face of shared memory.
-                //
-                // Additionally pulley currently panics on tail-call generation
-                // in Cranelift ABI call which will get implemented in the
-                // future but is listed here for now as unsupported.
                 if self.compiler_target().is_pulley() {
-                    return WasmFeatures::TAIL_CALL | WasmFeatures::THREADS;
+                    return WasmFeatures::THREADS;
                 }
 
                 // Other Cranelift backends are either 100% missing or complete

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -308,7 +308,7 @@ impl Compiler {
                 // support at this time (pulley is a work-in-progress) and so
                 // individual tests are listed below as "should fail" even if
                 // they're not covered in this list.
-                if config.tail_call() || config.wide_arithmetic() {
+                if config.wide_arithmetic() {
                     return true;
                 }
             }
@@ -424,6 +424,15 @@ impl WastTest {
                 "spec_testsuite/proposals/relaxed-simd/relaxed_laneselect.wast",
                 "spec_testsuite/proposals/relaxed-simd/relaxed_madd_nmadd.wast",
                 "spec_testsuite/proposals/relaxed-simd/relaxed_min_max.wast",
+                "spec_testsuite/proposals/memory64/simd_lane.wast",
+                "spec_testsuite/proposals/memory64/simd_memory-multi.wast",
+                "spec_testsuite/proposals/memory64/relaxed_min_max.wast",
+                "spec_testsuite/proposals/memory64/relaxed_madd_nmadd.wast",
+                "spec_testsuite/proposals/memory64/relaxed_laneselect.wast",
+                "spec_testsuite/proposals/memory64/relaxed_dot_product.wast",
+                "spec_testsuite/proposals/memory64/i16x8_relaxed_q15mulr_s.wast",
+                "spec_testsuite/proposals/memory64/i32x4_relaxed_trunc.wast",
+                "spec_testsuite/proposals/memory64/i8x16_relaxed_swizzle.wast",
                 "spec_testsuite/simd_align.wast",
                 "spec_testsuite/simd_bitwise.wast",
                 "spec_testsuite/simd_boolean.wast",

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1066,6 +1066,13 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xjump(&mut self, reg: XReg) -> ControlFlow<Done> {
+        unsafe {
+            self.pc = UnsafeBytecodeStream::new(NonNull::new_unchecked(self.state[reg].get_ptr()));
+        }
+        ControlFlow::Continue(())
+    }
+
     fn br_if32(&mut self, cond: XReg, offset: PcRelOffset) -> ControlFlow<Done> {
         let cond = self.state[cond].get_u32();
         if cond != 0 {

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -101,6 +101,10 @@ macro_rules! for_each_op {
             /// Unconditionally transfer control to the PC at the given offset.
             jump = Jump { offset: PcRelOffset };
 
+            /// Unconditionally transfer control to the PC at specified
+            /// register.
+            xjump = XJump { reg: XReg };
+
             /// Conditionally transfer control to the given PC offset if
             /// `low32(cond)` contains a non-zero value.
             br_if32 = BrIf { cond: XReg, offset: PcRelOffset };

--- a/tests/misc_testsuite/tail-call/loop-across-modules.wast
+++ b/tests/misc_testsuite/tail-call/loop-across-modules.wast
@@ -42,5 +42,5 @@
   (start $start)
 )
 
-(assert_return (invoke $B "g" (i32.const 100000000))
+(assert_return (invoke $B "g" (i32.const 100000))
                (i32.const 42))


### PR DESCRIPTION
This commit fleshes out the Cranelift lowerings of tail calls which gets the wasm tail call proposal itself working on Pulley. Most of the bits and pieces here were copied over from the riscv64 backend and then edited to suit Pulley.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
