### PR TITLE
Run the full test suite on 32-bit platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,6 +4105,7 @@ dependencies = [
  "component-test-util",
  "cranelift-codegen",
  "cranelift-filetests",
+ "cranelift-native",
  "cranelift-reader",
  "criterion",
  "env_logger 0.11.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ wasmtime-test-macros = { path = "crates/test-macros" }
 pulley-interpreter = { workspace = true, features = ["disas"] }
 wasmtime-wast-util = { path = 'crates/wast-util' }
 wasm-encoder = { workspace = true }
+cranelift-native = { workspace = true }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }

--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -53,9 +53,10 @@ fn main() {
     if isas.is_empty() || host_isa {
         // Try to match native target.
         let target_name = target_triple.split('-').next().unwrap();
-        let isa = meta::isa_from_arch(&target_name).expect("error when identifying target");
-        println!("cargo:rustc-cfg=feature=\"{isa}\"");
-        isas.push(isa);
+        if let Ok(isa) = meta::isa_from_arch(&target_name) {
+            println!("cargo:rustc-cfg=feature=\"{isa}\"");
+            isas.push(isa);
+        }
     }
 
     let cur_dir = env::current_dir().expect("Can't access current working directory");

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -3051,7 +3051,7 @@ mod tests {
     fn inst_size_test() {
         // This test will help with unintentionally growing the size
         // of the Inst enum.
-        let expected = if cfg!(target_pointer_width = "32") {
+        let expected = if cfg!(target_pointer_width = "32") && !cfg!(target_arch = "arm") {
             28
         } else {
             32

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -3051,6 +3051,11 @@ mod tests {
     fn inst_size_test() {
         // This test will help with unintentionally growing the size
         // of the Inst enum.
-        assert_eq!(32, std::mem::size_of::<Inst>());
+        let expected = if cfg!(target_pointer_width = "32") {
+            28
+        } else {
+            32
+        };
+        assert_eq!(expected, std::mem::size_of::<Inst>());
     }
 }

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -481,15 +481,19 @@ where
             }
             // "far" calls are pulley->host calls so they use a different opcode
             // which is lowered with a special relocation in the backend.
-            CallDest::ExtName(name, RelocDistance::Far) => smallvec![Inst::IndirectCallHost {
-                info: Box::new(info.map(|()| name.clone()))
+            CallDest::ExtName(name, RelocDistance::Far) => {
+                smallvec![Inst::IndirectCallHost {
+                    info: Box::new(info.map(|()| name.clone()))
+                }
+                .into()]
             }
-            .into()],
             // Indirect calls are all assumed to be pulley->pulley calls
-            CallDest::Reg(reg) => smallvec![Inst::IndirectCall {
-                info: Box::new(info.map(|()| XReg::new(*reg).unwrap()))
+            CallDest::Reg(reg) => {
+                smallvec![Inst::IndirectCall {
+                    info: Box::new(info.map(|()| XReg::new(*reg).unwrap()))
+                }
+                .into()]
             }
-            .into()],
         }
     }
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1749,11 +1749,11 @@ mod test {
     fn size_of_constant_structs() {
         assert_eq!(size_of::<Constant>(), 4);
         assert_eq!(size_of::<VCodeConstant>(), 4);
-        assert_eq!(size_of::<ConstantData>(), 24);
-        assert_eq!(size_of::<VCodeConstantData>(), 32);
+        assert_eq!(size_of::<ConstantData>(), 3 * size_of::<usize>());
+        assert_eq!(size_of::<VCodeConstantData>(), 4 * size_of::<usize>());
         assert_eq!(
             size_of::<PrimaryMap<VCodeConstant, VCodeConstantData>>(),
-            24
+            3 * size_of::<usize>()
         );
         // TODO The VCodeConstants structure's memory size could be further optimized.
         // With certain versions of Rust, each `HashMap` in `VCodeConstants` occupied at

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -611,6 +611,7 @@ extern "C" fn __cranelift_x86_pshufb(a: __m128i, b: __m128i) -> __m128i {
 }
 
 #[cfg(test)]
+#[cfg(target_pointer_width = "64")] // 32-bit platforms not supported at this time
 mod test {
     use super::*;
     use cranelift_reader::{parse_functions, parse_test, ParseOptions};

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -611,7 +611,6 @@ extern "C" fn __cranelift_x86_pshufb(a: __m128i, b: __m128i) -> __m128i {
 }
 
 #[cfg(test)]
-#[cfg(target_pointer_width = "64")] // 32-bit platforms not supported at this time
 mod test {
     use super::*;
     use cranelift_reader::{parse_functions, parse_test, ParseOptions};
@@ -622,6 +621,10 @@ mod test {
 
     #[test]
     fn nop() {
+        // Skip this test when cranelift doesn't support the native platform.
+        if cranelift_native::builder().is_err() {
+            return;
+        }
         let code = String::from(
             "
             test run
@@ -656,6 +659,10 @@ mod test {
 
     #[test]
     fn trampolines() {
+        // Skip this test when cranelift doesn't support the native platform.
+        if cranelift_native::builder().is_err() {
+            return;
+        }
         let function = parse(
             "
             function %test(f32, i8, i64x2, i8) -> f32x4, i64 {

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -126,6 +126,7 @@ fn create_target_isa(isa_spec: &IsaSpec) -> Result<OwnedTargetIsa> {
 }
 
 #[cfg(test)]
+#[cfg(target_pointer_width = "64")] // 32-bit platforms not supported yet
 mod test {
     use super::*;
 

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -126,12 +126,14 @@ fn create_target_isa(isa_spec: &IsaSpec) -> Result<OwnedTargetIsa> {
 }
 
 #[cfg(test)]
-#[cfg(target_pointer_width = "64")] // 32-bit platforms not supported yet
 mod test {
     use super::*;
 
     #[test]
     fn nop() {
+        if cranelift_native::builder().is_err() {
+            return;
+        }
         let code = String::from(
             "
             function %test() -> i8 {

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -34,6 +34,12 @@ wasmtime-versioned-export-macros = { workspace = true }
 itertools = "0.12"
 pulley-interpreter = { workspace = true, optional = true }
 
+# On 32-bit platforms where Cranelift currently doesn't have any supported host
+# unconditionally enable the `pulley` feature of the Cranelift backend to ensure
+# that it's possible to run wasm code by default.
+[target.'cfg(target_pointer_width = "32")'.dependencies]
+cranelift-codegen = { workspace = true, features = ['pulley'] }
+
 [features]
 all-arch = ["cranelift-codegen/all-arch"]
 host-arch = ["cranelift-codegen/host-arch"]

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -34,12 +34,6 @@ wasmtime-versioned-export-macros = { workspace = true }
 itertools = "0.12"
 pulley-interpreter = { workspace = true, optional = true }
 
-# On 32-bit platforms where Cranelift currently doesn't have any supported host
-# unconditionally enable the `pulley` feature of the Cranelift backend to ensure
-# that it's possible to run wasm code by default.
-[target.'cfg(target_pointer_width = "32")'.dependencies]
-cranelift-codegen = { workspace = true, features = ['pulley'] }
-
 [features]
 all-arch = ["cranelift-codegen/all-arch"]
 host-arch = ["cranelift-codegen/host-arch"]

--- a/crates/cranelift/src/debug/transform/address_transform.rs
+++ b/crates/cranelift/src/debug/transform/address_transform.rs
@@ -491,7 +491,6 @@ impl AddressTransform {
     }
 
     #[cfg(test)]
-    #[cfg(target_pointer_width = "64")]
     pub fn mock(
         module_map: &wasmtime_environ::PrimaryMap<
             wasmtime_environ::DefinedFuncIndex,
@@ -661,8 +660,6 @@ impl AddressTransform {
 }
 
 #[cfg(test)]
-#[cfg(target_pointer_width = "64")] // cranelift doesn't support native 32-bit
-                                    // platforms
 mod tests {
     use super::{build_function_lookup, get_wasm_code_offset, AddressTransform};
     use crate::{CompiledFunctionMetadata, FunctionAddressMap};
@@ -787,6 +784,10 @@ mod tests {
 
     #[test]
     fn test_addr_translate() {
+        // Ignore this test if cranelift doesn't support the native platform.
+        if cranelift_native::builder().is_err() {
+            return;
+        }
         let func = CompiledFunctionMetadata {
             address_map: create_simple_func(11),
             ..Default::default()

--- a/crates/cranelift/src/debug/transform/address_transform.rs
+++ b/crates/cranelift/src/debug/transform/address_transform.rs
@@ -491,6 +491,7 @@ impl AddressTransform {
     }
 
     #[cfg(test)]
+    #[cfg(target_pointer_width = "64")]
     pub fn mock(
         module_map: &wasmtime_environ::PrimaryMap<
             wasmtime_environ::DefinedFuncIndex,
@@ -660,6 +661,8 @@ impl AddressTransform {
 }
 
 #[cfg(test)]
+#[cfg(target_pointer_width = "64")] // cranelift doesn't support native 32-bit
+                                    // platforms
 mod tests {
     use super::{build_function_lookup, get_wasm_code_offset, AddressTransform};
     use crate::{CompiledFunctionMetadata, FunctionAddressMap};

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -856,8 +856,6 @@ impl std::fmt::Debug for JumpTargetMarker {
 
 #[cfg(test)]
 #[expect(trivial_numeric_casts, reason = "macro-generated code")]
-#[cfg(target_pointer_width = "64")] // cranelift doesn't support native 32-bit
-                                    // platforms
 mod tests {
     use super::{
         compile_expression, AddressTransform, CompiledExpression, CompiledExpressionPart,
@@ -1287,10 +1285,16 @@ mod tests {
         use super::ValueLabelRangesBuilder;
         use crate::debug::ModuleMemoryOffset;
 
+        // Ignore this test if cranelift doesn't support the native platform.
+        if cranelift_native::builder().is_err() {
+            return;
+        }
+
         let isa = lookup(triple!("x86_64"))
             .expect("expect x86_64 ISA")
             .finish(Flags::new(cranelift_codegen::settings::builder()))
             .expect("Creating ISA");
+
         let addr_tr = create_mock_address_transform();
         let (value_ranges, value_labels) = create_mock_value_ranges();
         let fi = FunctionFrameInfo {

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -856,6 +856,8 @@ impl std::fmt::Debug for JumpTargetMarker {
 
 #[cfg(test)]
 #[expect(trivial_numeric_casts, reason = "macro-generated code")]
+#[cfg(target_pointer_width = "64")] // cranelift doesn't support native 32-bit
+                                    // platforms
 mod tests {
     use super::{
         compile_expression, AddressTransform, CompiledExpression, CompiledExpressionPart,

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -237,17 +237,15 @@ impl<'a> ModuleTextBuilder<'a> {
                 //
                 // See the `test_call_indirect_host_width` in
                 // `pulley/tests/all.rs` for this guarantee as well.
-                #[cfg(feature = "pulley")]
                 RelocationTarget::PulleyHostcall(n) => {
-                    use pulley_interpreter::encode::Encode;
-
-                    assert_eq!(pulley_interpreter::CallIndirectHost::WIDTH, 4);
+                    #[cfg(feature = "pulley")]
+                    {
+                        use pulley_interpreter::encode::Encode;
+                        assert_eq!(pulley_interpreter::CallIndirectHost::WIDTH, 4);
+                    }
                     let byte = u8::try_from(n).unwrap();
                     self.text.write(reloc_offset + 3, &[byte]);
                 }
-
-                #[cfg(not(feature = "pulley"))]
-                RelocationTarget::PulleyHostcall(_) => unreachable!(),
             };
         }
         (symbol_id, off..off + body_len)

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -98,6 +98,14 @@ rustix = { workspace = true, optional = true }
 [target.'cfg(target_arch = "s390x")'.dependencies]
 psm = { workspace = true, optional = true }
 
+# On 32-bit platforms where Cranelift currently doesn't have any supported host
+# unconditionally pull in the `pulley-interpreter` crate. Runtime support is
+# enabled via `build.rs` which prints `feature="pulley"` by default here and
+# compilation support, if enabled via the `cranelift` feature, is handled in the
+# `wasmtime-cranelift` crate enabling Pulley on 32-bit platforms.
+[target.'cfg(target_pointer_width = "32")'.dependencies]
+pulley-interpreter = { workspace = true }
+
 [dev-dependencies]
 env_logger = { workspace = true }
 proptest = { workspace = true }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -23,7 +23,7 @@ wasmtime-jit-debug = { workspace = true, features = ["gdb_jit_int", "perf_jitdum
 wasmtime-jit-icache-coherence = { workspace = true, optional = true }
 wasmtime-cache = { workspace = true, optional = true }
 wasmtime-fiber = { workspace = true, optional = true }
-wasmtime-cranelift = { workspace = true, optional = true }
+wasmtime-cranelift = { workspace = true, optional = true, features = ['pulley'] }
 wasmtime-winch = { workspace = true, optional = true }
 wasmtime-component-macro = { workspace = true, optional = true }
 wasmtime-component-util = { workspace = true, optional = true }
@@ -31,7 +31,7 @@ wasmtime-slab = { workspace = true, optional = true }
 wasmtime-versioned-export-macros = { workspace = true }
 wasmtime-wmemcheck = { workspace = true, optional = true }
 wasmtime-math = { workspace = true }
-pulley-interpreter = { workspace = true, optional = true }
+pulley-interpreter = { workspace = true }
 target-lexicon = { workspace = true }
 wasmparser = { workspace = true }
 wasm-encoder = { workspace = true, optional = true }
@@ -98,14 +98,6 @@ rustix = { workspace = true, optional = true }
 [target.'cfg(target_arch = "s390x")'.dependencies]
 psm = { workspace = true, optional = true }
 
-# On 32-bit platforms where Cranelift currently doesn't have any supported host
-# unconditionally pull in the `pulley-interpreter` crate. Runtime support is
-# enabled via `build.rs` which prints `feature="pulley"` by default here and
-# compilation support, if enabled via the `cranelift` feature, is handled in the
-# `wasmtime-cranelift` crate enabling Pulley on 32-bit platforms.
-[target.'cfg(target_pointer_width = "32")'.dependencies]
-pulley-interpreter = { workspace = true }
-
 [dev-dependencies]
 env_logger = { workspace = true }
 proptest = { workspace = true }
@@ -164,7 +156,12 @@ winch = ["dep:wasmtime-winch", "std"]
 # targets will be available. When paired with the `runtime` feature, the Pulley
 # interpreter will be built into the runtime and you can interpret WebAssembly
 # modules that have been compiled to Pulley bytecode.
-pulley = ["dep:pulley-interpreter", "wasmtime-cranelift?/pulley"]
+pulley = [
+  # Note that this is intentionally empty. This feature is dynamically activated
+  # in `build.rs` as well when the host platform does not have Cranelift support
+  # for example. That means that dependencies for pulley need to be already
+  # activated anyway.
+]
 
 # Enables support for incremental compilation cache to be enabled in `Config`.
 incremental-cache = ["wasmtime-cranelift?/incremental-cache", "std"]
@@ -255,7 +252,7 @@ runtime = [
   "dep:psm",
   "dep:rustix",
   "rustix/mm",
-  "pulley-interpreter?/interp",
+  "pulley-interpreter/interp",
   "dep:wasmtime-jit-icache-coherence",
 ]
 
@@ -322,7 +319,7 @@ std = [
   'object/std',
   'once_cell',
   'wasmtime-fiber?/std',
-  'pulley-interpreter?/std',
+  'pulley-interpreter/std',
   'wasmtime-math/std',
 ]
 

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -26,6 +26,16 @@ fn main() {
 
     #[cfg(feature = "runtime")]
     build_c_helpers();
+
+    // Flag pulley as enabled unconditionally on 32-bit targets to ensure that
+    // wasm is runnable by default like it is on other 64-bit native platforms.
+    // Note that this doesn't actually enable the Cargo feature, it just changes
+    // the cfg's passed to the crate, so for example care is still taken in
+    // `Cargo.toml` to handle pulley-specific dependencies on 32-bit platforms.
+    let target_pointer_width = std::env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
+    if target_pointer_width == "32" {
+        println!("cargo:rustc-cfg=feature=\"pulley\"");
+    }
 }
 
 fn cfg(key: &str) -> bool {

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -27,15 +27,26 @@ fn main() {
     #[cfg(feature = "runtime")]
     build_c_helpers();
 
-    // Flag pulley as enabled unconditionally on 32-bit targets to ensure that
-    // wasm is runnable by default like it is on other 64-bit native platforms.
-    // Note that this doesn't actually enable the Cargo feature, it just changes
-    // the cfg's passed to the crate, so for example care is still taken in
-    // `Cargo.toml` to handle pulley-specific dependencies on 32-bit platforms.
-    let target_pointer_width = std::env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
-    if target_pointer_width == "32" {
-        println!("cargo:rustc-cfg=feature=\"pulley\"");
+    // Determine whether Pulley will be enabled and used for this target.
+    match std::env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+        // These targets use Cranelift by default as they have backends in
+        // Cranelift. Pulley can still be used on an opt-in basis, but it's not
+        // otherwise explicitly enabled here.
+        "x86_64" | "riscv64" | "s390x" | "aarch64" => {}
+
+        // All other targets at this time use Pulley by default. That means
+        // that the pulley feature is "enabled" here and the default target is
+        // pulley. Note that by enabling the feature here it doesn't actually
+        // enable the Cargo feature, it just passes a cfg to rustc. That means
+        // that conditional dependencies enabled in `Cargo.toml` (or other
+        // features) by `pulley` aren't activated, which is why the `pulley`
+        // feature of this crate depends on nothing else.
+        _ => {
+            println!("cargo:rustc-cfg=feature=\"pulley\"");
+            println!("cargo:rustc-cfg=default_target_pulley");
+        }
     }
+    println!("cargo:rustc-check-cfg=cfg(default_target_pulley)");
 }
 
 fn cfg(key: &str) -> bool {

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2054,17 +2054,9 @@ impl Config {
             return target;
         }
 
-        // Without an explicitly configured target the goal is then to select
-        // some default which can reasonably run code on this host. If pulley is
-        // enabled and the host has no support at all in the cranelift/winch
-        // backends then pulley becomes the default target. This means, for
-        // example, that 32-bit platforms will default to running pulley at this
-        // time.
-        let any_compiler_support = cfg!(target_arch = "x86_64")
-            || cfg!(target_arch = "aarch64")
-            || cfg!(target_arch = "riscv64")
-            || cfg!(target_arch = "s390x");
-        if !any_compiler_support && cfg!(feature = "pulley") {
+        // If the `build.rs` script determined that this platform uses pulley by
+        // default, then use Pulley.
+        if cfg!(default_target_pulley) {
             return target_lexicon::Triple::pulley_host();
         }
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -583,7 +583,7 @@ impl<T> Store<T> {
                 #[cfg(feature = "component-model")]
                 host_resource_data: Default::default(),
                 interpreter: if cfg!(feature = "pulley") && engine.target().is_pulley() {
-                    Some(Interpreter::new())
+                    Some(Interpreter::new(engine))
                 } else {
                     None
                 },

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -192,6 +192,7 @@ impl InterpreterRef<'_> {
     #[allow(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
+        unused_macro_rules,
         reason = "macro-generated code"
     )]
     #[cfg_attr(

--- a/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
@@ -6,7 +6,7 @@
 
 use crate::runtime::vm::VMOpaqueContext;
 use crate::runtime::Uninhabited;
-use crate::ValRaw;
+use crate::{Engine, ValRaw};
 use core::marker;
 use core::mem;
 use core::ptr::NonNull;
@@ -19,7 +19,7 @@ const _: () = assert!(mem::size_of::<Interpreter>() == 0);
 const _: () = assert!(mem::size_of::<Option<Interpreter>>() == 0);
 
 impl Interpreter {
-    pub fn new() -> Interpreter {
+    pub fn new(_engine: &Engine) -> Interpreter {
         unreachable!()
     }
 

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -187,8 +187,8 @@ impl Disas for u128 {
 
 impl Disas for PcRelOffset {
     fn disas(&self, position: usize, disas: &mut String) {
-        let offset = isize::try_from(i32::from(*self)).unwrap();
-        let target = position.wrapping_add(offset as usize);
+        let offset = i64::from(i32::from(*self));
+        let target = (position as u64).wrapping_add(offset as u64);
         write!(disas, "{offset:#x}    // target = {target:#x}").unwrap()
     }
 }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -987,9 +987,9 @@ impl Interpreter<'_> {
 
     /// Calculates the "g32" address given the inputs to the addressing mode.
     fn g32_addr<T>(&self, base: XReg, addr: XReg, offset: u8) -> *mut T {
-        let addr = self.state[base].get_ptr::<T>() as usize
-            + self.state[addr].get_u32() as usize
-            + usize::from(offset);
+        let addr = (self.state[base].get_ptr::<T>() as usize)
+            .wrapping_add(self.state[addr].get_u32() as usize)
+            .wrapping_add(usize::from(offset));
         addr as *mut T
     }
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2073,8 +2073,11 @@ after empty
 }
 
 #[test]
-#[cfg(target_pointer_width = "64")] // cranelift only supports 64-bit platforms
 fn settings_command() -> Result<()> {
+    // Skip this test on platforms that Cranelift doesn't support.
+    if cranelift_native::builder().is_err() {
+        return Ok(());
+    }
     let output = run_wasmtime(&["settings"])?;
     assert!(output.contains("Cranelift settings for target"));
     Ok(())

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -62,8 +62,9 @@ pub fn run_wasmtime(args: &[&str]) -> Result<String> {
     let output = run_wasmtime_for_output(args, None)?;
     if !output.status.success() {
         bail!(
-            "Failed to execute wasmtime with: {:?}\n{}",
+            "Failed to execute wasmtime with: {:?}\nstatus: {}\n{}",
             args,
+            output.status,
             String::from_utf8_lossy(&output.stderr)
         );
     }
@@ -574,6 +575,10 @@ fn run_cwasm_from_stdin() -> Result<()> {
 #[cfg(feature = "wasi-threads")]
 #[test]
 fn run_threads() -> Result<()> {
+    // Skip this test on platforms that don't support threads.
+    if crate::threads::engine().is_none() {
+        return Ok(());
+    }
     let wasm = build_wasm("tests/all/cli_tests/threads.wat")?;
     let stdout = run_wasmtime(&[
         "run",
@@ -597,6 +602,10 @@ fn run_threads() -> Result<()> {
 #[cfg(feature = "wasi-threads")]
 #[test]
 fn run_simple_with_wasi_threads() -> Result<()> {
+    // Skip this test on platforms that don't support threads.
+    if crate::threads::engine().is_none() {
+        return Ok(());
+    }
     // We expect to be able to run Wasm modules that do not have correct
     // wasi-thread entry points or imported shared memory as long as no threads
     // are spawned.
@@ -919,10 +928,12 @@ fn table_growth_failure2() -> Result<()> {
         .output()?;
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("forcing trap when growing table to 4294967296 elements"),
-        "bad stderr: {stderr}"
-    );
+    let expected = if cfg!(target_pointer_width = "32") {
+        "overflow calculating new table size"
+    } else {
+        "forcing trap when growing table to 4294967296 elements"
+    };
+    assert!(stderr.contains(expected), "bad stderr: {stderr}");
     Ok(())
 }
 
@@ -2062,6 +2073,7 @@ after empty
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")] // cranelift only supports 64-bit platforms
 fn settings_command() -> Result<()> {
     let output = run_wasmtime(&["settings"])?;
     assert!(output.contains("Cranelift settings for target"));

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1,5 +1,4 @@
 use super::ref_types_module;
-use super::skip_pooling_allocator_tests;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
 use wasmtime::*;
@@ -280,11 +279,9 @@ fn global_drops_externref() -> Result<()> {
     let _ = env_logger::try_init();
     test_engine(&Engine::default())?;
 
-    if !skip_pooling_allocator_tests() {
-        test_engine(&Engine::new(
-            Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()),
-        )?)?;
-    }
+    let mut config = Config::new();
+    config.allocation_strategy(crate::small_pool_config());
+    test_engine(&Engine::new(&config)?)?;
 
     return Ok(());
 
@@ -331,11 +328,9 @@ fn table_drops_externref() -> Result<()> {
     let _ = env_logger::try_init();
     test_engine(&Engine::default())?;
 
-    if !skip_pooling_allocator_tests() {
-        test_engine(&Engine::new(
-            Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()),
-        )?)?;
-    }
+    let mut config = Config::new();
+    config.allocation_strategy(crate::small_pool_config());
+    test_engine(&Engine::new(&config)?)?;
 
     return Ok(());
 

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -83,7 +83,7 @@ pub(crate) fn skip_pooling_allocator_tests() -> bool {
     // There are a couple of issues when running the pooling allocator tests under QEMU:
     // - high memory usage that may exceed the limits imposed by the environment (e.g. CI)
     // - https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
-    cfg!(target_pointer_width = "32") || std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok()
+    std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok()
 }
 
 /// Get the default pooling allocator configuration for tests, which is a

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -83,7 +83,7 @@ pub(crate) fn skip_pooling_allocator_tests() -> bool {
     // There are a couple of issues when running the pooling allocator tests under QEMU:
     // - high memory usage that may exceed the limits imposed by the environment (e.g. CI)
     // - https://github.com/bytecodealliance/wasmtime/pull/2518#issuecomment-747280133
-    std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok()
+    cfg!(target_pointer_width = "32") || std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok()
 }
 
 /// Get the default pooling allocator configuration for tests, which is a

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -94,9 +94,14 @@ fn test_traps(store: &mut Store<()>, funcs: &[TestFunc], addr: u32, mem: &Memory
 #[cfg_attr(miri, ignore)]
 fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
     const GB: u64 = 1 << 30;
+    const MB: u64 = 1 << 20;
 
     let mut engines = Vec::new();
-    let sizes = [0, 1 * GB, 4 * GB];
+    let sizes = if cfg!(target_pointer_width = "32") {
+        [0, 10 * MB, 20 * MB]
+    } else {
+        [0, 1 * GB, 4 * GB]
+    };
     for &memory_reservation in sizes.iter() {
         for &guard_size in sizes.iter() {
             for &guard_before_linear_memory in [true, false].iter() {
@@ -654,6 +659,7 @@ fn shared_memory_wait_notify() -> Result<()> {
 
 #[wasmtime_test]
 #[cfg_attr(miri, ignore)]
+#[cfg(target_pointer_width = "64")] // requires large VM reservation
 fn init_with_negative_segment(_: &mut Config) -> Result<()> {
     let engine = Engine::default();
     let module = Module::new(

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -6,20 +6,43 @@ use wasmtime_test_macros::wasmtime_test;
 
 #[test]
 fn checks_incompatible_target() -> Result<()> {
-    let mut target = target_lexicon::Triple::host();
-    target.operating_system = target_lexicon::OperatingSystem::Unknown;
-    match Module::new(
-        &Engine::new(Config::new().target(&target.to_string())?)?,
-        "(module)",
-    ) {
-        Ok(_) => unreachable!(),
-        Err(e) => assert!(
-            format!("{e:?}").contains("configuration does not match the host"),
-            "bad error: {e:?}"
-        ),
+    // For platforms that Cranelift supports make sure a mismatch generates an
+    // error
+    if cfg!(target_arch = "x86_64")
+        || cfg!(target_arch = "aarch64")
+        || cfg!(target_arch = "s390x")
+        || cfg!(target_arch = "riscv64")
+    {
+        let mut target = target_lexicon::Triple::host();
+        target.operating_system = target_lexicon::OperatingSystem::Unknown;
+        assert_invalid_target(&target.to_string())?;
     }
 
-    Ok(())
+    // Otherwise make sure that the wrong pulley target is rejected on all
+    // platforms.
+    let wrong_pulley = if cfg!(target_pointer_width = "32") {
+        "pulley64"
+    } else {
+        "pulley32"
+    };
+    assert_invalid_target(wrong_pulley)?;
+
+    return Ok(());
+
+    fn assert_invalid_target(target: &str) -> Result<()> {
+        match Module::new(
+            &Engine::new(Config::new().target(&target.to_string())?)?,
+            "(module)",
+        ) {
+            Ok(_) => unreachable!(),
+            Err(e) => assert!(
+                format!("{e:?}").contains("configuration does not match the host"),
+                "bad error: {e:?}"
+            ),
+        }
+
+        Ok(())
+    }
 }
 
 #[test]
@@ -45,7 +68,7 @@ fn caches_across_engines() {
         // differ in wasm features enabled (which can affect
         // runtime/compilation settings)
         let res = Module::deserialize(
-            &Engine::new(Config::new().wasm_threads(false)).unwrap(),
+            &Engine::new(Config::new().wasm_relaxed_simd(false)).unwrap(),
             &bytes,
         );
         assert!(res.is_err());

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -30,10 +30,7 @@ fn checks_incompatible_target() -> Result<()> {
     return Ok(());
 
     fn assert_invalid_target(target: &str) -> Result<()> {
-        match Module::new(
-            &Engine::new(Config::new().target(&target.to_string())?)?,
-            "(module)",
-        ) {
+        match Module::new(&Engine::new(Config::new().target(target)?)?, "(module)") {
             Ok(_) => unreachable!(),
             Err(e) => assert!(
                 format!("{e:?}").contains("configuration does not match the host"),

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -868,6 +868,7 @@ fn total_component_instances_limit() -> Result<()> {
 
 #[test]
 #[cfg(feature = "component-model")]
+#[cfg(target_pointer_width = "64")] // error message tailored for 64-bit
 fn component_instance_size_limit() -> Result<()> {
     let mut pool = crate::small_pool_config();
     pool.max_component_instance_size(1);
@@ -1260,6 +1261,10 @@ fn tricky_empty_table_with_empty_virtual_memory_alloc() -> Result<()> {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn shared_memory_unsupported() -> Result<()> {
+    // Skip this test on platforms that don't support threads.
+    if crate::threads::engine().is_none() {
+        return Ok(());
+    }
     let mut config = Config::new();
     let mut cfg = PoolingAllocationConfig::default();
     // shrink the size of this allocator
@@ -1292,7 +1297,7 @@ fn shared_memory_unsupported() -> Result<()> {
 fn custom_page_sizes_reusing_same_slot() -> Result<()> {
     let mut config = Config::new();
     config.wasm_custom_page_sizes(true);
-    let mut cfg = PoolingAllocationConfig::default();
+    let mut cfg = crate::small_pool_config();
     // force the memories below to collide in the same memory slot
     cfg.total_memories(1);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(cfg));
@@ -1338,7 +1343,7 @@ fn custom_page_sizes_reusing_same_slot() -> Result<()> {
 fn instantiate_non_page_aligned_sizes() -> Result<()> {
     let mut config = Config::new();
     config.wasm_custom_page_sizes(true);
-    let mut cfg = PoolingAllocationConfig::default();
+    let mut cfg = crate::small_pool_config();
     cfg.total_memories(1);
     cfg.max_memory_size(761927);
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(cfg));

--- a/tests/all/relocs.rs
+++ b/tests/all/relocs.rs
@@ -13,6 +13,11 @@
 use wasmtime::*;
 
 const MB: usize = 1 << 20;
+const PADDING: usize = if cfg!(target_pointer_width = "32") {
+    1 * MB
+} else {
+    128 * MB
+};
 
 fn store_with_padding(padding: usize) -> Result<Store<()>> {
     let mut config = Config::new();
@@ -30,7 +35,7 @@ fn store_with_padding(padding: usize) -> Result<Store<()>> {
 
 #[test]
 fn forward_call_works() -> Result<()> {
-    let mut store = store_with_padding(128 * MB)?;
+    let mut store = store_with_padding(PADDING)?;
     let module = Module::new(
         store.engine(),
         r#"
@@ -51,7 +56,7 @@ fn forward_call_works() -> Result<()> {
 
 #[test]
 fn backwards_call_works() -> Result<()> {
-    let mut store = store_with_padding(128 * MB)?;
+    let mut store = store_with_padding(PADDING)?;
     let module = Module::new(
         store.engine(),
         r#"

--- a/tests/all/threads.rs
+++ b/tests/all/threads.rs
@@ -7,12 +7,27 @@ use std::{
 };
 use wasmtime::*;
 
+pub fn engine() -> Option<Engine> {
+    let mut config = Config::new();
+    config.wasm_threads(true);
+    match Engine::new(&config) {
+        Ok(engine) => {
+            assert!(cfg!(target_pointer_width = "64"));
+            Some(engine)
+        }
+        Err(e) => {
+            assert!(cfg!(target_pointer_width = "32"), "unexpected error {e:?}");
+            None
+        }
+    }
+}
+
 #[test]
 fn test_instantiate_shared_memory() -> Result<()> {
     let wat = r#"(module (memory 1 1 shared))"#;
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let _instance = Instance::new(&mut store, &module, &[])?;
@@ -22,9 +37,9 @@ fn test_instantiate_shared_memory() -> Result<()> {
 #[test]
 fn test_import_shared_memory() -> Result<()> {
     let wat = r#"(module (import "env" "memory" (memory 1 5 shared)))"#;
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let shared_memory = SharedMemory::new(&engine, MemoryType::shared(1, 5))?;
@@ -35,9 +50,9 @@ fn test_import_shared_memory() -> Result<()> {
 #[test]
 fn test_export_shared_memory() -> Result<()> {
     let wat = r#"(module (memory (export "memory") 1 5 shared))"#;
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let instance = Instance::new(&mut store, &module, &[])?;
@@ -57,9 +72,9 @@ fn test_sharing_of_shared_memory() -> Result<()> {
         (import "env" "memory" (memory 1 5 shared))
         (func (export "first_word") (result i32) (i32.load (i32.const 0)))
     )"#;
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let shared_memory = SharedMemory::new(&engine, MemoryType::shared(1, 5))?;
@@ -101,9 +116,9 @@ fn test_probe_shared_memory_size() -> Result<()> {
         (memory (export "memory") 1 2 shared)
         (func (export "size") (result i32) (memory.size))
     )"#;
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let instance = Instance::new(&mut store, &module, &[])?;
@@ -129,10 +144,9 @@ fn test_multi_memory() -> Result<()> {
         (memory (export "shared") 1 2 shared)
         (export "imported" (memory $imported))
     )"#;
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    config.wasm_multi_memory(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let incoming_shared_memory = SharedMemory::new(&engine, MemoryType::shared(5, 10))?;
@@ -168,9 +182,9 @@ fn test_grow_memory_in_multiple_threads() -> Result<()> {
         (func (export "grow") (param $delta i32) (result i32) (memory.grow (local.get $delta)))
     )"#;
 
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let shared_memory = SharedMemory::new(&engine, MemoryType::shared(1, NUM_GROW_OPS as u32))?;
     let mut threads = vec![];
@@ -240,9 +254,9 @@ fn test_memory_size_accessibility() -> Result<()> {
         )
     )"#;
 
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let shared_memory = SharedMemory::new(&engine, MemoryType::shared(1, NUM_GROW_OPS as u32))?;
     let done = Arc::new(AtomicBool::new(false));

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1349,12 +1349,15 @@ fn wasm_fault_address_reported_by_default() -> Result<()> {
     // It looks like the exact reported fault address may not be deterministic,
     // so assert that we have the right error message, but not the exact
     // address.
+    //
+    // Skip 32-bit platforms here which currently all use Pulley and don't use
+    // virtual memory for catching traps. This means that the trap error isn't
+    // available.
     let err = format!("{err:?}");
-    assert!(
-        err.contains("memory fault at wasm address ")
-            && err.contains(" in linear memory of size 0x10000"),
-        "bad error: {err}"
-    );
+    let contains_address = err.contains("memory fault at wasm address ")
+        && err.contains(" in linear memory of size 0x10000");
+    let address_expected = cfg!(target_pointer_width = "64");
+    assert_eq!(contains_address, address_expected, "bad error: {err}");
     Ok(())
 }
 

--- a/tests/all/wait_notify.rs
+++ b/tests/all/wait_notify.rs
@@ -1,5 +1,6 @@
 #![cfg(not(miri))]
 
+use crate::threads::engine;
 use std::time::Instant;
 use wasmtime::*;
 
@@ -17,9 +18,9 @@ fn atomic_wait_timeout_length() -> Result<()> {
         (data (i32.const 0) "\00\00\00\00")
     )"#
     );
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let shared_memory = SharedMemory::new(&engine, MemoryType::shared(1, 1))?;
@@ -61,9 +62,9 @@ fn atomic_wait_notify_basic() -> Result<()> {
         (data (i32.const 0) "\00\00\00\00")
         (data (i32.const 4) "\00\00\00\00")
     )"#;
-    let mut config = Config::new();
-    config.wasm_threads(true);
-    let engine = Engine::new(&config)?;
+    let Some(engine) = engine() else {
+        return Ok(());
+    };
     let module = Module::new(&engine, wat)?;
     let mut store = Store::new(&engine, ());
     let shared_memory = SharedMemory::new(&engine, MemoryType::shared(1, 1))?;

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -54,11 +54,15 @@ fn wasi_testsuite() -> Result<()> {
         &[],
         WASI_COMMON_IGNORE_LIST,
     )?;
-    run_all(
-        "tests/wasi_testsuite/wasi-threads",
-        &["-Sthreads", "-Wthreads"],
-        &[],
-    )?;
+
+    // Only run threaded tests on platforms that support threads.
+    if crate::threads::engine().is_some() {
+        run_all(
+            "tests/wasi_testsuite/wasi-threads",
+            &["-Sthreads", "-Wthreads"],
+            &[],
+        )?;
+    }
     Ok(())
 }
 

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -259,10 +259,14 @@ fn run_test(name: &str, stack_overflow: StackOverflow) {
     }
 
     match stack_overflow {
+        // If the host stack overflows then the result should always indicate a
+        // stack overflow. If the guest stack overflows then that won't actually
+        // trigger an overflow when Cranelift doesn't have native support
+        // because Pulley is used in that case.
         StackOverflow::Host | StackOverflow::Wasm => {
             let native_stack_overflow = is_stack_overflow(&output.status, &stderr);
             let expect_native_overflow =
-                stack_overflow == StackOverflow::Host || cfg!(target_pointer_width = "64");
+                stack_overflow == StackOverflow::Host || cranelift_native::builder().is_ok();
 
             if native_stack_overflow == expect_native_overflow {
                 assert!(

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -80,6 +80,13 @@ fn dummy_waker() -> Waker {
     }
 }
 
+#[derive(PartialEq, Copy, Clone)]
+enum StackOverflow {
+    No,
+    Host,
+    Wasm,
+}
+
 fn main() {
     if cfg!(miri) {
         return;
@@ -112,8 +119,8 @@ fn main() {
         );
     }
 
-    let tests: &[(&str, fn(), bool)] = &[
-        ("normal segfault", || segfault(), false),
+    let tests: &[(&str, fn(), StackOverflow)] = &[
+        ("normal segfault", || segfault(), StackOverflow::No),
         (
             "make instance then segfault",
             || {
@@ -123,7 +130,7 @@ fn main() {
                 let _instance = Instance::new(&mut store, &module, &[]).unwrap();
                 segfault();
             },
-            false,
+            StackOverflow::No,
         ),
         (
             "make instance then overrun the stack",
@@ -134,7 +141,7 @@ fn main() {
                 let _instance = Instance::new(&mut store, &module, &[]).unwrap();
                 overrun_the_stack();
             },
-            true,
+            StackOverflow::Host,
         ),
         (
             "segfault in a host function",
@@ -146,7 +153,7 @@ fn main() {
                 Instance::new(&mut store, &module, &[segfault.into()]).unwrap();
                 unreachable!();
             },
-            false,
+            StackOverflow::No,
         ),
         (
             "hit async stack guard page",
@@ -165,17 +172,17 @@ fn main() {
                 run_future(f.call_async(&mut store, &[], &mut [])).unwrap();
                 unreachable!();
             },
-            true,
+            StackOverflow::Host,
         ),
         (
             "overrun 8k with misconfigured host",
             || overrun_with_big_module(8 << 10),
-            true,
+            StackOverflow::Wasm,
         ),
         (
             "overrun 32k with misconfigured host",
             || overrun_with_big_module(32 << 10),
-            true,
+            StackOverflow::Wasm,
         ),
         #[cfg(not(any(target_arch = "riscv64")))]
         // Due to `InstanceAllocationStrategy::pooling()` trying to alloc more than 6000G memory space.
@@ -186,7 +193,13 @@ fn main() {
             || {
                 let mut config = Config::default();
                 config.async_support(true);
-                config.allocation_strategy(InstanceAllocationStrategy::pooling());
+                let mut cfg = PoolingAllocationConfig::default();
+                cfg.total_memories(1);
+                cfg.max_memory_size(1 << 16);
+                cfg.total_tables(1);
+                cfg.table_elements(10);
+                cfg.total_stacks(1);
+                config.allocation_strategy(cfg);
                 let engine = Engine::new(&config).unwrap();
                 let mut store = Store::new(&engine, ());
                 let f = Func::wrap_async(&mut store, |_, _: ()| {
@@ -199,7 +212,7 @@ fn main() {
                 run_future(f.call_async(&mut store, &[], &mut [])).unwrap();
                 unreachable!();
             },
-            true,
+            StackOverflow::Host,
         ),
     ];
     match env::var(VAR_NAME) {
@@ -224,7 +237,7 @@ fn main() {
     }
 }
 
-fn run_test(name: &str, stack_overflow: bool) {
+fn run_test(name: &str, stack_overflow: StackOverflow) {
     let me = env::current_exe().unwrap();
     let mut cmd = Command::new(me);
     cmd.env(VAR_NAME, name);
@@ -245,23 +258,30 @@ fn run_test(name: &str, stack_overflow: bool) {
         desc.push_str(&stderr.replace("\n", "\n    "));
     }
 
-    if stack_overflow {
-        if is_stack_overflow(&output.status, &stderr) {
-            assert!(
-                stdout.trim().ends_with(CONFIRM),
-                "failed to find confirmation in test `{name}`\n{desc}"
-            );
-        } else {
-            panic!("\n\nexpected a stack overflow on `{name}`\n{desc}\n\n");
+    match stack_overflow {
+        StackOverflow::Host | StackOverflow::Wasm => {
+            let native_stack_overflow = is_stack_overflow(&output.status, &stderr);
+            let expect_native_overflow =
+                stack_overflow == StackOverflow::Host || cfg!(target_pointer_width = "64");
+
+            if native_stack_overflow == expect_native_overflow {
+                assert!(
+                    stdout.trim().ends_with(CONFIRM),
+                    "failed to find confirmation in test `{name}`\n{desc}"
+                );
+            } else {
+                panic!("\n\nexpected a stack overflow on `{name}`\n{desc}\n\n");
+            }
         }
-    } else {
-        if is_segfault(&output.status) {
-            assert!(
-                stdout.trim().ends_with(CONFIRM) && stderr.is_empty(),
-                "failed to find confirmation in test `{name}`\n{desc}"
-            );
-        } else {
-            panic!("\n\nexpected a segfault on `{name}`\n{desc}\n\n");
+        StackOverflow::No => {
+            if is_segfault(&output.status) {
+                assert!(
+                    stdout.trim().ends_with(CONFIRM) && stderr.is_empty(),
+                    "failed to find confirmation in test `{name}`\n{desc}"
+                );
+            } else {
+                panic!("\n\nexpected a segfault on `{name}`\n{desc}\n\n");
+            }
         }
     }
 }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -615,8 +615,12 @@ where
         // In the defined case, mask the funcref address in place, by peeking into the
         // last element of the value stack, which was pushed by the `indirect` function
         // call above.
+        //
+        // Note that `FUNCREF_MASK` as type `usize` but here we want a 64-bit
+        // value so assert its actual value and then use a `-2` literal.
         self.masm.bind(defined)?;
-        let imm = RegImm::i64(FUNCREF_MASK as i64);
+        assert_eq!(FUNCREF_MASK as isize, -2);
+        let imm = RegImm::i64(-2);
         let dst = top.into();
         self.masm
             .and(writable!(dst), dst, imm, top.ty.try_into()?)?;


### PR DESCRIPTION
This commit switches to running the full test suite in its entirety (`./ci/run-tests.sh`) on 32-bit platforms in CI in addition to 64-bit platforms. This notably adds i686 and armv7 as architectures that are tested in CI.

Lots of little fixes here and there were applied to a number of tests. Many tests just don't run on 32-bit platforms or a platform without Cranelift support, and they've been annotated as such where necessary. Other tests were adjusted to run on all platforms a few minor bug fixes are here as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
