### PR TITLE
Optimize constant offset loads/stores in translation

### DIFF
--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -10,6 +10,7 @@ use core::fmt::{self, Display, Formatter};
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Sub};
 use core::str::FromStr;
 use core::{i32, u32};
+use cranelift_entity::{Signed, Unsigned};
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
 
@@ -92,7 +93,7 @@ impl Imm64 {
     /// Sign extend this immediate as if it were a signed integer of the given
     /// power-of-two width.
     #[must_use]
-    pub(crate) fn sign_extend_from_width(&self, bit_width: u32) -> Self {
+    pub fn sign_extend_from_width(&self, bit_width: u32) -> Self {
         debug_assert!(
             bit_width.is_power_of_two(),
             "{bit_width} is not a power of two"
@@ -106,6 +107,25 @@ impl Imm64 {
         let delta = 64 - bit_width;
         let sign_extended = (self.0 << delta) >> delta;
         Imm64(sign_extended)
+    }
+
+    /// Zero extend this immediate as if it were a signed integer of the given
+    /// power-of-two width.
+    #[must_use]
+    pub fn zero_extend_from_width(&self, bit_width: u32) -> Self {
+        debug_assert!(
+            bit_width.is_power_of_two(),
+            "{bit_width} is not a power of two"
+        );
+
+        if bit_width >= 64 {
+            return *self;
+        }
+
+        let bit_width = u64::from(bit_width);
+        let delta = 64 - bit_width;
+        let sign_extended = (self.0.unsigned() << delta) >> delta;
+        Imm64(sign_extended.signed())
     }
 }
 

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -109,8 +109,8 @@ impl Imm64 {
         Imm64(sign_extended)
     }
 
-    /// Zero extend this immediate as if it were a signed integer of the given
-    /// power-of-two width.
+    /// Zero extend this immediate as if it were an unsigned integer of the
+    /// given power-of-two width.
     #[must_use]
     pub fn zero_extend_from_width(&self, bit_width: u32) -> Self {
         debug_assert!(
@@ -124,8 +124,8 @@ impl Imm64 {
 
         let bit_width = u64::from(bit_width);
         let delta = 64 - bit_width;
-        let sign_extended = (self.0.unsigned() << delta) >> delta;
-        Imm64(sign_extended.signed())
+        let zero_extended = (self.0.unsigned() << delta) >> delta;
+        Imm64(zero_extended.signed())
     }
 }
 

--- a/tests/disas/pulley/memory-inbounds.wat
+++ b/tests/disas/pulley/memory-inbounds.wat
@@ -1,0 +1,31 @@
+;;! target = "pulley64"
+;;! test = "compile"
+
+(module
+  (memory 1)
+
+  (func (result i32)
+    (i32.const 0)
+    i32.load
+  )
+
+  (func (result i32)
+    (i32.const 100)
+    i32.load
+  )
+)
+;; wasm[0]::function[0]:
+;;       push_frame
+;;       xload64le_offset32 x3, x0, 96
+;;       xload32le_offset32 x0, x3, 0
+;;       pop_frame
+;;       ret
+;;
+;; wasm[0]::function[1]:
+;;       push_frame
+;;       xload64le_offset32 x5, x0, 96
+;;       xconst8 x6, 100
+;;       xadd64 x5, x5, x6
+;;       xload32le_offset32 x0, x5, 0
+;;       pop_frame
+;;       ret

--- a/tests/disas/pulley/memory-inbounds.wat
+++ b/tests/disas/pulley/memory-inbounds.wat
@@ -2,26 +2,30 @@
 ;;! test = "compile"
 
 (module
-  (memory 1)
+  (memory $m1 1 2)
 
-  (func (result i32)
-    (i32.const 0)
-    i32.load
-  )
+  (func $offset0 (result i32) (i32.const 0) i32.load $m1)
+  (func $offset100 (result i32) (i32.const 100) i32.load $m1)
+  (func $offset_mixed (result i32) (i32.const 100) i32.load $m1 offset=100)
+  (func $offset_just_ok (result i32) (i32.const 65532) i32.load $m1)
+  (func $offset_just_bad (result i32) (i32.const 65533) i32.load $m1)
+  (func $offset_just_ok_v2 (result i32) (i32.const 1) i32.load $m1 offset=65531)
+  (func $offset_just_bad_v2 (result i32) (i32.const 1) i32.load $m1 offset=65532)
 
-  (func (result i32)
-    (i32.const 100)
-    i32.load
-  )
+  (func $maybe_inbounds (result i32) (i32.const 131068) i32.load $m1)
+  (func $maybe_inbounds_v2 (result i32) (i32.const 0) i32.load $m1 offset=131068)
+  (func $never_inbounds (result i32) (i32.const 131069) i32.load $m1)
+  (func $never_inbounds_v2 (result i32) (i32.const 0) i32.load $m1 offset=131069)
 )
-;; wasm[0]::function[0]:
+
+;; wasm[0]::function[0]::offset0:
 ;;       push_frame
 ;;       xload64le_offset32 x3, x0, 96
 ;;       xload32le_offset32 x0, x3, 0
 ;;       pop_frame
 ;;       ret
 ;;
-;; wasm[0]::function[1]:
+;; wasm[0]::function[1]::offset100:
 ;;       push_frame
 ;;       xload64le_offset32 x5, x0, 96
 ;;       xconst8 x6, 100
@@ -29,3 +33,106 @@
 ;;       xload32le_offset32 x0, x5, 0
 ;;       pop_frame
 ;;       ret
+;;
+;; wasm[0]::function[2]::offset_mixed:
+;;       push_frame
+;;       xload64le_offset32 x5, x0, 96
+;;       xconst16 x6, 200
+;;       xadd64 x5, x5, x6
+;;       xload32le_offset32 x0, x5, 0
+;;       pop_frame
+;;       ret
+;;
+;; wasm[0]::function[3]::offset_just_ok:
+;;       push_frame
+;;       xload64le_offset32 x5, x0, 96
+;;       xconst32 x6, 65532
+;;       xadd64 x5, x5, x6
+;;       xload32le_offset32 x0, x5, 0
+;;       pop_frame
+;;       ret
+;;
+;; wasm[0]::function[4]::offset_just_bad:
+;;       push_frame
+;;       xload64le_offset32 x8, x0, 104
+;;       xconst8 x9, 4
+;;       xsub64 x9, x8, x9
+;;       xconst32 x8, 65533
+;;       br_if_xult64 x9, x8, 0x1a    // target = 0x2e
+;;   1b: xload64le_offset32 x9, x0, 96
+;;       xadd64 x9, x9, x8
+;;       xload32le_offset32 x0, x9, 0
+;;       pop_frame
+;;       ret
+;;   2e: trap
+;;
+;; wasm[0]::function[5]::offset_just_ok_v2:
+;;       push_frame
+;;       xload64le_offset32 x5, x0, 96
+;;       xconst32 x6, 65532
+;;       xadd64 x5, x5, x6
+;;       xload32le_offset32 x0, x5, 0
+;;       pop_frame
+;;       ret
+;;
+;; wasm[0]::function[6]::offset_just_bad_v2:
+;;       push_frame
+;;       xload64le_offset32 x9, x0, 104
+;;       xconst32 x10, 65536
+;;       xsub64 x9, x9, x10
+;;       xconst8 x10, 0
+;;       br_if_xeq64 x9, x10, 0x20    // target = 0x34
+;;   1b: xload64le_offset32 x10, x0, 96
+;;       xconst32 x11, 65533
+;;       xadd64 x10, x10, x11
+;;       xload32le_offset32 x0, x10, 0
+;;       pop_frame
+;;       ret
+;;   34: trap
+;;
+;; wasm[0]::function[7]::maybe_inbounds:
+;;       push_frame
+;;       xload64le_offset32 x8, x0, 104
+;;       xconst8 x9, 4
+;;       xsub64 x9, x8, x9
+;;       xconst32 x8, 131068
+;;       br_if_xult64 x9, x8, 0x1a    // target = 0x2e
+;;   1b: xload64le_offset32 x9, x0, 96
+;;       xadd64 x9, x9, x8
+;;       xload32le_offset32 x0, x9, 0
+;;       pop_frame
+;;       ret
+;;   2e: trap
+;;
+;; wasm[0]::function[8]::maybe_inbounds_v2:
+;;       push_frame
+;;       xconst8 x9, 0
+;;       xconst32 x10, 131072
+;;       xadd64_uoverflow_trap x9, x9, x10
+;;       xload64le_offset32 x10, x0, 104
+;;       br_if_xult64 x10, x9, 0x20    // target = 0x34
+;;   1b: xload64le_offset32 x10, x0, 96
+;;       xconst32 x11, 131068
+;;       xadd64 x10, x10, x11
+;;       xload32le_offset32 x0, x10, 0
+;;       pop_frame
+;;       ret
+;;   34: trap
+;;
+;; wasm[0]::function[9]::never_inbounds:
+;;       push_frame
+;;       xload64le_offset32 x8, x0, 104
+;;       xconst8 x9, 4
+;;       xsub64 x9, x8, x9
+;;       xconst32 x8, 131069
+;;       br_if_xult64 x9, x8, 0x1a    // target = 0x2e
+;;   1b: xload64le_offset32 x9, x0, 96
+;;       xadd64 x9, x9, x8
+;;       xload32le_offset32 x0, x9, 0
+;;       pop_frame
+;;       ret
+;;   2e: trap
+;;
+;; wasm[0]::function[10]::never_inbounds_v2:
+;;       push_frame
+;;       trap


### PR DESCRIPTION
This commit implements an optimization when lowering Wasm bytecode to CLIF to skip a bounds check when the offset in memory is statically known. This comes up in C/C++/Rust when `static` memory is addressed for example where LLVM emits an `i32.const 0` as the base address and puts the address of the variable in the `offset` instruction field. This isn't necessary for 64-bit platforms but when explicit bounds-checks are required this can help to eliminate a constant-true bounds-check.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
