### PR TITLE
pulley: Fold `iadd a, $N` into amode

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -540,6 +540,9 @@
 
 (decl amode (Value Offset32) Amode)
 (rule (amode addr (offset32 offset)) (Amode.RegOffset addr offset))
+(rule 1 (amode (iadd addr (i32_from_iconst b)) (offset32 offset))
+  (if-let new_offset (s32_add_fallible b offset))
+  (Amode.RegOffset addr new_offset))
 
 (rule (lower (has_type (ty_int (fits_in_64 ty)) (load flags addr offset)))
   (pulley_xload (amode addr offset) ty flags (ExtKind.None)))

--- a/cranelift/filetests/filetests/isa/pulley64/load.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/load.clif
@@ -61,3 +61,20 @@ block0(v0: i64):
 ; xload64le_offset32 x0, x0, 8
 ; ret
 
+
+function %load_i64_with_add_and_offset(i64) -> i64 {
+block0(v0: i64):
+    v1 = iadd_imm v0, 10
+    v2 = load.i64 v1+8
+    return v2
+}
+
+; VCode:
+; block0:
+;   x0 = xload64 x0+18 // flags =
+;   ret
+;
+; Disassembled:
+; xload64le_offset32 x0, x0, 18
+; ret
+

--- a/tests/disas/pulley/memory-inbounds.wat
+++ b/tests/disas/pulley/memory-inbounds.wat
@@ -27,111 +27,96 @@
 ;;
 ;; wasm[0]::function[1]::offset100:
 ;;       push_frame
-;;       xload64le_offset32 x5, x0, 96
-;;       xconst8 x6, 100
-;;       xadd64 x5, x5, x6
-;;       xload32le_offset32 x0, x5, 0
+;;       xload64le_offset32 x3, x0, 96
+;;       xload32le_offset32 x0, x3, 100
 ;;       pop_frame
 ;;       ret
 ;;
 ;; wasm[0]::function[2]::offset_mixed:
 ;;       push_frame
-;;       xload64le_offset32 x5, x0, 96
-;;       xconst16 x6, 200
-;;       xadd64 x5, x5, x6
-;;       xload32le_offset32 x0, x5, 0
+;;       xload64le_offset32 x3, x0, 96
+;;       xload32le_offset32 x0, x3, 200
 ;;       pop_frame
 ;;       ret
 ;;
 ;; wasm[0]::function[3]::offset_just_ok:
 ;;       push_frame
-;;       xload64le_offset32 x5, x0, 96
-;;       xconst32 x6, 65532
-;;       xadd64 x5, x5, x6
-;;       xload32le_offset32 x0, x5, 0
+;;       xload64le_offset32 x3, x0, 96
+;;       xload32le_offset32 x0, x3, 65532
 ;;       pop_frame
 ;;       ret
 ;;
 ;; wasm[0]::function[4]::offset_just_bad:
 ;;       push_frame
-;;       xload64le_offset32 x8, x0, 104
-;;       xconst8 x9, 4
-;;       xsub64 x9, x8, x9
+;;       xload64le_offset32 x7, x0, 104
+;;       xconst8 x8, 4
+;;       xsub64 x7, x7, x8
 ;;       xconst32 x8, 65533
-;;       br_if_xult64 x9, x8, 0x1a    // target = 0x2e
-;;   1b: xload64le_offset32 x9, x0, 96
-;;       xadd64 x9, x9, x8
-;;       xload32le_offset32 x0, x9, 0
+;;       br_if_xult64 x7, x8, 0x17    // target = 0x2b
+;;   1b: xload64le_offset32 x8, x0, 96
+;;       xload32le_offset32 x0, x8, 65533
 ;;       pop_frame
 ;;       ret
-;;   2e: trap
+;;   2b: trap
 ;;
 ;; wasm[0]::function[5]::offset_just_ok_v2:
 ;;       push_frame
-;;       xload64le_offset32 x5, x0, 96
-;;       xconst32 x6, 65532
-;;       xadd64 x5, x5, x6
-;;       xload32le_offset32 x0, x5, 0
+;;       xload64le_offset32 x3, x0, 96
+;;       xload32le_offset32 x0, x3, 65532
 ;;       pop_frame
 ;;       ret
 ;;
 ;; wasm[0]::function[6]::offset_just_bad_v2:
 ;;       push_frame
-;;       xload64le_offset32 x9, x0, 104
-;;       xconst32 x10, 65536
-;;       xsub64 x9, x9, x10
-;;       xconst8 x10, 0
-;;       br_if_xeq64 x9, x10, 0x20    // target = 0x34
-;;   1b: xload64le_offset32 x10, x0, 96
-;;       xconst32 x11, 65533
-;;       xadd64 x10, x10, x11
-;;       xload32le_offset32 x0, x10, 0
+;;       xload64le_offset32 x7, x0, 104
+;;       xconst32 x8, 65536
+;;       xsub64 x7, x7, x8
+;;       xconst8 x8, 0
+;;       br_if_xeq64 x7, x8, 0x17    // target = 0x2b
+;;   1b: xload64le_offset32 x8, x0, 96
+;;       xload32le_offset32 x0, x8, 65533
 ;;       pop_frame
 ;;       ret
-;;   34: trap
+;;   2b: trap
 ;;
 ;; wasm[0]::function[7]::maybe_inbounds:
 ;;       push_frame
-;;       xload64le_offset32 x8, x0, 104
-;;       xconst8 x9, 4
-;;       xsub64 x9, x8, x9
+;;       xload64le_offset32 x7, x0, 104
+;;       xconst8 x8, 4
+;;       xsub64 x7, x7, x8
 ;;       xconst32 x8, 131068
-;;       br_if_xult64 x9, x8, 0x1a    // target = 0x2e
-;;   1b: xload64le_offset32 x9, x0, 96
-;;       xadd64 x9, x9, x8
-;;       xload32le_offset32 x0, x9, 0
+;;       br_if_xult64 x7, x8, 0x17    // target = 0x2b
+;;   1b: xload64le_offset32 x8, x0, 96
+;;       xload32le_offset32 x0, x8, 131068
 ;;       pop_frame
 ;;       ret
-;;   2e: trap
+;;   2b: trap
 ;;
 ;; wasm[0]::function[8]::maybe_inbounds_v2:
 ;;       push_frame
-;;       xconst8 x9, 0
-;;       xconst32 x10, 131072
-;;       xadd64_uoverflow_trap x9, x9, x10
-;;       xload64le_offset32 x10, x0, 104
-;;       br_if_xult64 x10, x9, 0x20    // target = 0x34
-;;   1b: xload64le_offset32 x10, x0, 96
-;;       xconst32 x11, 131068
-;;       xadd64 x10, x10, x11
-;;       xload32le_offset32 x0, x10, 0
+;;       xconst8 x7, 0
+;;       xconst32 x8, 131072
+;;       xadd64_uoverflow_trap x7, x7, x8
+;;       xload64le_offset32 x8, x0, 104
+;;       br_if_xult64 x8, x7, 0x17    // target = 0x2b
+;;   1b: xload64le_offset32 x8, x0, 96
+;;       xload32le_offset32 x0, x8, 131068
 ;;       pop_frame
 ;;       ret
-;;   34: trap
+;;   2b: trap
 ;;
 ;; wasm[0]::function[9]::never_inbounds:
 ;;       push_frame
-;;       xload64le_offset32 x8, x0, 104
-;;       xconst8 x9, 4
-;;       xsub64 x9, x8, x9
+;;       xload64le_offset32 x7, x0, 104
+;;       xconst8 x8, 4
+;;       xsub64 x7, x7, x8
 ;;       xconst32 x8, 131069
-;;       br_if_xult64 x9, x8, 0x1a    // target = 0x2e
-;;   1b: xload64le_offset32 x9, x0, 96
-;;       xadd64 x9, x9, x8
-;;       xload32le_offset32 x0, x9, 0
+;;       br_if_xult64 x7, x8, 0x17    // target = 0x2b
+;;   1b: xload64le_offset32 x8, x0, 96
+;;       xload32le_offset32 x0, x8, 131069
 ;;       pop_frame
 ;;       ret
-;;   2e: trap
+;;   2b: trap
 ;;
 ;; wasm[0]::function[10]::never_inbounds_v2:
 ;;       push_frame


### PR DESCRIPTION
Pushes more into the 32-bit offset on load/store instructions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
