### PR TITLE
winch: Gracefully handle compilation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4741,6 +4741,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
+ "thiserror",
  "wasmparser 0.221.2",
  "wasmtime-cranelift",
  "wasmtime-environ",

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -25,6 +25,7 @@ regalloc2 = { workspace = true }
 gimli = { workspace = true }
 wasmtime-environ = { workspace = true }
 wasmtime-cranelift = { workspace = true }
+thiserror = { workspace = true }
 
 [features]
 x64 = ["cranelift-codegen/x86"]

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -1,9 +1,10 @@
+use anyhow::{bail, ensure, Result};
 use wasmtime_environ::{VMOffsets, WasmHeapType, WasmValType};
 
 use super::ControlStackFrame;
 use crate::{
     abi::{scratch, vmctx, ABIOperand, ABIResults, RetArea},
-    codegen::{CodeGenPhase, Emission, Prologue},
+    codegen::{CodeGenError, CodeGenPhase, Emission, Prologue},
     frame::Frame,
     isa::reg::RegClass,
     masm::{MacroAssembler, OperandSize, RegImm, SPOffset, ShiftKind, StackSlot},
@@ -42,18 +43,21 @@ pub(crate) struct CodeGenContext<'a, P: CodeGenPhase> {
 
 impl<'a> CodeGenContext<'a, Emission> {
     /// Prepares arguments for emitting an i32 shift operation.
-    pub fn i32_shift<M>(&mut self, masm: &mut M, kind: ShiftKind)
+    pub fn i32_shift<M>(&mut self, masm: &mut M, kind: ShiftKind) -> Result<()>
     where
         M: MacroAssembler,
     {
-        let top = self.stack.peek().expect("value at stack top");
+        let top = self
+            .stack
+            .peek()
+            .ok_or_else(|| CodeGenError::missing_values_in_stack())?;
 
         if top.is_i32_const() {
             let val = self
                 .stack
                 .pop_i32_const()
-                .expect("i32 const value at stack top");
-            let typed_reg = self.pop_to_reg(masm, None);
+                .ok_or_else(|| CodeGenError::missing_values_in_stack())?;
+            let typed_reg = self.pop_to_reg(masm, None)?;
             masm.shift_ir(
                 writable!(typed_reg.reg),
                 val as u64,
@@ -63,22 +67,26 @@ impl<'a> CodeGenContext<'a, Emission> {
             );
             self.stack.push(typed_reg.into());
         } else {
-            masm.shift(self, kind, OperandSize::S32);
+            masm.shift(self, kind, OperandSize::S32)?;
         }
+        Ok(())
     }
 
     /// Prepares arguments for emitting an i64 binary operation.
-    pub fn i64_shift<M>(&mut self, masm: &mut M, kind: ShiftKind)
+    pub fn i64_shift<M>(&mut self, masm: &mut M, kind: ShiftKind) -> Result<()>
     where
         M: MacroAssembler,
     {
-        let top = self.stack.peek().expect("value at stack top");
+        let top = self
+            .stack
+            .peek()
+            .ok_or_else(|| CodeGenError::missing_values_in_stack())?;
         if top.is_i64_const() {
             let val = self
                 .stack
                 .pop_i64_const()
-                .expect("i64 const value at stack top");
-            let typed_reg = self.pop_to_reg(masm, None);
+                .ok_or_else(|| CodeGenError::missing_values_in_stack())?;
+            let typed_reg = self.pop_to_reg(masm, None)?;
             masm.shift_ir(
                 writable!(typed_reg.reg),
                 val as u64,
@@ -88,8 +96,10 @@ impl<'a> CodeGenContext<'a, Emission> {
             );
             self.stack.push(typed_reg.into());
         } else {
-            masm.shift(self, kind, OperandSize::S64);
+            masm.shift(self, kind, OperandSize::S64)?;
         };
+
+        Ok(())
     }
 }
 
@@ -125,14 +135,18 @@ impl<'a> CodeGenContext<'a, Prologue> {
 impl<'a> CodeGenContext<'a, Emission> {
     /// Request a specific register to the register allocator,
     /// spilling if not available.
-    pub fn reg<M: MacroAssembler>(&mut self, named: Reg, masm: &mut M) -> Reg {
+    pub fn reg<M: MacroAssembler>(&mut self, named: Reg, masm: &mut M) -> Result<Reg> {
         self.regalloc.reg(named, |regalloc| {
             Self::spill_impl(&mut self.stack, regalloc, &self.frame, masm)
         })
     }
 
     /// Allocate a register for the given WebAssembly type.
-    pub fn reg_for_type<M: MacroAssembler>(&mut self, ty: WasmValType, masm: &mut M) -> Reg {
+    pub fn reg_for_type<M: MacroAssembler>(
+        &mut self,
+        ty: WasmValType,
+        masm: &mut M,
+    ) -> Result<Reg> {
         use WasmValType::*;
         match ty {
             I32 | I64 => self.reg_for_class(RegClass::Int, masm),
@@ -143,14 +157,18 @@ impl<'a> CodeGenContext<'a, Emission> {
                 WasmHeapType::Func | WasmHeapType::Extern => {
                     self.reg_for_class(RegClass::Int, masm)
                 }
-                ht => unimplemented!("Support for WasmHeapType: {ht}"),
+                _ => bail!(CodeGenError::unsupported_wasm_type()),
             },
         }
     }
 
     /// Request the register allocator to provide the next available
     /// register of the specified class.
-    pub fn reg_for_class<M: MacroAssembler>(&mut self, class: RegClass, masm: &mut M) -> Reg {
+    pub fn reg_for_class<M: MacroAssembler>(
+        &mut self,
+        class: RegClass,
+        masm: &mut M,
+    ) -> Result<Reg> {
         self.regalloc.reg_for_class(class, &mut |regalloc| {
             Self::spill_impl(&mut self.stack, regalloc, &self.frame, masm)
         })
@@ -158,13 +176,13 @@ impl<'a> CodeGenContext<'a, Emission> {
 
     /// Convenience wrapper around `CodeGenContext::reg_for_class`, to
     /// request the next available general purpose register.
-    pub fn any_gpr<M: MacroAssembler>(&mut self, masm: &mut M) -> Reg {
+    pub fn any_gpr<M: MacroAssembler>(&mut self, masm: &mut M) -> Result<Reg> {
         self.reg_for_class(RegClass::Int, masm)
     }
 
     /// Convenience wrapper around `CodeGenContext::reg_for_class`, to
     /// request the next available floating point register.
-    pub fn any_fpr<M: MacroAssembler>(&mut self, masm: &mut M) -> Reg {
+    pub fn any_fpr<M: MacroAssembler>(&mut self, masm: &mut M) -> Result<Reg> {
         self.reg_for_class(RegClass::Float, masm)
     }
 
@@ -176,13 +194,13 @@ impl<'a> CodeGenContext<'a, Emission> {
         regs: impl IntoIterator<Item = &'r Reg> + Copy,
         masm: &mut M,
         mut f: F,
-    ) -> T
+    ) -> Result<T>
     where
         M: MacroAssembler,
         F: FnMut(&mut Self, &mut M) -> T,
     {
         for r in regs {
-            self.reg(*r, masm);
+            self.reg(*r, masm)?;
         }
 
         let result = f(self, masm);
@@ -191,7 +209,7 @@ impl<'a> CodeGenContext<'a, Emission> {
             self.free_reg(*r);
         }
 
-        result
+        Ok(result)
     }
 
     /// Free the given register.
@@ -207,7 +225,11 @@ impl<'a> CodeGenContext<'a, Emission> {
     /// When a named register is requested and it's not at the top of the
     /// stack a move from register to register might happen, in which case
     /// the source register will be freed.
-    pub fn pop_to_reg<M: MacroAssembler>(&mut self, masm: &mut M, named: Option<Reg>) -> TypedReg {
+    pub fn pop_to_reg<M: MacroAssembler>(
+        &mut self,
+        masm: &mut M,
+        named: Option<Reg>,
+    ) -> Result<TypedReg> {
         let typed_reg = if let Some(dst) = named {
             self.stack.pop_named_reg(dst)
         } else {
@@ -215,36 +237,41 @@ impl<'a> CodeGenContext<'a, Emission> {
         };
 
         if let Some(dst) = typed_reg {
-            return dst;
+            return Ok(dst);
         }
 
         let val = self.stack.pop().expect("a value at stack top");
         let reg = if let Some(r) = named {
-            self.reg(r, masm)
+            self.reg(r, masm)?
         } else {
-            self.reg_for_type(val.ty(), masm)
+            self.reg_for_type(val.ty(), masm)?
         };
 
         if val.is_mem() {
             let mem = val.unwrap_mem();
-            debug_assert_eq!(mem.slot.offset.as_u32(), masm.sp_offset().as_u32());
-            masm.pop(writable!(reg), val.ty().into());
+            let curr_offset = masm.sp_offset().as_u32();
+            let slot_offset = mem.slot.offset.as_u32();
+            ensure!(
+                curr_offset == slot_offset,
+                CodeGenError::invalid_sp_offset(),
+            );
+            masm.pop(writable!(reg), val.ty().try_into()?);
         } else {
-            self.move_val_to_reg(&val, reg, masm);
+            self.move_val_to_reg(&val, reg, masm)?;
             // Free the source value if it is a register.
             if val.is_reg() {
                 self.free_reg(val.unwrap_reg());
             }
         }
 
-        TypedReg::new(val.ty(), reg)
+        Ok(TypedReg::new(val.ty(), reg))
     }
 
     /// Pops the value stack top and stores it at the specified address.
-    pub fn pop_to_addr<M: MacroAssembler>(&mut self, masm: &mut M, addr: M::Address) {
+    pub fn pop_to_addr<M: MacroAssembler>(&mut self, masm: &mut M, addr: M::Address) -> Result<()> {
         let val = self.stack.pop().expect("a value at stack top");
         let ty = val.ty();
-        let size: OperandSize = ty.into();
+        let size: OperandSize = ty.try_into()?;
         match val {
             Val::Reg(tr) => {
                 masm.store(tr.reg.into(), addr, size);
@@ -268,11 +295,18 @@ impl<'a> CodeGenContext<'a, Emission> {
                 masm.store(scratch.into(), addr, size);
             }
         }
+
+        Ok(())
     }
 
     /// Move a stack value to the given register.
-    pub fn move_val_to_reg<M: MacroAssembler>(&self, src: &Val, dst: Reg, masm: &mut M) {
-        let size: OperandSize = src.ty().into();
+    pub fn move_val_to_reg<M: MacroAssembler>(
+        &self,
+        src: &Val,
+        dst: Reg,
+        masm: &mut M,
+    ) -> Result<()> {
+        let size: OperandSize = src.ty().try_into()?;
         match src {
             Val::Reg(tr) => masm.mov(writable!(dst), RegImm::reg(tr.reg), size),
             Val::I32(imm) => masm.mov(writable!(dst), RegImm::i32(*imm), size),
@@ -290,45 +324,50 @@ impl<'a> CodeGenContext<'a, Emission> {
                 masm.load(addr, writable!(dst), size);
             }
         }
+        Ok(())
     }
 
     /// Prepares arguments for emitting a unary operation.
     ///
     /// The `emit` function returns the `TypedReg` to put on the value stack.
-    pub fn unop<F, M>(&mut self, masm: &mut M, size: OperandSize, emit: &mut F)
+    pub fn unop<F, M>(&mut self, masm: &mut M, size: OperandSize, emit: &mut F) -> Result<()>
     where
         F: FnMut(&mut M, Reg, OperandSize) -> TypedReg,
         M: MacroAssembler,
     {
-        let typed_reg = self.pop_to_reg(masm, None);
+        let typed_reg = self.pop_to_reg(masm, None)?;
         let dst = emit(masm, typed_reg.reg, size);
         self.stack.push(dst.into());
+
+        Ok(())
     }
 
     /// Prepares arguments for emitting a binary operation.
     ///
     /// The `emit` function returns the `TypedReg` to put on the value stack.
-    pub fn binop<F, M>(&mut self, masm: &mut M, size: OperandSize, emit: F)
+    pub fn binop<F, M>(&mut self, masm: &mut M, size: OperandSize, emit: F) -> Result<()>
     where
-        F: FnOnce(&mut M, Reg, Reg, OperandSize) -> TypedReg,
+        F: FnOnce(&mut M, Reg, Reg, OperandSize) -> Result<TypedReg>,
         M: MacroAssembler,
     {
-        let src = self.pop_to_reg(masm, None);
-        let dst = self.pop_to_reg(masm, None);
-        let dst = emit(masm, dst.reg, src.reg.into(), size);
+        let src = self.pop_to_reg(masm, None)?;
+        let dst = self.pop_to_reg(masm, None)?;
+        let dst = emit(masm, dst.reg, src.reg.into(), size)?;
         self.free_reg(src);
         self.stack.push(dst.into());
+
+        Ok(())
     }
 
     /// Prepares arguments for emitting an f32 or f64 comparison operation.
-    pub fn float_cmp_op<F, M>(&mut self, masm: &mut M, size: OperandSize, emit: F)
+    pub fn float_cmp_op<F, M>(&mut self, masm: &mut M, size: OperandSize, emit: F) -> Result<()>
     where
         F: FnOnce(&mut M, Reg, Reg, Reg, OperandSize),
         M: MacroAssembler,
     {
-        let src2 = self.pop_to_reg(masm, None);
-        let src1 = self.pop_to_reg(masm, None);
-        let dst = self.any_gpr(masm);
+        let src2 = self.pop_to_reg(masm, None)?;
+        let src1 = self.pop_to_reg(masm, None)?;
+        let dst = self.any_gpr(masm)?;
         emit(masm, dst, src1.reg, src2.reg, size);
         self.free_reg(src1);
         self.free_reg(src2);
@@ -338,17 +377,21 @@ impl<'a> CodeGenContext<'a, Emission> {
             // [f64 f64] -> i32
             // https://webassembly.github.io/spec/core/appendix/index-instructions.html
             OperandSize::S32 | OperandSize::S64 => TypedReg::i32(dst),
-            OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => unreachable!(),
+            OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => {
+                bail!(CodeGenError::unexpected_operand_size())
+            }
         };
         self.stack.push(dst.into());
+
+        Ok(())
     }
 
     /// Prepares arguments for emitting an i32 binary operation.
     ///
     /// The `emit` function returns the `TypedReg` to put on the value stack.
-    pub fn i32_binop<F, M>(&mut self, masm: &mut M, mut emit: F)
+    pub fn i32_binop<F, M>(&mut self, masm: &mut M, mut emit: F) -> Result<()>
     where
-        F: FnMut(&mut M, Reg, RegImm, OperandSize) -> TypedReg,
+        F: FnMut(&mut M, Reg, RegImm, OperandSize) -> Result<TypedReg>,
         M: MacroAssembler,
     {
         let top = self.stack.peek().expect("value at stack top");
@@ -358,22 +401,24 @@ impl<'a> CodeGenContext<'a, Emission> {
                 .stack
                 .pop_i32_const()
                 .expect("i32 const value at stack top");
-            let typed_reg = self.pop_to_reg(masm, None);
-            let dst = emit(masm, typed_reg.reg, RegImm::i32(val), OperandSize::S32);
+            let typed_reg = self.pop_to_reg(masm, None)?;
+            let dst = emit(masm, typed_reg.reg, RegImm::i32(val), OperandSize::S32)?;
             self.stack.push(dst.into());
         } else {
             self.binop(masm, OperandSize::S32, |masm, dst, src, size| {
                 emit(masm, dst, src.into(), size)
-            });
+            })?;
         }
+
+        Ok(())
     }
 
     /// Prepares arguments for emitting an i64 binary operation.
     ///
     /// The `emit` function returns the `TypedReg` to put on the value stack.
-    pub fn i64_binop<F, M>(&mut self, masm: &mut M, emit: F)
+    pub fn i64_binop<F, M>(&mut self, masm: &mut M, emit: F) -> Result<()>
     where
-        F: FnOnce(&mut M, Reg, RegImm, OperandSize) -> TypedReg,
+        F: FnOnce(&mut M, Reg, RegImm, OperandSize) -> Result<TypedReg>,
         M: MacroAssembler,
     {
         let top = self.stack.peek().expect("value at stack top");
@@ -382,37 +427,40 @@ impl<'a> CodeGenContext<'a, Emission> {
                 .stack
                 .pop_i64_const()
                 .expect("i64 const value at stack top");
-            let typed_reg = self.pop_to_reg(masm, None);
-            let dst = emit(masm, typed_reg.reg, RegImm::i64(val), OperandSize::S64);
+            let typed_reg = self.pop_to_reg(masm, None)?;
+            let dst = emit(masm, typed_reg.reg, RegImm::i64(val), OperandSize::S64)?;
             self.stack.push(dst.into());
         } else {
             self.binop(masm, OperandSize::S64, |masm, dst, src, size| {
                 emit(masm, dst, src.into(), size)
-            });
+            })?;
         };
+
+        Ok(())
     }
 
     /// Prepares arguments for emitting a convert operation.
-    pub fn convert_op<F, M>(&mut self, masm: &mut M, dst_ty: WasmValType, emit: F)
+    pub fn convert_op<F, M>(&mut self, masm: &mut M, dst_ty: WasmValType, emit: F) -> Result<()>
     where
         F: FnOnce(&mut M, Reg, Reg, OperandSize),
         M: MacroAssembler,
     {
-        let src = self.pop_to_reg(masm, None);
-        let dst = self.reg_for_type(dst_ty, masm);
+        let src = self.pop_to_reg(masm, None)?;
+        let dst = self.reg_for_type(dst_ty, masm)?;
         let dst_size = match dst_ty {
             WasmValType::I32 => OperandSize::S32,
             WasmValType::I64 => OperandSize::S64,
             WasmValType::F32 => OperandSize::S32,
             WasmValType::F64 => OperandSize::S64,
-            WasmValType::V128 => unreachable!(),
-            WasmValType::Ref(_) => unreachable!(),
+            WasmValType::V128 => bail!(CodeGenError::unsupported_wasm_type()),
+            WasmValType::Ref(_) => bail!(CodeGenError::unsupported_wasm_type()),
         };
 
         emit(masm, dst, src.into(), dst_size);
 
         self.free_reg(src);
         self.stack.push(TypedReg::new(dst_ty, dst).into());
+        Ok(())
     }
 
     /// Prepares arguments for emitting a convert operation with a temporary
@@ -423,44 +471,48 @@ impl<'a> CodeGenContext<'a, Emission> {
         dst_ty: WasmValType,
         tmp_reg_class: RegClass,
         emit: F,
-    ) where
+    ) -> Result<()>
+    where
         F: FnOnce(&mut M, Reg, Reg, Reg, OperandSize),
         M: MacroAssembler,
     {
-        let tmp_gpr = self.reg_for_class(tmp_reg_class, masm);
+        let tmp_gpr = self.reg_for_class(tmp_reg_class, masm)?;
         self.convert_op(masm, dst_ty, |masm, dst, src, dst_size| {
             emit(masm, dst, src, tmp_gpr, dst_size);
-        });
+        })?;
         self.free_reg(tmp_gpr);
+        Ok(())
     }
 
     /// Drops the last `n` elements of the stack, calling the provided
     /// function for each `n` stack value.
     /// The values are dropped in top-to-bottom order.
-    pub fn drop_last<F>(&mut self, last: usize, mut f: F)
+    pub fn drop_last<F>(&mut self, last: usize, mut f: F) -> Result<()>
     where
-        F: FnMut(&mut RegAlloc, &Val),
+        F: FnMut(&mut RegAlloc, &Val) -> Result<()>,
     {
         if last > 0 {
             let len = self.stack.len();
-            assert!(last <= len);
+            ensure!(last <= len, CodeGenError::unexpected_value_stack_index(),);
             let truncate = self.stack.len() - last;
             let stack_mut = self.stack.inner_mut();
 
             // Invoke the callback in top-to-bottom order.
             for v in stack_mut[truncate..].into_iter().rev() {
-                f(&mut self.regalloc, v)
+                f(&mut self.regalloc, v)?
             }
             stack_mut.truncate(truncate);
         }
+
+        Ok(())
     }
 
     /// Convenience wrapper around [`Self::spill_callback`].
     ///
     /// This function exists for cases in which triggering an unconditional
     /// spill is needed, like before entering control flow.
-    pub fn spill<M: MacroAssembler>(&mut self, masm: &mut M) {
-        Self::spill_impl(&mut self.stack, &mut self.regalloc, &self.frame, masm);
+    pub fn spill<M: MacroAssembler>(&mut self, masm: &mut M) -> Result<()> {
+        Self::spill_impl(&mut self.stack, &mut self.regalloc, &self.frame, masm)
     }
 
     /// Prepares the compiler to emit an uncoditional jump to the given
@@ -470,10 +522,15 @@ impl<'a> CodeGenContext<'a, Emission> {
     ///   branch.
     /// * Updating the reachability state.
     /// * Marking the destination frame as a destination target.
-    pub fn unconditional_jump<M, F>(&mut self, dest: &mut ControlStackFrame, masm: &mut M, mut f: F)
+    pub fn unconditional_jump<M, F>(
+        &mut self,
+        dest: &mut ControlStackFrame,
+        masm: &mut M,
+        mut f: F,
+    ) -> Result<()>
     where
         M: MacroAssembler,
-        F: FnMut(&mut M, &mut Self, &mut ControlStackFrame),
+        F: FnMut(&mut M, &mut Self, &mut ControlStackFrame) -> Result<()>,
     {
         let state = dest.stack_state();
         let target_offset = state.target_offset;
@@ -481,8 +538,11 @@ impl<'a> CodeGenContext<'a, Emission> {
         // Invariant: The SP, must be greater or equal to the target
         // SP, given that we haven't popped any results by this point
         // yet. But it may happen in the callback.
-        assert!(masm.sp_offset().as_u32() >= base_offset.as_u32());
-        f(masm, self, dest);
+        ensure!(
+            masm.sp_offset().as_u32() >= base_offset.as_u32(),
+            CodeGenError::invalid_sp_offset()
+        );
+        f(masm, self, dest)?;
 
         // The following snippet, pops the stack pointer to ensure that it
         // is correctly placed according to the expectations of the destination
@@ -517,6 +577,7 @@ impl<'a> CodeGenContext<'a, Emission> {
         dest.set_as_target();
         masm.jmp(*dest.label());
         self.reachable = false;
+        Ok(())
     }
 
     /// Push the ABI representation of the results stack.
@@ -525,7 +586,8 @@ impl<'a> CodeGenContext<'a, Emission> {
         results: &ABIResults,
         masm: &mut M,
         mut calculate_ret_area: F,
-    ) where
+    ) -> Result<()>
+    where
         M: MacroAssembler,
         F: FnMut(&ABIResults, &mut CodeGenContext<Emission>, &mut M) -> Option<RetArea>,
     {
@@ -536,8 +598,12 @@ impl<'a> CodeGenContext<'a, Emission> {
         for operand in results.operands().iter() {
             match operand {
                 ABIOperand::Reg { reg, ty, .. } => {
-                    assert!(self.regalloc.reg_available(*reg));
-                    let typed_reg = TypedReg::new(*ty, self.reg(*reg, masm));
+                    ensure!(
+                        self.regalloc.reg_available(*reg),
+                        CodeGenError::expected_register_to_be_available(),
+                    );
+
+                    let typed_reg = TypedReg::new(*ty, self.reg(*reg, masm)?);
                     self.stack.push(typed_reg.into());
                 }
                 ABIOperand::Stack { ty, offset, size } => match area.unwrap() {
@@ -550,22 +616,26 @@ impl<'a> CodeGenContext<'a, Emission> {
                     // with control flow and when calling functions; as a
                     // callee, only [Self::pop_abi_results] is needed when
                     // finalizing the function compilation.
-                    _ => unreachable!(),
+                    _ => bail!(CodeGenError::unexpected_function_call()),
                 },
             }
         }
+
+        Ok(())
     }
 
     /// Truncates the value stack to the specified target.
     /// This function is intended to only be used when restoring the code
     /// generation's reachability state, when handling an unreachable end or
     /// else.
-    pub fn truncate_stack_to(&mut self, target: usize) {
+    pub fn truncate_stack_to(&mut self, target: usize) -> Result<()> {
         if self.stack.len() > target {
             self.drop_last(self.stack.len() - target, |regalloc, val| match val {
-                Val::Reg(tr) => regalloc.free(tr.reg),
-                _ => {}
-            });
+                Val::Reg(tr) => Ok(regalloc.free(tr.reg)),
+                _ => Ok(()),
+            })
+        } else {
+            Ok(())
         }
     }
 
@@ -588,47 +658,54 @@ impl<'a> CodeGenContext<'a, Emission> {
         regalloc: &mut RegAlloc,
         frame: &Frame<Emission>,
         masm: &mut M,
-    ) {
-        stack.inner_mut().iter_mut().for_each(|v| match v {
-            Val::Reg(r) => {
-                let slot = masm.push(r.reg, r.ty.into());
-                regalloc.free(r.reg);
-                *v = Val::mem(r.ty, slot);
+    ) -> Result<()> {
+        for v in stack.inner_mut() {
+            match v {
+                Val::Reg(r) => {
+                    let slot = masm.push(r.reg, r.ty.try_into()?);
+                    regalloc.free(r.reg);
+                    *v = Val::mem(r.ty, slot);
+                }
+                Val::Local(local) => {
+                    let slot = frame.get_wasm_local(local.index);
+                    let addr = masm.local_address(&slot);
+                    let scratch = scratch!(M, &slot.ty);
+                    masm.load(addr, writable!(scratch), slot.ty.try_into()?);
+                    let stack_slot = masm.push(scratch, slot.ty.try_into()?);
+                    *v = Val::mem(slot.ty, stack_slot);
+                }
+                _ => {}
             }
-            Val::Local(local) => {
-                let slot = frame.get_wasm_local(local.index);
-                let addr = masm.local_address(&slot);
-                let scratch = scratch!(M, &slot.ty);
-                masm.load(addr, writable!(scratch), slot.ty.into());
-                let stack_slot = masm.push(scratch, slot.ty.into());
-                *v = Val::mem(slot.ty, stack_slot);
-            }
-            _ => {}
-        });
+        }
+
+        Ok(())
     }
 
     /// Prepares for emitting a binary operation where four 64-bit operands are
     /// used to produce two 64-bit operands, e.g. a 128-bit binop.
-    pub fn binop128<F, M>(&mut self, masm: &mut M, emit: F)
+    pub fn binop128<F, M>(&mut self, masm: &mut M, emit: F) -> Result<()>
     where
         F: FnOnce(&mut M, Reg, Reg, Reg, Reg) -> (TypedReg, TypedReg),
         M: MacroAssembler,
     {
-        let rhs_hi = self.pop_to_reg(masm, None);
-        let rhs_lo = self.pop_to_reg(masm, None);
-        let lhs_hi = self.pop_to_reg(masm, None);
-        let lhs_lo = self.pop_to_reg(masm, None);
+        let rhs_hi = self.pop_to_reg(masm, None)?;
+        let rhs_lo = self.pop_to_reg(masm, None)?;
+        let lhs_hi = self.pop_to_reg(masm, None)?;
+        let lhs_lo = self.pop_to_reg(masm, None)?;
         let (lo, hi) = emit(masm, lhs_lo.reg, lhs_hi.reg, rhs_lo.reg, rhs_hi.reg);
         self.free_reg(rhs_hi);
         self.free_reg(rhs_lo);
         self.stack.push(lo.into());
         self.stack.push(hi.into());
+
+        Ok(())
     }
 
     /// Pops a register from the stack and then immediately frees it. Used to
     /// discard values from the last operation, for example.
-    pub fn pop_and_free<M: MacroAssembler>(&mut self, masm: &mut M) {
-        let reg = self.pop_to_reg(masm, None);
+    pub fn pop_and_free<M: MacroAssembler>(&mut self, masm: &mut M) -> Result<()> {
+        let reg = self.pop_to_reg(masm, None)?;
         self.free_reg(reg.reg);
+        Ok(())
     }
 }

--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -1,0 +1,147 @@
+//! Classification of code generation errors.
+
+use thiserror::Error;
+
+/// A code generation error.
+#[derive(Error, Debug)]
+pub(crate) enum CodeGenError {
+    /// 32-bit platform support.
+    #[error("32-bit platforms are not supported")]
+    Unsupported32BitPlatform,
+    /// Unsupported WebAssembly type.
+    #[error("Unsupported Wasm type")]
+    UnsupportedWasmType,
+    /// Missing implementation for a current instruction.
+    #[error("Unimplemented Wasm instruction")]
+    UnimplementedWasmInstruction,
+    /// Unsupported eager initialization of tables.
+    #[error("Unsupported eager initialization of tables")]
+    UnsupportedTableEagerInit,
+    /// An internal error.
+    ///
+    /// This error means that an internal invariant was not met and usually
+    /// implies a compiler bug.
+    #[error("Winch internal error")]
+    Internal(InternalError),
+}
+
+/// An internal error.
+#[derive(Error, Debug)]
+pub(crate) enum InternalError {
+    /// Register allocation error.
+    #[error("Expected register to be available")]
+    ExpectedRegisterToBeAvailable,
+    /// Control frame expected.
+    #[error("Expected control frame")]
+    ControlFrameExpected,
+    /// Control frame for if expected.
+    #[error("Control frame for if expected")]
+    IfControlFrameExpected,
+    /// Not enough values in the value stack.
+    #[error("Not enough values in the value stack")]
+    MissingValuesInStack,
+    /// Unexpected operand size. 32 or 64 bits are supported.
+    #[error("Unexpected operand size for operation")]
+    UnexpectedOperandSize,
+    /// Accessing the value stack with an invalid index.
+    #[error("Unexpected value stack index")]
+    UnexpectedValueStackIndex,
+    /// Expects a specific state in the value stack.
+    #[error("Unexpected value in value stack")]
+    UnexpectedValueInValueStack,
+    /// A mismatch occured in the control frame state.
+    #[error("Mismatch in control frame state")]
+    ControlFrameStateMismatch,
+    /// Expected a specific table element value.
+    #[error("Table element value expected")]
+    TableElementValueExpected,
+    /// Illegal fuel tracking state.
+    #[error("Illegal fuel state")]
+    IllegalFuelState,
+    /// Missing special function argument.
+    #[error("Argument for `VMContext` expected")]
+    VMContextArgumentExpected,
+    /// Expected memory location to be addressed via the stack pointer.
+    #[error("Expected stack pointer addressing")]
+    SPAddressingExpected,
+    /// Stack pointer offset is illegal.
+    #[error("Invalid stack pointer offset")]
+    InvalidSPOffset,
+    /// Unexpected function call at location.
+    #[error("Unexpected function call in current context")]
+    UnexpectedFunctionCall,
+}
+
+impl CodeGenError {
+    pub(crate) const fn unsupported_wasm_type() -> Self {
+        Self::UnsupportedWasmType
+    }
+
+    pub(crate) const fn unsupported_table_eager_init() -> Self {
+        Self::UnsupportedTableEagerInit
+    }
+
+    pub(crate) const fn unimplemented_wasm_instruction() -> Self {
+        Self::UnimplementedWasmInstruction
+    }
+
+    pub(crate) const fn unsupported_32_bit_platform() -> Self {
+        Self::Unsupported32BitPlatform
+    }
+
+    pub(crate) const fn unexpected_function_call() -> Self {
+        Self::Internal(InternalError::UnexpectedFunctionCall)
+    }
+
+    pub(crate) const fn sp_addressing_expected() -> Self {
+        Self::Internal(InternalError::SPAddressingExpected)
+    }
+
+    pub(crate) const fn invalid_sp_offset() -> Self {
+        Self::Internal(InternalError::InvalidSPOffset)
+    }
+
+    pub(crate) const fn expected_register_to_be_available() -> Self {
+        Self::Internal(InternalError::ExpectedRegisterToBeAvailable)
+    }
+
+    pub(crate) fn vmcontext_arg_expected() -> Self {
+        Self::Internal(InternalError::VMContextArgumentExpected)
+    }
+
+    pub(crate) const fn control_frame_expected() -> Self {
+        Self::Internal(InternalError::ControlFrameExpected)
+    }
+
+    pub(crate) const fn if_control_frame_expected() -> Self {
+        Self::Internal(InternalError::IfControlFrameExpected)
+    }
+
+    pub(crate) const fn missing_values_in_stack() -> Self {
+        Self::Internal(InternalError::MissingValuesInStack)
+    }
+
+    pub(crate) const fn unexpected_operand_size() -> Self {
+        Self::Internal(InternalError::UnexpectedOperandSize)
+    }
+
+    pub(crate) const fn unexpected_value_stack_index() -> Self {
+        Self::Internal(InternalError::UnexpectedValueStackIndex)
+    }
+
+    pub(crate) const fn unexpected_value_in_value_stack() -> Self {
+        Self::Internal(InternalError::UnexpectedValueInValueStack)
+    }
+
+    pub(crate) const fn control_frame_state_mismatch() -> Self {
+        Self::Internal(InternalError::ControlFrameStateMismatch)
+    }
+
+    pub(crate) const fn table_element_value_expected() -> Self {
+        Self::Internal(InternalError::TableElementValueExpected)
+    }
+
+    pub(crate) const fn illegal_fuel_state() -> Self {
+        Self::Internal(InternalError::IllegalFuelState)
+    }
+}

--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -14,6 +14,9 @@ pub(crate) enum CodeGenError {
     /// Missing implementation for a current instruction.
     #[error("Unimplemented Wasm instruction")]
     UnimplementedWasmInstruction,
+    /// Unimplemented MacroAssembler instruction.
+    #[error("Unimplemented Masm instruction")]
+    UnimplementedMasmInstruction,
     /// Unsupported eager initialization of tables.
     #[error("Unsupported eager initialization of tables")]
     UnsupportedTableEagerInit,
@@ -70,6 +73,18 @@ pub(crate) enum InternalError {
     /// Unexpected function call at location.
     #[error("Unexpected function call in current context")]
     UnexpectedFunctionCall,
+    /// Invalid local offset.
+    #[error("Invalid local offset")]
+    InvalidLocalOffset,
+    /// Unsupported immediate for instruction.
+    #[error("Unsupported immediate")]
+    UnsupportedImm,
+    /// Invalid operand combination.
+    #[error("Invalid operand combination")]
+    InvalidOperandCombination,
+    /// Invalid two argument form.
+    #[error("Invalid two argument form")]
+    InvalidTwoArgumentForm,
 }
 
 impl CodeGenError {
@@ -143,5 +158,25 @@ impl CodeGenError {
 
     pub(crate) const fn illegal_fuel_state() -> Self {
         Self::Internal(InternalError::IllegalFuelState)
+    }
+
+    pub(crate) const fn invalid_local_offset() -> Self {
+        Self::Internal(InternalError::InvalidLocalOffset)
+    }
+
+    pub(crate) const fn unsupported_imm() -> Self {
+        Self::Internal(InternalError::UnsupportedImm)
+    }
+
+    pub(crate) const fn invalid_two_arg_form() -> Self {
+        Self::Internal(InternalError::InvalidTwoArgumentForm)
+    }
+
+    pub(crate) const fn invalid_operand_combination() -> Self {
+        Self::Internal(InternalError::InvalidOperandCombination)
+    }
+
+    pub(crate) const fn unimplemented_masm_instruction() -> Self {
+        Self::UnimplementedMasmInstruction
     }
 }

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -287,8 +287,8 @@ impl Frame<Emission> {
         &self,
         index: u32,
         masm: &mut M,
-    ) -> (WasmValType, M::Address) {
+    ) -> Result<(WasmValType, M::Address)> {
         let slot = self.get_wasm_local(index);
-        (slot.ty, masm.local_address(&slot))
+        Ok((slot.ty, masm.local_address(&slot)?))
     }
 }

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -95,7 +95,7 @@ impl TargetIsa for Aarch64 {
         let pointer_bytes = self.pointer_bytes();
         let vmoffsets = VMOffsets::new(pointer_bytes, &translation.module);
         let mut body = body.get_binary_reader();
-        let mut masm = Aarch64Masm::new(pointer_bytes, self.shared_flags.clone());
+        let mut masm = Aarch64Masm::new(pointer_bytes, self.shared_flags.clone())?;
         let stack = Stack::new();
         let abi_sig = wasm_sig::<abi::Aarch64ABI>(sig);
 

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -130,7 +130,7 @@ impl TargetIsa for Aarch64 {
         let names = body_codegen.env.take_name_map();
         let base = body_codegen.source_location.base;
         Ok(CompiledFunction::new(
-            masm.finalize(base),
+            masm.finalize(base)?,
             names,
             self.function_alignment(),
         ))

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -4,7 +4,7 @@ use super::{
     asm::{Assembler, PatchableAddToReg},
     regs::{self, rbp, rsp},
 };
-use anyhow::Result;
+use anyhow::{anyhow, bail, Result};
 
 use crate::masm::{
     DivKind, ExtendKind, FloatCmpKind, Imm as I, IntCmpKind, MacroAssembler as Masm, MulWideKind,
@@ -13,7 +13,7 @@ use crate::masm::{
 };
 use crate::{
     abi::{self, align_to, calculate_frame_adjustment, LocalSlot},
-    codegen::{ptr_type_from_ptr_size, CodeGenContext, Emission, FuncEnv},
+    codegen::{ptr_type_from_ptr_size, CodeGenContext, CodeGenError, Emission, FuncEnv},
     stack::{TypedReg, Val},
 };
 use crate::{
@@ -66,7 +66,7 @@ impl Masm for MacroAssembler {
     type Ptr = u8;
     type ABI = X64ABI;
 
-    fn frame_setup(&mut self) {
+    fn frame_setup(&mut self) -> Result<()> {
         let frame_pointer = rbp();
         let stack_pointer = rsp();
 
@@ -80,21 +80,23 @@ impl Masm for MacroAssembler {
 
         self.asm
             .mov_rr(stack_pointer, writable!(frame_pointer), OperandSize::S64);
+
+        Ok(())
     }
 
-    fn check_stack(&mut self, vmctx: Reg) {
+    fn check_stack(&mut self, vmctx: Reg) -> Result<()> {
         let ptr_size: u8 = self.ptr_size.bytes().try_into().unwrap();
         let scratch = regs::scratch();
 
         self.load_ptr(
-            self.address_at_reg(vmctx, ptr_size.vmcontext_runtime_limits().into()),
+            self.address_at_reg(vmctx, ptr_size.vmcontext_runtime_limits().into())?,
             writable!(scratch),
-        );
+        )?;
 
         self.load_ptr(
             Address::offset(scratch, ptr_size.vmruntime_limits_stack_limit().into()),
             writable!(scratch),
-        );
+        )?;
 
         self.add_stack_max(scratch);
 
@@ -111,9 +113,10 @@ impl Masm for MacroAssembler {
                 offset_downward_to_clobbers: 0,
             })
         }
+        Ok(())
     }
 
-    fn push(&mut self, reg: Reg, size: OperandSize) -> StackSlot {
+    fn push(&mut self, reg: Reg, size: OperandSize) -> Result<StackSlot> {
         let bytes = match (reg.class(), size) {
             (RegClass::Int, OperandSize::S64) => {
                 let word_bytes = <Self::ABI as ABI>::word_bytes() as u32;
@@ -123,112 +126,119 @@ impl Masm for MacroAssembler {
             }
             (RegClass::Int, OperandSize::S32) => {
                 let bytes = size.bytes();
-                self.reserve_stack(bytes);
+                self.reserve_stack(bytes)?;
                 let sp_offset = SPOffset::from_u32(self.sp_offset);
                 self.asm
-                    .mov_rm(reg, &self.address_from_sp(sp_offset), size, TRUSTED_FLAGS);
+                    .mov_rm(reg, &self.address_from_sp(sp_offset)?, size, TRUSTED_FLAGS);
                 bytes
             }
             (RegClass::Float, _) => {
                 let bytes = size.bytes();
-                self.reserve_stack(bytes);
+                self.reserve_stack(bytes)?;
                 let sp_offset = SPOffset::from_u32(self.sp_offset);
                 self.asm
-                    .xmm_mov_rm(reg, &self.address_from_sp(sp_offset), size, TRUSTED_FLAGS);
+                    .xmm_mov_rm(reg, &self.address_from_sp(sp_offset)?, size, TRUSTED_FLAGS);
                 bytes
             }
             _ => unreachable!(),
         };
 
-        StackSlot {
+        Ok(StackSlot {
             offset: SPOffset::from_u32(self.sp_offset),
             size: bytes,
-        }
+        })
     }
 
-    fn reserve_stack(&mut self, bytes: u32) {
+    fn reserve_stack(&mut self, bytes: u32) -> Result<()> {
         if bytes == 0 {
-            return;
+            return Ok(());
         }
 
         self.asm
             .sub_ir(bytes as i32, writable!(rsp()), OperandSize::S64);
         self.increment_sp(bytes);
+
+        Ok(())
     }
 
-    fn free_stack(&mut self, bytes: u32) {
+    fn free_stack(&mut self, bytes: u32) -> Result<()> {
         if bytes == 0 {
-            return;
+            return Ok(());
         }
         self.asm
             .add_ir(bytes as i32, writable!(rsp()), OperandSize::S64);
         self.decrement_sp(bytes);
+
+        Ok(())
     }
 
-    fn reset_stack_pointer(&mut self, offset: SPOffset) {
+    fn reset_stack_pointer(&mut self, offset: SPOffset) -> Result<()> {
         self.sp_offset = offset.as_u32();
+
+        Ok(())
     }
 
-    fn local_address(&mut self, local: &LocalSlot) -> Address {
-        let (reg, offset) = local
-            .addressed_from_sp()
-            .then(|| {
-                let offset = self.sp_offset.checked_sub(local.offset).unwrap_or_else(|| {
-                    panic!(
-                        "Invalid local offset = {}; sp offset = {}",
-                        local.offset, self.sp_offset
-                    )
-                });
-                (rsp(), offset)
-            })
-            .unwrap_or((rbp(), local.offset));
+    fn local_address(&mut self, local: &LocalSlot) -> Result<Address> {
+        let (reg, offset) = if local.addressed_from_sp() {
+            let offset = self
+                .sp_offset
+                .checked_sub(local.offset)
+                .ok_or_else(|| CodeGenError::invalid_local_offset())?;
+            (rsp(), offset)
+        } else {
+            (rbp(), local.offset)
+        };
 
-        Address::offset(reg, offset)
+        Ok(Address::offset(reg, offset))
     }
 
-    fn address_from_sp(&self, offset: SPOffset) -> Self::Address {
-        Address::offset(regs::rsp(), self.sp_offset - offset.as_u32())
+    fn address_from_sp(&self, offset: SPOffset) -> Result<Self::Address> {
+        Ok(Address::offset(
+            regs::rsp(),
+            self.sp_offset - offset.as_u32(),
+        ))
     }
 
-    fn address_at_sp(&self, offset: SPOffset) -> Self::Address {
-        Address::offset(regs::rsp(), offset.as_u32())
+    fn address_at_sp(&self, offset: SPOffset) -> Result<Self::Address> {
+        Ok(Address::offset(regs::rsp(), offset.as_u32()))
     }
 
-    fn address_at_vmctx(&self, offset: u32) -> Self::Address {
-        Address::offset(vmctx!(Self), offset)
+    fn address_at_vmctx(&self, offset: u32) -> Result<Self::Address> {
+        Ok(Address::offset(vmctx!(Self), offset))
     }
 
-    fn store_ptr(&mut self, src: Reg, dst: Self::Address) {
-        self.store(src.into(), dst, self.ptr_size);
+    fn store_ptr(&mut self, src: Reg, dst: Self::Address) -> Result<()> {
+        self.store(src.into(), dst, self.ptr_size)
     }
 
-    fn store(&mut self, src: RegImm, dst: Address, size: OperandSize) {
-        self.store_impl(src, dst, size, TRUSTED_FLAGS);
+    fn store(&mut self, src: RegImm, dst: Address, size: OperandSize) -> Result<()> {
+        self.store_impl(src, dst, size, TRUSTED_FLAGS)
     }
 
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize) {
-        self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS);
+    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize) -> Result<()> {
+        self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)
     }
 
-    fn pop(&mut self, dst: WritableReg, size: OperandSize) {
+    fn pop(&mut self, dst: WritableReg, size: OperandSize) -> Result<()> {
         let current_sp = SPOffset::from_u32(self.sp_offset);
-        match (dst.to_reg().class(), size) {
+        let _ = match (dst.to_reg().class(), size) {
             (RegClass::Int, OperandSize::S32) => {
-                let addr = self.address_from_sp(current_sp);
+                let addr = self.address_from_sp(current_sp)?;
                 self.asm.movzx_mr(&addr, dst, size.into(), TRUSTED_FLAGS);
-                self.free_stack(size.bytes());
+                self.free_stack(size.bytes())?;
             }
             (RegClass::Int, OperandSize::S64) => {
                 self.asm.pop_r(dst);
                 self.decrement_sp(<Self::ABI as ABI>::word_bytes() as u32);
             }
             (RegClass::Float, _) | (RegClass::Vector, _) => {
-                let addr = self.address_from_sp(current_sp);
+                let addr = self.address_from_sp(current_sp)?;
                 self.asm.xmm_mov_mr(&addr, dst, size, TRUSTED_FLAGS);
-                self.free_stack(size.bytes());
+                self.free_stack(size.bytes())?;
             }
-            _ => unreachable!(),
-        }
+            _ => bail!(CodeGenError::invalid_operand_combination()),
+        };
+        Ok(())
     }
 
     fn call(
@@ -238,10 +248,10 @@ impl Masm for MacroAssembler {
     ) -> Result<u32> {
         let alignment: u32 = <Self::ABI as abi::ABI>::call_stack_align().into();
         let addend: u32 = <Self::ABI as abi::ABI>::arg_base_offset().into();
-        let delta = calculate_frame_adjustment(self.sp_offset().as_u32(), addend, alignment);
+        let delta = calculate_frame_adjustment(self.sp_offset()?.as_u32(), addend, alignment);
         let aligned_args_size = align_to(stack_args_size, alignment);
         let total_stack = delta + aligned_args_size;
-        self.reserve_stack(total_stack);
+        self.reserve_stack(total_stack)?;
         let (callee, cc) = load_callee(self)?;
         match callee {
             CalleeKind::Indirect(reg) => self.asm.call_with_reg(cc, reg),
@@ -251,16 +261,17 @@ impl Masm for MacroAssembler {
         Ok(total_stack)
     }
 
-    fn load_ptr(&mut self, src: Self::Address, dst: WritableReg) {
-        self.load(src, dst, self.ptr_size);
+    fn load_ptr(&mut self, src: Self::Address, dst: WritableReg) -> Result<()> {
+        self.load(src, dst, self.ptr_size)
     }
 
-    fn load_addr(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize) {
+    fn load_addr(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize) -> Result<()> {
         self.asm.lea(&src, dst, size);
+        Ok(())
     }
 
-    fn load(&mut self, src: Address, dst: WritableReg, size: OperandSize) {
-        self.load_impl::<Self>(src, dst, size, TRUSTED_FLAGS);
+    fn load(&mut self, src: Address, dst: WritableReg, size: OperandSize) -> Result<()> {
+        self.load_impl::<Self>(src, dst, size, TRUSTED_FLAGS)
     }
 
     fn wasm_load(
@@ -269,69 +280,80 @@ impl Masm for MacroAssembler {
         dst: WritableReg,
         size: OperandSize,
         kind: Option<ExtendKind>,
-    ) {
+    ) -> Result<()> {
         if let Some(ext) = kind {
             self.asm.movsx_mr(&src, dst, ext, UNTRUSTED_FLAGS);
+            Ok(())
         } else {
             self.load_impl::<Self>(src, dst, size, UNTRUSTED_FLAGS)
         }
     }
 
-    fn sp_offset(&self) -> SPOffset {
-        SPOffset::from_u32(self.sp_offset)
+    fn sp_offset(&self) -> Result<SPOffset> {
+        Ok(SPOffset::from_u32(self.sp_offset))
     }
 
-    fn zero(&mut self, reg: WritableReg) {
+    fn zero(&mut self, reg: WritableReg) -> Result<()> {
         self.asm.xor_rr(
             reg.to_reg(),
             reg,
             OperandSize::from_bytes(<Self::ABI>::word_bytes()),
         );
+        Ok(())
     }
 
-    fn mov(&mut self, dst: WritableReg, src: RegImm, size: OperandSize) {
+    fn mov(&mut self, dst: WritableReg, src: RegImm, size: OperandSize) -> Result<()> {
         match (src, dst.to_reg()) {
-            rr @ (RegImm::Reg(src), dst_reg) => match (src.class(), dst_reg.class()) {
-                (RegClass::Int, RegClass::Int) => self.asm.mov_rr(src, dst, size),
-                (RegClass::Float, RegClass::Float) => self.asm.xmm_mov_rr(src, dst, size),
-                _ => Self::handle_invalid_operand_combination(rr.0, rr.1),
+            (RegImm::Reg(src), dst_reg) => match (src.class(), dst_reg.class()) {
+                (RegClass::Int, RegClass::Int) => Ok(self.asm.mov_rr(src, dst, size)),
+                (RegClass::Float, RegClass::Float) => Ok(self.asm.xmm_mov_rr(src, dst, size)),
+                _ => bail!(CodeGenError::invalid_operand_combination()),
             },
             (RegImm::Imm(imm), _) => match imm {
-                I::I32(v) => self.asm.mov_ir(v as u64, dst, size),
-                I::I64(v) => self.asm.mov_ir(v, dst, size),
+                I::I32(v) => Ok(self.asm.mov_ir(v as u64, dst, size)),
+                I::I64(v) => Ok(self.asm.mov_ir(v, dst, size)),
                 I::F32(v) => {
                     let addr = self.asm.add_constant(v.to_le_bytes().as_slice());
                     self.asm.xmm_mov_mr(&addr, dst, size, TRUSTED_FLAGS);
+                    Ok(())
                 }
                 I::F64(v) => {
                     let addr = self.asm.add_constant(v.to_le_bytes().as_slice());
                     self.asm.xmm_mov_mr(&addr, dst, size, TRUSTED_FLAGS);
+                    Ok(())
                 }
                 I::V128(v) => {
                     let addr = self.asm.add_constant(v.to_le_bytes().as_slice());
                     self.asm.xmm_mov_mr(&addr, dst, size, TRUSTED_FLAGS);
+                    Ok(())
                 }
             },
         }
     }
 
-    fn cmov(&mut self, dst: WritableReg, src: Reg, cc: IntCmpKind, size: OperandSize) {
+    fn cmov(
+        &mut self,
+        dst: WritableReg,
+        src: Reg,
+        cc: IntCmpKind,
+        size: OperandSize,
+    ) -> Result<()> {
         match (src.class(), dst.to_reg().class()) {
-            (RegClass::Int, RegClass::Int) => self.asm.cmov(src, dst, cc, size),
-            (RegClass::Float, RegClass::Float) => self.asm.xmm_cmov(src, dst, cc, size),
-            _ => Self::handle_invalid_operand_combination(src, dst.to_reg()),
+            (RegClass::Int, RegClass::Int) => Ok(self.asm.cmov(src, dst, cc, size)),
+            (RegClass::Float, RegClass::Float) => Ok(self.asm.xmm_cmov(src, dst, cc, size)),
+            _ => Err(anyhow!(CodeGenError::invalid_operand_combination())),
         }
     }
 
-    fn add(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn add(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         match (rhs, dst) {
             (RegImm::Imm(imm), _) => {
                 if let Some(v) = imm.to_i32() {
                     self.asm.add_ir(v, dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size);
+                    self.load_constant(&imm, writable!(scratch), size)?;
                     self.asm.add_rr(scratch, dst, size);
                 }
             }
@@ -340,6 +362,8 @@ impl Masm for MacroAssembler {
                 self.asm.add_rr(src, dst, size);
             }
         }
+
+        Ok(())
     }
 
     fn checked_uadd(
@@ -349,20 +373,21 @@ impl Masm for MacroAssembler {
         rhs: RegImm,
         size: OperandSize,
         trap: TrapCode,
-    ) {
-        self.add(dst, lhs, rhs, size);
+    ) -> Result<()> {
+        self.add(dst, lhs, rhs, size)?;
         self.asm.trapif(CC::B, trap);
+        Ok(())
     }
 
-    fn sub(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn sub(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         match (rhs, dst) {
             (RegImm::Imm(imm), reg) => {
                 if let Some(v) = imm.to_i32() {
                     self.asm.sub_ir(v, reg, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size);
+                    self.load_constant(&imm, writable!(scratch), size)?;
                     self.asm.sub_rr(scratch, reg, size);
                 }
             }
@@ -371,17 +396,19 @@ impl Masm for MacroAssembler {
                 self.asm.sub_rr(src, dst, size);
             }
         }
+
+        Ok(())
     }
 
-    fn mul(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn mul(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         match (rhs, dst) {
             (RegImm::Imm(imm), _) => {
                 if let Some(v) = imm.to_i32() {
                     self.asm.mul_ir(v, dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size);
+                    self.load_constant(&imm, writable!(scratch), size)?;
                     self.asm.mul_rr(scratch, dst, size);
                 }
             }
@@ -390,48 +417,64 @@ impl Masm for MacroAssembler {
                 self.asm.mul_rr(src, dst, size);
             }
         }
+
+        Ok(())
     }
 
-    fn float_add(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn float_add(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         self.asm.xmm_add_rr(rhs, dst, size);
+        Ok(())
     }
 
-    fn float_sub(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn float_sub(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         self.asm.xmm_sub_rr(rhs, dst, size);
+        Ok(())
     }
 
-    fn float_mul(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn float_mul(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         self.asm.xmm_mul_rr(rhs, dst, size);
+        Ok(())
     }
 
-    fn float_div(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn float_div(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         self.asm.xmm_div_rr(rhs, dst, size);
+        Ok(())
     }
 
-    fn float_min(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn float_min(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         self.asm.xmm_min_seq(rhs, dst, size);
+        Ok(())
     }
 
-    fn float_max(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn float_max(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         self.asm.xmm_max_seq(rhs, dst, size);
+        Ok(())
     }
 
-    fn float_copysign(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn float_copysign(
+        &mut self,
+        dst: WritableReg,
+        lhs: Reg,
+        rhs: Reg,
+        size: OperandSize,
+    ) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         let scratch_gpr = regs::scratch();
         let scratch_xmm = regs::scratch_xmm();
         let sign_mask = match size {
             OperandSize::S32 => I::I32(0x80000000),
             OperandSize::S64 => I::I64(0x8000000000000000),
-            OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => unreachable!(),
+            OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => {
+                bail!(CodeGenError::unexpected_operand_size())
+            }
         };
-        self.load_constant(&sign_mask, writable!(scratch_gpr), size);
+        self.load_constant(&sign_mask, writable!(scratch_gpr), size)?;
         self.asm
             .gpr_to_xmm(scratch_gpr, writable!(scratch_xmm), size);
 
@@ -446,36 +489,43 @@ impl Masm for MacroAssembler {
 
         // Copy sign bit from src to dst.
         self.asm.xmm_or_rr(rhs, dst, size);
+        Ok(())
     }
 
-    fn float_neg(&mut self, dst: WritableReg, size: OperandSize) {
-        assert_eq!(dst.to_reg().class(), RegClass::Float);
+    fn float_neg(&mut self, dst: WritableReg, size: OperandSize) -> Result<()> {
+        debug_assert_eq!(dst.to_reg().class(), RegClass::Float);
         let mask = match size {
             OperandSize::S32 => I::I32(0x80000000),
             OperandSize::S64 => I::I64(0x8000000000000000),
-            OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => unreachable!(),
+            OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => {
+                bail!(CodeGenError::unexpected_operand_size())
+            }
         };
         let scratch_gpr = regs::scratch();
-        self.load_constant(&mask, writable!(scratch_gpr), size);
+        self.load_constant(&mask, writable!(scratch_gpr), size)?;
         let scratch_xmm = regs::scratch_xmm();
         self.asm
             .gpr_to_xmm(scratch_gpr, writable!(scratch_xmm), size);
         self.asm.xmm_xor_rr(scratch_xmm, dst, size);
+        Ok(())
     }
 
-    fn float_abs(&mut self, dst: WritableReg, size: OperandSize) {
-        assert_eq!(dst.to_reg().class(), RegClass::Float);
+    fn float_abs(&mut self, dst: WritableReg, size: OperandSize) -> Result<()> {
+        debug_assert_eq!(dst.to_reg().class(), RegClass::Float);
         let mask = match size {
             OperandSize::S32 => I::I32(0x7fffffff),
             OperandSize::S64 => I::I64(0x7fffffffffffffff),
-            OperandSize::S128 | OperandSize::S16 | OperandSize::S8 => unreachable!(),
+            OperandSize::S128 | OperandSize::S16 | OperandSize::S8 => {
+                bail!(CodeGenError::unexpected_operand_size())
+            }
         };
         let scratch_gpr = regs::scratch();
-        self.load_constant(&mask, writable!(scratch_gpr), size);
+        self.load_constant(&mask, writable!(scratch_gpr), size)?;
         let scratch_xmm = regs::scratch_xmm();
         self.asm
             .gpr_to_xmm(scratch_gpr, writable!(scratch_xmm), size);
         self.asm.xmm_and_rr(scratch_xmm, dst, size);
+        Ok(())
     }
 
     fn float_round<
@@ -499,19 +549,20 @@ impl Masm for MacroAssembler {
         }
     }
 
-    fn float_sqrt(&mut self, dst: WritableReg, src: Reg, size: OperandSize) {
+    fn float_sqrt(&mut self, dst: WritableReg, src: Reg, size: OperandSize) -> Result<()> {
         self.asm.sqrt(src, dst, size);
+        Ok(())
     }
 
-    fn and(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn and(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         match (rhs, dst) {
             (RegImm::Imm(imm), _) => {
                 if let Some(v) = imm.to_i32() {
                     self.asm.and_ir(v, dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size);
+                    self.load_constant(&imm, writable!(scratch), size)?;
                     self.asm.and_rr(scratch, dst, size);
                 }
             }
@@ -520,17 +571,19 @@ impl Masm for MacroAssembler {
                 self.asm.and_rr(src, dst, size);
             }
         }
+
+        Ok(())
     }
 
-    fn or(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn or(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         match (rhs, dst) {
             (RegImm::Imm(imm), _) => {
                 if let Some(v) = imm.to_i32() {
                     self.asm.or_ir(v, dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size);
+                    self.load_constant(&imm, writable!(scratch), size)?;
                     self.asm.or_rr(scratch, dst, size);
                 }
             }
@@ -539,17 +592,19 @@ impl Masm for MacroAssembler {
                 self.asm.or_rr(src, dst, size);
             }
         }
+
+        Ok(())
     }
 
-    fn xor(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
+    fn xor(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
         match (rhs, dst) {
             (RegImm::Imm(imm), _) => {
                 if let Some(v) = imm.to_i32() {
                     self.asm.xor_ir(v, dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size);
+                    self.load_constant(&imm, writable!(scratch), size)?;
                     self.asm.xor_rr(scratch, dst, size);
                 }
             }
@@ -558,6 +613,8 @@ impl Masm for MacroAssembler {
                 self.asm.xor_rr(src, dst, size);
             }
         }
+
+        Ok(())
     }
 
     fn shift_ir(
@@ -567,9 +624,10 @@ impl Masm for MacroAssembler {
         lhs: Reg,
         kind: ShiftKind,
         size: OperandSize,
-    ) {
-        Self::ensure_two_argument_form(&dst.to_reg(), &lhs);
-        self.asm.shift_ir(imm as u8, dst, kind, size)
+    ) -> Result<()> {
+        Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
+        self.asm.shift_ir(imm as u8, dst, kind, size);
+        Ok(())
     }
 
     fn shift(
@@ -648,32 +706,33 @@ impl Masm for MacroAssembler {
         Ok(())
     }
 
-    fn frame_restore(&mut self) {
-        assert_eq!(self.sp_offset, 0);
+    fn frame_restore(&mut self) -> Result<()> {
+        debug_assert_eq!(self.sp_offset, 0);
         self.asm.pop_r(writable!(rbp()));
         self.asm.ret();
+        Ok(())
     }
 
-    fn finalize(mut self, base: Option<SourceLoc>) -> MachBufferFinalized<Final> {
+    fn finalize(mut self, base: Option<SourceLoc>) -> Result<MachBufferFinalized<Final>> {
         if let Some(patch) = self.stack_max_use_add {
             patch.finalize(i32::try_from(self.sp_max).unwrap(), self.asm.buffer_mut());
         }
 
-        self.asm.finalize(base)
+        Ok(self.asm.finalize(base))
     }
 
-    fn address_at_reg(&self, reg: Reg, offset: u32) -> Self::Address {
-        Address::offset(reg, offset)
+    fn address_at_reg(&self, reg: Reg, offset: u32) -> Result<Self::Address> {
+        Ok(Address::offset(reg, offset))
     }
 
-    fn cmp(&mut self, src1: Reg, src2: RegImm, size: OperandSize) {
+    fn cmp(&mut self, src1: Reg, src2: RegImm, size: OperandSize) -> Result<()> {
         match src2 {
             RegImm::Imm(imm) => {
                 if let Some(v) = imm.to_i32() {
                     self.asm.cmp_ir(src1, v, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size);
+                    self.load_constant(&imm, writable!(scratch), size)?;
                     self.asm.cmp_rr(src1, scratch, size);
                 }
             }
@@ -681,11 +740,20 @@ impl Masm for MacroAssembler {
                 self.asm.cmp_rr(src1, src2, size);
             }
         }
+
+        Ok(())
     }
 
-    fn cmp_with_set(&mut self, dst: WritableReg, src: RegImm, kind: IntCmpKind, size: OperandSize) {
-        self.cmp(dst.to_reg(), src, size);
+    fn cmp_with_set(
+        &mut self,
+        dst: WritableReg,
+        src: RegImm,
+        kind: IntCmpKind,
+        size: OperandSize,
+    ) -> Result<()> {
+        self.cmp(dst.to_reg(), src, size)?;
         self.asm.setcc(kind, dst);
+        Ok(())
     }
 
     fn float_cmp_with_set(
@@ -695,7 +763,7 @@ impl Masm for MacroAssembler {
         src2: Reg,
         kind: FloatCmpKind,
         size: OperandSize,
-    ) {
+    ) -> Result<()> {
         // Float comparisons needs to be ordered (that is, comparing with a NaN
         // should return 0) except for not equal which needs to be unordered.
         // We use ucomis{s, d} because comis{s, d} has an undefined result if
@@ -718,7 +786,7 @@ impl Masm for MacroAssembler {
         };
         self.asm.ucomis(src1, src2, size);
         self.asm.setcc(set_kind, dst);
-        match kind {
+        let _ = match kind {
             FloatCmpKind::Eq | FloatCmpKind::Gt | FloatCmpKind::Ge => {
                 // Return false if either operand is NaN by ensuring PF is
                 // unset.
@@ -734,10 +802,11 @@ impl Masm for MacroAssembler {
                 self.asm.or_rr(scratch, dst, size);
             }
             FloatCmpKind::Lt | FloatCmpKind::Le => (),
-        }
+        };
+        Ok(())
     }
 
-    fn clz(&mut self, dst: WritableReg, src: Reg, size: OperandSize) {
+    fn clz(&mut self, dst: WritableReg, src: Reg, size: OperandSize) -> Result<()> {
         if self.flags.has_lzcnt() {
             self.asm.lzcnt(src, dst, size);
         } else {
@@ -752,9 +821,11 @@ impl Masm for MacroAssembler {
             self.asm.add_ir(size.num_bits() as i32, dst, size);
             self.asm.sub_rr(scratch, dst, size);
         }
+
+        Ok(())
     }
 
-    fn ctz(&mut self, dst: WritableReg, src: Reg, size: OperandSize) {
+    fn ctz(&mut self, dst: WritableReg, src: Reg, size: OperandSize) -> Result<()> {
         if self.flags.has_bmi1() {
             self.asm.tzcnt(src, dst, size);
         } else {
@@ -772,16 +843,19 @@ impl Masm for MacroAssembler {
                 .shift_ir(size.log2(), writable!(scratch), ShiftKind::Shl, size);
             self.asm.add_rr(scratch, dst, size);
         }
+
+        Ok(())
     }
 
-    fn get_label(&mut self) -> MachLabel {
+    fn get_label(&mut self) -> Result<MachLabel> {
         let buffer = self.asm.buffer_mut();
-        buffer.get_label()
+        Ok(buffer.get_label())
     }
 
-    fn bind(&mut self, label: MachLabel) {
+    fn bind(&mut self, label: MachLabel) -> Result<()> {
         let buffer = self.asm.buffer_mut();
         buffer.bind_label(label, &mut Default::default());
+        Ok(())
     }
 
     fn branch(
@@ -791,7 +865,7 @@ impl Masm for MacroAssembler {
         rhs: RegImm,
         taken: MachLabel,
         size: OperandSize,
-    ) {
+    ) -> Result<()> {
         use IntCmpKind::*;
 
         match &(lhs, rhs) {
@@ -802,16 +876,18 @@ impl Masm for MacroAssembler {
                 if (kind == Eq || kind == Ne) && (rlhs == rrhs) {
                     self.asm.test_rr(*rlhs, *rrhs, size);
                 } else {
-                    self.cmp(lhs, rhs, size);
+                    self.cmp(lhs, rhs, size)?;
                 }
             }
-            _ => self.cmp(lhs, rhs, size),
+            _ => self.cmp(lhs, rhs, size)?,
         }
         self.asm.jmp_if(kind, taken);
+        Ok(())
     }
 
-    fn jmp(&mut self, target: MachLabel) {
+    fn jmp(&mut self, target: MachLabel) -> Result<()> {
         self.asm.jmp(target);
+        Ok(())
     }
 
     fn popcnt(&mut self, context: &mut CodeGenContext<Emission>, size: OperandSize) -> Result<()> {
@@ -842,14 +918,14 @@ impl Masm for MacroAssembler {
                     [0x55555555i64, 0x33333333i64, 0x0f0f0f0fi64, 0x01010101i64],
                     24u8,
                 ),
-                _ => unreachable!(),
+                _ => bail!(CodeGenError::unexpected_operand_size()),
             };
             self.asm.mov_rr(src.into(), tmp, size);
 
             // x -= (x >> 1) & m1;
             self.asm.shift_ir(1u8, dst, ShiftKind::ShrU, size);
             let lhs = dst.to_reg();
-            self.and(writable!(lhs), lhs, RegImm::i64(masks[0]), size);
+            self.and(writable!(lhs), lhs, RegImm::i64(masks[0]), size)?;
             self.asm.sub_rr(dst.to_reg(), tmp, size);
 
             // x = (x & m2) + ((x >> 2) & m2);
@@ -857,7 +933,7 @@ impl Masm for MacroAssembler {
             // Load `0x3333...` into the scratch reg once, allowing us to use
             // `and_rr` and avoid inadvertently loading it twice as with `and`
             let scratch = regs::scratch();
-            self.load_constant(&I::i64(masks[1]), writable!(scratch), size);
+            self.load_constant(&I::i64(masks[1]), writable!(scratch), size)?;
             self.asm.and_rr(scratch, dst, size);
             self.asm.shift_ir(2u8, tmp, ShiftKind::ShrU, size);
             self.asm.and_rr(scratch, tmp, size);
@@ -868,11 +944,11 @@ impl Masm for MacroAssembler {
             self.asm.shift_ir(4u8, dst.into(), ShiftKind::ShrU, size);
             self.asm.add_rr(tmp.to_reg(), dst, size);
             let lhs = dst.to_reg();
-            self.and(writable!(lhs), lhs, RegImm::i64(masks[2]), size);
+            self.and(writable!(lhs), lhs, RegImm::i64(masks[2]), size)?;
 
             // (x * h01) >> shift_amt
             let lhs = dst.to_reg();
-            self.mul(writable!(lhs), lhs, RegImm::i64(masks[3]), size);
+            self.mul(writable!(lhs), lhs, RegImm::i64(masks[3]), size)?;
             self.asm
                 .shift_ir(shift_amt, dst.into(), ShiftKind::ShrU, size);
 
@@ -883,16 +959,18 @@ impl Masm for MacroAssembler {
         }
     }
 
-    fn wrap(&mut self, dst: WritableReg, src: Reg) {
+    fn wrap(&mut self, dst: WritableReg, src: Reg) -> Result<()> {
         self.asm.mov_rr(src.into(), dst, OperandSize::S32);
+        Ok(())
     }
 
-    fn extend(&mut self, dst: WritableReg, src: Reg, kind: ExtendKind) {
+    fn extend(&mut self, dst: WritableReg, src: Reg, kind: ExtendKind) -> Result<()> {
         if let ExtendKind::I64ExtendI32U = kind {
             self.asm.movzx_rr(src, dst, kind);
         } else {
             self.asm.movsx_rr(src, dst, kind);
         }
+        Ok(())
     }
 
     fn signed_truncate(
@@ -902,7 +980,7 @@ impl Masm for MacroAssembler {
         src_size: OperandSize,
         dst_size: OperandSize,
         kind: TruncKind,
-    ) {
+    ) -> Result<()> {
         self.asm.cvt_float_to_sint_seq(
             src,
             dst,
@@ -912,6 +990,7 @@ impl Masm for MacroAssembler {
             dst_size,
             kind.is_checked(),
         );
+        Ok(())
     }
 
     fn unsigned_truncate(
@@ -922,7 +1001,7 @@ impl Masm for MacroAssembler {
         src_size: OperandSize,
         dst_size: OperandSize,
         kind: TruncKind,
-    ) {
+    ) -> Result<()> {
         self.asm.cvt_float_to_uint_seq(
             src,
             dst,
@@ -933,6 +1012,8 @@ impl Masm for MacroAssembler {
             dst_size,
             kind.is_checked(),
         );
+
+        Ok(())
     }
 
     fn signed_convert(
@@ -941,8 +1022,9 @@ impl Masm for MacroAssembler {
         src: Reg,
         src_size: OperandSize,
         dst_size: OperandSize,
-    ) {
+    ) -> Result<()> {
         self.asm.cvt_sint_to_float(src, dst, src_size, dst_size);
+        Ok(())
     }
 
     fn unsigned_convert(
@@ -952,54 +1034,73 @@ impl Masm for MacroAssembler {
         tmp_gpr: Reg,
         src_size: OperandSize,
         dst_size: OperandSize,
-    ) {
+    ) -> Result<()> {
         // Need to convert unsigned uint32 to uint64 for conversion instruction sequence.
         if let OperandSize::S32 = src_size {
-            self.extend(writable!(src), src, ExtendKind::I64ExtendI32U);
+            self.extend(writable!(src), src, ExtendKind::I64ExtendI32U)?;
         }
 
         self.asm
             .cvt_uint64_to_float_seq(src, dst, regs::scratch(), tmp_gpr, dst_size);
+        Ok(())
     }
 
-    fn reinterpret_float_as_int(&mut self, dst: WritableReg, src: Reg, size: OperandSize) {
+    fn reinterpret_float_as_int(
+        &mut self,
+        dst: WritableReg,
+        src: Reg,
+        size: OperandSize,
+    ) -> Result<()> {
         self.asm.xmm_to_gpr(src, dst, size);
+        Ok(())
     }
 
-    fn reinterpret_int_as_float(&mut self, dst: WritableReg, src: Reg, size: OperandSize) {
+    fn reinterpret_int_as_float(
+        &mut self,
+        dst: WritableReg,
+        src: Reg,
+        size: OperandSize,
+    ) -> Result<()> {
         self.asm.gpr_to_xmm(src.into(), dst, size);
+        Ok(())
     }
 
-    fn demote(&mut self, dst: WritableReg, src: Reg) {
+    fn demote(&mut self, dst: WritableReg, src: Reg) -> Result<()> {
         self.asm
             .cvt_float_to_float(src.into(), dst.into(), OperandSize::S64, OperandSize::S32);
+        Ok(())
     }
 
-    fn promote(&mut self, dst: WritableReg, src: Reg) {
+    fn promote(&mut self, dst: WritableReg, src: Reg) -> Result<()> {
         self.asm
             .cvt_float_to_float(src.into(), dst, OperandSize::S32, OperandSize::S64);
+        Ok(())
     }
 
-    fn unreachable(&mut self) {
-        self.asm.trap(TRAP_UNREACHABLE)
+    fn unreachable(&mut self) -> Result<()> {
+        self.asm.trap(TRAP_UNREACHABLE);
+        Ok(())
     }
 
-    fn trap(&mut self, code: TrapCode) {
+    fn trap(&mut self, code: TrapCode) -> Result<()> {
         self.asm.trap(code);
+        Ok(())
     }
 
-    fn trapif(&mut self, cc: IntCmpKind, code: TrapCode) {
+    fn trapif(&mut self, cc: IntCmpKind, code: TrapCode) -> Result<()> {
         self.asm.trapif(cc, code);
+        Ok(())
     }
 
-    fn trapz(&mut self, src: Reg, code: TrapCode) {
+    fn trapz(&mut self, src: Reg, code: TrapCode) -> Result<()> {
         self.asm.test_rr(src, src, self.ptr_size);
         self.asm.trapif(IntCmpKind::Eq, code);
+        Ok(())
     }
 
-    fn jmp_table(&mut self, targets: &[MachLabel], index: Reg, tmp: Reg) {
+    fn jmp_table(&mut self, targets: &[MachLabel], index: Reg, tmp: Reg) -> Result<()> {
         // At least one default target.
-        assert!(targets.len() >= 1);
+        debug_assert!(targets.len() >= 1);
         let default_index = targets.len() - 1;
         // Emit bounds check, by conditionally moving the max cases
         // into the given index reg if the contents of the index reg
@@ -1014,18 +1115,20 @@ impl Masm for MacroAssembler {
         let rest = &targets[0..default_index];
         let tmp1 = regs::scratch();
         self.asm.jmp_table(rest.into(), default, index, tmp1, tmp);
+        Ok(())
     }
 
-    fn start_source_loc(&mut self, loc: RelSourceLoc) -> (CodeOffset, RelSourceLoc) {
-        self.asm.buffer_mut().start_srcloc(loc)
+    fn start_source_loc(&mut self, loc: RelSourceLoc) -> Result<(CodeOffset, RelSourceLoc)> {
+        Ok(self.asm.buffer_mut().start_srcloc(loc))
     }
 
-    fn end_source_loc(&mut self) {
+    fn end_source_loc(&mut self) -> Result<()> {
         self.asm.buffer_mut().end_srcloc();
+        Ok(())
     }
 
-    fn current_code_offset(&self) -> CodeOffset {
-        self.asm.buffer().cur_offset()
+    fn current_code_offset(&self) -> Result<CodeOffset> {
+        Ok(self.asm.buffer().cur_offset())
     }
 
     fn add128(
@@ -1036,11 +1139,12 @@ impl Masm for MacroAssembler {
         lhs_hi: Reg,
         rhs_lo: Reg,
         rhs_hi: Reg,
-    ) {
-        Self::ensure_two_argument_form(&dst_lo.to_reg(), &lhs_lo);
-        Self::ensure_two_argument_form(&dst_hi.to_reg(), &lhs_hi);
+    ) -> Result<()> {
+        Self::ensure_two_argument_form(&dst_lo.to_reg(), &lhs_lo)?;
+        Self::ensure_two_argument_form(&dst_hi.to_reg(), &lhs_hi)?;
         self.asm.add_rr(rhs_lo, dst_lo, OperandSize::S64);
         self.asm.adc_rr(rhs_hi, dst_hi, OperandSize::S64);
+        Ok(())
     }
 
     fn sub128(
@@ -1051,11 +1155,12 @@ impl Masm for MacroAssembler {
         lhs_hi: Reg,
         rhs_lo: Reg,
         rhs_hi: Reg,
-    ) {
-        Self::ensure_two_argument_form(&dst_lo.to_reg(), &lhs_lo);
-        Self::ensure_two_argument_form(&dst_hi.to_reg(), &lhs_hi);
+    ) -> Result<()> {
+        Self::ensure_two_argument_form(&dst_lo.to_reg(), &lhs_lo)?;
+        Self::ensure_two_argument_form(&dst_hi.to_reg(), &lhs_hi)?;
         self.asm.sub_rr(rhs_lo, dst_lo, OperandSize::S64);
         self.asm.sbb_rr(rhs_hi, dst_hi, OperandSize::S64);
+        Ok(())
     }
 
     fn mul_wide(
@@ -1145,16 +1250,22 @@ impl MacroAssembler {
         self.sp_offset -= bytes;
     }
 
-    fn load_constant(&mut self, constant: &I, dst: WritableReg, size: OperandSize) {
+    fn load_constant(&mut self, constant: &I, dst: WritableReg, size: OperandSize) -> Result<()> {
         match constant {
-            I::I32(v) => self.asm.mov_ir(*v as u64, dst, size),
-            I::I64(v) => self.asm.mov_ir(*v, dst, size),
-            _ => panic!(),
+            I::I32(v) => Ok(self.asm.mov_ir(*v as u64, dst, size)),
+            I::I64(v) => Ok(self.asm.mov_ir(*v, dst, size)),
+            _ => Err(anyhow!(CodeGenError::unsupported_imm())),
         }
     }
 
     /// A common implementation for zero-extend stack loads.
-    fn load_impl<M>(&mut self, src: Address, dst: WritableReg, size: OperandSize, flags: MemFlags)
+    fn load_impl<M>(
+        &mut self,
+        src: Address,
+        dst: WritableReg,
+        size: OperandSize,
+        flags: MemFlags,
+    ) -> Result<()>
     where
         M: Masm,
     {
@@ -1172,11 +1283,19 @@ impl MacroAssembler {
         } else {
             self.asm.xmm_mov_mr(&src, dst, size, flags);
         }
+
+        Ok(())
     }
 
     /// A common implementation for stack stores.
-    fn store_impl(&mut self, src: RegImm, dst: Address, size: OperandSize, flags: MemFlags) {
-        match src {
+    fn store_impl(
+        &mut self,
+        src: RegImm,
+        dst: Address,
+        size: OperandSize,
+        flags: MemFlags,
+    ) -> Result<()> {
+        let _ = match src {
             RegImm::Imm(imm) => match imm {
                 I::I32(v) => self.asm.mov_im(v as i32, &dst, size, flags),
                 I::I64(v) => match v.try_into() {
@@ -1228,21 +1347,15 @@ impl MacroAssembler {
                     self.asm.xmm_mov_rm(reg, &dst, size, flags);
                 }
             }
+        };
+        Ok(())
+    }
+
+    fn ensure_two_argument_form(dst: &Reg, lhs: &Reg) -> Result<()> {
+        if dst != lhs {
+            Err(anyhow!(CodeGenError::invalid_two_arg_form()))
+        } else {
+            Ok(())
         }
-    }
-
-    fn handle_invalid_operand_combination<T>(src: impl Into<RegImm>, dst: impl Into<RegImm>) -> T {
-        panic!(
-            "Invalid operand combination; src={:?}, dst={:?}",
-            src.into(),
-            dst.into()
-        );
-    }
-
-    fn ensure_two_argument_form(dst: &Reg, lhs: &Reg) {
-        assert!(
-            dst == lhs,
-            "the destination and first source argument must be the same, dst={dst:?}, lhs={lhs:?}"
-        );
     }
 }

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -143,7 +143,7 @@ impl TargetIsa for X64 {
 
         let names = body_codegen.env.take_name_map();
         Ok(CompiledFunction::new(
-            masm.finalize(base),
+            masm.finalize(base)?,
             names,
             self.function_alignment(),
         ))

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -104,7 +104,7 @@ impl TargetIsa for X64 {
             pointer_bytes,
             self.shared_flags.clone(),
             self.isa_flags.clone(),
-        );
+        )?;
         let stack = Stack::new();
 
         let abi_sig = wasm_sig::<abi::X64ABI>(sig);

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -543,57 +543,57 @@ pub(crate) trait MacroAssembler {
     type ABI: abi::ABI;
 
     /// Emit the function prologue.
-    fn prologue(&mut self, vmctx: Reg) {
-        self.frame_setup();
-        self.check_stack(vmctx);
+    fn prologue(&mut self, vmctx: Reg) -> Result<()> {
+        self.frame_setup()?;
+        self.check_stack(vmctx)
     }
 
     /// Generate the frame setup sequence.
-    fn frame_setup(&mut self);
+    fn frame_setup(&mut self) -> Result<()>;
 
     /// Generate the frame restore sequence.
-    fn frame_restore(&mut self);
+    fn frame_restore(&mut self) -> Result<()>;
 
     /// Emit a stack check.
-    fn check_stack(&mut self, vmctx: Reg);
+    fn check_stack(&mut self, vmctx: Reg) -> Result<()>;
 
     /// Emit the function epilogue.
-    fn epilogue(&mut self) {
-        self.frame_restore();
+    fn epilogue(&mut self) -> Result<()> {
+        self.frame_restore()
     }
 
     /// Reserve stack space.
-    fn reserve_stack(&mut self, bytes: u32);
+    fn reserve_stack(&mut self, bytes: u32) -> Result<()>;
 
     /// Free stack space.
-    fn free_stack(&mut self, bytes: u32);
+    fn free_stack(&mut self, bytes: u32) -> Result<()>;
 
     /// Reset the stack pointer to the given offset;
     ///
     /// Used to reset the stack pointer to a given offset
     /// when dealing with unreachable code.
-    fn reset_stack_pointer(&mut self, offset: SPOffset);
+    fn reset_stack_pointer(&mut self, offset: SPOffset) -> Result<()>;
 
     /// Get the address of a local slot.
-    fn local_address(&mut self, local: &LocalSlot) -> Self::Address;
+    fn local_address(&mut self, local: &LocalSlot) -> Result<Self::Address>;
 
     /// Constructs an address with an offset that is relative to the
     /// current position of the stack pointer (e.g. [sp + (sp_offset -
     /// offset)].
-    fn address_from_sp(&self, offset: SPOffset) -> Self::Address;
+    fn address_from_sp(&self, offset: SPOffset) -> Result<Self::Address>;
 
     /// Constructs an address with an offset that is absolute to the
     /// current position of the stack pointer (e.g. [sp + offset].
-    fn address_at_sp(&self, offset: SPOffset) -> Self::Address;
+    fn address_at_sp(&self, offset: SPOffset) -> Result<Self::Address>;
 
     /// Alias for [`Self::address_at_reg`] using the VMContext register as
     /// a base. The VMContext register is derived from the ABI type that is
     /// associated to the MacroAssembler.
-    fn address_at_vmctx(&self, offset: u32) -> Self::Address;
+    fn address_at_vmctx(&self, offset: u32) -> Result<Self::Address>;
 
     /// Construct an address that is absolute to the current position
     /// of the given register.
-    fn address_at_reg(&self, reg: Reg, offset: u32) -> Self::Address;
+    fn address_at_reg(&self, reg: Reg, offset: u32) -> Result<Self::Address>;
 
     /// Emit a function call to either a local or external function.
     fn call(
@@ -603,14 +603,14 @@ pub(crate) trait MacroAssembler {
     ) -> Result<u32>;
 
     /// Get stack pointer offset.
-    fn sp_offset(&self) -> SPOffset;
+    fn sp_offset(&self) -> Result<SPOffset>;
 
     /// Perform a stack store.
-    fn store(&mut self, src: RegImm, dst: Self::Address, size: OperandSize);
+    fn store(&mut self, src: RegImm, dst: Self::Address, size: OperandSize) -> Result<()>;
 
     /// Alias for `MacroAssembler::store` with the operand size corresponding
     /// to the pointer size of the target.
-    fn store_ptr(&mut self, src: Reg, dst: Self::Address);
+    fn store_ptr(&mut self, src: Reg, dst: Self::Address) -> Result<()>;
 
     /// Perform a WebAssembly store.
     /// A WebAssembly store introduces several additional invariants compared to
@@ -620,10 +620,10 @@ pub(crate) trait MacroAssembler {
     /// regards to the endianness depending on the target ISA. For this reason,
     /// [Self::wasm_store], should be explicitly used when emitting WebAssembly
     /// stores.
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize);
+    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize) -> Result<()>;
 
     /// Perform a zero-extended stack load.
-    fn load(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize);
+    fn load(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize) -> Result<()>;
 
     /// Perform a WebAssembly load.
     /// A WebAssembly load introduces several additional invariants compared to
@@ -639,27 +639,39 @@ pub(crate) trait MacroAssembler {
         dst: WritableReg,
         size: OperandSize,
         kind: Option<ExtendKind>,
-    );
+    ) -> Result<()>;
 
     /// Alias for `MacroAssembler::load` with the operand size corresponding
     /// to the pointer size of the target.
-    fn load_ptr(&mut self, src: Self::Address, dst: WritableReg);
+    fn load_ptr(&mut self, src: Self::Address, dst: WritableReg) -> Result<()>;
 
     /// Loads the effective address into destination.
-    fn load_addr(&mut self, _src: Self::Address, _dst: WritableReg, _size: OperandSize);
+    fn load_addr(
+        &mut self,
+        _src: Self::Address,
+        _dst: WritableReg,
+        _size: OperandSize,
+    ) -> Result<()>;
 
     /// Pop a value from the machine stack into the given register.
-    fn pop(&mut self, dst: WritableReg, size: OperandSize);
+    fn pop(&mut self, dst: WritableReg, size: OperandSize) -> Result<()>;
 
     /// Perform a move.
-    fn mov(&mut self, dst: WritableReg, src: RegImm, size: OperandSize);
+    fn mov(&mut self, dst: WritableReg, src: RegImm, size: OperandSize) -> Result<()>;
 
     /// Perform a conditional move.
-    fn cmov(&mut self, dst: WritableReg, src: Reg, cc: IntCmpKind, size: OperandSize);
+    fn cmov(&mut self, dst: WritableReg, src: Reg, cc: IntCmpKind, size: OperandSize)
+        -> Result<()>;
 
     /// Performs a memory move of bytes from src to dest.
     /// Bytes are moved in blocks of 8 bytes, where possible.
-    fn memmove(&mut self, src: SPOffset, dst: SPOffset, bytes: u32, direction: MemMoveDirection) {
+    fn memmove(
+        &mut self,
+        src: SPOffset,
+        dst: SPOffset,
+        bytes: u32,
+        direction: MemMoveDirection,
+    ) -> Result<()> {
         match direction {
             MemMoveDirection::LowToHigh => debug_assert!(dst.as_u32() < src.as_u32()),
             MemMoveDirection::HighToLow => debug_assert!(dst.as_u32() > src.as_u32()),
@@ -680,13 +692,13 @@ pub(crate) trait MacroAssembler {
             src_offs += word_bytes;
 
             self.load_ptr(
-                self.address_from_sp(SPOffset::from_u32(src_offs)),
+                self.address_from_sp(SPOffset::from_u32(src_offs))?,
                 writable!(scratch),
-            );
+            )?;
             self.store_ptr(
                 scratch.into(),
-                self.address_from_sp(SPOffset::from_u32(dst_offs)),
-            );
+                self.address_from_sp(SPOffset::from_u32(dst_offs))?,
+            )?;
         }
 
         if remaining > 0 {
@@ -697,20 +709,21 @@ pub(crate) trait MacroAssembler {
             src_offs += half_word;
 
             self.load(
-                self.address_from_sp(SPOffset::from_u32(src_offs)),
+                self.address_from_sp(SPOffset::from_u32(src_offs))?,
                 writable!(scratch),
                 ptr_size,
-            );
+            )?;
             self.store(
                 scratch.into(),
-                self.address_from_sp(SPOffset::from_u32(dst_offs)),
+                self.address_from_sp(SPOffset::from_u32(dst_offs))?,
                 ptr_size,
-            );
+            )?;
         }
+        Ok(())
     }
 
     /// Perform add operation.
-    fn add(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn add(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()>;
 
     /// Perform a checked unsigned integer addition, emitting the provided trap
     /// if the addition overflows.
@@ -721,43 +734,49 @@ pub(crate) trait MacroAssembler {
         rhs: RegImm,
         size: OperandSize,
         trap: TrapCode,
-    );
+    ) -> Result<()>;
 
     /// Perform subtraction operation.
-    fn sub(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn sub(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()>;
 
     /// Perform multiplication operation.
-    fn mul(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn mul(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point add operation.
-    fn float_add(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_add(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point subtraction operation.
-    fn float_sub(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_sub(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point multiply operation.
-    fn float_mul(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_mul(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point divide operation.
-    fn float_div(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_div(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point minimum operation. In x86, this will emit
     /// multiple instructions.
-    fn float_min(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_min(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point maximum operation. In x86, this will emit
     /// multiple instructions.
-    fn float_max(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_max(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point copysign operation. In x86, this will emit
     /// multiple instructions.
-    fn float_copysign(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg, size: OperandSize);
+    fn float_copysign(
+        &mut self,
+        dst: WritableReg,
+        lhs: Reg,
+        rhs: Reg,
+        size: OperandSize,
+    ) -> Result<()>;
 
     /// Perform a floating point abs operation.
-    fn float_abs(&mut self, dst: WritableReg, size: OperandSize);
+    fn float_abs(&mut self, dst: WritableReg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point negation operation.
-    fn float_neg(&mut self, dst: WritableReg, size: OperandSize);
+    fn float_neg(&mut self, dst: WritableReg, size: OperandSize) -> Result<()>;
 
     /// Perform a floating point floor operation.
     fn float_round<
@@ -772,16 +791,16 @@ pub(crate) trait MacroAssembler {
     ) -> Result<()>;
 
     /// Perform a floating point square root operation.
-    fn float_sqrt(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
+    fn float_sqrt(&mut self, dst: WritableReg, src: Reg, size: OperandSize) -> Result<()>;
 
     /// Perform logical and operation.
-    fn and(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn and(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()>;
 
     /// Perform logical or operation.
-    fn or(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn or(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()>;
 
     /// Perform logical exclusive or operation.
-    fn xor(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize);
+    fn xor(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()>;
 
     /// Perform a shift operation between a register and an immediate.
     fn shift_ir(
@@ -791,7 +810,7 @@ pub(crate) trait MacroAssembler {
         lhs: Reg,
         kind: ShiftKind,
         size: OperandSize,
-    );
+    ) -> Result<()>;
 
     /// Perform a shift operation between two registers.
     /// This case is special in that some architectures have specific expectations
@@ -838,7 +857,7 @@ pub(crate) trait MacroAssembler {
     /// Note that `src1` is the left-hand-side of the comparison and `src2` is
     /// the right-hand-side, so if testing `a < b` then `src1 == a` and
     /// `src2 == b`
-    fn cmp(&mut self, src1: Reg, src2: RegImm, size: OperandSize);
+    fn cmp(&mut self, src1: Reg, src2: RegImm, size: OperandSize) -> Result<()>;
 
     /// Compare src and dst and put the result in dst.
     /// This function will potentially emit a series of instructions.
@@ -846,7 +865,13 @@ pub(crate) trait MacroAssembler {
     /// The initial value in `dst` is the left-hand-side of the comparison and
     /// the initial value in `src` is the right-hand-side of the comparison.
     /// That means for `a < b` then `dst == a` and `src == b`.
-    fn cmp_with_set(&mut self, dst: WritableReg, src: RegImm, kind: IntCmpKind, size: OperandSize);
+    fn cmp_with_set(
+        &mut self,
+        dst: WritableReg,
+        src: RegImm,
+        kind: IntCmpKind,
+        size: OperandSize,
+    ) -> Result<()>;
 
     /// Compare floats in src1 and src2 and put the result in dst.
     /// In x86, this will emit multiple instructions.
@@ -857,17 +882,17 @@ pub(crate) trait MacroAssembler {
         src2: Reg,
         kind: FloatCmpKind,
         size: OperandSize,
-    );
+    ) -> Result<()>;
 
     /// Count the number of leading zeroes in src and put the result in dst.
     /// In x64, this will emit multiple instructions if the `has_lzcnt` flag is
     /// false.
-    fn clz(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
+    fn clz(&mut self, dst: WritableReg, src: Reg, size: OperandSize) -> Result<()>;
 
     /// Count the number of trailing zeroes in src and put the result in dst.masm
     /// In x64, this will emit multiple instructions if the `has_tzcnt` flag is
     /// false.
-    fn ctz(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
+    fn ctz(&mut self, dst: WritableReg, src: Reg, size: OperandSize) -> Result<()>;
 
     /// Push the register to the stack, returning the stack slot metadata.
     // NB
@@ -875,23 +900,23 @@ pub(crate) trait MacroAssembler {
     // unless explicitly aligned otherwise.  Typically, stack alignment is
     // maintained at call sites and during the execution of
     // epilogues.
-    fn push(&mut self, src: Reg, size: OperandSize) -> StackSlot;
+    fn push(&mut self, src: Reg, size: OperandSize) -> Result<StackSlot>;
 
     /// Finalize the assembly and return the result.
-    fn finalize(self, base: Option<SourceLoc>) -> MachBufferFinalized<Final>;
+    fn finalize(self, base: Option<SourceLoc>) -> Result<MachBufferFinalized<Final>>;
 
     /// Zero a particular register.
-    fn zero(&mut self, reg: WritableReg);
+    fn zero(&mut self, reg: WritableReg) -> Result<()>;
 
     /// Count the number of 1 bits in src and put the result in dst. In x64,
     /// this will emit multiple instructions if the `has_popcnt` flag is false.
     fn popcnt(&mut self, context: &mut CodeGenContext<Emission>, size: OperandSize) -> Result<()>;
 
     /// Converts an i64 to an i32 by discarding the high 32 bits.
-    fn wrap(&mut self, dst: WritableReg, src: Reg);
+    fn wrap(&mut self, dst: WritableReg, src: Reg) -> Result<()>;
 
     /// Extends an integer of a given size to a larger size.
-    fn extend(&mut self, dst: WritableReg, src: Reg, kind: ExtendKind);
+    fn extend(&mut self, dst: WritableReg, src: Reg, kind: ExtendKind) -> Result<()>;
 
     /// Emits one or more instructions to perform a signed truncation of a
     /// float into an integer.
@@ -902,7 +927,7 @@ pub(crate) trait MacroAssembler {
         src_size: OperandSize,
         dst_size: OperandSize,
         kind: TruncKind,
-    );
+    ) -> Result<()>;
 
     /// Emits one or more instructions to perform an unsigned truncation of a
     /// float into an integer.
@@ -914,7 +939,7 @@ pub(crate) trait MacroAssembler {
         src_size: OperandSize,
         dst_size: OperandSize,
         kind: TruncKind,
-    );
+    ) -> Result<()>;
 
     /// Emits one or more instructions to perform a signed convert of an
     /// integer into a float.
@@ -924,7 +949,7 @@ pub(crate) trait MacroAssembler {
         src: Reg,
         src_size: OperandSize,
         dst_size: OperandSize,
-    );
+    ) -> Result<()>;
 
     /// Emits one or more instructions to perform an unsigned convert of an
     /// integer into a float.
@@ -935,29 +960,39 @@ pub(crate) trait MacroAssembler {
         tmp_gpr: Reg,
         src_size: OperandSize,
         dst_size: OperandSize,
-    );
+    ) -> Result<()>;
 
     /// Reinterpret a float as an integer.
-    fn reinterpret_float_as_int(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
+    fn reinterpret_float_as_int(
+        &mut self,
+        dst: WritableReg,
+        src: Reg,
+        size: OperandSize,
+    ) -> Result<()>;
 
     /// Reinterpret an integer as a float.
-    fn reinterpret_int_as_float(&mut self, dst: WritableReg, src: Reg, size: OperandSize);
+    fn reinterpret_int_as_float(
+        &mut self,
+        dst: WritableReg,
+        src: Reg,
+        size: OperandSize,
+    ) -> Result<()>;
 
     /// Demote an f64 to an f32.
-    fn demote(&mut self, dst: WritableReg, src: Reg);
+    fn demote(&mut self, dst: WritableReg, src: Reg) -> Result<()>;
 
     /// Promote an f32 to an f64.
-    fn promote(&mut self, dst: WritableReg, src: Reg);
+    fn promote(&mut self, dst: WritableReg, src: Reg) -> Result<()>;
 
     /// Zero a given memory range.
     ///
     /// The default implementation divides the given memory range
     /// into word-sized slots. Then it unrolls a series of store
     /// instructions, effectively assigning zero to each slot.
-    fn zero_mem_range(&mut self, mem: &Range<u32>) {
+    fn zero_mem_range(&mut self, mem: &Range<u32>) -> Result<()> {
         let word_size = <Self::ABI as abi::ABI>::word_bytes() as u32;
         if mem.is_empty() {
-            return;
+            return Ok(());
         }
 
         let start = if mem.start % word_size == 0 {
@@ -966,8 +1001,8 @@ pub(crate) trait MacroAssembler {
             // Ensure that the start of the range is at least 4-byte aligned.
             assert!(mem.start % 4 == 0);
             let start = align_to(mem.start, word_size);
-            let addr: Self::Address = self.local_address(&LocalSlot::i32(start));
-            self.store(RegImm::i32(0), addr, OperandSize::S32);
+            let addr: Self::Address = self.local_address(&LocalSlot::i32(start))?;
+            self.store(RegImm::i32(0), addr, OperandSize::S32)?;
             // Ensure that the new start of the range, is word-size aligned.
             assert!(start % word_size == 0);
             start
@@ -978,30 +1013,32 @@ pub(crate) trait MacroAssembler {
 
         if slots == 1 {
             let slot = LocalSlot::i64(start + word_size);
-            let addr: Self::Address = self.local_address(&slot);
-            self.store(RegImm::i64(0), addr, OperandSize::S64);
+            let addr: Self::Address = self.local_address(&slot)?;
+            self.store(RegImm::i64(0), addr, OperandSize::S64)?;
         } else {
             // TODO
             // Add an upper bound to this generation;
             // given a considerably large amount of slots
             // this will be inefficient.
             let zero = scratch!(Self);
-            self.zero(writable!(zero));
+            self.zero(writable!(zero))?;
             let zero = RegImm::reg(zero);
 
             for step in (start..end).into_iter().step_by(word_size as usize) {
                 let slot = LocalSlot::i64(step + word_size);
-                let addr: Self::Address = self.local_address(&slot);
-                self.store(zero, addr, OperandSize::S64);
+                let addr: Self::Address = self.local_address(&slot)?;
+                self.store(zero, addr, OperandSize::S64)?;
             }
         }
+
+        Ok(())
     }
 
     /// Generate a label.
-    fn get_label(&mut self) -> MachLabel;
+    fn get_label(&mut self) -> Result<MachLabel>;
 
     /// Bind the given label at the current code offset.
-    fn bind(&mut self, label: MachLabel);
+    fn bind(&mut self, label: MachLabel) -> Result<()>;
 
     /// Conditional branch.
     ///
@@ -1015,49 +1052,52 @@ pub(crate) trait MacroAssembler {
         rhs: RegImm,
         taken: MachLabel,
         size: OperandSize,
-    );
+    ) -> Result<()>;
 
     /// Emits and unconditional jump to the given label.
-    fn jmp(&mut self, target: MachLabel);
+    fn jmp(&mut self, target: MachLabel) -> Result<()>;
 
     /// Emits a jump table sequence. The default label is specified as
     /// the last element of the targets slice.
-    fn jmp_table(&mut self, targets: &[MachLabel], index: Reg, tmp: Reg);
+    fn jmp_table(&mut self, targets: &[MachLabel], index: Reg, tmp: Reg) -> Result<()>;
 
     /// Emit an unreachable code trap.
-    fn unreachable(&mut self);
+    fn unreachable(&mut self) -> Result<()>;
 
     /// Emit an unconditional trap.
-    fn trap(&mut self, code: TrapCode);
+    fn trap(&mut self, code: TrapCode) -> Result<()>;
 
     /// Traps if the condition code is met.
-    fn trapif(&mut self, cc: IntCmpKind, code: TrapCode);
+    fn trapif(&mut self, cc: IntCmpKind, code: TrapCode) -> Result<()>;
 
     /// Trap if the source register is zero.
-    fn trapz(&mut self, src: Reg, code: TrapCode);
+    fn trapz(&mut self, src: Reg, code: TrapCode) -> Result<()>;
 
     /// Ensures that the stack pointer is correctly positioned before an unconditional
     /// jump according to the requirements of the destination target.
-    fn ensure_sp_for_jump(&mut self, target: SPOffset) {
+    fn ensure_sp_for_jump(&mut self, target: SPOffset) -> Result<()> {
         let bytes = self
-            .sp_offset()
+            .sp_offset()?
             .as_u32()
             .checked_sub(target.as_u32())
             .unwrap_or(0);
+
         if bytes > 0 {
-            self.free_stack(bytes);
+            self.free_stack(bytes)?;
         }
+
+        Ok(())
     }
 
     /// Mark the start of a source location returning the machine code offset
     /// and the relative source code location.
-    fn start_source_loc(&mut self, loc: RelSourceLoc) -> (CodeOffset, RelSourceLoc);
+    fn start_source_loc(&mut self, loc: RelSourceLoc) -> Result<(CodeOffset, RelSourceLoc)>;
 
     /// Mark the end of a source location.
-    fn end_source_loc(&mut self);
+    fn end_source_loc(&mut self) -> Result<()>;
 
     /// The current offset, in bytes from the beginning of the function.
-    fn current_code_offset(&self) -> CodeOffset;
+    fn current_code_offset(&self) -> Result<CodeOffset>;
 
     /// Performs a 128-bit addition
     fn add128(
@@ -1068,7 +1108,7 @@ pub(crate) trait MacroAssembler {
         lhs_hi: Reg,
         rhs_lo: Reg,
         rhs_hi: Reg,
-    );
+    ) -> Result<()>;
 
     /// Performs a 128-bit subtraction
     fn sub128(
@@ -1079,7 +1119,7 @@ pub(crate) trait MacroAssembler {
         lhs_hi: Reg,
         rhs_lo: Reg,
         rhs_hi: Reg,
-    );
+    ) -> Result<()>;
 
     /// Performs a widening multiplication from two 64-bit operands into a
     /// 128-bit result.

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -1,4 +1,5 @@
-use crate::{isa::reg::Reg, masm::StackSlot};
+use crate::{codegen::CodeGenError, isa::reg::Reg, masm::StackSlot};
+use anyhow::{anyhow, Result};
 use smallvec::SmallVec;
 use wasmparser::{Ieee32, Ieee64};
 use wasmtime_environ::WasmValType;
@@ -278,6 +279,16 @@ impl Stack {
     pub fn new() -> Self {
         Self {
             inner: Default::default(),
+        }
+    }
+
+    /// Ensures that there are at least `n` elements in the value stack,
+    /// and returns the index calculated by: stack length minus `n`.
+    pub fn ensure_index_at(&self, n: usize) -> Result<usize> {
+        if self.len() >= n {
+            Ok(self.len() - n)
+        } else {
+            Err(anyhow!(CodeGenError::missing_values_in_stack()))
         }
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -17,7 +17,7 @@ use crate::reg::{writable, Reg};
 use crate::stack::{TypedReg, Val};
 use anyhow::{anyhow, bail, ensure, Result};
 use regalloc2::RegClass;
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use wasmparser::{
     BlockType, BrTable, Ieee32, Ieee64, MemArg, VisitOperator, VisitSimdOperator, V128,
 };
@@ -289,7 +289,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_add(writable!(dst), dst, src, size);
+                masm.float_add(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f32(dst))
             },
         )
@@ -300,7 +300,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_add(writable!(dst), dst, src, size);
+                masm.float_add(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f64(dst))
             },
         )
@@ -311,7 +311,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_sub(writable!(dst), dst, src, size);
+                masm.float_sub(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f32(dst))
             },
         )
@@ -322,7 +322,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_sub(writable!(dst), dst, src, size);
+                masm.float_sub(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f64(dst))
             },
         )
@@ -333,7 +333,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_mul(writable!(dst), dst, src, size);
+                masm.float_mul(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f32(dst))
             },
         )
@@ -344,7 +344,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_mul(writable!(dst), dst, src, size);
+                masm.float_mul(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f64(dst))
             },
         )
@@ -355,7 +355,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_div(writable!(dst), dst, src, size);
+                masm.float_div(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f32(dst))
             },
         )
@@ -366,7 +366,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_div(writable!(dst), dst, src, size);
+                masm.float_div(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f64(dst))
             },
         )
@@ -377,7 +377,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_min(writable!(dst), dst, src, size);
+                masm.float_min(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f32(dst))
             },
         )
@@ -388,7 +388,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_min(writable!(dst), dst, src, size);
+                masm.float_min(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f64(dst))
             },
         )
@@ -399,7 +399,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_max(writable!(dst), dst, src, size);
+                masm.float_max(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f32(dst))
             },
         )
@@ -410,7 +410,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_max(writable!(dst), dst, src, size);
+                masm.float_max(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f64(dst))
             },
         )
@@ -421,7 +421,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_copysign(writable!(dst), dst, src, size);
+                masm.float_copysign(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f32(dst))
             },
         )
@@ -432,7 +432,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
-                masm.float_copysign(writable!(dst), dst, src, size);
+                masm.float_copysign(writable!(dst), dst, src, size)?;
                 Ok(TypedReg::f64(dst))
             },
         )
@@ -441,32 +441,32 @@ where
     fn visit_f32_abs(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_abs(writable!(reg), size);
-                TypedReg::f32(reg)
+                masm.float_abs(writable!(reg), size)?;
+                Ok(TypedReg::f32(reg))
             })
     }
 
     fn visit_f64_abs(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_abs(writable!(reg), size);
-                TypedReg::f64(reg)
+                masm.float_abs(writable!(reg), size)?;
+                Ok(TypedReg::f64(reg))
             })
     }
 
     fn visit_f32_neg(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_neg(writable!(reg), size);
-                TypedReg::f32(reg)
+                masm.float_neg(writable!(reg), size)?;
+                Ok(TypedReg::f32(reg))
             })
     }
 
     fn visit_f64_neg(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_neg(writable!(reg), size);
-                TypedReg::f64(reg)
+                masm.float_neg(writable!(reg), size)?;
+                Ok(TypedReg::f64(reg))
             })
     }
 
@@ -577,16 +577,16 @@ where
     fn visit_f32_sqrt(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_sqrt(writable!(reg), reg, size);
-                TypedReg::f32(reg)
+                masm.float_sqrt(writable!(reg), reg, size)?;
+                Ok(TypedReg::f32(reg))
             })
     }
 
     fn visit_f64_sqrt(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_sqrt(writable!(reg), reg, size);
-                TypedReg::f64(reg)
+                masm.float_sqrt(writable!(reg), reg, size)?;
+                Ok(TypedReg::f64(reg))
             })
     }
 
@@ -595,7 +595,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Eq, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Eq, size)
             },
         )
     }
@@ -605,7 +605,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Eq, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Eq, size)
             },
         )
     }
@@ -615,7 +615,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ne, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ne, size)
             },
         )
     }
@@ -625,7 +625,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ne, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ne, size)
             },
         )
     }
@@ -635,7 +635,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Lt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Lt, size)
             },
         )
     }
@@ -645,7 +645,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Lt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Lt, size)
             },
         )
     }
@@ -655,7 +655,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Gt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Gt, size)
             },
         )
     }
@@ -665,7 +665,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Gt, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Gt, size)
             },
         )
     }
@@ -675,7 +675,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Le, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Le, size)
             },
         )
     }
@@ -685,7 +685,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Le, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Le, size)
             },
         )
     }
@@ -695,7 +695,7 @@ where
             self.masm,
             OperandSize::S32,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ge, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ge, size)
             },
         )
     }
@@ -705,7 +705,7 @@ where
             self.masm,
             OperandSize::S64,
             &mut |masm: &mut M, dst, src1, src2, size| {
-                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ge, size);
+                masm.float_cmp_with_set(writable!(dst), src1, src2, FloatCmpKind::Ge, size)
             },
         )
     }
@@ -713,7 +713,7 @@ where
     fn visit_f32_convert_i32_s(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::F32, |masm, dst, src, dst_size| {
-                masm.signed_convert(writable!(dst), src, OperandSize::S32, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S32, dst_size)
             })
     }
 
@@ -723,7 +723,7 @@ where
             WasmValType::F32,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S32, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S32, dst_size)
             },
         )
     }
@@ -731,7 +731,7 @@ where
     fn visit_f32_convert_i64_s(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::F32, |masm, dst, src, dst_size| {
-                masm.signed_convert(writable!(dst), src, OperandSize::S64, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S64, dst_size)
             })
     }
 
@@ -741,7 +741,7 @@ where
             WasmValType::F32,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S64, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S64, dst_size)
             },
         )
     }
@@ -749,7 +749,7 @@ where
     fn visit_f64_convert_i32_s(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::F64, |masm, dst, src, dst_size| {
-                masm.signed_convert(writable!(dst), src, OperandSize::S32, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S32, dst_size)
             })
     }
 
@@ -759,7 +759,7 @@ where
             WasmValType::F64,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S32, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S32, dst_size)
             },
         )
     }
@@ -767,7 +767,7 @@ where
     fn visit_f64_convert_i64_s(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::F64, |masm, dst, src, dst_size| {
-                masm.signed_convert(writable!(dst), src, OperandSize::S64, dst_size);
+                masm.signed_convert(writable!(dst), src, OperandSize::S64, dst_size)
             })
     }
 
@@ -777,7 +777,7 @@ where
             WasmValType::F64,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
-                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S64, dst_size);
+                masm.unsigned_convert(writable!(dst), src, tmp_gpr, OperandSize::S64, dst_size)
             },
         )
     }
@@ -785,71 +785,71 @@ where
     fn visit_f32_reinterpret_i32(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::F32, |masm, dst, src, size| {
-                masm.reinterpret_int_as_float(writable!(dst), src.into(), size);
+                masm.reinterpret_int_as_float(writable!(dst), src.into(), size)
             })
     }
 
     fn visit_f64_reinterpret_i64(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::F64, |masm, dst, src, size| {
-                masm.reinterpret_int_as_float(writable!(dst), src.into(), size);
+                masm.reinterpret_int_as_float(writable!(dst), src.into(), size)
             })
     }
 
     fn visit_f32_demote_f64(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, _size| {
-                masm.demote(writable!(reg), reg);
-                TypedReg::f32(reg)
+                masm.demote(writable!(reg), reg)?;
+                Ok(TypedReg::f32(reg))
             })
     }
 
     fn visit_f64_promote_f32(&mut self) -> Self::Output {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, _size| {
-                masm.promote(writable!(reg), reg);
-                TypedReg::f64(reg)
+                masm.promote(writable!(reg), reg)?;
+                Ok(TypedReg::f64(reg))
             })
     }
 
     fn visit_i32_add(&mut self) -> Self::Output {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.add(writable!(dst), dst, src, size);
+            masm.add(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i32(dst))
         })
     }
 
     fn visit_i64_add(&mut self) -> Self::Output {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.add(writable!(dst), dst, src, size);
+            masm.add(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i64(dst))
         })
     }
 
     fn visit_i32_sub(&mut self) -> Self::Output {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.sub(writable!(dst), dst, src, size);
+            masm.sub(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i32(dst))
         })
     }
 
     fn visit_i64_sub(&mut self) -> Self::Output {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.sub(writable!(dst), dst, src, size);
+            masm.sub(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i64(dst))
         })
     }
 
     fn visit_i32_mul(&mut self) -> Self::Output {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.mul(writable!(dst), dst, src, size);
+            masm.mul(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i32(dst))
         })
     }
 
     fn visit_i64_mul(&mut self) -> Self::Output {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.mul(writable!(dst), dst, src, size);
+            masm.mul(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i64(dst))
         })
     }
@@ -994,8 +994,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.cmp_with_set(writable!(reg.into()), RegImm::i32(0), IntCmpKind::Eq, size);
-            TypedReg::i32(reg)
+            masm.cmp_with_set(writable!(reg.into()), RegImm::i32(0), IntCmpKind::Eq, size)?;
+            Ok(TypedReg::i32(reg))
         })
     }
 
@@ -1003,8 +1003,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.cmp_with_set(writable!(reg.into()), RegImm::i64(0), IntCmpKind::Eq, size);
-            TypedReg::i32(reg) // Return value for `i64.eqz` is an `i32`.
+            masm.cmp_with_set(writable!(reg.into()), RegImm::i64(0), IntCmpKind::Eq, size)?;
+            Ok(TypedReg::i32(reg)) // Return value for `i64.eqz` is an `i32`.
         })
     }
 
@@ -1012,8 +1012,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.clz(writable!(reg), reg, size);
-            TypedReg::i32(reg)
+            masm.clz(writable!(reg), reg, size)?;
+            Ok(TypedReg::i32(reg))
         })
     }
 
@@ -1021,8 +1021,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.clz(writable!(reg), reg, size);
-            TypedReg::i64(reg)
+            masm.clz(writable!(reg), reg, size)?;
+            Ok(TypedReg::i64(reg))
         })
     }
 
@@ -1030,8 +1030,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.ctz(writable!(reg), reg, size);
-            TypedReg::i32(reg)
+            masm.ctz(writable!(reg), reg, size)?;
+            Ok(TypedReg::i32(reg))
         })
     }
 
@@ -1039,49 +1039,49 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.ctz(writable!(reg), reg, size);
-            TypedReg::i64(reg)
+            masm.ctz(writable!(reg), reg, size)?;
+            Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i32_and(&mut self) -> Self::Output {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.and(writable!(dst), dst, src, size);
+            masm.and(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i32(dst))
         })
     }
 
     fn visit_i64_and(&mut self) -> Self::Output {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.and(writable!(dst), dst, src, size);
+            masm.and(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i64(dst))
         })
     }
 
     fn visit_i32_or(&mut self) -> Self::Output {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.or(writable!(dst), dst, src, size);
+            masm.or(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i32(dst))
         })
     }
 
     fn visit_i64_or(&mut self) -> Self::Output {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.or(writable!(dst), dst, src, size);
+            masm.or(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i64(dst))
         })
     }
 
     fn visit_i32_xor(&mut self) -> Self::Output {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.xor(writable!(dst), dst, src, size);
+            masm.xor(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i32(dst))
         })
     }
 
     fn visit_i64_xor(&mut self) -> Self::Output {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
-            masm.xor(writable!(dst), dst, src, size);
+            masm.xor(writable!(dst), dst, src, size)?;
             Ok(TypedReg::i64(dst))
         })
     }
@@ -1170,8 +1170,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.wrap(writable!(reg), reg);
-            TypedReg::i32(reg)
+            masm.wrap(writable!(reg), reg)?;
+            Ok(TypedReg::i32(reg))
         })
     }
 
@@ -1179,8 +1179,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32S);
-            TypedReg::i64(reg)
+            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32S)?;
+            Ok(TypedReg::i64(reg))
         })
     }
 
@@ -1188,8 +1188,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32U);
-            TypedReg::i64(reg)
+            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32U)?;
+            Ok(TypedReg::i64(reg))
         })
     }
 
@@ -1197,8 +1197,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I32Extend8S);
-            TypedReg::i32(reg)
+            masm.extend(writable!(reg), reg, ExtendKind::I32Extend8S)?;
+            Ok(TypedReg::i32(reg))
         })
     }
 
@@ -1206,8 +1206,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I32Extend16S);
-            TypedReg::i32(reg)
+            masm.extend(writable!(reg), reg, ExtendKind::I32Extend16S)?;
+            Ok(TypedReg::i32(reg))
         })
     }
 
@@ -1215,8 +1215,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend8S);
-            TypedReg::i64(reg)
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend8S)?;
+            Ok(TypedReg::i64(reg))
         })
     }
 
@@ -1224,8 +1224,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend16S);
-            TypedReg::i64(reg)
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend16S)?;
+            Ok(TypedReg::i64(reg))
         })
     }
 
@@ -1233,8 +1233,8 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32S);
-            TypedReg::i64(reg)
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32S)?;
+            Ok(TypedReg::i64(reg))
         })
     }
 
@@ -1243,7 +1243,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Unchecked)
             })
     }
 
@@ -1262,7 +1262,7 @@ where
                     S32,
                     dst_size,
                     TruncKind::Unchecked,
-                );
+                )
             },
         )
     }
@@ -1272,7 +1272,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Unchecked)
             })
     }
 
@@ -1291,7 +1291,7 @@ where
                     S64,
                     dst_size,
                     TruncKind::Unchecked,
-                );
+                )
             },
         )
     }
@@ -1301,7 +1301,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Unchecked)
             })
     }
 
@@ -1320,7 +1320,7 @@ where
                     S32,
                     dst_size,
                     TruncKind::Unchecked,
-                );
+                )
             },
         )
     }
@@ -1330,7 +1330,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Unchecked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Unchecked)
             })
     }
 
@@ -1349,7 +1349,7 @@ where
                     S64,
                     dst_size,
                     TruncKind::Unchecked,
-                );
+                )
             },
         )
     }
@@ -1357,14 +1357,14 @@ where
     fn visit_i32_reinterpret_f32(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, size| {
-                masm.reinterpret_float_as_int(writable!(dst), src.into(), size);
+                masm.reinterpret_float_as_int(writable!(dst), src.into(), size)
             })
     }
 
     fn visit_i64_reinterpret_f64(&mut self) -> Self::Output {
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, size| {
-                masm.reinterpret_float_as_int(writable!(dst), src.into(), size);
+                masm.reinterpret_float_as_int(writable!(dst), src.into(), size)
             })
     }
 
@@ -1419,7 +1419,7 @@ where
             .map(|v| v.unwrap_reg())
             .ok_or_else(|| CodeGenError::missing_values_in_stack())?;
         self.masm
-            .trapz(funcref_ptr.into(), TRAP_INDIRECT_CALL_TO_NULL);
+            .trapz(funcref_ptr.into(), TRAP_INDIRECT_CALL_TO_NULL)?;
         self.emit_typecheck_funcref(funcref_ptr.into(), type_index)?;
 
         let callee = self.env.funcref(type_index);
@@ -1553,9 +1553,9 @@ where
                     value.into(),
                     RegImm::i64(FUNCREF_INIT_BIT as i64),
                     ptr_type.try_into()?,
-                );
+                )?;
 
-                self.masm.store_ptr(value.into(), elem_addr);
+                self.masm.store_ptr(value.into(), elem_addr)?;
 
                 self.context.free_reg(value);
                 self.context.free_reg(index);
@@ -1663,7 +1663,7 @@ where
             // the result of the memory32_grow builtin.
             (WasmValType::I64, WasmValType::I32) => {
                 let top: Reg = self.context.pop_to_reg(self.masm, None)?.into();
-                self.masm.wrap(writable!(top.into()), top.into());
+                self.masm.wrap(writable!(top.into()), top.into())?;
                 self.context.stack.push(TypedReg::i32(top).into());
                 Ok(())
             }
@@ -1735,7 +1735,9 @@ where
         let frame = &mut self.control_frames[index];
         self.context
             .unconditional_jump(frame, self.masm, |masm, cx, frame| {
-                frame.pop_abi_results::<M, _>(cx, masm, |results, _, _| results.ret_area().copied())
+                frame.pop_abi_results::<M, _>(cx, masm, |results, _, _| {
+                    Ok(results.ret_area().copied())
+                })
             })
     }
 
@@ -1765,12 +1767,14 @@ where
                     // it must be recalculated so that any values that are
                     // generated are correctly placed near the current stack
                     // pointer.
-                    results.on_stack().then(|| {
+                    if results.on_stack() {
                         let stack_consumed = context.stack.sizeof(results.stack_operands_len());
-                        let base = masm.sp_offset().as_u32() - stack_consumed;
+                        let base = masm.sp_offset()?.as_u32() - stack_consumed;
                         let offs = base + results.size();
-                        RetArea::sp(SPOffset::from_u32(offs))
-                    })
+                        Ok(Some(RetArea::sp(SPOffset::from_u32(offs))))
+                    } else {
+                        Ok(None)
+                    }
                 },
             )?;
             top
@@ -1778,17 +1782,17 @@ where
 
         // Emit instructions to balance the machine stack if the frame has
         // a different offset.
-        let current_sp_offset = self.masm.sp_offset();
+        let current_sp_offset = self.masm.sp_offset()?;
         let results_size = frame.results::<M>().size();
         let state = frame.stack_state();
         let (label, cmp, needs_cleanup) = if current_sp_offset > state.target_offset {
-            (self.masm.get_label(), IntCmpKind::Eq, true)
+            (self.masm.get_label()?, IntCmpKind::Eq, true)
         } else {
             (*frame.label(), IntCmpKind::Ne, false)
         };
 
         self.masm
-            .branch(cmp, top.reg.into(), top.reg.into(), label, OperandSize::S32);
+            .branch(cmp, top.reg.into(), top.reg.into(), label, OperandSize::S32)?;
         self.context.free_reg(top);
 
         if needs_cleanup {
@@ -1799,14 +1803,14 @@ where
                 state.target_offset,
                 results_size,
                 MemMoveDirection::LowToHigh,
-            );
-            self.masm.ensure_sp_for_jump(state.target_offset);
-            self.masm.jmp(*frame.label());
+            )?;
+            self.masm.ensure_sp_for_jump(state.target_offset)?;
+            self.masm.jmp(*frame.label())?;
 
             // Restore sp_offset to what it was for falling through and emit
             // fallthrough label.
-            self.masm.reset_stack_pointer(current_sp_offset);
-            self.masm.bind(label);
+            self.masm.reset_stack_pointer(current_sp_offset)?;
+            self.masm.bind(label)?;
         }
 
         Ok(())
@@ -1818,7 +1822,10 @@ where
         // SmallVec<[_; 5]> to match the binary emission layer (e.g
         // see `JmpTableSeq'), but here we use 5 instead since we
         // bundle the default target as the last element in the array.
-        let labels: SmallVec<[_; 5]> = (0..len).map(|_| self.masm.get_label()).collect();
+        let mut labels: SmallVec<[_; 5]> = smallvec![];
+        for _ in 0..len {
+            labels.push(self.masm.get_label()?);
+        }
 
         let default_index = control_index(targets.default(), self.control_frames.len())?;
         let default_frame = &mut self.control_frames[default_index];
@@ -1836,17 +1843,17 @@ where
             default_frame.top_abi_results::<M, _>(
                 &mut self.context,
                 self.masm,
-                |results, _, _| results.ret_area().copied(),
+                |results, _, _| Ok(results.ret_area().copied()),
             )?;
             index_and_tmp
         };
 
-        self.masm.jmp_table(&labels, index.into(), tmp);
+        self.masm.jmp_table(&labels, index.into(), tmp)?;
         // Save the original stack pointer offset; we will reset the stack
         // pointer to this offset after jumping to each of the targets. Each
         // jump might adjust the stack according to the base offset of the
         // target.
-        let current_sp = self.masm.sp_offset();
+        let current_sp = self.masm.sp_offset()?;
 
         for (t, l) in targets
             .targets()
@@ -1859,23 +1866,23 @@ where
             // Reset the stack pointer to its original offset. This is needed
             // because each jump will potentially adjust the stack pointer
             // according to the base offset of the target.
-            self.masm.reset_stack_pointer(current_sp);
+            self.masm.reset_stack_pointer(current_sp)?;
 
             // NB: We don't perform any result handling as it was
             // already taken care of above before jumping to the
             // jump table.
-            self.masm.bind(*l);
+            self.masm.bind(*l)?;
             // Ensure that the stack pointer is correctly positioned before
             // jumping to the jump table code.
             let state = frame.stack_state();
-            self.masm.ensure_sp_for_jump(state.target_offset);
-            self.masm.jmp(*frame.label());
+            self.masm.ensure_sp_for_jump(state.target_offset)?;
+            self.masm.jmp(*frame.label())?;
             frame.set_as_target();
         }
         // Finally reset the stack pointer to the original location.
         // The reachability analysis, will ensure it's correctly located
         // once reachability is restored.
-        self.masm.reset_stack_pointer(current_sp);
+        self.masm.reset_stack_pointer(current_sp)?;
         self.context.reachable = false;
         self.context.free_reg(index.reg);
         self.context.free_reg(tmp);
@@ -1891,12 +1898,14 @@ where
         let outermost = &mut self.control_frames[0];
         self.context
             .unconditional_jump(outermost, self.masm, |masm, cx, frame| {
-                frame.pop_abi_results::<M, _>(cx, masm, |results, _, _| results.ret_area().copied())
+                frame.pop_abi_results::<M, _>(cx, masm, |results, _, _| {
+                    Ok(results.ret_area().copied())
+                })
             })
     }
 
     fn visit_unreachable(&mut self) -> Self::Output {
-        self.masm.unreachable();
+        self.masm.unreachable()?;
         self.context.reachable = false;
         // Set the implicit outermost frame as target to perform the necessary
         // stack clean up.
@@ -1915,9 +1924,9 @@ where
 
     fn visit_global_get(&mut self, global_index: u32) -> Self::Output {
         let index = GlobalIndex::from_u32(global_index);
-        let (ty, addr) = self.emit_get_global_addr(index);
+        let (ty, addr) = self.emit_get_global_addr(index)?;
         let dst = self.context.reg_for_type(ty, self.masm)?;
-        self.masm.load(addr, writable!(dst), ty.try_into()?);
+        self.masm.load(addr, writable!(dst), ty.try_into()?)?;
         self.context.stack.push(Val::reg(dst, ty));
 
         Ok(())
@@ -1925,11 +1934,12 @@ where
 
     fn visit_global_set(&mut self, global_index: u32) -> Self::Output {
         let index = GlobalIndex::from_u32(global_index);
-        let (ty, addr) = self.emit_get_global_addr(index);
+        let (ty, addr) = self.emit_get_global_addr(index)?;
 
         let typed_reg = self.context.pop_to_reg(self.masm, None)?;
         self.context.free_reg(typed_reg.reg);
-        self.masm.store(typed_reg.reg.into(), addr, ty.try_into()?);
+        self.masm
+            .store(typed_reg.reg.into(), addr, ty.try_into()?)?;
 
         Ok(())
     }
@@ -1937,7 +1947,7 @@ where
     fn visit_drop(&mut self) -> Self::Output {
         self.context.drop_last(1, |regalloc, val| match val {
             Val::Reg(tr) => Ok(regalloc.free(tr.reg.into())),
-            Val::Memory(m) => Ok(self.masm.free_stack(m.slot.size)),
+            Val::Memory(m) => self.masm.free_stack(m.slot.size),
             _ => Ok(()),
         })
     }
@@ -1947,7 +1957,7 @@ where
         let val2 = self.context.pop_to_reg(self.masm, None)?;
         let val1 = self.context.pop_to_reg(self.masm, None)?;
         self.masm
-            .cmp(cond.reg.into(), RegImm::i32(0), OperandSize::S32);
+            .cmp(cond.reg.into(), RegImm::i32(0), OperandSize::S32)?;
         // Conditionally move val1 to val2 if the comparison is
         // not zero.
         self.masm.cmov(
@@ -1955,7 +1965,7 @@ where
             val1.into(),
             IntCmpKind::Ne,
             val1.ty.try_into()?,
-        );
+        )?;
         self.context.stack.push(val2.into());
         self.context.free_reg(val1.reg);
         self.context.free_reg(cond);
@@ -2085,7 +2095,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Checked)
             })
     }
 
@@ -2104,7 +2114,7 @@ where
                     S32,
                     dst_size,
                     TruncKind::Checked,
-                );
+                )
             },
         )
     }
@@ -2114,7 +2124,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Checked)
             })
     }
 
@@ -2133,7 +2143,7 @@ where
                     S64,
                     dst_size,
                     TruncKind::Checked,
-                );
+                )
             },
         )
     }
@@ -2143,7 +2153,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S32, dst_size, TruncKind::Checked)
             })
     }
 
@@ -2162,7 +2172,7 @@ where
                     S32,
                     dst_size,
                     TruncKind::Checked,
-                );
+                )
             },
         )
     }
@@ -2172,7 +2182,7 @@ where
 
         self.context
             .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
-                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Checked);
+                masm.signed_truncate(writable!(dst), src, S64, dst_size, TruncKind::Checked)
             })
     }
 
@@ -2191,7 +2201,7 @@ where
                     S64,
                     dst_size,
                     TruncKind::Checked,
-                );
+                )
             },
         )
     }
@@ -2206,8 +2216,8 @@ where
                     lhs_hi,
                     rhs_lo,
                     rhs_hi,
-                );
-                (TypedReg::i64(lhs_lo), TypedReg::i64(lhs_hi))
+                )?;
+                Ok((TypedReg::i64(lhs_lo), TypedReg::i64(lhs_hi)))
             })
     }
 
@@ -2221,8 +2231,8 @@ where
                     lhs_hi,
                     rhs_lo,
                     rhs_hi,
-                );
-                (TypedReg::i64(lhs_lo), TypedReg::i64(lhs_hi))
+                )?;
+                Ok((TypedReg::i64(lhs_lo), TypedReg::i64(lhs_hi)))
             })
     }
 
@@ -2264,7 +2274,7 @@ where
 {
     fn cmp_i32s(&mut self, kind: IntCmpKind) -> Result<()> {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.cmp_with_set(writable!(dst), src, kind, size);
+            masm.cmp_with_set(writable!(dst), src, kind, size)?;
             Ok(TypedReg::i32(dst))
         })
     }
@@ -2272,7 +2282,7 @@ where
     fn cmp_i64s(&mut self, kind: IntCmpKind) -> Result<()> {
         self.context
             .i64_binop(self.masm, move |masm, dst, src, size| {
-                masm.cmp_with_set(writable!(dst), src, kind, size);
+                masm.cmp_with_set(writable!(dst), src, kind, size)?;
                 Ok(TypedReg::i32(dst)) // Return value for comparisons is an `i32`.
             })
     }


### PR DESCRIPTION
Closes: https://github.com/bytecodealliance/wasmtime/issues/8096

This commit threads `anyhow::Result`  through most of Winch's compilation process in order to gracefully handle compilation errors instead of panicking.

The error classification is intentionally very granular, to avoid string allocation which could impact compilation performance.

The errors largely fit in two categories:

* Unimplemented/Unsupported
* Internal

The firs category signals partial or no support for Wasmtime features and or Wasm proposals. These errors are meant to be temporary while such features or proposals are in development.

The second category signals that a compilation invariant was not met. These errors are considered internal and their presence usually means a bug in the compiler.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
