### PR TITLE
pulley: Implement `scalar_to_vector` CLIF lowering

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -966,3 +966,22 @@
   (pulley_vinsertf32 a b lane))
 (rule (lower (insertlane a @ (value_type $F64X2) b (u8_from_uimm8 lane)))
   (pulley_vinsertf64 a b lane))
+
+;;;; Rules for `scalar_to_vector` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Note that this doesn't use special pulley instructions at this time and
+;; generates a bytecode-wise relatively inefficient lowering. Should be
+;; relatively easy to optimize if necessary in the future.
+
+(rule (lower (scalar_to_vector a @ (value_type $I8)))
+  (pulley_vinsertx8 (pulley_vconst128 0) a 0))
+(rule (lower (scalar_to_vector a @ (value_type $I16)))
+  (pulley_vinsertx16 (pulley_vconst128 0) a 0))
+(rule (lower (scalar_to_vector a @ (value_type $I32)))
+  (pulley_vinsertx32 (pulley_vconst128 0) a 0))
+(rule (lower (scalar_to_vector a @ (value_type $I64)))
+  (pulley_vinsertx64 (pulley_vconst128 0) a 0))
+(rule (lower (scalar_to_vector a @ (value_type $F32)))
+  (pulley_vinsertf32 (pulley_vconst128 0) a 0))
+(rule (lower (scalar_to_vector a @ (value_type $F64)))
+  (pulley_vinsertf64 (pulley_vconst128 0) a 0))

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
@@ -7,6 +7,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %scalartovector_i32(i32) -> i32x4 {
 block0(v0: i32):

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -453,7 +453,6 @@ impl WastTest {
                 "spec_testsuite/simd_i8x16_sat_arith.wast",
                 "spec_testsuite/simd_lane.wast",
                 "spec_testsuite/simd_load.wast",
-                "spec_testsuite/simd_load_zero.wast",
                 "spec_testsuite/simd_splat.wast",
             ];
 


### PR DESCRIPTION
No new pulley opcodes here, just reusing preexisting opcodes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
