### PR TITLE
pulley: Shuffle opcodes to free some 1-byte opcodes

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -485,8 +485,8 @@ where
     }
 
     fn worst_case_size() -> CodeOffset {
-        // `Vconst128 { dst, imm }` is 18 bytes (opcode + dst + 16-byte imm)
-        18
+        // `Vconst128 { dst, imm }` is 20 bytes (3 byte opcode + dst + 16-byte imm)
+        20
     }
 
     fn ref_type_regclass(_settings: &settings::Flags) -> RegClass {

--- a/pulley/src/op.rs
+++ b/pulley/src/op.rs
@@ -69,7 +69,7 @@ macro_rules! define_extended_op {
         /// An extended operation/instruction.
         ///
         /// These tend to be colder than `Op`s.
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
         pub enum ExtendedOp {
             $(
@@ -80,7 +80,7 @@ macro_rules! define_extended_op {
 
         $(
             $( #[$attr] )*
-            #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+            #[derive(Clone, Copy, Debug, PartialEq, Eq)]
             #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
             pub struct $name { $(
                 $(

--- a/pulley/src/opcode.rs
+++ b/pulley/src/opcode.rs
@@ -28,10 +28,7 @@ macro_rules! define_opcode {
             /// The value of the maximum defined opcode.
             pub const MAX: u8 = Opcode::ExtendedOp as u8;
         }
-    };
-
-    ( @max $x:ident ) => { 0 };
-    ( @max $x:ident $( $xs:ident )* ) => { 1 + define_opcode!(@max $( $xs )* ) };
+    }
 }
 for_each_op!(define_opcode);
 
@@ -77,7 +74,9 @@ macro_rules! define_extended_opcode {
 
         impl ExtendedOpcode {
             /// The value of the maximum defined extended opcode.
-            pub const MAX: u16 = define_opcode!( @max $( $name )* ) + 1;
+            pub const MAX: u16 = $(
+                if true { 1 } else { ExtendedOpcode::$name as u16 } +
+            )* 0;
         }
     };
 }

--- a/pulley/tests/all/disas.rs
+++ b/pulley/tests/all/disas.rs
@@ -87,10 +87,10 @@ fn push_pop_many() {
         r#"
        0: push_frame
        1: xpush32_many x0, x1, x2, x3, x4
-       6: xadd32 x0, x0, x1
-       9: xpop32_many x0, x1, x2, x3, x4
-       e: pop_frame
-       f: ret
+       8: xadd32 x0, x0, x1
+       b: xpop32_many x0, x1, x2, x3, x4
+      12: pop_frame
+      13: ret
         "#,
     );
 }

--- a/pulley/tests/all/disas.rs
+++ b/pulley/tests/all/disas.rs
@@ -66,9 +66,9 @@ fn push_pop_many() {
         &[
             // Prologue.
             Op::PushFrame(PushFrame {}),
-            Op::XPush32Many(XPush32Many {
+            Op::ExtendedOp(ExtendedOp::XPush32Many(XPush32Many {
                 srcs: RegSet::from_iter([XReg::x0, XReg::x1, XReg::x2, XReg::x3, XReg::x4]),
-            }),
+            })),
             // Function body.
             Op::Xadd32(Xadd32 {
                 operands: BinaryOperands {
@@ -78,9 +78,9 @@ fn push_pop_many() {
                 },
             }),
             // Epilogue.
-            Op::XPop32Many(XPop32Many {
+            Op::ExtendedOp(ExtendedOp::XPop32Many(XPop32Many {
                 dsts: RegSet::from_iter([XReg::x0, XReg::x1, XReg::x2, XReg::x3, XReg::x4]),
-            }),
+            })),
             Op::PopFrame(PopFrame {}),
             Op::Ret(Ret {}),
         ],

--- a/tests/disas/pulley/memory-inbounds.wat
+++ b/tests/disas/pulley/memory-inbounds.wat
@@ -98,12 +98,12 @@
 ;;       xconst32 x8, 131072
 ;;       xadd64_uoverflow_trap x7, x7, x8
 ;;       xload64le_offset32 x8, x0, 104
-;;       br_if_xult64 x8, x7, 0x17    // target = 0x2b
-;;   1b: xload64le_offset32 x8, x0, 96
+;;       br_if_xult64 x8, x7, 0x17    // target = 0x2d
+;;   1d: xload64le_offset32 x8, x0, 96
 ;;       xload32le_offset32 x0, x8, 131068
 ;;       pop_frame
 ;;       ret
-;;   2b: trap
+;;   2d: trap
 ;;
 ;; wasm[0]::function[9]::never_inbounds:
 ;;       push_frame


### PR DESCRIPTION
In the near future the set of opcodes here are going to be expanded along a number of axes such as:

* More modes of addressing loads/stores other than just `reg + offset32`.
* Opcodes with immediate operands rather than unconditional register operands.

The 1-byte opcode namespace is already filling up and there's a bit of a mishmash of what's 1-byte and what's "extended" for now. To help bridge this gap in the interim shuffle all float/vector-related opcodes into the "extended" opcode namespace. This frees up a large chunk of the 1-byte opcode namespace for future expansion with extensions like above.

I'll note that I'm not 100% sure that the opcodes will all stay here after this reshuffling. I haven't done any profiling/performance analysis to gauge the impact of this change. The immediate goal is to start experimenting with non-float/vector programs and get them profiling well. This will require more "macro opcodes" such as new addressing modes and opcodes-with-immediates. These are expected to be relatively hot opcodes and thus probably want to be in the "fast" 1-byte namespace, hence the shuffling here.

My plan is to in the future do a bit of an evaluation with a float/vector program and see whether it make sense to shuffle some of them into this 1-bytecode space as well. More radically it might make sense to remove the split between ops/extended ops and instead just have a 2-byte opcode space entirely. That's all left for future evaluations though.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
