### PR TITLE
pulley: Add add/sub-with immediate opcodes

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -129,41 +129,92 @@
 
 ;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type $I8 (iadd a b)))
-      (pulley_xadd32 a b))
+(rule 0 (lower (has_type (ty_int (fits_in_64 ty)) (iadd a b))) (pulley_xadd32 a b))
+(rule 1 (lower (has_type $I64 (iadd a b))) (pulley_xadd64 a b))
 
-(rule (lower (has_type $I16 (iadd a b)))
-      (pulley_xadd32 a b))
+;; Fold constants into the instruction if possible
+(rule 2 (lower (has_type (ty_int (fits_in_32 _)) (iadd a (u32_from_iconst b))))
+  (pulley_xadd32_u32 a b))
+(rule 3 (lower (has_type (ty_int (fits_in_32 _)) (iadd a (u8_from_iconst b))))
+  (pulley_xadd32_u8 a b))
+(rule 4 (lower (has_type $I64 (iadd a (u32_from_iconst b))))
+  (pulley_xadd64_u32 a b))
+(rule 5 (lower (has_type $I64 (iadd a (u8_from_iconst b))))
+  (pulley_xadd64_u8 a b))
 
-(rule (lower (has_type $I32 (iadd a b)))
-      (pulley_xadd32 a b))
+;; If the rhs is a constant and the negated version can fit within a smaller
+;; constant then switch this to a subtraction with the negated constant.
+(rule 6 (lower (has_type (ty_int (fits_in_32 _)) (iadd a b)))
+  (if-let c (u32_from_negated_iconst b))
+  (pulley_xsub32_u32 a c))
+(rule 7 (lower (has_type $I64 (iadd a b)))
+  (if-let c (u32_from_negated_iconst b))
+  (pulley_xsub64_u32 a c))
+(rule 8 (lower (has_type (ty_int (fits_in_32 _)) (iadd a b)))
+  (if-let c (u8_from_negated_iconst b))
+  (pulley_xsub32_u8 a c))
+(rule 9 (lower (has_type $I64 (iadd a b)))
+  (if-let c (u8_from_negated_iconst b))
+  (pulley_xsub64_u8 a c))
 
-(rule (lower (has_type $I64 (iadd a b)))
-      (pulley_xadd64 a b))
+;; Helper extract a constant from a `Value`, negate it, and fit it within a
+;; `u8`.
+(decl pure partial u8_from_negated_iconst (Value) u8)
+(rule (u8_from_negated_iconst (i32_from_iconst i))
+  (if-let neg_i64 (i64_neg (i32_as_i64 i)))
+  (if-let neg_u64 (u64_try_from_i64 neg_i64))
+  (if-let neg_u8 (u8_try_from_u64 neg_u64))
+  neg_u8)
 
-(rule (lower (has_type $I8X16 (iadd a b))) (pulley_vaddi8x16 a b))
-(rule (lower (has_type $I16X8 (iadd a b))) (pulley_vaddi16x8 a b))
-(rule (lower (has_type $I32X4 (iadd a b))) (pulley_vaddi32x4 a b))
-(rule (lower (has_type $I64X2 (iadd a b))) (pulley_vaddi64x2 a b))
+;; Helper extract a constant from a `Value`, negate it, and fit it within a
+;; `u32`.
+(decl pure partial u32_from_negated_iconst (Value) u32)
+(rule (u32_from_negated_iconst (i32_from_iconst i))
+  (if-let neg_i64 (i64_neg (i32_as_i64 i)))
+  (if-let neg_u64 (u64_try_from_i64 neg_i64))
+  (if-let neg_u32 (u32_try_from_u64 neg_u64))
+  neg_u32)
+
+
+(rule 1 (lower (has_type $I8X16 (iadd a b))) (pulley_vaddi8x16 a b))
+(rule 1 (lower (has_type $I16X8 (iadd a b))) (pulley_vaddi16x8 a b))
+(rule 1 (lower (has_type $I32X4 (iadd a b))) (pulley_vaddi32x4 a b))
+(rule 1 (lower (has_type $I64X2 (iadd a b))) (pulley_vaddi64x2 a b))
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type $I8 (isub a b)))
-      (pulley_xsub32 a b))
+(rule 0 (lower (has_type (ty_int (fits_in_32 _)) (isub a b))) (pulley_xsub32 a b))
+(rule 1 (lower (has_type $I64 (isub a b))) (pulley_xsub64 a b))
 
-(rule (lower (has_type $I16 (isub a b)))
-      (pulley_xsub32 a b))
+;; Fold a rhs constant into the instruction if possible.
+(rule 2 (lower (has_type (ty_int (fits_in_32 _)) (isub a (u32_from_iconst b))))
+  (pulley_xsub32_u32 a b))
+(rule 3 (lower (has_type (ty_int (fits_in_32 _)) (isub a (u8_from_iconst b))))
+  (pulley_xsub32_u8 a b))
+(rule 4 (lower (has_type $I64 (isub a (u32_from_iconst b))))
+  (pulley_xsub64_u32 a b))
+(rule 5 (lower (has_type $I64 (isub a (u8_from_iconst b))))
+  (pulley_xsub64_u8 a b))
 
-(rule (lower (has_type $I32 (isub a b)))
-      (pulley_xsub32 a b))
+;; If the rhs is a constant and the negated version can fit within a smaller
+;; constant then switch this to an addition with the negated constant.
+(rule 6 (lower (has_type (ty_int (fits_in_32 _)) (isub a b)))
+  (if-let c (u32_from_negated_iconst b))
+  (pulley_xadd32_u32 a c))
+(rule 7 (lower (has_type $I64 (isub a b)))
+  (if-let c (u32_from_negated_iconst b))
+  (pulley_xadd64_u32 a c))
+(rule 8 (lower (has_type (ty_int (fits_in_32 _)) (isub a b)))
+  (if-let c (u8_from_negated_iconst b))
+  (pulley_xadd32_u8 a c))
+(rule 9 (lower (has_type $I64 (isub a b)))
+  (if-let c (u8_from_negated_iconst b))
+  (pulley_xadd64_u8 a c))
 
-(rule (lower (has_type $I64 (isub a b)))
-      (pulley_xsub64 a b))
-
-(rule (lower (has_type $I8X16 (isub a b))) (pulley_vsubi8x16 a b))
-(rule (lower (has_type $I16X8 (isub a b))) (pulley_vsubi16x8 a b))
-(rule (lower (has_type $I32X4 (isub a b))) (pulley_vsubi32x4 a b))
-(rule (lower (has_type $I64X2 (isub a b))) (pulley_vsubi64x2 a b))
+(rule 1 (lower (has_type $I8X16 (isub a b))) (pulley_vsubi8x16 a b))
+(rule 1 (lower (has_type $I16X8 (isub a b))) (pulley_vsubi16x8 a b))
+(rule 1 (lower (has_type $I32X4 (isub a b))) (pulley_vsubi32x4 a b))
+(rule 1 (lower (has_type $I64X2 (isub a b))) (pulley_vsubi64x2 a b))
 
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -931,6 +931,14 @@ macro_rules! isle_common_prelude_methods {
             val as u16
         }
 
+        fn u8_try_from_u64(&mut self, val: u64) -> Option<u8> {
+            u8::try_from(val).ok()
+        }
+
+        fn u64_try_from_i64(&mut self, val: i64) -> Option<u64> {
+            u64::try_from(val).ok()
+        }
+
         fn u16_try_from_u64(&mut self, val: u64) -> Option<u16> {
             u16::try_from(val).ok()
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -109,11 +109,17 @@
 (decl pure u64_as_i64 (u64) i64)
 (extern constructor u64_as_i64 u64_as_i64)
 
+(decl pure partial u8_try_from_u64 (u64) u8)
+(extern constructor u8_try_from_u64 u8_try_from_u64)
+
 (decl pure partial u16_try_from_u64 (u64) u16)
 (extern constructor u16_try_from_u64 u16_try_from_u64)
 
 (decl pure partial u32_try_from_u64 (u64) u32)
 (extern constructor u32_try_from_u64 u32_try_from_u64)
+
+(decl pure partial u64_try_from_i64 (i64) u64)
+(extern constructor u64_try_from_i64 u64_try_from_i64)
 
 (decl pure partial i8_try_from_u64 (u64) i8)
 (extern constructor i8_try_from_u64 i8_try_from_u64)

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -306,6 +306,14 @@
 (decl def_inst (Inst) Value)
 (extern extractor def_inst def_inst)
 
+(decl u8_from_iconst (u8) Value)
+(extractor (u8_from_iconst x)
+           (def_inst (iconst (uimm8 x))))
+
+(decl u32_from_iconst (u32) Value)
+(extractor (u32_from_iconst x)
+           (u64_from_iconst (u64_as_u32 x)))
+
 ;; Extract a constant `u64` from a value defined by an `iconst`.
 (spec (u64_from_iconst arg) (provide (= arg (zero_ext 64 result))))
 (decl u64_from_iconst (u64) Value)

--- a/cranelift/filetests/filetests/isa/pulley32/isub.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/isub.clif
@@ -3,219 +3,116 @@ target pulley32
 
 function %i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
-    v2 = iadd v0, v1
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xadd32 x0, x0, x1
+;   xsub32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
-; xadd32 x0, x0, x1
+; xsub32 x0, x0, x1
 ; ret
 
 function %i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
-    v2 = iadd v0, v1
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xadd32 x0, x0, x1
+;   xsub32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
-; xadd32 x0, x0, x1
+; xsub32 x0, x0, x1
 ; ret
 
 function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
-    v2 = iadd v0, v1
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xadd32 x0, x0, x1
+;   xsub32 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
-; xadd32 x0, x0, x1
+; xsub32 x0, x0, x1
 ; ret
 
 function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
-    v2 = iadd v0, v1
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xadd64 x0, x0, x1
+;   xsub64 x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
-; xadd64 x0, x0, x1
+; xsub64 x0, x0, x1
 ; ret
 
 function %i8_imm(i8) -> i8 {
 block0(v0: i8):
-    v2 = iadd_imm v0, 10
+    v1 = iconst.i8 10
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xadd32_u8 x0, x0, 10
+;   xsub32_u8 x0, x0, 10
 ;   ret
 ;
 ; Disassembled:
-; xadd32_u8 x0, x0, 10
+; xsub32_u8 x0, x0, 10
 ; ret
 
 function %i16_imm(i16) -> i16 {
 block0(v0: i16):
-    v2 = iadd_imm v0, 10
+    v1 = iconst.i16 10
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xadd32_u8 x0, x0, 10
+;   xsub32_u8 x0, x0, 10
 ;   ret
 ;
 ; Disassembled:
-; xadd32_u8 x0, x0, 10
+; xsub32_u8 x0, x0, 10
 ; ret
 
 function %i32_imm(i32) -> i32 {
 block0(v0: i32):
-    v2 = iadd_imm v0, 10
+    v1 = iconst.i32 10
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xadd32_u8 x0, x0, 10
+;   xsub32_u8 x0, x0, 10
 ;   ret
 ;
 ; Disassembled:
-; xadd32_u8 x0, x0, 10
+; xsub32_u8 x0, x0, 10
 ; ret
 
 function %i64_imm(i64) -> i64 {
 block0(v0: i64):
-    v2 = iadd_imm v0, 10
-    return v2
-}
-
-; VCode:
-; block0:
-;   xadd64_u8 x0, x0, 10
-;   ret
-;
-; Disassembled:
-; xadd64_u8 x0, x0, 10
-; ret
-
-function %i32_imm_big(i32) -> i32 {
-block0(v0: i32):
-    v2 = iadd_imm v0, 65536
-    return v2
-}
-
-; VCode:
-; block0:
-;   xadd32_u32 x0, x0, 65536
-;   ret
-;
-; Disassembled:
-; xadd32_u32 x0, x0, 65536
-; ret
-
-function %i64_imm_big(i64) -> i64 {
-block0(v0: i64):
-    v2 = iadd_imm v0, 65536
-    return v2
-}
-
-; VCode:
-; block0:
-;   xadd64_u32 x0, x0, 65536
-;   ret
-;
-; Disassembled:
-; xadd64_u32 x0, x0, 65536
-; ret
-
-function %i64_imm_super_big(i64) -> i64 {
-block0(v0: i64):
-    v2 = iadd_imm v0, 0x1_1111_1111
-    return v2
-}
-
-; VCode:
-; block0:
-;   xconst64 x3, 4581298449
-;   xadd64 x0, x0, x3
-;   ret
-;
-; Disassembled:
-; xconst64 x3, 4581298449
-; xadd64 x0, x0, x3
-; ret
-
-function %i8_negative_imm(i8) -> i8 {
-block0(v0: i8):
-    v2 = iadd_imm v0, -10
-    return v2
-}
-
-; VCode:
-; block0:
-;   xsub32_u8 x0, x0, 10
-;   ret
-;
-; Disassembled:
-; xsub32_u8 x0, x0, 10
-; ret
-
-function %i16_negative_imm(i16) -> i16 {
-block0(v0: i16):
-    v2 = iadd_imm v0, -10
-    return v2
-}
-
-; VCode:
-; block0:
-;   xsub32_u8 x0, x0, 10
-;   ret
-;
-; Disassembled:
-; xsub32_u8 x0, x0, 10
-; ret
-
-function %i32_negative_imm(i32) -> i32 {
-block0(v0: i32):
-    v2 = iadd_imm v0, -10
-    return v2
-}
-
-; VCode:
-; block0:
-;   xsub32_u8 x0, x0, 10
-;   ret
-;
-; Disassembled:
-; xsub32_u8 x0, x0, 10
-; ret
-
-function %i64_negative_imm(i64) -> i64 {
-block0(v0: i64):
-    v2 = iadd_imm v0, -10
+    v1 = iconst.i64 10
+    v2 = isub v0, v1
     return v2
 }
 
@@ -228,9 +125,10 @@ block0(v0: i64):
 ; xsub64_u8 x0, x0, 10
 ; ret
 
-function %i32_negative_imm_big(i32) -> i32 {
+function %i32_imm_big(i32) -> i32 {
 block0(v0: i32):
-    v2 = iadd_imm v0, -65536
+    v1 = iconst.i32 65536
+    v2 = isub v0, v1
     return v2
 }
 
@@ -243,9 +141,10 @@ block0(v0: i32):
 ; xsub32_u32 x0, x0, 65536
 ; ret
 
-function %i64_negative_imm_big(i64) -> i64 {
+function %i64_imm_big(i64) -> i64 {
 block0(v0: i64):
-    v2 = iadd_imm v0, -65536
+    v1 = iconst.i64 65536
+    v2 = isub v0, v1
     return v2
 }
 
@@ -258,18 +157,99 @@ block0(v0: i64):
 ; xsub64_u32 x0, x0, 65536
 ; ret
 
-function %i32_negative_i32_min(i32) -> i32 {
-block0(v0: i32):
-    v2 = iadd_imm v0, 0x8000_0000
+function %i8_negative_imm(i8) -> i8 {
+block0(v0: i8):
+    v1 = iconst.i8 -10
+    v2 = isub v0, v1
     return v2
 }
 
 ; VCode:
 ; block0:
-;   xsub32_u32 x0, x0, 2147483648
+;   xadd32_u8 x0, x0, 10
 ;   ret
 ;
 ; Disassembled:
-; xsub32_u32 x0, x0, 2147483648
+; xadd32_u8 x0, x0, 10
+; ret
+
+function %i16_negative_imm(i16) -> i16 {
+block0(v0: i16):
+    v1 = iconst.i16 -10
+    v2 = isub v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   xadd32_u8 x0, x0, 10
+;   ret
+;
+; Disassembled:
+; xadd32_u8 x0, x0, 10
+; ret
+
+function %i32_negative_imm(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 -10
+    v2 = isub v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   xadd32_u8 x0, x0, 10
+;   ret
+;
+; Disassembled:
+; xadd32_u8 x0, x0, 10
+; ret
+
+function %i64_negative_imm(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 -10
+    v2 = isub v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   xadd64_u8 x0, x0, 10
+;   ret
+;
+; Disassembled:
+; xadd64_u8 x0, x0, 10
+; ret
+
+function %i32_negative_big_imm(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 -65536
+    v2 = isub v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   xadd32_u32 x0, x0, 65536
+;   ret
+;
+; Disassembled:
+; xadd32_u32 x0, x0, 65536
+; ret
+
+function %i64_negative_big_imm(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 -65536
+    v2 = isub v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   xadd64_u32 x0, x0, 65536
+;   ret
+;
+; Disassembled:
+; xadd64_u32 x0, x0, 65536
 ; ret
 

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1244,10 +1244,30 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xadd32_u8(&mut self, dst: XReg, src1: XReg, src2: u8) -> ControlFlow<Done> {
+        self.xadd32_u32(dst, src1, src2.into())
+    }
+
+    fn xadd32_u32(&mut self, dst: XReg, src1: XReg, src2: u32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_u32();
+        self.state[dst].set_u32(a.wrapping_add(src2.into()));
+        ControlFlow::Continue(())
+    }
+
     fn xadd64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
         self.state[operands.dst].set_u64(a.wrapping_add(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xadd64_u8(&mut self, dst: XReg, src1: XReg, src2: u8) -> ControlFlow<Done> {
+        self.xadd64_u32(dst, src1, src2.into())
+    }
+
+    fn xadd64_u32(&mut self, dst: XReg, src1: XReg, src2: u32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_u64();
+        self.state[dst].set_u64(a.wrapping_add(src2.into()));
         ControlFlow::Continue(())
     }
 
@@ -1258,10 +1278,30 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xsub32_u8(&mut self, dst: XReg, src1: XReg, src2: u8) -> ControlFlow<Done> {
+        self.xsub32_u32(dst, src1, src2.into())
+    }
+
+    fn xsub32_u32(&mut self, dst: XReg, src1: XReg, src2: u32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_u32();
+        self.state[dst].set_u32(a.wrapping_sub(src2.into()));
+        ControlFlow::Continue(())
+    }
+
     fn xsub64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
         self.state[operands.dst].set_u64(a.wrapping_sub(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xsub64_u8(&mut self, dst: XReg, src1: XReg, src2: u8) -> ControlFlow<Done> {
+        self.xsub64_u32(dst, src1, src2.into())
+    }
+
+    fn xsub64_u32(&mut self, dst: XReg, src1: XReg, src2: u32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_u64();
+        self.state[dst].set_u64(a.wrapping_sub(src2.into()));
         ControlFlow::Continue(())
     }
 

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -162,17 +162,33 @@ macro_rules! for_each_op {
             ///
             /// The upper 32-bits of `dst` are unmodified.
             xadd32 = Xadd32 { operands: BinaryOperands<XReg> };
+            /// Same as `xadd32` but `src2` is a zero-extended 8-bit immediate.
+            xadd32_u8 = Xadd32U8 { dst: XReg, src1: XReg, src2: u8 };
+            /// Same as `xadd32` but `src2` is a 32-bit immediate.
+            xadd32_u32 = Xadd32U32 { dst: XReg, src1: XReg, src2: u32 };
 
             /// 64-bit wrapping addition: `dst = src1 + src2`.
             xadd64 = Xadd64 { operands: BinaryOperands<XReg> };
+            /// Same as `xadd64` but `src2` is a zero-extended 8-bit immediate.
+            xadd64_u8 = Xadd64U8 { dst: XReg, src1: XReg, src2: u8 };
+            /// Same as `xadd64` but `src2` is a zero-extended 32-bit immediate.
+            xadd64_u32 = Xadd64U32 { dst: XReg, src1: XReg, src2: u32 };
 
             /// 32-bit wrapping subtraction: `low32(dst) = low32(src1) - low32(src2)`.
             ///
             /// The upper 32-bits of `dst` are unmodified.
             xsub32 = Xsub32 { operands: BinaryOperands<XReg> };
+            /// Same as `xsub32` but `src2` is a zero-extended 8-bit immediate.
+            xsub32_u8 = Xsub32U8 { dst: XReg, src1: XReg, src2: u8 };
+            /// Same as `xsub32` but `src2` is a 32-bit immediate.
+            xsub32_u32 = Xsub32U32 { dst: XReg, src1: XReg, src2: u32 };
 
             /// 64-bit wrapping subtraction: `dst = src1 - src2`.
             xsub64 = Xsub64 { operands: BinaryOperands<XReg> };
+            /// Same as `xsub64` but `src2` is a zero-extended 8-bit immediate.
+            xsub64_u8 = Xsub64U8 { dst: XReg, src1: XReg, src2: u8 };
+            /// Same as `xsub64` but `src2` is a zero-extended 32-bit immediate.
+            xsub64_u32 = Xsub64U32 { dst: XReg, src1: XReg, src2: u32 };
 
             /// `low32(dst) = low32(src1) * low32(src2)`
             xmul32 = XMul32 { operands: BinaryOperands<XReg> };

--- a/tests/disas/pulley/memory-inbounds.wat
+++ b/tests/disas/pulley/memory-inbounds.wat
@@ -48,16 +48,15 @@
 ;;
 ;; wasm[0]::function[4]::offset_just_bad:
 ;;       push_frame
-;;       xload64le_offset32 x7, x0, 104
-;;       xconst8 x8, 4
-;;       xsub64 x7, x7, x8
-;;       xconst32 x8, 65533
-;;       br_if_xult64 x7, x8, 0x17    // target = 0x2b
-;;   1b: xload64le_offset32 x8, x0, 96
-;;       xload32le_offset32 x0, x8, 65533
+;;       xload64le_offset32 x6, x0, 104
+;;       xsub64_u8 x6, x6, 4
+;;       xconst32 x7, 65533
+;;       br_if_xult64 x6, x7, 0x17    // target = 0x29
+;;   19: xload64le_offset32 x7, x0, 96
+;;       xload32le_offset32 x0, x7, 65533
 ;;       pop_frame
 ;;       ret
-;;   2b: trap
+;;   29: trap
 ;;
 ;; wasm[0]::function[5]::offset_just_ok_v2:
 ;;       push_frame
@@ -68,29 +67,27 @@
 ;;
 ;; wasm[0]::function[6]::offset_just_bad_v2:
 ;;       push_frame
-;;       xload64le_offset32 x7, x0, 104
-;;       xconst32 x8, 65536
-;;       xsub64 x7, x7, x8
-;;       xconst8 x8, 0
-;;       br_if_xeq64 x7, x8, 0x17    // target = 0x2b
-;;   1b: xload64le_offset32 x8, x0, 96
-;;       xload32le_offset32 x0, x8, 65533
+;;       xload64le_offset32 x6, x0, 104
+;;       xsub64_u32 x6, x6, 65536
+;;       xconst8 x7, 0
+;;       br_if_xeq64 x6, x7, 0x17    // target = 0x29
+;;   19: xload64le_offset32 x7, x0, 96
+;;       xload32le_offset32 x0, x7, 65533
 ;;       pop_frame
 ;;       ret
-;;   2b: trap
+;;   29: trap
 ;;
 ;; wasm[0]::function[7]::maybe_inbounds:
 ;;       push_frame
-;;       xload64le_offset32 x7, x0, 104
-;;       xconst8 x8, 4
-;;       xsub64 x7, x7, x8
-;;       xconst32 x8, 131068
-;;       br_if_xult64 x7, x8, 0x17    // target = 0x2b
-;;   1b: xload64le_offset32 x8, x0, 96
-;;       xload32le_offset32 x0, x8, 131068
+;;       xload64le_offset32 x6, x0, 104
+;;       xsub64_u8 x6, x6, 4
+;;       xconst32 x7, 131068
+;;       br_if_xult64 x6, x7, 0x17    // target = 0x29
+;;   19: xload64le_offset32 x7, x0, 96
+;;       xload32le_offset32 x0, x7, 131068
 ;;       pop_frame
 ;;       ret
-;;   2b: trap
+;;   29: trap
 ;;
 ;; wasm[0]::function[8]::maybe_inbounds_v2:
 ;;       push_frame
@@ -107,16 +104,15 @@
 ;;
 ;; wasm[0]::function[9]::never_inbounds:
 ;;       push_frame
-;;       xload64le_offset32 x7, x0, 104
-;;       xconst8 x8, 4
-;;       xsub64 x7, x7, x8
-;;       xconst32 x8, 131069
-;;       br_if_xult64 x7, x8, 0x17    // target = 0x2b
-;;   1b: xload64le_offset32 x8, x0, 96
-;;       xload32le_offset32 x0, x8, 131069
+;;       xload64le_offset32 x6, x0, 104
+;;       xsub64_u8 x6, x6, 4
+;;       xconst32 x7, 131069
+;;       br_if_xult64 x6, x7, 0x17    // target = 0x29
+;;   19: xload64le_offset32 x7, x0, 96
+;;       xload32le_offset32 x0, x7, 131069
 ;;       pop_frame
 ;;       ret
-;;   2b: trap
+;;   29: trap
 ;;
 ;; wasm[0]::function[10]::never_inbounds_v2:
 ;;       push_frame


### PR DESCRIPTION
This commit extends the pulley opcode space with integer addition/subtraction where `src2` is an immediate. The goal here is to be a "sort of macro instruction" despite it not being too too macro here. This cuts down on `xconstN` instructions which both saves space in the final binary and should be slightly more optimal perf-wise due to only one dispatch being needed.

In this commit the `xadd32` instruction is previously 3 bytes: one for an opcode and 2 bytes for the dst/src1/src2 binary operands. Adding a small constant to a register previously took 5 bytes where 2 bytes were needed for `xconst8 N` then 3 for the addition. Here the encoding size of the new instruction is 4 bytes: 1 for the opcode, 2 for dst/src1, and one for the immediate. This is currently chosen to mostly optimize dispatch in the interpreter loop as opposed to code size (as only a single byte is saved). In the future thought it would be possible to extend `BinaryOperands` to one operand being a 6-bit immediate to preserve the same code size.

This also notably adds, for addition/subtraction, only unsigned immediates. With addition/subtraction being inverses of one another supporting signed immediates isn't necessary and helps free up another bit for packing numbers into these opcodes.

This change reduces the size of `spidermonkey.cwasm` from 31M to 29M locally.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
