### PR TITLE
Add Default and Debug impls to SparseMap

### DIFF
--- a/cranelift/entity/src/sparse.rs
+++ b/cranelift/entity/src/sparse.rs
@@ -220,9 +220,8 @@ where
     V: SparseMapValue<K> + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SparseMap")
-            .field("sparse", &self.sparse)
-            .field("dense", &self.dense)
+        f.debug_map()
+            .entries(self.values().map(|v| (v.key(), v)))
             .finish()
     }
 }
@@ -405,8 +404,8 @@ mod tests {
         let mut map = SparseMap::new();
         assert_eq!(map.insert(Obj(i1, "hi")), None);
 
-        let debug = format!("{:?}", map);
-        let expected= "SparseMap { sparse: SecondaryMap { elems: [0, 0], default: 0, unused: PhantomData<cranelift_entity::sparse::tests::Inst> }, dense: [Obj(inst1, \"hi\")] }";
+        let debug = format!("{map:?}");
+        let expected = "{inst1: Obj(inst1, \"hi\")}";
         assert_eq!(debug, expected);
     }
 }

--- a/cranelift/entity/src/sparse.rs
+++ b/cranelift/entity/src/sparse.rs
@@ -10,6 +10,7 @@
 use crate::map::SecondaryMap;
 use crate::EntityRef;
 use alloc::vec::Vec;
+use core::fmt;
 use core::mem;
 use core::slice;
 use core::u32;
@@ -203,6 +204,29 @@ where
     }
 }
 
+impl<K, V> Default for SparseMap<K, V>
+where
+    K: EntityRef,
+    V: SparseMapValue<K>,
+{
+    fn default() -> SparseMap<K, V> {
+        SparseMap::new()
+    }
+}
+
+impl<K, V> fmt::Debug for SparseMap<K, V>
+where
+    K: EntityRef + fmt::Debug,
+    V: SparseMapValue<K> + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SparseMap")
+            .field("sparse", &self.sparse)
+            .field("dense", &self.dense)
+            .finish()
+    }
+}
+
 /// Iterating over the elements of a set.
 impl<'a, K, V> IntoIterator for &'a SparseMap<K, V>
 where
@@ -234,6 +258,8 @@ pub type SparseSet<T> = SparseMap<T, T>;
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use super::*;
 
     /// An opaque reference to an instruction in a function.
@@ -363,5 +389,24 @@ mod tests {
         assert_eq!(set.insert(i1), None);
         assert_eq!(set.get(i0), Some(&i0));
         assert_eq!(set.get(i1), Some(&i1));
+    }
+
+    #[test]
+    fn default_impl() {
+        let map: SparseMap<Inst, Obj> = SparseMap::default();
+
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let i1 = Inst::new(1);
+        let mut map = SparseMap::new();
+        assert_eq!(map.insert(Obj(i1, "hi")), None);
+
+        let debug = format!("{:?}", map);
+        let expected= "SparseMap { sparse: SecondaryMap { elems: [0, 0], default: 0, unused: PhantomData<cranelift_entity::sparse::tests::Inst> }, dense: [Obj(inst1, \"hi\")] }";
+        assert_eq!(debug, expected);
     }
 }


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/issues/9856

Add `Default` and `Debug` trait impls to `SparseMap` (for the latter, only impl `Debug` if `K` and `V` impl `Debug`).

closes #9856 
