### PR TITLE
pulley: Add immediate payloads to more opcodes

### DIFF
--- a/cranelift/codegen/meta/src/pulley.rs
+++ b/cranelift/codegen/meta/src/pulley.rs
@@ -137,12 +137,14 @@ pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
                     pat.push_str(",");
                     format_string.push_str(&format!(" // trap={{{name}:?}}"));
                 }
-                Operand::Binop { .. } => {
+                Operand::Binop { src2, .. } => {
                     pat.push_str("dst, src1, src2,");
                     format_string.push_str(" {dst}, {src1}, {src2}");
                     locals.push_str(&format!("let dst = reg_name(*dst.to_reg());\n"));
                     locals.push_str(&format!("let src1 = reg_name(**src1);\n"));
-                    locals.push_str(&format!("let src2 = reg_name(**src2);\n"));
+                    if src2.contains("Reg") {
+                        locals.push_str(&format!("let src2 = reg_name(**src2);\n"));
+                    }
                 }
             }
         }
@@ -189,11 +191,14 @@ pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
                     }
                 }
                 Operand::TrapCode { .. } => {}
-                Operand::Binop { .. } => {
-                    pat.push_str("dst, src1, src2,");
+                Operand::Binop { src2, .. } => {
+                    pat.push_str("dst, src1,");
                     uses.push("src1");
-                    uses.push("src2");
                     defs.push("dst");
+                    if src2.contains("Reg") {
+                        pat.push_str("src2,");
+                        uses.push("src2");
+                    }
                 }
             }
         }

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -129,6 +129,7 @@
 (rule (raw_inst_to_inst inst) (MInst.Raw inst))
 (convert RawInst MInst raw_inst_to_inst)
 
+(type U6 (primitive U6))
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -223,6 +223,15 @@
 (rule (lower (has_type $I32 (imul a b))) (pulley_xmul32 a b))
 (rule (lower (has_type $I64 (imul a b))) (pulley_xmul64 a b))
 
+(rule 1 (lower (has_type (ty_int (fits_in_32 _)) (imul a (i32_from_iconst b))))
+  (pulley_xmul32_s32 a b))
+(rule 2 (lower (has_type $I64 (imul a (i32_from_iconst b))))
+  (pulley_xmul64_s32 a b))
+(rule 3 (lower (has_type (ty_int (fits_in_32 _)) (imul a (i8_from_iconst b))))
+  (pulley_xmul32_s8 a b))
+(rule 4 (lower (has_type $I64 (imul a (i8_from_iconst b))))
+  (pulley_xmul64_s8 a b))
+
 (rule (lower (has_type $I8X16 (imul a b))) (pulley_vmuli8x16 a b))
 (rule (lower (has_type $I16X8 (imul a b))) (pulley_vmuli16x8 a b))
 (rule (lower (has_type $I32X4 (imul a b))) (pulley_vmuli32x4 a b))
@@ -294,10 +303,30 @@
 (rule (lower (has_type $I64 (ishl a b)))
   (pulley_xshl64 a b))
 
+;; Special-case constant shift amounts.
+(rule 1 (lower (has_type $I32 (ishl a b)))
+  (if-let n (u6_shift_from_iconst b))
+  (pulley_xshl32_u6 a n))
+(rule 1 (lower (has_type $I64 (ishl a b)))
+  (if-let n (u6_shift_from_iconst b))
+  (pulley_xshl64_u6 a n))
+
+;; vector shifts
+
 (rule (lower (has_type $I8X16 (ishl a b))) (pulley_vshli8x16 a b))
 (rule (lower (has_type $I16X8 (ishl a b))) (pulley_vshli16x8 a b))
 (rule (lower (has_type $I32X4 (ishl a b))) (pulley_vshli32x4 a b))
 (rule (lower (has_type $I64X2 (ishl a b))) (pulley_vshli64x2 a b))
+
+;; Helper to extract a constant from `Value`, mask it to 6 bits, and then make a
+;; `U6`.
+(decl pure partial u6_shift_from_iconst (Value) U6)
+(rule (u6_shift_from_iconst (u64_from_iconst val))
+  (if-let (u6_from_u8 x) (u64_as_u8 (u64_and val 0x3f)))
+  x)
+
+(decl u6_from_u8 (U6) u8)
+(extern extractor u6_from_u8 u6_from_u8)
 
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -312,6 +341,16 @@
 
 (rule (lower (has_type $I64 (ushr a b)))
   (pulley_xshr64_u a b))
+
+;; Special-case constant shift amounts.
+(rule 1 (lower (has_type $I32 (ushr a b)))
+  (if-let n (u6_shift_from_iconst b))
+  (pulley_xshr32_u_u6 a n))
+(rule 1 (lower (has_type $I64 (ushr a b)))
+  (if-let n (u6_shift_from_iconst b))
+  (pulley_xshr64_u_u6 a n))
+
+;; vector shifts
 
 (rule (lower (has_type $I8X16 (ushr a b))) (pulley_vshri8x16_u a b))
 (rule (lower (has_type $I16X8 (ushr a b))) (pulley_vshri16x8_u a b))
@@ -332,6 +371,16 @@
 (rule (lower (has_type $I64 (sshr a b)))
   (pulley_xshr64_s a b))
 
+;; Special-case constant shift amounts.
+(rule 1 (lower (has_type $I32 (sshr a b)))
+  (if-let n (u6_shift_from_iconst b))
+  (pulley_xshr32_s_u6 a n))
+(rule 1 (lower (has_type $I64 (sshr a b)))
+  (if-let n (u6_shift_from_iconst b))
+  (pulley_xshr64_s_u6 a n))
+
+;; vector shifts
+
 (rule (lower (has_type $I8X16 (sshr a b))) (pulley_vshri8x16_s a b))
 (rule (lower (has_type $I16X8 (sshr a b))) (pulley_vshri16x8_s a b))
 (rule (lower (has_type $I32X4 (sshr a b))) (pulley_vshri32x4_s a b))
@@ -339,33 +388,51 @@
 
 ;;;; Rules for `band` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 0 (lower (has_type (fits_in_32 _) (band a b)))
-  (pulley_xband32 a b))
+(rule 0 (lower (has_type (fits_in_32 _) (band a b))) (pulley_xband32 a b))
+(rule 1 (lower (has_type $I64 (band a b))) (pulley_xband64 a b))
 
-(rule 1 (lower (has_type $I64 (band a b)))
-  (pulley_xband64 a b))
+(rule 3 (lower (has_type (ty_int (fits_in_32 _)) (band a (i32_from_iconst b))))
+  (pulley_xband32_s32 a b))
+(rule 4 (lower (has_type $I64 (band a (i32_from_iconst b))))
+  (pulley_xband64_s32 a b))
+(rule 5 (lower (has_type (ty_int (fits_in_32 _)) (band a (i8_from_iconst b))))
+  (pulley_xband32_s8 a b))
+(rule 6 (lower (has_type $I64 (band a (i8_from_iconst b))))
+  (pulley_xband64_s8 a b))
 
 (rule 2 (lower (has_type (ty_vec128 _) (band a b)))
   (pulley_vband128 a b))
 
 ;;;; Rules for `bor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 0 (lower (has_type (fits_in_32 _) (bor a b)))
-  (pulley_xbor32 a b))
+(rule 0 (lower (has_type (fits_in_32 _) (bor a b))) (pulley_xbor32 a b))
+(rule 1 (lower (has_type $I64 (bor a b))) (pulley_xbor64 a b))
 
-(rule 1 (lower (has_type $I64 (bor a b)))
-  (pulley_xbor64 a b))
+(rule 3 (lower (has_type (ty_int (fits_in_32 _)) (bor a (i32_from_iconst b))))
+  (pulley_xbor32_s32 a b))
+(rule 4 (lower (has_type $I64 (bor a (i32_from_iconst b))))
+  (pulley_xbor64_s32 a b))
+(rule 5 (lower (has_type (ty_int (fits_in_32 _)) (bor a (i8_from_iconst b))))
+  (pulley_xbor32_s8 a b))
+(rule 6 (lower (has_type $I64 (bor a (i8_from_iconst b))))
+  (pulley_xbor64_s8 a b))
 
 (rule 2 (lower (has_type (ty_vec128 _) (bor a b)))
   (pulley_vbor128 a b))
 
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 0 (lower (has_type (fits_in_32 _) (bxor a b)))
-  (pulley_xbxor32 a b))
+(rule 0 (lower (has_type (fits_in_32 _) (bxor a b))) (pulley_xbxor32 a b))
+(rule 1 (lower (has_type $I64 (bxor a b))) (pulley_xbxor64 a b))
 
-(rule 1 (lower (has_type $I64 (bxor a b)))
-  (pulley_xbxor64 a b))
+(rule 3 (lower (has_type (ty_int (fits_in_32 _)) (bxor a (i32_from_iconst b))))
+  (pulley_xbxor32_s32 a b))
+(rule 4 (lower (has_type $I64 (bxor a (i32_from_iconst b))))
+  (pulley_xbxor64_s32 a b))
+(rule 5 (lower (has_type (ty_int (fits_in_32 _)) (bxor a (i8_from_iconst b))))
+  (pulley_xbxor32_s8 a b))
+(rule 6 (lower (has_type $I64 (bxor a (i8_from_iconst b))))
+  (pulley_xbxor64_s8 a b))
 
 (rule 2 (lower (has_type (ty_vec128 _) (bxor a b)))
   (pulley_vbxor128 a b))

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -21,6 +21,7 @@ use crate::machinst::{
     CallInfo, IsTailCall, MachInst, Reg, VCodeConstant, VCodeConstantData,
 };
 use alloc::boxed::Box;
+use pulley_interpreter::U6;
 use regalloc2::PReg;
 type Unit = ();
 type VecArgPair = Vec<ArgPair>;
@@ -113,6 +114,10 @@ where
 
     fn cond_invert(&mut self, cond: &Cond) -> Cond {
         cond.invert()
+    }
+
+    fn u6_from_u8(&mut self, imm: u8) -> Option<U6> {
+        U6::new(imm)
     }
 }
 

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -919,6 +919,10 @@ macro_rules! isle_common_prelude_methods {
             val.try_into().ok()
         }
 
+        fn i32_as_i8(&mut self, val: i32) -> Option<i8> {
+            val.try_into().ok()
+        }
+
         fn u8_as_i8(&mut self, val: u8) -> i8 {
             val as i8
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -158,6 +158,9 @@
 (decl u32_as_u16 (u16) u32)
 (extern extractor u32_as_u16 u32_as_u16)
 
+(decl i32_as_i8 (i8) i32)
+(extern extractor i32_as_i8 i32_as_i8)
+
 (decl pure u64_as_i32 (u64) i32)
 (extern constructor u64_as_i32 u64_as_i32)
 

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -320,6 +320,10 @@
 (extractor (u64_from_iconst x)
            (def_inst (iconst (u64_from_imm64 x))))
 
+(decl i8_from_iconst (i8) Value)
+(extractor (i8_from_iconst x)
+           (i32_from_iconst (i32_as_i8 x)))
+
 ;; Extract a constant `i32` from a value defined by an `iconst`.
 ;; The value is sign extended to 32 bits.
 (spec (i32_from_iconst arg)

--- a/cranelift/filetests/filetests/isa/pulley64/band.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/band.clif
@@ -1,0 +1,182 @@
+test compile precise-output
+target pulley64
+
+function %i8_imm(i8) -> i8 {
+block0(v0: i8):
+  v2 = band_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xband32_s8 x0, x0, 7
+; ret
+
+function %i8_imm2(i8) -> i8 {
+block0(v0: i8):
+  v2 = band_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xband32_s8 x0, x0, -7
+; ret
+
+function %i16_imm(i16) -> i16 {
+block0(v0: i16):
+  v2 = band_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xband32_s8 x0, x0, 7
+; ret
+
+function %i16_imm2(i16) -> i16 {
+block0(v0: i16):
+  v2 = band_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xband32_s8 x0, x0, -7
+; ret
+
+function %i32_imm(i32) -> i32 {
+block0(v0: i32):
+  v2 = band_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xband32_s8 x0, x0, 7
+; ret
+
+function %i32_imm2(i32) -> i32 {
+block0(v0: i32):
+  v2 = band_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xband32_s8 x0, x0, -7
+; ret
+
+function %i32_imm_big(i32) -> i32 {
+block0(v0: i32):
+  v2 = band_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xband32_s32 x0, x0, 77777
+; ret
+
+function %i32_imm_big2(i32) -> i32 {
+block0(v0: i32):
+  v2 = band_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband32_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xband32_s32 x0, x0, -77777
+; ret
+
+function %i64_imm(i64) -> i64 {
+block0(v0: i64):
+  v2 = band_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband64_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xband64_s8 x0, x0, 7
+; ret
+
+function %i64_imm2(i64) -> i64 {
+block0(v0: i64):
+  v2 = band_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband64_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xband64_s8 x0, x0, -7
+; ret
+
+function %i64_imm_big(i64) -> i64 {
+block0(v0: i64):
+  v2 = band_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband64_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xband64_s32 x0, x0, 77777
+; ret
+
+function %i64_imm_big2(i64) -> i64 {
+block0(v0: i64):
+  v2 = band_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xband64_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xband64_s32 x0, x0, -77777
+; ret

--- a/cranelift/filetests/filetests/isa/pulley64/bor.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/bor.clif
@@ -1,0 +1,182 @@
+test compile precise-output
+target pulley64
+
+function %i8_imm(i8) -> i8 {
+block0(v0: i8):
+  v2 = bor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbor32_s8 x0, x0, 7
+; ret
+
+function %i8_imm2(i8) -> i8 {
+block0(v0: i8):
+  v2 = bor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbor32_s8 x0, x0, -7
+; ret
+
+function %i16_imm(i16) -> i16 {
+block0(v0: i16):
+  v2 = bor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbor32_s8 x0, x0, 7
+; ret
+
+function %i16_imm2(i16) -> i16 {
+block0(v0: i16):
+  v2 = bor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbor32_s8 x0, x0, -7
+; ret
+
+function %i32_imm(i32) -> i32 {
+block0(v0: i32):
+  v2 = bor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbor32_s8 x0, x0, 7
+; ret
+
+function %i32_imm2(i32) -> i32 {
+block0(v0: i32):
+  v2 = bor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbor32_s8 x0, x0, -7
+; ret
+
+function %i32_imm_big(i32) -> i32 {
+block0(v0: i32):
+  v2 = bor_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xbor32_s32 x0, x0, 77777
+; ret
+
+function %i32_imm_big2(i32) -> i32 {
+block0(v0: i32):
+  v2 = bor_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor32_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xbor32_s32 x0, x0, -77777
+; ret
+
+function %i64_imm(i64) -> i64 {
+block0(v0: i64):
+  v2 = bor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor64_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbor64_s8 x0, x0, 7
+; ret
+
+function %i64_imm2(i64) -> i64 {
+block0(v0: i64):
+  v2 = bor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor64_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbor64_s8 x0, x0, -7
+; ret
+
+function %i64_imm_big(i64) -> i64 {
+block0(v0: i64):
+  v2 = bor_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor64_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xbor64_s32 x0, x0, 77777
+; ret
+
+function %i64_imm_big2(i64) -> i64 {
+block0(v0: i64):
+  v2 = bor_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbor64_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xbor64_s32 x0, x0, -77777
+; ret

--- a/cranelift/filetests/filetests/isa/pulley64/bxor.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/bxor.clif
@@ -1,0 +1,182 @@
+test compile precise-output
+target pulley64
+
+function %i8_imm(i8) -> i8 {
+block0(v0: i8):
+  v2 = bxor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbxor32_s8 x0, x0, 7
+; ret
+
+function %i8_imm2(i8) -> i8 {
+block0(v0: i8):
+  v2 = bxor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbxor32_s8 x0, x0, -7
+; ret
+
+function %i16_imm(i16) -> i16 {
+block0(v0: i16):
+  v2 = bxor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbxor32_s8 x0, x0, 7
+; ret
+
+function %i16_imm2(i16) -> i16 {
+block0(v0: i16):
+  v2 = bxor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbxor32_s8 x0, x0, -7
+; ret
+
+function %i32_imm(i32) -> i32 {
+block0(v0: i32):
+  v2 = bxor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbxor32_s8 x0, x0, 7
+; ret
+
+function %i32_imm2(i32) -> i32 {
+block0(v0: i32):
+  v2 = bxor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbxor32_s8 x0, x0, -7
+; ret
+
+function %i32_imm_big(i32) -> i32 {
+block0(v0: i32):
+  v2 = bxor_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xbxor32_s32 x0, x0, 77777
+; ret
+
+function %i32_imm_big2(i32) -> i32 {
+block0(v0: i32):
+  v2 = bxor_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor32_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xbxor32_s32 x0, x0, -77777
+; ret
+
+function %i64_imm(i64) -> i64 {
+block0(v0: i64):
+  v2 = bxor_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor64_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xbxor64_s8 x0, x0, 7
+; ret
+
+function %i64_imm2(i64) -> i64 {
+block0(v0: i64):
+  v2 = bxor_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor64_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xbxor64_s8 x0, x0, -7
+; ret
+
+function %i64_imm_big(i64) -> i64 {
+block0(v0: i64):
+  v2 = bxor_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor64_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xbxor64_s32 x0, x0, 77777
+; ret
+
+function %i64_imm_big2(i64) -> i64 {
+block0(v0: i64):
+  v2 = bxor_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xbxor64_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xbxor64_s32 x0, x0, -77777
+; ret

--- a/cranelift/filetests/filetests/isa/pulley64/imul.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/imul.clif
@@ -1,0 +1,183 @@
+test compile precise-output
+target pulley64
+
+function %i8_imm(i8) -> i8 {
+block0(v0: i8):
+  v2 = imul_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xmul32_s8 x0, x0, 7
+; ret
+
+function %i8_imm2(i8) -> i8 {
+block0(v0: i8):
+  v2 = imul_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xmul32_s8 x0, x0, -7
+; ret
+
+function %i16_imm(i16) -> i16 {
+block0(v0: i16):
+  v2 = imul_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xmul32_s8 x0, x0, 7
+; ret
+
+function %i16_imm2(i16) -> i16 {
+block0(v0: i16):
+  v2 = imul_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xmul32_s8 x0, x0, -7
+; ret
+
+function %i32_imm(i32) -> i32 {
+block0(v0: i32):
+  v2 = imul_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xmul32_s8 x0, x0, 7
+; ret
+
+function %i32_imm2(i32) -> i32 {
+block0(v0: i32):
+  v2 = imul_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xmul32_s8 x0, x0, -7
+; ret
+
+function %i32_imm_big(i32) -> i32 {
+block0(v0: i32):
+  v2 = imul_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xmul32_s32 x0, x0, 77777
+; ret
+
+function %i32_imm_big2(i32) -> i32 {
+block0(v0: i32):
+  v2 = imul_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul32_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xmul32_s32 x0, x0, -77777
+; ret
+
+function %i64_imm(i64) -> i64 {
+block0(v0: i64):
+  v2 = imul_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul64_s8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xmul64_s8 x0, x0, 7
+; ret
+
+function %i64_imm2(i64) -> i64 {
+block0(v0: i64):
+  v2 = imul_imm v0, -7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul64_s8 x0, x0, -7
+;   ret
+;
+; Disassembled:
+; xmul64_s8 x0, x0, -7
+; ret
+
+function %i64_imm_big(i64) -> i64 {
+block0(v0: i64):
+  v2 = imul_imm v0, 77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul64_s32 x0, x0, 77777
+;   ret
+;
+; Disassembled:
+; xmul64_s32 x0, x0, 77777
+; ret
+
+function %i64_imm_big2(i64) -> i64 {
+block0(v0: i64):
+  v2 = imul_imm v0, -77777
+  return v2
+}
+
+; VCode:
+; block0:
+;   xmul64_s32 x0, x0, -77777
+;   ret
+;
+; Disassembled:
+; xmul64_s32 x0, x0, -77777
+; ret
+

--- a/cranelift/filetests/filetests/isa/pulley64/shifts.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/shifts.clif
@@ -1,0 +1,184 @@
+test compile precise-output
+target pulley64
+
+function %i32_imm(i32) -> i32 {
+block0(v0: i32):
+  v2 = ishl_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshl32_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshl32_u8 x0, x0, 7
+; ret
+
+function %i32_imm2(i32) -> i32 {
+block0(v0: i32):
+  v2 = ishl_imm v0, 0x187
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshl32_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshl32_u8 x0, x0, 7
+; ret
+
+
+function %i64_imm(i64) -> i64 {
+block0(v0: i64):
+  v2 = ishl_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshl64_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshl64_u8 x0, x0, 7
+; ret
+
+function %i64_imm2(i64) -> i64 {
+block0(v0: i64):
+  v2 = ishl_imm v0, 0x187
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshl64_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshl64_u8 x0, x0, 7
+; ret
+
+
+function %i32_ushr_imm(i32) -> i32 {
+block0(v0: i32):
+  v2 = ushr_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr32_u_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr32_u_u8 x0, x0, 7
+; ret
+
+function %i32_ushr_imm2(i32) -> i32 {
+block0(v0: i32):
+  v2 = ushr_imm v0, 0x187
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr32_u_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr32_u_u8 x0, x0, 7
+; ret
+
+function %i64_ushr_imm(i64) -> i64 {
+block0(v0: i64):
+  v2 = ushr_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr64_u_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr64_u_u8 x0, x0, 7
+; ret
+
+function %i64_ushr_imm2(i64) -> i64 {
+block0(v0: i64):
+  v2 = ushr_imm v0, 0x187
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr64_u_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr64_u_u8 x0, x0, 7
+; ret
+
+function %i32_sshr_imm(i32) -> i32 {
+block0(v0: i32):
+  v2 = sshr_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr32_s_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr32_s_u8 x0, x0, 7
+; ret
+
+function %i32_sshr_imm2(i32) -> i32 {
+block0(v0: i32):
+  v2 = sshr_imm v0, 0x187
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr32_s_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr32_s_u8 x0, x0, 7
+; ret
+
+function %i64_sshr_imm(i64) -> i64 {
+block0(v0: i64):
+  v2 = sshr_imm v0, 7
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr64_s_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr64_s_u8 x0, x0, 7
+; ret
+
+function %i64_sshr_imm2(i64) -> i64 {
+block0(v0: i64):
+  v2 = sshr_imm v0, 0x187
+  return v2
+}
+
+; VCode:
+; block0:
+;   xshr64_s_u8 x0, x0, 7
+;   ret
+;
+; Disassembled:
+; xshr64_s_u8 x0, x0, 7
+; ret

--- a/cranelift/filetests/filetests/isa/pulley64/shifts.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/shifts.clif
@@ -9,11 +9,11 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   xshl32_u8 x0, x0, 7
+;   xshl32_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshl32_u8 x0, x0, 7
+; xshl32_u6 x0, x0, 7
 ; ret
 
 function %i32_imm2(i32) -> i32 {
@@ -24,13 +24,12 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   xshl32_u8 x0, x0, 7
+;   xshl32_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshl32_u8 x0, x0, 7
+; xshl32_u6 x0, x0, 7
 ; ret
-
 
 function %i64_imm(i64) -> i64 {
 block0(v0: i64):
@@ -40,11 +39,11 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   xshl64_u8 x0, x0, 7
+;   xshl64_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshl64_u8 x0, x0, 7
+; xshl64_u6 x0, x0, 7
 ; ret
 
 function %i64_imm2(i64) -> i64 {
@@ -55,13 +54,12 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   xshl64_u8 x0, x0, 7
+;   xshl64_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshl64_u8 x0, x0, 7
+; xshl64_u6 x0, x0, 7
 ; ret
-
 
 function %i32_ushr_imm(i32) -> i32 {
 block0(v0: i32):
@@ -71,11 +69,11 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   xshr32_u_u8 x0, x0, 7
+;   xshr32_u_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr32_u_u8 x0, x0, 7
+; xshr32_u_u6 x0, x0, 7
 ; ret
 
 function %i32_ushr_imm2(i32) -> i32 {
@@ -86,11 +84,11 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   xshr32_u_u8 x0, x0, 7
+;   xshr32_u_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr32_u_u8 x0, x0, 7
+; xshr32_u_u6 x0, x0, 7
 ; ret
 
 function %i64_ushr_imm(i64) -> i64 {
@@ -101,11 +99,11 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   xshr64_u_u8 x0, x0, 7
+;   xshr64_u_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr64_u_u8 x0, x0, 7
+; xshr64_u_u6 x0, x0, 7
 ; ret
 
 function %i64_ushr_imm2(i64) -> i64 {
@@ -116,11 +114,11 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   xshr64_u_u8 x0, x0, 7
+;   xshr64_u_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr64_u_u8 x0, x0, 7
+; xshr64_u_u6 x0, x0, 7
 ; ret
 
 function %i32_sshr_imm(i32) -> i32 {
@@ -131,11 +129,11 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   xshr32_s_u8 x0, x0, 7
+;   xshr32_s_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr32_s_u8 x0, x0, 7
+; xshr32_s_u6 x0, x0, 7
 ; ret
 
 function %i32_sshr_imm2(i32) -> i32 {
@@ -146,11 +144,11 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   xshr32_s_u8 x0, x0, 7
+;   xshr32_s_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr32_s_u8 x0, x0, 7
+; xshr32_s_u6 x0, x0, 7
 ; ret
 
 function %i64_sshr_imm(i64) -> i64 {
@@ -161,11 +159,11 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   xshr64_s_u8 x0, x0, 7
+;   xshr64_s_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr64_s_u8 x0, x0, 7
+; xshr64_s_u6 x0, x0, 7
 ; ret
 
 function %i64_sshr_imm2(i64) -> i64 {
@@ -176,9 +174,10 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   xshr64_s_u8 x0, x0, 7
+;   xshr64_s_u6 x0, x0, 7
 ;   ret
 ;
 ; Disassembled:
-; xshr64_s_u8 x0, x0, 7
+; xshr64_s_u6 x0, x0, 7
 ; ret
+

--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -431,6 +431,15 @@ impl<D: Reg, S1: Reg, S2: Reg> Decode for BinaryOperands<D, S1, S2> {
     }
 }
 
+impl<D: Reg, S1: Reg> Decode for BinaryOperands<D, S1, U6> {
+    fn decode<T>(bytecode: &mut T) -> Result<Self, T::Error>
+    where
+        T: BytecodeStream,
+    {
+        u16::decode(bytecode).map(|bits| Self::from_bits(bits))
+    }
+}
+
 impl<S: Decode + ScalarBitSetStorage> Decode for ScalarBitSet<S> {
     fn decode<T>(bytecode: &mut T) -> Result<Self, T::Error>
     where

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -193,6 +193,12 @@ impl Disas for PcRelOffset {
     }
 }
 
+impl Disas for U6 {
+    fn disas(&self, _position: usize, disas: &mut String) {
+        write!(disas, "{}", u8::from(*self)).unwrap();
+    }
+}
+
 fn disas_list<T: Disas>(position: usize, disas: &mut String, iter: impl IntoIterator<Item = T>) {
     let mut iter = iter.into_iter();
     let Some(first) = iter.next() else { return };
@@ -209,6 +215,20 @@ where
     D: Reg + Disas,
     S1: Reg + Disas,
     S2: Reg + Disas,
+{
+    fn disas(&self, position: usize, disas: &mut String) {
+        self.dst.disas(position, disas);
+        write!(disas, ", ").unwrap();
+        self.src1.disas(position, disas);
+        write!(disas, ", ").unwrap();
+        self.src2.disas(position, disas);
+    }
+}
+
+impl<D, S1> Disas for BinaryOperands<D, S1, U6>
+where
+    D: Reg + Disas,
+    S1: Reg + Disas,
 {
     fn disas(&self, position: usize, disas: &mut String) {
         self.dst.disas(position, disas);

--- a/pulley/src/encode.rs
+++ b/pulley/src/encode.rs
@@ -180,6 +180,17 @@ impl<D: Reg, S1: Reg, S2: Reg> Encode for BinaryOperands<D, S1, S2> {
     }
 }
 
+impl<D: Reg, S1: Reg> Encode for BinaryOperands<D, S1, U6> {
+    const WIDTH: u8 = 2;
+
+    fn encode<E>(&self, sink: &mut E)
+    where
+        E: Extend<u8>,
+    {
+        self.to_bits().encode(sink);
+    }
+}
+
 impl<R: Reg + Encode> Encode for RegSet<R> {
     const WIDTH: u8 = 4;
 

--- a/pulley/src/imms.rs
+++ b/pulley/src/imms.rs
@@ -1,5 +1,7 @@
 //! Immediates.
 
+use core::fmt;
+
 /// A PC-relative offset.
 ///
 /// This is relative to the start of this offset's containing instruction.
@@ -27,5 +29,41 @@ impl From<PcRelOffset> for i32 {
     #[inline]
     fn from(offset: PcRelOffset) -> Self {
         offset.0
+    }
+}
+
+/// A 6-byte unsigned integer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct U6(u8);
+
+impl U6 {
+    /// Attempts to create a new `U6` from the provided byte
+    pub fn new(val: u8) -> Option<U6> {
+        if val << 2 >> 2 == val {
+            Some(U6(val))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for U6 {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let byte = u.arbitrary::<u8>()?;
+        Ok(U6(byte << 2 >> 2))
+    }
+}
+
+impl From<U6> for u8 {
+    #[inline]
+    fn from(val: U6) -> Self {
+        val.0
+    }
+}
+
+impl fmt::Display for U6 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        u8::from(*self).fmt(f)
     }
 }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1312,10 +1312,30 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xmul32_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xmul32_s32(dst, src1, src2.into())
+    }
+
+    fn xmul32_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i32();
+        self.state[dst].set_i32(a.wrapping_mul(src2));
+        ControlFlow::Continue(())
+    }
+
     fn xmul64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
         self.state[operands.dst].set_u64(a.wrapping_mul(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xmul64_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xmul64_s32(dst, src1, src2.into())
+    }
+
+    fn xmul64_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i64();
+        self.state[dst].set_i64(a.wrapping_mul(src2.into()));
         ControlFlow::Continue(())
     }
 
@@ -1357,6 +1377,48 @@ impl OpVisitor for Interpreter<'_> {
     fn xshr64_s(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64();
         let b = self.state[operands.src2].get_u32();
+        self.state[operands.dst].set_i64(a.wrapping_shr(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xshl32_u6(&mut self, operands: BinaryOperands<XReg, XReg, U6>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_u32();
+        let b = u32::from(u8::from(operands.src2));
+        self.state[operands.dst].set_u32(a.wrapping_shl(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xshr32_u_u6(&mut self, operands: BinaryOperands<XReg, XReg, U6>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_u32();
+        let b = u32::from(u8::from(operands.src2));
+        self.state[operands.dst].set_u32(a.wrapping_shr(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xshr32_s_u6(&mut self, operands: BinaryOperands<XReg, XReg, U6>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_i32();
+        let b = u32::from(u8::from(operands.src2));
+        self.state[operands.dst].set_i32(a.wrapping_shr(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xshl64_u6(&mut self, operands: BinaryOperands<XReg, XReg, U6>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_u64();
+        let b = u32::from(u8::from(operands.src2));
+        self.state[operands.dst].set_u64(a.wrapping_shl(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xshr64_u_u6(&mut self, operands: BinaryOperands<XReg, XReg, U6>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_u64();
+        let b = u32::from(u8::from(operands.src2));
+        self.state[operands.dst].set_u64(a.wrapping_shr(b));
+        ControlFlow::Continue(())
+    }
+
+    fn xshr64_s_u6(&mut self, operands: BinaryOperands<XReg, XReg, U6>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_i64();
+        let b = u32::from(u8::from(operands.src2));
         self.state[operands.dst].set_i64(a.wrapping_shr(b));
         ControlFlow::Continue(())
     }
@@ -1769,10 +1831,30 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xband32_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xband32_s32(dst, src1, src2.into())
+    }
+
+    fn xband32_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i32();
+        self.state[dst].set_i32(a & src2);
+        ControlFlow::Continue(())
+    }
+
     fn xband64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
         self.state[operands.dst].set_u64(a & b);
+        ControlFlow::Continue(())
+    }
+
+    fn xband64_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xband64_s32(dst, src1, src2.into())
+    }
+
+    fn xband64_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i64();
+        self.state[dst].set_i64(a & i64::from(src2));
         ControlFlow::Continue(())
     }
 
@@ -1783,10 +1865,30 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xbor32_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xbor32_s32(dst, src1, src2.into())
+    }
+
+    fn xbor32_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i32();
+        self.state[dst].set_i32(a | src2);
+        ControlFlow::Continue(())
+    }
+
     fn xbor64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
         self.state[operands.dst].set_u64(a | b);
+        ControlFlow::Continue(())
+    }
+
+    fn xbor64_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xbor64_s32(dst, src1, src2.into())
+    }
+
+    fn xbor64_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i64();
+        self.state[dst].set_i64(a | i64::from(src2));
         ControlFlow::Continue(())
     }
 
@@ -1797,10 +1899,30 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xbxor32_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xbxor32_s32(dst, src1, src2.into())
+    }
+
+    fn xbxor32_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i32();
+        self.state[dst].set_i32(a ^ src2);
+        ControlFlow::Continue(())
+    }
+
     fn xbxor64(&mut self, operands: BinaryOperands<XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64();
         let b = self.state[operands.src2].get_u64();
         self.state[operands.dst].set_u64(a ^ b);
+        ControlFlow::Continue(())
+    }
+
+    fn xbxor64_s8(&mut self, dst: XReg, src1: XReg, src2: i8) -> ControlFlow<Done> {
+        self.xbxor64_s32(dst, src1, src2.into())
+    }
+
+    fn xbxor64_s32(&mut self, dst: XReg, src1: XReg, src2: i32) -> ControlFlow<Done> {
+        let a = self.state[src1].get_i64();
+        self.state[dst].set_i64(a ^ i64::from(src2));
         ControlFlow::Continue(())
     }
 

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -192,9 +192,17 @@ macro_rules! for_each_op {
 
             /// `low32(dst) = low32(src1) * low32(src2)`
             xmul32 = XMul32 { operands: BinaryOperands<XReg> };
+            /// Same as `xmul64` but `src2` is a sign-extended 8-bit immediate.
+            xmul32_s8 = Xmul32S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xmul32` but `src2` is a sign-extended 32-bit immediate.
+            xmul32_s32 = Xmul32S32 { dst: XReg, src1: XReg, src2: i32 };
 
             /// `dst = src1 * src2`
             xmul64 = XMul64 { operands: BinaryOperands<XReg> };
+            /// Same as `xmul64` but `src2` is a sign-extended 8-bit immediate.
+            xmul64_s8 = Xmul64S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xmul64` but `src2` is a sign-extended 64-bit immediate.
+            xmul64_s32 = Xmul64S32 { dst: XReg, src1: XReg, src2: i32 };
 
             /// `low32(dst) = trailing_zeros(low32(src))`
             xctz32 = Xctz32 { dst: XReg, src: XReg };
@@ -233,6 +241,19 @@ macro_rules! for_each_op {
             xshr64_s = Xshr64S { operands: BinaryOperands<XReg> };
             /// `dst = src1 >> low6(src2)`
             xshr64_u = Xshr64U { operands: BinaryOperands<XReg> };
+
+            /// `low32(dst) = low32(src1) << low5(src2)`
+            xshl32_u6 = Xshl32U6 { operands: BinaryOperands<XReg, XReg, U6> };
+            /// `low32(dst) = low32(src1) >> low5(src2)`
+            xshr32_s_u6 = Xshr32SU6 { operands: BinaryOperands<XReg, XReg, U6> };
+            /// `low32(dst) = low32(src1) >> low5(src2)`
+            xshr32_u_u6 = Xshr32UU6 { operands: BinaryOperands<XReg, XReg, U6> };
+            /// `dst = src1 << low5(src2)`
+            xshl64_u6 = Xshl64U6 { operands: BinaryOperands<XReg, XReg, U6> };
+            /// `dst = src1 >> low6(src2)`
+            xshr64_s_u6 = Xshr64SU6 { operands: BinaryOperands<XReg, XReg, U6> };
+            /// `dst = src1 >> low6(src2)`
+            xshr64_u_u6 = Xshr64UU6 { operands: BinaryOperands<XReg, XReg, U6> };
 
             /// `low32(dst) = -low32(src)`
             xneg32 = Xneg32 { dst: XReg, src: XReg };
@@ -354,17 +375,41 @@ macro_rules! for_each_op {
 
             /// `low32(dst) = low32(src1) & low32(src2)`
             xband32 = XBand32 { operands: BinaryOperands<XReg> };
+            /// Same as `xband64` but `src2` is a sign-extended 8-bit immediate.
+            xband32_s8 = Xband32S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xband32` but `src2` is a sign-extended 32-bit immediate.
+            xband32_s32 = Xband32S32 { dst: XReg, src1: XReg, src2: i32 };
             /// `dst = src1 & src2`
             xband64 = XBand64 { operands: BinaryOperands<XReg> };
+            /// Same as `xband64` but `src2` is a sign-extended 8-bit immediate.
+            xband64_s8 = Xband64S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xband64` but `src2` is a sign-extended 32-bit immediate.
+            xband64_s32 = Xband64S32 { dst: XReg, src1: XReg, src2: i32 };
             /// `low32(dst) = low32(src1) | low32(src2)`
             xbor32 = XBor32 { operands: BinaryOperands<XReg> };
+            /// Same as `xbor64` but `src2` is a sign-extended 8-bit immediate.
+            xbor32_s8 = Xbor32S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xbor32` but `src2` is a sign-extended 32-bit immediate.
+            xbor32_s32 = Xbor32S32 { dst: XReg, src1: XReg, src2: i32 };
             /// `dst = src1 | src2`
             xbor64 = XBor64 { operands: BinaryOperands<XReg> };
+            /// Same as `xbor64` but `src2` is a sign-extended 8-bit immediate.
+            xbor64_s8 = Xbor64S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xbor64` but `src2` is a sign-extended 32-bit immediate.
+            xbor64_s32 = Xbor64S32 { dst: XReg, src1: XReg, src2: i32 };
 
             /// `low32(dst) = low32(src1) ^ low32(src2)`
             xbxor32 = XBxor32 { operands: BinaryOperands<XReg> };
+            /// Same as `xbxor64` but `src2` is a sign-extended 8-bit immediate.
+            xbxor32_s8 = Xbxor32S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xbxor32` but `src2` is a sign-extended 32-bit immediate.
+            xbxor32_s32 = Xbxor32S32 { dst: XReg, src1: XReg, src2: i32 };
             /// `dst = src1 ^ src2`
             xbxor64 = XBxor64 { operands: BinaryOperands<XReg> };
+            /// Same as `xbxor64` but `src2` is a sign-extended 8-bit immediate.
+            xbxor64_s8 = Xbxor64S8 { dst: XReg, src1: XReg, src2: i8 };
+            /// Same as `xbxor64` but `src2` is a sign-extended 32-bit immediate.
+            xbxor64_s32 = Xbxor64S32 { dst: XReg, src1: XReg, src2: i32 };
 
             /// `low32(dst) = !low32(src1)`
             xbnot32 = XBnot32 { dst: XReg, src: XReg };


### PR DESCRIPTION
This commit adds immediate payloads to the following instructions:

* `xmul32` - `xmul32_s8` / `xmul32_s32`
* `xmul64` - `xmul64_s8` / `xmul64_s32`
* `xband32` - `xband32_s8` / `xband32_s32`
* `xband64` - `xband64_s8` / `xband64_s32`
* `xbor32` - `xbor32_s8` / `xbor32_s32`
* `xbor64` - `xbor64_s8` / `xbor64_s32`
* `xbxor32` - `xbxor32_s8` / `xbxor32_s32`
* `xbxor64` - `xbxor64_s8` / `xbxor64_s32`
* `xshl32` - `xshl32_u6`
* `xshl64` - `xshl64_u6`
* `xshr32_u` - `xshl32_u_u6`
* `xshr64_u` - `xshl64_u_u6`
* `xshr32_s` - `xshl32_s_u6`
* `xshr64_s` - `xshl64_s_u6`

For shifts there's no need to have 32-bit immediates (or even 8-bit) since 6 bits is enough to encode all the immediates. This means that the 6-bit immediate is packed within `BinaryOperands` as a new `U6` type.

This commit unfortunately does not shrink `spidermonkey.cwasm` significantly beyond the prior 29M. This is nevertheless expected to be relatively important for performance.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
