### PR TITLE
pulley: Remove unwind metadata from Cranelift backend

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -4,7 +4,7 @@ use super::{inst::*, PulleyFlags, PulleyTargetKind};
 use crate::isa::pulley_shared::{PointerWidth, PulleyBackend};
 use crate::{
     ir::{self, types::*, MemFlags, Signature},
-    isa::{self},
+    isa,
     machinst::*,
     settings, CodegenResult,
 };

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -18,9 +18,6 @@
     ;; A pseudo-instruction that moves vregs to return registers.
     (Rets (rets VecRetPair))
 
-    ;; A pseudo-instruction to update unwind info.
-    (Unwind (inst UnwindInst))
-
     ;; Implementation of `br_table`, uses `idx` to jump to one of `targets` or
     ;; jumps to `default` if it's out-of-bounds.
     (BrTable

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -130,7 +130,7 @@ fn pulley_emit<P>(
 {
     match inst {
         // Pseduo-instructions that don't actually encode to anything.
-        Inst::Args { .. } | Inst::Rets { .. } | Inst::Unwind { .. } => {}
+        Inst::Args { .. } | Inst::Rets { .. } => {}
 
         Inst::TrapIf { cond, code } => {
             let trap = sink.defer_trap(*code);

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -129,7 +129,7 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             }
         }
 
-        Inst::Unwind { .. } | Inst::Nop => {}
+        Inst::Nop => {}
 
         Inst::TrapIf { cond, code: _ } => {
             cond.get_operands(collector);
@@ -577,8 +577,6 @@ impl Inst {
                 }
                 s
             }
-
-            Inst::Unwind { inst } => format!("unwind {inst:?}"),
 
             Inst::TrapIf { cond, code } => {
                 format!("trap_{cond} // code = {code:?}")

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -31,6 +31,12 @@ type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
 type BoxReturnCallIndInfo = Box<ReturnCallInfo<XReg>>;
 type BoxExternalName = Box<ExternalName>;
 
+#[expect(
+    unused_imports,
+    reason = "used on other backends, used here to suppress warning elsewhere"
+)]
+use crate::machinst::isle::UnwindInst as _;
+
 pub(crate) struct PulleyIsleContext<'a, 'b, I, B>
 where
     I: VCodeInst,


### PR DESCRIPTION
This is a copy/paste from the riscv64 backend originally but there's no need to integrate with native unwinders on Pulley so there's no need to track this information. This removes the `Unwind` pseudo-inst entirely.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
