### PR TITLE
pulley: Add macro instructions for function prologue/epilogue

### DIFF
--- a/cranelift/bitset/src/scalar.rs
+++ b/cranelift/bitset/src/scalar.rs
@@ -556,14 +556,17 @@ pub trait ScalarBitSetStorage:
 macro_rules! impl_storage {
     ( $int:ty ) => {
         impl ScalarBitSetStorage for $int {
+            #[inline]
             fn leading_zeros(self) -> u8 {
                 u8::try_from(self.leading_zeros()).unwrap()
             }
 
+            #[inline]
             fn trailing_zeros(self) -> u8 {
                 u8::try_from(self.trailing_zeros()).unwrap()
             }
 
+            #[inline]
             fn count_ones(self) -> u8 {
                 u8::try_from(self.count_ones()).unwrap()
             }

--- a/cranelift/codegen/meta/src/pulley.rs
+++ b/cranelift/codegen/meta/src/pulley.rs
@@ -69,6 +69,10 @@ impl Inst<'_> {
                     Operand::Binop { dst, src1, src2 }
                 }
                 ("dst", ty) => Operand::Writable { name, ty },
+                (name, "RegSet < XReg >") => Operand::Normal {
+                    name,
+                    ty: "XRegSet",
+                },
                 (name, ty) => Operand::Normal { name, ty },
             })
             .chain(if self.name.contains("Trap") {
@@ -120,10 +124,17 @@ pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
                     if i > 0 {
                         format_string.push_str(",");
                     }
+
+                    if ty == "XRegSet" {
+                        format_string.push_str(" {");
+                        format_string.push_str(name);
+                        format_string.push_str(":?}");
+                        continue;
+                    }
+
                     format_string.push_str(" {");
                     format_string.push_str(name);
                     format_string.push_str("}");
-
                     if ty.contains("Reg") {
                         if name == "dst" {
                             locals.push_str(&format!("let {name} = reg_name(*{name}.to_reg());\n"));
@@ -176,6 +187,12 @@ pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
         let mut defs = Vec::new();
         for op in inst.operands() {
             match op {
+                // `{Push,Pop}FrameSave` doesn't participate in register allocation.
+                Operand::Normal {
+                    name: _,
+                    ty: "XRegSet",
+                } if *name == "PushFrameSave" || *name == "PopFrameSave" => {}
+
                 Operand::Normal { name, ty } => {
                     if ty.contains("Reg") {
                         uses.push(name);

--- a/cranelift/codegen/meta/src/pulley.rs
+++ b/cranelift/codegen/meta/src/pulley.rs
@@ -187,11 +187,12 @@ pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
         let mut defs = Vec::new();
         for op in inst.operands() {
             match op {
-                // `{Push,Pop}FrameSave` doesn't participate in register allocation.
+                // `{Push,Pop}Frame{Save,Restore}` doesn't participate in
+                // register allocation.
                 Operand::Normal {
                     name: _,
                     ty: "XRegSet",
-                } if *name == "PushFrameSave" || *name == "PopFrameSave" => {}
+                } if *name == "PushFrameSave" || *name == "PopFrameRestore" => {}
 
                 Operand::Normal { name, ty } => {
                     if ty.contains("Reg") {

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -386,7 +386,7 @@ where
                 frame_size,
                 saved_by_pulley,
             } => insts.push(
-                RawInst::PopFrameSave {
+                RawInst::PopFrameRestore {
                     amt: *frame_size,
                     regs: pulley_interpreter::RegSet::from_bitset(*saved_by_pulley),
                 }

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use core::marker::PhantomData;
+use cranelift_bitset::ScalarBitSet;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
 use std::borrow::ToOwned;
@@ -288,6 +289,17 @@ where
         smallvec![inst.into()]
     }
 
+    /// Generates the entire prologue for the function.
+    ///
+    /// Note that this is different from other backends where it's not spread
+    /// out among a few individual functions. That's because the goal here is to
+    /// generate a single macro-instruction for the entire prologue in the most
+    /// common cases and we don't want to spread the logic over multiple
+    /// functions.
+    ///
+    /// The general machinst methods are split to accomodate stack checks and
+    /// things like stack probes, all of which are empty on Pulley because
+    /// Pulley has its own stack check mechanism.
     fn gen_prologue_frame_setup(
         _call_conv: isa::CallConv,
         _flags: &settings::Flags,
@@ -296,8 +308,37 @@ where
     ) -> SmallInstVec<Self::I> {
         let mut insts = SmallVec::new();
 
-        if frame_layout.setup_area_size > 0 {
-            insts.push(RawInst::PushFrame.into());
+        let incoming_args_diff = frame_layout.tail_args_size - frame_layout.incoming_args_size;
+        if incoming_args_diff > 0 {
+            // Decrement SP by the amount of additional incoming argument space
+            // we need
+            insts.extend(Self::gen_sp_reg_adjust(-(incoming_args_diff as i32)));
+        }
+
+        let style = frame_layout.pulley_frame_style();
+
+        match &style {
+            FrameStyle::None => {}
+            FrameStyle::PulleySetupNoClobbers => insts.push(RawInst::PushFrame.into()),
+            FrameStyle::PulleySetupAndSaveClobbers {
+                frame_size,
+                saved_by_pulley,
+            } => insts.push(
+                RawInst::PushFrameSave {
+                    amt: *frame_size,
+                    regs: pulley_interpreter::RegSet::from_bitset(*saved_by_pulley),
+                }
+                .into(),
+            ),
+            FrameStyle::Manual { frame_size } => insts.extend(Self::gen_sp_reg_adjust(
+                -i32::try_from(*frame_size).unwrap(),
+            )),
+        }
+
+        for (offset, ty, reg) in frame_layout.manually_managed_clobbers(&style) {
+            insts.push(
+                Inst::gen_store(Amode::SpOffset { offset }, reg, ty, MemFlags::trusted()).into(),
+            );
         }
 
         insts
@@ -308,29 +349,69 @@ where
         _call_conv: isa::CallConv,
         _flags: &settings::Flags,
         _isa_flags: &PulleyFlags,
+        _frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Self::I> {
+        // Note that this is intentionally empty as `gen_return` does
+        // everything.
+        SmallVec::new()
+    }
+
+    fn gen_return(
+        _call_conv: isa::CallConv,
+        _isa_flags: &PulleyFlags,
         frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
         let mut insts = SmallVec::new();
 
-        if frame_layout.setup_area_size > 0 {
-            insts.push(RawInst::PopFrame.into());
+        let style = frame_layout.pulley_frame_style();
+
+        // Restore clobbered registers that are manually managed in Cranelift.
+        for (offset, ty, reg) in frame_layout.manually_managed_clobbers(&style) {
+            insts.push(
+                Inst::gen_load(
+                    Writable::from_reg(reg),
+                    Amode::SpOffset { offset },
+                    ty,
+                    MemFlags::trusted(),
+                )
+                .into(),
+            );
         }
 
+        // Perform the inverse of `gen_prologue_frame_setup`.
+        match &style {
+            FrameStyle::None => {}
+            FrameStyle::PulleySetupNoClobbers => insts.push(RawInst::PopFrame.into()),
+            FrameStyle::PulleySetupAndSaveClobbers {
+                frame_size,
+                saved_by_pulley,
+            } => insts.push(
+                RawInst::PopFrameSave {
+                    amt: *frame_size,
+                    regs: pulley_interpreter::RegSet::from_bitset(*saved_by_pulley),
+                }
+                .into(),
+            ),
+            FrameStyle::Manual { frame_size } => {
+                insts.extend(Self::gen_sp_reg_adjust(i32::try_from(*frame_size).unwrap()))
+            }
+        }
+
+        // Handle final stack adjustments for the tail-call ABI.
         if frame_layout.tail_args_size > 0 {
             insts.extend(Self::gen_sp_reg_adjust(
                 frame_layout.tail_args_size.try_into().unwrap(),
             ));
         }
 
+        // And finally, return.
+        //
+        // FIXME: if `frame_layout.tail_args_size` is zero this instruction
+        // should get folded into the macro-instructions above. No need to have
+        // all functions do `pop_frame; ret`, that could be `pop_frame_and_ret`.
+        // Should benchmark whether this is worth it though.
+        insts.push(RawInst::Ret {}.into());
         insts
-    }
-
-    fn gen_return(
-        _call_conv: isa::CallConv,
-        _isa_flags: &PulleyFlags,
-        _frame_layout: &FrameLayout,
-    ) -> SmallInstVec<Self::I> {
-        smallvec![RawInst::Ret {}.into()]
     }
 
     fn gen_probestack(_insts: &mut SmallInstVec<Self::I>, _frame_size: u32) {
@@ -341,110 +422,20 @@ where
     fn gen_clobber_save(
         _call_conv: isa::CallConv,
         _flags: &settings::Flags,
-        frame_layout: &FrameLayout,
+        _frame_layout: &FrameLayout,
     ) -> SmallVec<[Self::I; 16]> {
-        let mut insts = SmallVec::new();
-        let setup_frame = frame_layout.setup_area_size > 0;
-
-        let incoming_args_diff = frame_layout.tail_args_size - frame_layout.incoming_args_size;
-        if incoming_args_diff > 0 {
-            // Pulley does not generate/probestack/stack checks/etc and doesn't
-            // expose the direct ability to modify fp/lr, so simulate a pop,
-            // perform the sp adjustment, then perform the same push that was
-            // done previously in the prologue.
-            //
-            // Note that for now this'll generate `push_frame pop_frame` pairs
-            // in the prologue which isn't great, and updating that is left for
-            // a future refactoring to only do a `push_frame` once (e.g. skip
-            // the one above if this block is going to be executed)
-            if setup_frame {
-                insts.push(RawInst::PopFrame.into());
-            }
-            // Decrement SP by the amount of additional incoming argument space
-            // we need
-            insts.extend(Self::gen_sp_reg_adjust(-(incoming_args_diff as i32)));
-
-            if setup_frame {
-                insts.push(RawInst::PushFrame.into());
-            }
-        }
-
-        // Adjust the stack pointer downward for clobbers, the function fixed
-        // frame (spillslots and storage slots), and outgoing arguments.
-        let stack_size = frame_layout.clobber_size
-            + frame_layout.fixed_frame_storage_size
-            + frame_layout.outgoing_args_size;
-
-        // Store each clobbered register in order at offsets from SP, placing
-        // them above the fixed frame slots.
-        if stack_size > 0 {
-            insts.extend(Self::gen_sp_reg_adjust(-i32::try_from(stack_size).unwrap()));
-
-            let mut cur_offset = 8;
-            for reg in &frame_layout.clobbered_callee_saves {
-                let r_reg = reg.to_reg();
-                let ty = match r_reg.class() {
-                    RegClass::Int => I64,
-                    RegClass::Float => F64,
-                    RegClass::Vector => unreachable!("no vector registers are callee-save"),
-                };
-                insts.push(
-                    Inst::gen_store(
-                        Amode::SpOffset {
-                            offset: i32::try_from(stack_size - cur_offset).unwrap(),
-                        },
-                        Reg::from(reg.to_reg()),
-                        ty,
-                        MemFlags::trusted(),
-                    )
-                    .into(),
-                );
-
-                cur_offset += 8
-            }
-        }
-
-        insts
+        // Note that this is intentionally empty because everything necessary
+        // was already done in `gen_prologue_frame_setup`.
+        SmallVec::new()
     }
 
     fn gen_clobber_restore(
         _call_conv: isa::CallConv,
         _flags: &settings::Flags,
-        frame_layout: &FrameLayout,
+        _frame_layout: &FrameLayout,
     ) -> SmallVec<[Self::I; 16]> {
-        let mut insts = SmallVec::new();
-
-        let stack_size = frame_layout.clobber_size
-            + frame_layout.fixed_frame_storage_size
-            + frame_layout.outgoing_args_size;
-
-        let mut cur_offset = 8;
-        for reg in &frame_layout.clobbered_callee_saves {
-            let rreg = reg.to_reg();
-            let ty = match rreg.class() {
-                RegClass::Int => I64,
-                RegClass::Float => F64,
-                RegClass::Vector => unreachable!("vector registers are never callee-saved"),
-            };
-            insts.push(
-                Inst::gen_load(
-                    reg.map(Reg::from),
-                    Amode::SpOffset {
-                        offset: i32::try_from(stack_size - cur_offset).unwrap(),
-                    },
-                    ty,
-                    MemFlags::trusted(),
-                )
-                .into(),
-            );
-            cur_offset += 8
-        }
-
-        if stack_size > 0 {
-            insts.extend(Self::gen_sp_reg_adjust(stack_size as i32));
-        }
-
-        insts
+        // Intentionally empty as restores happen for Pulley in `gen_return`.
+        SmallVec::new()
     }
 
     fn gen_call(
@@ -567,6 +558,158 @@ where
     ) {
         // Pulley doesn't need inline probestacks because it always checks stack
         // decrements.
+    }
+}
+
+/// Different styles of management of fp/lr and clobbered registers.
+///
+/// This helps decide, depending on Cranelift settings and frame layout, what
+/// macro instruction is used to setup the pulley frame.
+enum FrameStyle {
+    /// No management is happening, fp/lr aren't saved by Pulley or Cranelift.
+    /// No stack is being allocated either.
+    None,
+
+    /// No stack is being allocated and nothing is clobbered, but Pulley should
+    /// save the fp/lr combo.
+    PulleySetupNoClobbers,
+
+    /// Pulley is managing the fp/lr combo, the stack size, and clobbered
+    /// X-class registers.
+    ///
+    /// Note that `saved_by_pulley` is not the exhaustive set of clobbered
+    /// registers. It's only those that are part of the `PushFrameSave`
+    /// instruction.
+    PulleySetupAndSaveClobbers {
+        /// The size of the frame, including clobbers, that's being allocated.
+        frame_size: u32,
+        /// Registers that pulley is saving/restoring.
+        saved_by_pulley: ScalarBitSet<u32>,
+    },
+
+    /// Cranelift is manually managing everything, both clobbers and stack
+    /// increments/decrements.
+    ///
+    /// Note that fp/lr are not saved in this mode.
+    Manual {
+        /// The size of the stack being allocated.
+        frame_size: u32,
+    },
+}
+
+/// Pulley-specific helpers when dealing with ABI code.
+impl FrameLayout {
+    /// Whether or not this frame saves fp/lr.
+    fn setup_frame(&self) -> bool {
+        self.setup_area_size > 0
+    }
+
+    /// Returns the stack size allocated by this function, excluding incoming
+    /// tail args or the optional "setup area" of fp/lr.
+    fn stack_size(&self) -> u32 {
+        self.clobber_size + self.fixed_frame_storage_size + self.outgoing_args_size
+    }
+
+    /// Returns the style of frame being used for this function.
+    ///
+    /// See `FrameStyle` for more information.
+    fn pulley_frame_style(&self) -> FrameStyle {
+        let saved_by_pulley = self.clobbered_xregs_saved_by_pulley();
+        match (
+            self.stack_size(),
+            self.setup_frame(),
+            saved_by_pulley.is_empty(),
+        ) {
+            // No stack allocated, not saving fp/lr, no clobbers, nothing to do
+            (0, false, true) => FrameStyle::None,
+
+            // No stack allocated, saving fp/lr, no clobbers, so this is
+            // pulley-managed via push/pop_frame.
+            (0, true, true) => FrameStyle::PulleySetupNoClobbers,
+
+            // Some stack is being allocated and pulley is managing fp/lr. Let
+            // pulley manage clobbered registers as well, regardless if they're
+            // present or not.
+            (frame_size, true, _) => FrameStyle::PulleySetupAndSaveClobbers {
+                frame_size,
+                saved_by_pulley,
+            },
+
+            // Some stack is being allocated, but pulley isn't managing fp/lr,
+            // so we're manually doing everything.
+            (frame_size, false, true) => FrameStyle::Manual { frame_size },
+
+            // If there's no frame setup and there's clobbered registers this
+            // technically should have already hit a case above, so panic here.
+            (_, false, false) => unreachable!(),
+        }
+    }
+
+    /// Returns the set of clobbered registers that Pulley is managing via its
+    /// macro instructions rather than the generated code.
+    fn clobbered_xregs_saved_by_pulley(&self) -> ScalarBitSet<u32> {
+        let mut clobbered: ScalarBitSet<u32> = ScalarBitSet::new();
+        // Pulley only manages clobbers if it's also managing fp/lr.
+        if !self.setup_frame() {
+            return clobbered;
+        }
+        let mut found_manual_clobber = false;
+        for reg in self.clobbered_callee_saves.iter() {
+            let r_reg = reg.to_reg();
+            // Pulley can only manage clobbers of integer registers at this
+            // time, float registers are managed manually.
+            //
+            // Also assert that all pulley-managed clobbers come first,
+            // otherwise the loop below in `manually_managed_clobbers` is
+            // incorrect.
+            if r_reg.class() == RegClass::Int {
+                assert!(!found_manual_clobber);
+                clobbered.insert(r_reg.hw_enc());
+            } else {
+                found_manual_clobber = true;
+            }
+        }
+        clobbered
+    }
+
+    /// Returns an iterator over the clobbers that Cranelift is managing, not
+    /// Pulley.
+    ///
+    /// If this frame has clobbers then they're either saved by Pulley with
+    /// `FrameStyle::PulleySetupAndSaveClobbers`. Cranelift might need to manage
+    /// these registers depending on Cranelift settings. Cranelift also always
+    /// manages floating-point registers.
+    fn manually_managed_clobbers<'a>(
+        &'a self,
+        style: &'a FrameStyle,
+    ) -> impl Iterator<Item = (i32, Type, Reg)> + 'a {
+        let mut offset = self.stack_size();
+        self.clobbered_callee_saves.iter().filter_map(move |reg| {
+            // Allocate space for this clobber no matter what. If pulley is
+            // managing this then we're just accounting for the pulley-saved
+            // registers as well. Note that all pulley-managed registers come
+            // first in the list here.
+            offset -= 8;
+            let r_reg = reg.to_reg();
+            let ty = match r_reg.class() {
+                RegClass::Int => {
+                    // If this register is saved by pulley, skip this clobber.
+                    if let FrameStyle::PulleySetupAndSaveClobbers {
+                        saved_by_pulley, ..
+                    } = style
+                    {
+                        if saved_by_pulley.contains(r_reg.hw_enc()) {
+                            return None;
+                        }
+                    }
+                    I64
+                }
+                RegClass::Float => F64,
+                RegClass::Vector => unreachable!("no vector registers are callee-save"),
+            };
+            let offset = i32::try_from(offset).unwrap();
+            Some((offset, ty, Reg::from(reg.to_reg())))
+        })
     }
 }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -153,6 +153,7 @@
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
 (type BoxReturnCallIndInfo (primitive BoxReturnCallIndInfo))
+(type XRegSet (primitive XRegSet))
 
 ;;;; Address Modes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -573,7 +573,9 @@ fn pulley_emit<P>(
 
         Inst::Raw { raw } => {
             match raw {
-                RawInst::PushFrame | RawInst::StackAlloc32 { .. } => {
+                RawInst::PushFrame
+                | RawInst::StackAlloc32 { .. }
+                | RawInst::PushFrameSave { .. } => {
                     sink.add_trap(ir::TrapCode::STACK_OVERFLOW);
                 }
                 _ => {}

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -31,6 +31,7 @@ type BoxCallIndInfo = Box<CallInfo<XReg>>;
 type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
 type BoxReturnCallIndInfo = Box<ReturnCallInfo<XReg>>;
 type BoxExternalName = Box<ExternalName>;
+type XRegSet = pulley_interpreter::RegSet<pulley_interpreter::XReg>;
 
 #[expect(
     unused_imports,

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -129,8 +129,7 @@ block0:
 }
 
 ; VCode:
-;   push_frame
-;   stack_alloc32 48
+;   push_frame_save 48, {}
 ; block0:
 ;   xconst8 x15, 0
 ;   xstore64 OutgoingArg(0), x15 // flags =  notrap aligned
@@ -155,13 +154,11 @@ block0:
 ;   xmov x13, x15
 ;   xmov x14, x15
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   stack_free32 48
-;   pop_frame
+;   pop_frame_restore 48, {}
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; stack_alloc32 48
+; push_frame_save 48, 
 ; xconst8 x15, 0
 ; xstore64le_offset8 sp, 0, x15
 ; xstore64le_offset8 sp, 8, x15
@@ -184,9 +181,8 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call 0x0    // target = 0x4e
-; stack_free32 48
-; pop_frame
+; call 0x0    // target = 0x51
+; pop_frame_restore 48, 
 ; ret
 
 function %colocated_stack_rets() -> i64 {
@@ -226,15 +222,7 @@ block0:
 }
 
 ; VCode:
-;   push_frame
-;   stack_alloc32 112
-;   xstore64 sp+104, x17 // flags =  notrap aligned
-;   xstore64 sp+96, x18 // flags =  notrap aligned
-;   xstore64 sp+88, x20 // flags =  notrap aligned
-;   xstore64 sp+80, x21 // flags =  notrap aligned
-;   xstore64 sp+72, x22 // flags =  notrap aligned
-;   xstore64 sp+64, x23 // flags =  notrap aligned
-;   xstore64 sp+56, x29 // flags =  notrap aligned
+;   push_frame_save 112, {x17, x18, x20, x21, x22, x23, x29}
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
@@ -270,29 +258,13 @@ block0:
 ;   xadd64 x14, x0, x14
 ;   xadd64 x13, x13, x13
 ;   xadd64 x0, x14, x13
-;   x17 = xload64 sp+104 // flags = notrap aligned
-;   x18 = xload64 sp+96 // flags = notrap aligned
-;   x20 = xload64 sp+88 // flags = notrap aligned
-;   x21 = xload64 sp+80 // flags = notrap aligned
-;   x22 = xload64 sp+72 // flags = notrap aligned
-;   x23 = xload64 sp+64 // flags = notrap aligned
-;   x29 = xload64 sp+56 // flags = notrap aligned
-;   stack_free32 112
-;   pop_frame
+;   pop_frame_restore 112, {x17, x18, x20, x21, x22, x23, x29}
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; stack_alloc32 112
-; xstore64le_offset8 sp, 104, x17
-; xstore64le_offset8 sp, 96, x18
-; xstore64le_offset8 sp, 88, x20
-; xstore64le_offset8 sp, 80, x21
-; xstore64le_offset8 sp, 72, x22
-; xstore64le_offset8 sp, 64, x23
-; xstore64le_offset8 sp, 56, x29
+; push_frame_save 112, x17, x18, x20, x21, x22, x23, x29
 ; xmov x0, sp
-; call 0x0    // target = 0x25
+; call 0x0    // target = 0xc
 ; xmov x20, x13
 ; xmov x22, x11
 ; xload64le_offset8 x29, sp, 0
@@ -325,15 +297,7 @@ block0:
 ; xadd64 x14, x0, x14
 ; xadd64 x13, x13, x13
 ; xadd64 x0, x14, x13
-; xload64le_offset8 x17, sp, 104
-; xload64le_offset8 x18, sp, 96
-; xload64le_offset8 x20, sp, 88
-; xload64le_offset8 x21, sp, 80
-; xload64le_offset8 x22, sp, 72
-; xload64le_offset8 x23, sp, 64
-; xload64le_offset8 x29, sp, 56
-; stack_free32 112
-; pop_frame
+; pop_frame_restore 112, x17, x18, x20, x21, x22, x23, x29
 ; ret
 
 function %call_indirect(i32) -> i64 {

--- a/cranelift/filetests/filetests/isa/pulley32/stack_addr.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/stack_addr.clif
@@ -9,19 +9,15 @@ block0():
 }
 
 ; VCode:
-;   push_frame
-;   stack_alloc32 16
+;   push_frame_save 16, {}
 ; block0:
 ;   x0 = load_addr Slot(0)
-;   stack_free32 16
-;   pop_frame
+;   pop_frame_restore 16, {}
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; stack_alloc32 16
+; push_frame_save 16, 
 ; xmov x0, sp
-; stack_free32 16
-; pop_frame
+; pop_frame_restore 16, 
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -129,8 +129,7 @@ block0:
 }
 
 ; VCode:
-;   push_frame
-;   stack_alloc32 48
+;   push_frame_save 48, {}
 ; block0:
 ;   xconst8 x15, 0
 ;   xstore64 OutgoingArg(0), x15 // flags =  notrap aligned
@@ -155,13 +154,11 @@ block0:
 ;   xmov x13, x15
 ;   xmov x14, x15
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   stack_free32 48
-;   pop_frame
+;   pop_frame_restore 48, {}
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; stack_alloc32 48
+; push_frame_save 48, 
 ; xconst8 x15, 0
 ; xstore64le_offset8 sp, 0, x15
 ; xstore64le_offset8 sp, 8, x15
@@ -184,9 +181,8 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call 0x0    // target = 0x4e
-; stack_free32 48
-; pop_frame
+; call 0x0    // target = 0x51
+; pop_frame_restore 48, 
 ; ret
 
 function %colocated_stack_rets() -> i64 {
@@ -226,15 +222,7 @@ block0:
 }
 
 ; VCode:
-;   push_frame
-;   stack_alloc32 112
-;   xstore64 sp+104, x17 // flags =  notrap aligned
-;   xstore64 sp+96, x18 // flags =  notrap aligned
-;   xstore64 sp+88, x20 // flags =  notrap aligned
-;   xstore64 sp+80, x21 // flags =  notrap aligned
-;   xstore64 sp+72, x22 // flags =  notrap aligned
-;   xstore64 sp+64, x23 // flags =  notrap aligned
-;   xstore64 sp+56, x29 // flags =  notrap aligned
+;   push_frame_save 112, {x17, x18, x20, x21, x22, x23, x29}
 ; block0:
 ;   x0 = load_addr OutgoingArg(0)
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }, CallRetPair { vreg: Writable { reg: p1i }, preg: p1i }, CallRetPair { vreg: Writable { reg: p2i }, preg: p2i }, CallRetPair { vreg: Writable { reg: p3i }, preg: p3i }, CallRetPair { vreg: Writable { reg: p4i }, preg: p4i }, CallRetPair { vreg: Writable { reg: p5i }, preg: p5i }, CallRetPair { vreg: Writable { reg: p6i }, preg: p6i }, CallRetPair { vreg: Writable { reg: p7i }, preg: p7i }, CallRetPair { vreg: Writable { reg: p8i }, preg: p8i }, CallRetPair { vreg: Writable { reg: p9i }, preg: p9i }, CallRetPair { vreg: Writable { reg: p10i }, preg: p10i }, CallRetPair { vreg: Writable { reg: p11i }, preg: p11i }, CallRetPair { vreg: Writable { reg: p12i }, preg: p12i }, CallRetPair { vreg: Writable { reg: p13i }, preg: p13i }, CallRetPair { vreg: Writable { reg: p14i }, preg: p14i }, CallRetPair { vreg: Writable { reg: p15i }, preg: p15i }], clobbers: PRegSet { bits: [0, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
@@ -270,29 +258,13 @@ block0:
 ;   xadd64 x14, x0, x14
 ;   xadd64 x13, x13, x13
 ;   xadd64 x0, x14, x13
-;   x17 = xload64 sp+104 // flags = notrap aligned
-;   x18 = xload64 sp+96 // flags = notrap aligned
-;   x20 = xload64 sp+88 // flags = notrap aligned
-;   x21 = xload64 sp+80 // flags = notrap aligned
-;   x22 = xload64 sp+72 // flags = notrap aligned
-;   x23 = xload64 sp+64 // flags = notrap aligned
-;   x29 = xload64 sp+56 // flags = notrap aligned
-;   stack_free32 112
-;   pop_frame
+;   pop_frame_restore 112, {x17, x18, x20, x21, x22, x23, x29}
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; stack_alloc32 112
-; xstore64le_offset8 sp, 104, x17
-; xstore64le_offset8 sp, 96, x18
-; xstore64le_offset8 sp, 88, x20
-; xstore64le_offset8 sp, 80, x21
-; xstore64le_offset8 sp, 72, x22
-; xstore64le_offset8 sp, 64, x23
-; xstore64le_offset8 sp, 56, x29
+; push_frame_save 112, x17, x18, x20, x21, x22, x23, x29
 ; xmov x0, sp
-; call 0x0    // target = 0x25
+; call 0x0    // target = 0xc
 ; xmov x20, x13
 ; xmov x22, x11
 ; xload64le_offset8 x29, sp, 0
@@ -325,15 +297,7 @@ block0:
 ; xadd64 x14, x0, x14
 ; xadd64 x13, x13, x13
 ; xadd64 x0, x14, x13
-; xload64le_offset8 x17, sp, 104
-; xload64le_offset8 x18, sp, 96
-; xload64le_offset8 x20, sp, 88
-; xload64le_offset8 x21, sp, 80
-; xload64le_offset8 x22, sp, 72
-; xload64le_offset8 x23, sp, 64
-; xload64le_offset8 x29, sp, 56
-; stack_free32 112
-; pop_frame
+; pop_frame_restore 112, x17, x18, x20, x21, x22, x23, x29
 ; ret
 
 function %call_indirect(i64) -> i64 {
@@ -375,8 +339,7 @@ block0:
 }
 
 ; VCode:
-;   push_frame
-;   stack_alloc32 64
+;   push_frame_save 64, {}
 ; block0:
 ;   xconst8 x15, 0
 ;   xstore64 OutgoingArg(0), x15 // flags =  notrap aligned
@@ -403,13 +366,11 @@ block0:
 ;   xmov x13, x15
 ;   xmov x14, x15
 ;   call CallInfo { dest: TestCase(%g), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }, CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }, CallArgPair { vreg: p15i, preg: p15i }], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   stack_free32 64
-;   pop_frame
+;   pop_frame_restore 64, {}
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; stack_alloc32 64
+; push_frame_save 64, 
 ; xconst8 x15, 0
 ; xstore64le_offset8 sp, 0, x15
 ; xstore64le_offset8 sp, 8, x15
@@ -434,8 +395,7 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call 0x0    // target = 0x56
-; stack_free32 64
-; pop_frame
+; call 0x0    // target = 0x59
+; pop_frame_restore 64, 
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/stack_addr.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/stack_addr.clif
@@ -9,19 +9,15 @@ block0():
 }
 
 ; VCode:
-;   push_frame
-;   stack_alloc32 16
+;   push_frame_save 16, {}
 ; block0:
 ;   x0 = load_addr Slot(0)
-;   stack_free32 16
-;   pop_frame
+;   pop_frame_restore 16, {}
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; stack_alloc32 16
+; push_frame_save 16, 
 ; xmov x0, sp
-; stack_free32 16
-; pop_frame
+; pop_frame_restore 16, 
 ; ret
 

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1798,6 +1798,50 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[inline]
+    fn push_frame_save(&mut self, amt: u32, regs: RegSet<XReg>) -> ControlFlow<Done> {
+        // Decrement the stack pointer `amt` bytes plus 2 pointers more for
+        // fp/lr.
+        let ptr_size = size_of::<usize>();
+        let full_amt = usize::try_from(amt).unwrap() + 2 * ptr_size;
+        let new_sp = self.state[XReg::sp].get_ptr::<u8>().wrapping_sub(full_amt);
+        self.set_sp::<crate::PushFrameSave>(new_sp)?;
+
+        unsafe {
+            // Emulate `push_frame` by placing `lr` and `fp` onto the stack, in
+            // that order, at the top of the allocated area.
+            self.store(XReg::sp, (full_amt - 1 * ptr_size) as i32, self.state.lr);
+            self.store(XReg::sp, (full_amt - 2 * ptr_size) as i32, self.state.fp);
+
+            // Set `fp` to the top of our frame, where `fp` is stored.
+            let mut offset = amt as i32;
+            self.state.fp = self.state[XReg::sp]
+                .get_ptr::<u8>()
+                .byte_offset(offset as isize);
+
+            // Next save any registers in `regs` to the stack.
+            for reg in regs {
+                offset -= 8;
+                self.store(XReg::sp, offset, self.state[reg].get_u64());
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn pop_frame_save(&mut self, amt: u32, regs: RegSet<XReg>) -> ControlFlow<Done> {
+        // Restore all registers in `regs`, followed by the normal `pop_frame`
+        // opcode below to restore fp/lr.
+        unsafe {
+            let mut offset = amt as i32;
+            for reg in regs {
+                offset -= 8;
+                let val = self.load(XReg::sp, offset);
+                self.state[reg].set_u64(val);
+            }
+        }
+        self.pop_frame()
+    }
+
     fn pop_frame(&mut self) -> ControlFlow<Done> {
         self.set_sp_unchecked(self.state.fp);
         let fp = self.pop();

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1828,7 +1828,7 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
-    fn pop_frame_save(&mut self, amt: u32, regs: RegSet<XReg>) -> ControlFlow<Done> {
+    fn pop_frame_restore(&mut self, amt: u32, regs: RegSet<XReg>) -> ControlFlow<Done> {
         // Restore all registers in `regs`, followed by the normal `pop_frame`
         // opcode below to restore fp/lr.
         unsafe {

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -450,7 +450,7 @@ macro_rules! for_each_op {
             push_frame_save = PushFrameSave { amt: u32, regs: RegSet<XReg> };
             /// Inverse of `push_frame_save`. Restores `regs` from the top of
             /// the stack, then runs `stack_free32 amt`, then runs `pop_frame`.
-            pop_frame_save = PopFrameSave { amt: u32, regs: RegSet<XReg> };
+            pop_frame_restore = PopFrameRestore { amt: u32, regs: RegSet<XReg> };
 
             /// `sp = sp.checked_sub(amt)`
             stack_alloc32 = StackAlloc32 { amt: u32 };

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -442,6 +442,16 @@ macro_rules! for_each_op {
             /// `sp = fp; pop fp; pop lr`
             pop_frame = PopFrame ;
 
+            /// Macro-instruction to enter a function, allocate some stack, and
+            /// then save some registers.
+            ///
+            /// This is equivalent to `push_frame`, `stack_alloc32 amt`, then
+            /// saving all of `regs` to the top of the stack just allocated.
+            push_frame_save = PushFrameSave { amt: u32, regs: RegSet<XReg> };
+            /// Inverse of `push_frame_save`. Restores `regs` from the top of
+            /// the stack, then runs `stack_free32 amt`, then runs `pop_frame`.
+            pop_frame_save = PopFrameSave { amt: u32, regs: RegSet<XReg> };
+
             /// `sp = sp.checked_sub(amt)`
             stack_alloc32 = StackAlloc32 { amt: u32 };
 

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -261,10 +261,32 @@ impl<R: Reg> Into<ScalarBitSet<u32>> for RegSet<R> {
 
 impl<R: Reg> IntoIterator for RegSet<R> {
     type Item = R;
-    type IntoIter = core::iter::FilterMap<cranelift_bitset::scalar::Iter<u32>, fn(u8) -> Option<R>>;
+    type IntoIter = RegSetIntoIter<R>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.bitset.into_iter().filter_map(R::new)
+        RegSetIntoIter {
+            iter: self.bitset.into_iter(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Returned iterator from `RegSet::into_iter`
+pub struct RegSetIntoIter<R> {
+    iter: cranelift_bitset::scalar::Iter<u32>,
+    _marker: PhantomData<R>,
+}
+
+impl<R: Reg> Iterator for RegSetIntoIter<R> {
+    type Item = R;
+    fn next(&mut self) -> Option<R> {
+        Some(R::new(self.iter.next()?).unwrap())
+    }
+}
+
+impl<R: Reg> DoubleEndedIterator for RegSetIntoIter<R> {
+    fn next_back(&mut self) -> Option<R> {
+        Some(R::new(self.iter.next_back()?).unwrap())
     }
 }
 

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -14,5 +14,5 @@
 ;;       br_if_xulteq64 x6, x7, 0x9    // target = 0x1a
 ;;   18: pop_frame
 ;;       ret
-;;   1a: call 0xa1    // target = 0xbb
+;;   1a: call 0x9f    // target = 0xb9
 ;;   1f: jump 0xfffffffffffffff9    // target = 0x18


### PR DESCRIPTION
This commit adds two new instructions to Pulley to combine the operations of setting up a frame, allocating stack, and saving clobbered registers. This is all combined into a single instruction which is relatively large but is much smaller than each of these individual operations exploded out.

This is a size win on `spidermonkey.cwasm` by about 1M and locally in a small `fib.wat` test this is also a good speedup by reducing the number of instructions executed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
