### PR TITLE
Remove async-trait in bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4435,6 +4435,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "trait-variant",
  "url",
  "wasmtime",
  "wiggle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3987,6 +3998,7 @@ dependencies = [
  "sptr",
  "target-lexicon",
  "tempfile",
+ "trait-variant",
  "wasi-common",
  "wasm-encoder 0.221.2",
  "wasm-wave",
@@ -4130,6 +4142,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "trait-variant",
  "walkdir",
  "wasi-common",
  "wasm-encoder 0.221.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ humantime = { workspace = true }
 tempfile = { workspace = true, optional = true }
 
 async-trait = { workspace = true }
+trait-variant = { workspace = true }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
 tokio = { workspace = true, optional = true, features = [ "signal", "macros" ] }
@@ -96,6 +97,7 @@ criterion = { workspace = true }
 num_cpus = "1.13.0"
 memchr = "2.4"
 async-trait = { workspace = true }
+trait-variant = { workspace = true }
 wat = { workspace = true }
 rayon = "1.5.0"
 wasmtime-wast = { workspace = true, features = ['component-model'] }
@@ -313,6 +315,7 @@ tracing = "0.1.26"
 bitflags = "2.0"
 thiserror = "1.0.43"
 async-trait = "0.1.71"
+trait-variant = "0.1.2"
 heck = "0.5"
 similar = "2.1.0"
 toml = "0.8.10"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -32,6 +32,7 @@ io-lifetimes = { workspace = true }
 fs-set-times = { workspace = true }
 bitflags = { workspace = true }
 async-trait = { workspace = true }
+trait-variant = {workspace = true}
 system-interface = { workspace = true}
 futures = { workspace = true }
 url = { workspace = true }

--- a/crates/wasi/src/bindings.rs
+++ b/crates/wasi/src/bindings.rs
@@ -47,7 +47,6 @@
 //!     ctx: WasiCtx,
 //! }
 //!
-//! #[async_trait::async_trait]
 //! impl example::wasi::custom_host::Host for MyState {
 //!     async fn my_custom_function(&mut self) {
 //!         // ..

--- a/crates/wasi/src/host/filesystem.rs
+++ b/crates/wasi/src/host/filesystem.rs
@@ -32,7 +32,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> types::Host for WasiImpl<T>
 where
     T: WasiView,
@@ -57,7 +56,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> HostDescriptor for WasiImpl<T>
 where
     T: WasiView,
@@ -854,7 +852,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> HostDirectoryEntryStream for WasiImpl<T>
 where
     T: WasiView,

--- a/crates/wasi/src/host/io.rs
+++ b/crates/wasi/src/host/io.rs
@@ -37,7 +37,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> streams::HostOutputStream for WasiImpl<T>
 where
     T: WasiView,
@@ -171,7 +170,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> streams::HostInputStream for WasiImpl<T>
 where
     T: WasiView,

--- a/crates/wasi/src/host/tcp.rs
+++ b/crates/wasi/src/host/tcp.rs
@@ -14,7 +14,6 @@ use wasmtime::component::Resource;
 
 impl<T> tcp::Host for WasiImpl<T> where T: WasiView {}
 
-#[async_trait::async_trait]
 impl<T> crate::host::tcp::tcp::HostTcpSocket for WasiImpl<T>
 where
     T: WasiView,

--- a/crates/wasi/src/host/udp.rs
+++ b/crates/wasi/src/host/udp.rs
@@ -24,7 +24,6 @@ const MAX_UDP_DATAGRAM_SIZE: usize = u16::MAX as usize;
 
 impl<T> udp::Host for WasiImpl<T> where T: WasiView {}
 
-#[async_trait::async_trait]
 impl<T> udp::HostUdpSocket for WasiImpl<T>
 where
     T: WasiView,
@@ -398,7 +397,6 @@ impl Subscribe for IncomingDatagramStream {
     }
 }
 
-#[async_trait::async_trait]
 impl<T> udp::HostOutgoingDatagramStream for WasiImpl<T>
 where
     T: WasiView,

--- a/crates/wasi/src/ip_name_lookup.rs
+++ b/crates/wasi/src/ip_name_lookup.rs
@@ -19,7 +19,6 @@ pub enum ResolveAddressStream {
     Done(Result<vec::IntoIter<IpAddress>, SocketError>),
 }
 
-#[async_trait::async_trait]
 impl<T> Host for WasiImpl<T>
 where
     T: WasiView,
@@ -43,7 +42,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> HostResolveAddressStream for WasiImpl<T>
 where
     T: WasiView,

--- a/crates/wasi/src/pipe.rs
+++ b/crates/wasi/src/pipe.rs
@@ -75,6 +75,7 @@ impl MemoryOutputPipe {
     }
 }
 
+#[async_trait::async_trait]
 impl HostOutputStream for MemoryOutputPipe {
     fn write(&mut self, bytes: Bytes) -> Result<(), StreamError> {
         let mut buf = self.buffer.lock().unwrap();
@@ -217,6 +218,7 @@ impl Subscribe for AsyncReadStream {
 #[derive(Copy, Clone)]
 pub struct SinkOutputStream;
 
+#[async_trait::async_trait]
 impl HostOutputStream for SinkOutputStream {
     fn write(&mut self, _buf: Bytes) -> Result<(), StreamError> {
         Ok(())
@@ -257,6 +259,7 @@ impl Subscribe for ClosedInputStream {
 #[derive(Copy, Clone)]
 pub struct ClosedOutputStream;
 
+#[async_trait::async_trait]
 impl HostOutputStream for ClosedOutputStream {
     fn write(&mut self, _: Bytes) -> Result<(), StreamError> {
         Err(StreamError::Closed)

--- a/crates/wasi/src/poll.rs
+++ b/crates/wasi/src/poll.rs
@@ -116,7 +116,6 @@ where
     Ok(table.push_child(pollable, &resource)?)
 }
 
-#[async_trait::async_trait]
 impl<T> poll::Host for WasiImpl<T>
 where
     T: WasiView,
@@ -178,7 +177,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> crate::bindings::io::poll::HostPollable for WasiImpl<T>
 where
     T: WasiView,

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -52,6 +52,7 @@ once_cell = { version = "1.12.0", optional = true }
 rayon = { version = "1.0", optional = true }
 object = { workspace = true }
 async-trait = { workspace = true, optional = true }
+trait-variant = { workspace = true, optional = true }
 encoding_rs = { version = "0.8.31", optional = true }
 bumpalo = "3.11.0"
 fxprof-processed-profile = { version = "0.6.0", optional = true }
@@ -183,6 +184,7 @@ cache = ["dep:wasmtime-cache", "std"]
 async = [
   "dep:wasmtime-fiber",
   "dep:async-trait",
+  "dep:trait-variant",
   "wasmtime-component-macro?/async",
   "runtime",
 ]

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -260,7 +260,7 @@ pub(crate) use self::store::ComponentStoreData;
 ///     // This option defaults to `false`.
 ///     verbose_tracing: false,
 ///
-///     // Imports will be async functions through #[async_trait] and exports
+///     // Imports will be async functions and exports
 ///     // are also invoked as async functions. Requires `Config::async_support`
 ///     // to be `true`.
 ///     //

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -148,6 +148,8 @@ pub mod __internal {
     #[cfg(feature = "async")]
     pub use async_trait::async_trait;
     pub use core::mem::transmute;
+    #[cfg(feature = "async")]
+    pub use trait_variant::make as trait_variant_make;
     pub use wasmtime_environ;
     pub use wasmtime_environ::component::{CanonicalAbiInfo, ComponentTypes, InterfaceType};
 }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -145,8 +145,6 @@ pub mod __internal {
     pub use alloc::string::String;
     pub use alloc::vec::Vec;
     pub use anyhow;
-    #[cfg(feature = "async")]
-    pub use async_trait::async_trait;
     pub use core::mem::transmute;
     #[cfg(feature = "async")]
     pub use trait_variant::make as trait_variant_make;

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1358,7 +1358,10 @@ impl Wasmtime {
         let wt = self.wasmtime_path();
         let world_camel = to_rust_upper_camel_case(&resolve.worlds[world].name);
         if self.opts.async_.maybe_async() {
-            uwriteln!(self.src, "#[{wt}::component::__internal::trait_variant_make(::core::marker::Send)]")
+            uwriteln!(
+                self.src,
+                "#[{wt}::component::__internal::trait_variant_make(::core::marker::Send)]"
+            )
         }
         uwrite!(self.src, "pub trait {world_camel}Imports");
         let mut supertraits = vec![];
@@ -1707,7 +1710,10 @@ impl<'a> InterfaceGenerator<'a> {
 
             // Generate resource trait
             if self.gen.opts.async_.maybe_async() {
-                uwriteln!(self.src, "#[{wt}::component::__internal::trait_variant_make(::core::marker::Send)]")
+                uwriteln!(
+                    self.src,
+                    "#[{wt}::component::__internal::trait_variant_make(::core::marker::Send)]"
+                )
             }
             uwriteln!(self.src, "pub trait Host{camel} {{");
 
@@ -2380,7 +2386,10 @@ impl<'a> InterfaceGenerator<'a> {
 
         let is_maybe_async = self.gen.opts.async_.maybe_async();
         if is_maybe_async {
-            uwriteln!(self.src, "#[{wt}::component::__internal::trait_variant_make(::core::marker::Send)]")
+            uwriteln!(
+                self.src,
+                "#[{wt}::component::__internal::trait_variant_make(::core::marker::Send)]"
+            )
         }
         // Generate the `pub trait` which represents the host functionality for
         // this import which additionally inherits from all resource traits

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -338,7 +338,6 @@ mod async_config {
 
     struct T;
 
-    #[async_trait::async_trait]
     impl T1Imports for T {
         async fn x(&mut self) {}
 
@@ -364,7 +363,6 @@ mod async_config {
         },
     });
 
-    #[async_trait::async_trait]
     impl T2Imports for T {
         fn x(&mut self) {}
 
@@ -390,7 +388,6 @@ mod async_config {
         },
     });
 
-    #[async_trait::async_trait]
     impl T3Imports for T {
         async fn x(&mut self) {}
 


### PR DESCRIPTION
Closes #9823 

I ran `cargo test -p wasmtime-wasi` and all tests passed, so now I'd like to go through the whole CI.

There are only 2 cases remaining unresolved due to the use of dyn objects, i.e., `wasmtime::runtime::store::CallHookHandler` and `wasmtime::runtime::limits::ResourceLimiterAsync`, but they are related to the runtime, so I don't think they are very relevant to the issue and I left them unchanged.
