### PR TITLE
pulley: Fix mistakes in compare-with-immediate

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -727,8 +727,13 @@
 (rule (lower_fcmp $F32 (FloatCC.LessThanOrEqual) a b) (pulley_flteq32 a b))
 (rule (lower_fcmp $F64 (FloatCC.LessThanOrEqual) a b) (pulley_flteq64 a b))
 
-;; NB: Pulley doesn't have lowerings for `Ordered` or `Unordered` `FloatCC`
-;; conditions as that's not needed by wasm at this time.
+;; Ordered == !a.is_nan() && !b.is_nan()
+(rule (lower_fcmp ty (FloatCC.Ordered) a b)
+  (pulley_xband32 (lower_fcmp ty (FloatCC.Equal) a a) (lower_fcmp ty (FloatCC.Equal) b b)))
+
+;; OrderedNotEqual == a < b || a > b
+(rule (lower_fcmp ty (FloatCC.OrderedNotEqual) a b)
+  (pulley_xbor32 (lower_fcmp ty (FloatCC.LessThan) a b) (lower_fcmp ty (FloatCC.GreaterThan) a b)))
 
 ;; Pulley doesn't have instructions for `>` and `>=`, so we have to reverse the
 ;; operation.
@@ -736,6 +741,11 @@
   (lower_fcmp ty (FloatCC.LessThan) b a))
 (rule (lower_fcmp ty (FloatCC.GreaterThanOrEqual) a b)
   (lower_fcmp ty (FloatCC.LessThanOrEqual) b a))
+
+;; For other `Unordered*` comparisons generate its complement and invert the result.
+(rule -1 (lower_fcmp ty cc a b)
+  (if-let true (floatcc_unordered cc))
+  (pulley_xbxor32_s8 (lower_fcmp ty (floatcc_complement cc) a b) 1))
 
 ;;;; Rules for `load` and friends ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -937,13 +947,13 @@
 
 ;; Note the operand swaps here
 (rule (emit_cond (Cond.IfXsgt32I32 src1 src2))
-  (pulley_xslteq32 (imm $I32 (i64_as_u64 (i32_as_i64 src2))) src1))
-(rule (emit_cond (Cond.IfXsgteq32I32 src1 src2))
   (pulley_xslt32 (imm $I32 (i64_as_u64 (i32_as_i64 src2))) src1))
+(rule (emit_cond (Cond.IfXsgteq32I32 src1 src2))
+  (pulley_xslteq32 (imm $I32 (i64_as_u64 (i32_as_i64 src2))) src1))
 (rule (emit_cond (Cond.IfXugt32I32 src1 src2))
-  (pulley_xulteq32 (imm $I32 (u32_as_u64 src2)) src1))
-(rule (emit_cond (Cond.IfXugteq32I32 src1 src2))
   (pulley_xult32 (imm $I32 (u32_as_u64 src2)) src1))
+(rule (emit_cond (Cond.IfXugteq32I32 src1 src2))
+  (pulley_xulteq32 (imm $I32 (u32_as_u64 src2)) src1))
 
 (rule (emit_cond (Cond.IfXeq64I32 src1 src2))
   (pulley_xeq64 src1 (imm $I64 (i64_as_u64 (i32_as_i64 src2)))))
@@ -960,13 +970,13 @@
 
 ;; Note the operand swaps here
 (rule (emit_cond (Cond.IfXsgt64I32 src1 src2))
-  (pulley_xslteq64 (imm $I64 (i64_as_u64 (i32_as_i64 src2))) src1))
-(rule (emit_cond (Cond.IfXsgteq64I32 src1 src2))
   (pulley_xslt64 (imm $I64 (i64_as_u64 (i32_as_i64 src2))) src1))
+(rule (emit_cond (Cond.IfXsgteq64I32 src1 src2))
+  (pulley_xslteq64 (imm $I64 (i64_as_u64 (i32_as_i64 src2))) src1))
 (rule (emit_cond (Cond.IfXugt64I32 src1 src2))
-  (pulley_xulteq64 (imm $I64 (u32_as_u64 src2)) src1))
-(rule (emit_cond (Cond.IfXugteq64I32 src1 src2))
   (pulley_xult64 (imm $I64 (u32_as_u64 src2)) src1))
+(rule (emit_cond (Cond.IfXugteq64I32 src1 src2))
+  (pulley_xulteq64 (imm $I64 (u32_as_u64 src2)) src1))
 
 ;;;; Rules for `bitcast` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/runtests/fcmp-ge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ge.clif
@@ -6,6 +6,10 @@ target aarch64
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_ge_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-one.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-one.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_one_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ord.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ord.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_ord_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_ueq_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uge.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_uge_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_ugt_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ule.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_ule_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ult.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fcmp_ult_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-uno.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uno.clif
@@ -5,6 +5,10 @@ target x86_64 has_avx
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 
 function %fcmp_uno_f32(f32, f32) -> i8 {

--- a/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
@@ -7,6 +7,10 @@ target riscv64
 target riscv64 has_zfa
 target riscv64 has_c has_zcb
 target s390x
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fmax_p_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
@@ -7,6 +7,10 @@ target riscv64
 target riscv64 has_zfa
 target riscv64 has_c has_zcb
 target s390x
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fmin_p_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-eq.clif
@@ -45,3 +45,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_eq_i64(0, 0) == 1
 ; run: %icmp_eq_i64(1, 0) == 0
 ; run: %icmp_eq_i64(-1, -1) == 1
+
+function %icmp_eq_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm eq v0, 10
+    return v2
+}
+; run: %icmp_eq_i8_imm(10) == 1
+; run: %icmp_eq_i8_imm(0) == 0
+; run: %icmp_eq_i8_imm(-1) == 0
+
+function %icmp_eq_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm eq v0, 10
+    return v2
+}
+; run: %icmp_eq_i16_imm(10) == 1
+; run: %icmp_eq_i16_imm(0) == 0
+; run: %icmp_eq_i16_imm(-1) == 0
+
+function %icmp_eq_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm eq v0, 10
+    return v2
+}
+; run: %icmp_eq_i32_imm(10) == 1
+; run: %icmp_eq_i32_imm(0) == 0
+; run: %icmp_eq_i32_imm(-1) == 0
+
+function %icmp_eq_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm eq v0, 10
+    return v2
+}
+; run: %icmp_eq_i64_imm(10) == 1
+; run: %icmp_eq_i64_imm(0) == 0
+; run: %icmp_eq_i64_imm(-1) == 0

--- a/cranelift/filetests/filetests/runtests/icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ne.clif
@@ -45,3 +45,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_ne_i64(0, 0) == 0
 ; run: %icmp_ne_i64(1, 0) == 1
 ; run: %icmp_ne_i64(-1, -1) == 0
+
+function %icmp_ne_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm ne v0, 10
+    return v2
+}
+; run: %icmp_ne_i8_imm(10) == 0
+; run: %icmp_ne_i8_imm(0) == 1
+; run: %icmp_ne_i8_imm(-1) == 1
+
+function %icmp_ne_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm ne v0, 10
+    return v2
+}
+; run: %icmp_ne_i16_imm(10) == 0
+; run: %icmp_ne_i16_imm(0) == 1
+; run: %icmp_ne_i16_imm(-1) == 1
+
+function %icmp_ne_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm ne v0, 10
+    return v2
+}
+; run: %icmp_ne_i32_imm(10) == 0
+; run: %icmp_ne_i32_imm(0) == 1
+; run: %icmp_ne_i32_imm(-1) == 1
+
+function %icmp_ne_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm ne v0, 10
+    return v2
+}
+; run: %icmp_ne_i64_imm(10) == 0
+; run: %icmp_ne_i64_imm(0) == 1
+; run: %icmp_ne_i64_imm(-1) == 1

--- a/cranelift/filetests/filetests/runtests/icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sge.clif
@@ -58,3 +58,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_sge_i64(0, 1) == 0
 ; run: %icmp_sge_i64(-5, -1) == 0
 ; run: %icmp_sge_i64(1, -1) == 1
+
+function %icmp_sge_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm sge v0, 10
+    return v2
+}
+; run: %icmp_sge_i8_imm(10) == 1
+; run: %icmp_sge_i8_imm(0) == 0
+; run: %icmp_sge_i8_imm(-1) == 0
+
+function %icmp_sge_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm sge v0, 10
+    return v2
+}
+; run: %icmp_sge_i16_imm(10) == 1
+; run: %icmp_sge_i16_imm(0) == 0
+; run: %icmp_sge_i16_imm(-1) == 0
+
+function %icmp_sge_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm sge v0, 10
+    return v2
+}
+; run: %icmp_sge_i32_imm(10) == 1
+; run: %icmp_sge_i32_imm(0) == 0
+; run: %icmp_sge_i32_imm(-1) == 0
+
+function %icmp_sge_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm sge v0, 10
+    return v2
+}
+; run: %icmp_sge_i64_imm(10) == 1
+; run: %icmp_sge_i64_imm(0) == 0
+; run: %icmp_sge_i64_imm(-1) == 0

--- a/cranelift/filetests/filetests/runtests/icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sgt.clif
@@ -58,3 +58,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_sgt_i64(0, 1) == 0
 ; run: %icmp_sgt_i64(-5, -1) == 0
 ; run: %icmp_sgt_i64(1, -1) == 1
+
+function %icmp_sgt_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm sgt v0, 10
+    return v2
+}
+; run: %icmp_sgt_i8_imm(10) == 0
+; run: %icmp_sgt_i8_imm(0) == 0
+; run: %icmp_sgt_i8_imm(-1) == 0
+
+function %icmp_sgt_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm sgt v0, 10
+    return v2
+}
+; run: %icmp_sgt_i16_imm(10) == 0
+; run: %icmp_sgt_i16_imm(0) == 0
+; run: %icmp_sgt_i16_imm(-1) == 0
+
+function %icmp_sgt_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm sgt v0, 10
+    return v2
+}
+; run: %icmp_sgt_i32_imm(10) == 0
+; run: %icmp_sgt_i32_imm(0) == 0
+; run: %icmp_sgt_i32_imm(-1) == 0
+
+function %icmp_sgt_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm sgt v0, 10
+    return v2
+}
+; run: %icmp_sgt_i64_imm(10) == 0
+; run: %icmp_sgt_i64_imm(0) == 0
+; run: %icmp_sgt_i64_imm(-1) == 0

--- a/cranelift/filetests/filetests/runtests/icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sle.clif
@@ -58,3 +58,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_sle_i64(0, 1) == 1
 ; run: %icmp_sle_i64(-5, -1) == 1
 ; run: %icmp_sle_i64(1, -1) == 0
+
+function %icmp_sle_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm sle v0, 10
+    return v2
+}
+; run: %icmp_sle_i8_imm(10) == 1
+; run: %icmp_sle_i8_imm(0) == 1
+; run: %icmp_sle_i8_imm(-1) == 1
+
+function %icmp_sle_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm sle v0, 10
+    return v2
+}
+; run: %icmp_sle_i16_imm(10) == 1
+; run: %icmp_sle_i16_imm(0) == 1
+; run: %icmp_sle_i16_imm(-1) == 1
+
+function %icmp_sle_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm sle v0, 10
+    return v2
+}
+; run: %icmp_sle_i32_imm(10) == 1
+; run: %icmp_sle_i32_imm(0) == 1
+; run: %icmp_sle_i32_imm(-1) == 1
+
+function %icmp_sle_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm sle v0, 10
+    return v2
+}
+; run: %icmp_sle_i64_imm(10) == 1
+; run: %icmp_sle_i64_imm(0) == 1
+; run: %icmp_sle_i64_imm(-1) == 1

--- a/cranelift/filetests/filetests/runtests/icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-slt.clif
@@ -5,6 +5,10 @@ target x86_64
 target riscv64
 target riscv64 has_c has_zcb
 target s390x
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %icmp_slt_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -53,3 +57,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_slt_i64(0, 1) == 1
 ; run: %icmp_slt_i64(-5, -1) == 1
 ; run: %icmp_slt_i64(1, -1) == 0
+
+function %icmp_slt_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm slt v0, 10
+    return v2
+}
+; run: %icmp_slt_i8_imm(10) == 0
+; run: %icmp_slt_i8_imm(0) == 1
+; run: %icmp_slt_i8_imm(-1) == 1
+
+function %icmp_slt_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm slt v0, 10
+    return v2
+}
+; run: %icmp_slt_i16_imm(10) == 0
+; run: %icmp_slt_i16_imm(0) == 1
+; run: %icmp_slt_i16_imm(-1) == 1
+
+function %icmp_slt_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm slt v0, 10
+    return v2
+}
+; run: %icmp_slt_i32_imm(10) == 0
+; run: %icmp_slt_i32_imm(0) == 1
+; run: %icmp_slt_i32_imm(-1) == 1
+
+function %icmp_slt_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm slt v0, 10
+    return v2
+}
+; run: %icmp_slt_i64_imm(10) == 0
+; run: %icmp_slt_i64_imm(0) == 1
+; run: %icmp_slt_i64_imm(-1) == 1

--- a/cranelift/filetests/filetests/runtests/icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-uge.clif
@@ -67,3 +67,39 @@ block0:
     return v17
 }
 ; run: %constant_inputs() == 1
+
+function %icmp_uge_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm uge v0, 10
+    return v2
+}
+; run: %icmp_uge_i8_imm(10) == 1
+; run: %icmp_uge_i8_imm(0) == 0
+; run: %icmp_uge_i8_imm(-1) == 1
+
+function %icmp_uge_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm uge v0, 10
+    return v2
+}
+; run: %icmp_uge_i16_imm(10) == 1
+; run: %icmp_uge_i16_imm(0) == 0
+; run: %icmp_uge_i16_imm(-1) == 1
+
+function %icmp_uge_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm uge v0, 10
+    return v2
+}
+; run: %icmp_uge_i32_imm(10) == 1
+; run: %icmp_uge_i32_imm(0) == 0
+; run: %icmp_uge_i32_imm(-1) == 1
+
+function %icmp_uge_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm uge v0, 10
+    return v2
+}
+; run: %icmp_uge_i64_imm(10) == 1
+; run: %icmp_uge_i64_imm(0) == 0
+; run: %icmp_uge_i64_imm(-1) == 1

--- a/cranelift/filetests/filetests/runtests/icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ugt.clif
@@ -67,3 +67,39 @@ block0:
 }
 
 ; run: %icmp_ugt_const() == 0
+
+function %icmp_ugt_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm ugt v0, 10
+    return v2
+}
+; run: %icmp_ugt_i8_imm(10) == 0
+; run: %icmp_ugt_i8_imm(0) == 0
+; run: %icmp_ugt_i8_imm(-1) == 1
+
+function %icmp_ugt_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm ugt v0, 10
+    return v2
+}
+; run: %icmp_ugt_i16_imm(10) == 0
+; run: %icmp_ugt_i16_imm(0) == 0
+; run: %icmp_ugt_i16_imm(-1) == 1
+
+function %icmp_ugt_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm ugt v0, 10
+    return v2
+}
+; run: %icmp_ugt_i32_imm(10) == 0
+; run: %icmp_ugt_i32_imm(0) == 0
+; run: %icmp_ugt_i32_imm(-1) == 1
+
+function %icmp_ugt_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm ugt v0, 10
+    return v2
+}
+; run: %icmp_ugt_i64_imm(10) == 0
+; run: %icmp_ugt_i64_imm(0) == 0
+; run: %icmp_ugt_i64_imm(-1) == 1

--- a/cranelift/filetests/filetests/runtests/icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ule.clif
@@ -57,3 +57,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_ule_i64(0, 1) == 1
 ; run: %icmp_ule_i64(-5, -1) == 1
 ; run: %icmp_ule_i64(1, -1) == 1
+
+function %icmp_ule_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm ule v0, 10
+    return v2
+}
+; run: %icmp_ule_i8_imm(10) == 1
+; run: %icmp_ule_i8_imm(0) == 1
+; run: %icmp_ule_i8_imm(-1) == 0
+
+function %icmp_ule_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm ule v0, 10
+    return v2
+}
+; run: %icmp_ule_i16_imm(10) == 1
+; run: %icmp_ule_i16_imm(0) == 1
+; run: %icmp_ule_i16_imm(-1) == 0
+
+function %icmp_ule_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm ule v0, 10
+    return v2
+}
+; run: %icmp_ule_i32_imm(10) == 1
+; run: %icmp_ule_i32_imm(0) == 1
+; run: %icmp_ule_i32_imm(-1) == 0
+
+function %icmp_ule_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm ule v0, 10
+    return v2
+}
+; run: %icmp_ule_i64_imm(10) == 1
+; run: %icmp_ule_i64_imm(0) == 1
+; run: %icmp_ule_i64_imm(-1) == 0

--- a/cranelift/filetests/filetests/runtests/icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ult.clif
@@ -57,3 +57,39 @@ block0(v0: i64, v1: i64):
 ; run: %icmp_ult_i64(0, 1) == 1
 ; run: %icmp_ult_i64(-5, -1) == 1
 ; run: %icmp_ult_i64(1, -1) == 1
+
+function %icmp_ult_i8_imm(i8) -> i8 {
+block0(v0: i8):
+    v2 = icmp_imm ult v0, 10
+    return v2
+}
+; run: %icmp_ult_i8_imm(10) == 0
+; run: %icmp_ult_i8_imm(0) == 1
+; run: %icmp_ult_i8_imm(-1) == 0
+
+function %icmp_ult_i16_imm(i16) -> i8 {
+block0(v0: i16):
+    v2 = icmp_imm ult v0, 10
+    return v2
+}
+; run: %icmp_ult_i16_imm(10) == 0
+; run: %icmp_ult_i16_imm(0) == 1
+; run: %icmp_ult_i16_imm(-1) == 0
+
+function %icmp_ult_i32_imm(i32) -> i8 {
+block0(v0: i32):
+    v2 = icmp_imm ult v0, 10
+    return v2
+}
+; run: %icmp_ult_i32_imm(10) == 0
+; run: %icmp_ult_i32_imm(0) == 1
+; run: %icmp_ult_i32_imm(-1) == 0
+
+function %icmp_ult_i64_imm(i64) -> i8 {
+block0(v0: i64):
+    v2 = icmp_imm ult v0, 10
+    return v2
+}
+; run: %icmp_ult_i64_imm(10) == 0
+; run: %icmp_ult_i64_imm(0) == 1
+; run: %icmp_ult_i64_imm(-1) == 0

--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -6,6 +6,10 @@ target x86_64
 target riscv64
 target riscv64 has_zicond
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %select_eq_f32(f32, f32) -> i32 {
 block0(v0: f32, v1: f32):
@@ -180,3 +184,219 @@ block0(v0: i64, v1: i64, v2: i64):
 ; run: %select_icmp_ne_zero(0, 42, 35) == 35
 ; run: %select_icmp_ne_zero(42, 42, 35) == 42
 
+
+function %select_icmp32_eq_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm eq v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_eq_imm(7, 42, 35) == 42
+; run: %select_icmp32_eq_imm(0, 42, 35) == 35
+; run: %select_icmp32_eq_imm(-1, 42, 35) == 35
+
+function %select_icmp64_eq_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm eq v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_eq_imm(7, 42, 35) == 42
+; run: %select_icmp64_eq_imm(0, 42, 35) == 35
+; run: %select_icmp64_eq_imm(-1, 42, 35) == 35
+
+function %select_icmp32_ne_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm ne v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_ne_imm(7, 42, 35) == 35
+; run: %select_icmp32_ne_imm(0, 42, 35) == 42
+; run: %select_icmp32_ne_imm(-1, 42, 35) == 42
+
+function %select_icmp64_ne_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm ne v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_ne_imm(7, 42, 35) == 35
+; run: %select_icmp64_ne_imm(0, 42, 35) == 42
+; run: %select_icmp64_ne_imm(-1, 42, 35) == 42
+
+function %select_icmp32_slt_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm slt v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_slt_imm(8, 42, 35) == 35
+; run: %select_icmp32_slt_imm(7, 42, 35) == 35
+; run: %select_icmp32_slt_imm(0, 42, 35) == 42
+; run: %select_icmp32_slt_imm(-1, 42, 35) == 42
+
+function %select_icmp64_slt_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm slt v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_slt_imm(8, 42, 35) == 35
+; run: %select_icmp64_slt_imm(7, 42, 35) == 35
+; run: %select_icmp64_slt_imm(0, 42, 35) == 42
+; run: %select_icmp64_slt_imm(-1, 42, 35) == 42
+
+function %select_icmp32_ult_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm ult v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_ult_imm(8, 42, 35) == 35
+; run: %select_icmp32_ult_imm(7, 42, 35) == 35
+; run: %select_icmp32_ult_imm(0, 42, 35) == 42
+; run: %select_icmp32_ult_imm(-1, 42, 35) == 35
+
+function %select_icmp64_ult_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm ult v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_ult_imm(8, 42, 35) == 35
+; run: %select_icmp64_ult_imm(7, 42, 35) == 35
+; run: %select_icmp64_ult_imm(0, 42, 35) == 42
+; run: %select_icmp64_ult_imm(-1, 42, 35) == 35
+
+function %select_icmp32_sle_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm sle v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_sle_imm(8, 42, 35) == 35
+; run: %select_icmp32_sle_imm(7, 42, 35) == 42
+; run: %select_icmp32_sle_imm(0, 42, 35) == 42
+; run: %select_icmp32_sle_imm(-1, 42, 35) == 42
+
+function %select_icmp64_sle_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm sle v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_sle_imm(8, 42, 35) == 35
+; run: %select_icmp64_sle_imm(7, 42, 35) == 42
+; run: %select_icmp64_sle_imm(0, 42, 35) == 42
+; run: %select_icmp64_sle_imm(-1, 42, 35) == 42
+
+function %select_icmp32_ule_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm ule v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_ule_imm(8, 42, 35) == 35
+; run: %select_icmp32_ule_imm(7, 42, 35) == 42
+; run: %select_icmp32_ule_imm(0, 42, 35) == 42
+; run: %select_icmp32_ule_imm(-1, 42, 35) == 35
+
+function %select_icmp64_ule_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm ule v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_ule_imm(8, 42, 35) == 35
+; run: %select_icmp64_ule_imm(7, 42, 35) == 42
+; run: %select_icmp64_ule_imm(0, 42, 35) == 42
+; run: %select_icmp64_ule_imm(-1, 42, 35) == 35
+
+function %select_icmp32_sgt_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm sgt v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_sgt_imm(8, 42, 35) == 42
+; run: %select_icmp32_sgt_imm(7, 42, 35) == 35
+; run: %select_icmp32_sgt_imm(0, 42, 35) == 35
+; run: %select_icmp32_sgt_imm(-1, 42, 35) == 35
+
+function %select_icmp64_sgt_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm sgt v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_sgt_imm(8, 42, 35) == 42
+; run: %select_icmp64_sgt_imm(7, 42, 35) == 35
+; run: %select_icmp64_sgt_imm(0, 42, 35) == 35
+; run: %select_icmp64_sgt_imm(-1, 42, 35) == 35
+
+function %select_icmp32_ugt_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm ugt v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_ugt_imm(8, 42, 35) == 42
+; run: %select_icmp32_ugt_imm(7, 42, 35) == 35
+; run: %select_icmp32_ugt_imm(0, 42, 35) == 35
+; run: %select_icmp32_ugt_imm(-1, 42, 35) == 42
+
+function %select_icmp64_ugt_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm ugt v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_ugt_imm(8, 42, 35) == 42
+; run: %select_icmp64_ugt_imm(7, 42, 35) == 35
+; run: %select_icmp64_ugt_imm(0, 42, 35) == 35
+; run: %select_icmp64_ugt_imm(-1, 42, 35) == 42
+
+function %select_icmp32_sge_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm sge v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_sge_imm(8, 42, 35) == 42
+; run: %select_icmp32_sge_imm(7, 42, 35) == 42
+; run: %select_icmp32_sge_imm(0, 42, 35) == 35
+; run: %select_icmp32_sge_imm(-1, 42, 35) == 35
+
+function %select_icmp64_sge_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm sge v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_sge_imm(8, 42, 35) == 42
+; run: %select_icmp64_sge_imm(7, 42, 35) == 42
+; run: %select_icmp64_sge_imm(0, 42, 35) == 35
+; run: %select_icmp64_sge_imm(-1, 42, 35) == 35
+
+function %select_icmp32_uge_imm(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = icmp_imm uge v0, 7
+  v4 = select.i32 v3, v1, v2
+  return v4
+}
+; run: %select_icmp32_uge_imm(8, 42, 35) == 42
+; run: %select_icmp32_uge_imm(7, 42, 35) == 42
+; run: %select_icmp32_uge_imm(0, 42, 35) == 35
+; run: %select_icmp32_uge_imm(-1, 42, 35) == 42
+
+function %select_icmp64_uge_imm(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = icmp_imm uge v0, 7
+  v4 = select.i64 v3, v1, v2
+  return v4
+}
+; run: %select_icmp64_uge_imm(8, 42, 35) == 42
+; run: %select_icmp64_uge_imm(7, 42, 35) == 42
+; run: %select_icmp64_uge_imm(0, 42, 35) == 35
+; run: %select_icmp64_uge_imm(-1, 42, 35) == 42

--- a/cranelift/filetests/filetests/runtests/spill-reload.clif
+++ b/cranelift/filetests/filetests/runtests/spill-reload.clif
@@ -4,6 +4,10 @@ target aarch64
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %f(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> i64 {
 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32, v9: i32, v10: i32, v11: i32, v12: i32, v13: i32, v14: i32, v15: i32, v16: i32, v17: i32, v18: i32, v19: i32):


### PR DESCRIPTION
This commit fixes a few mistakes that were introduced in #9863. Specifically when lowering `Cond.If...` and the arguments needed swapping the condition was also inverted by accident. More `*.clif` runtests were added to catch this case and expose it. Additionally Pulley now has lowering for all the `FloatCC` orderings to be able to run the `select.clif` runtest which primarily exposed the issue.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
