### PR TITLE
pulley: Refactor and reuse `imm` for floats

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -389,18 +389,8 @@
 (rule 0 (imm $I64 x) (pulley_xconst64 (u64_as_i64 x)))
 
 ;; Base cases for floats.
-(rule 0 (imm $F32 c) (gen_bitcast (imm $I32 c) $I32 $F32))
-(rule 0 (imm $F64 c) (gen_bitcast (imm $I64 c) $I64 $F64))
-
-;;;; Bitcasts ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; Bitcast from the first type, into the second type.
-(decl gen_bitcast (Reg Type Type) Reg)
-(rule (gen_bitcast r $F32 $I32) (pulley_bitcast_float_from_int_32 r))
-(rule (gen_bitcast r $F64 $I64) (pulley_bitcast_float_from_int_64 r))
-(rule (gen_bitcast r $I32 $F32) (pulley_bitcast_int_from_float_32 r))
-(rule (gen_bitcast r $I64 $F64) (pulley_bitcast_int_from_float_64 r))
-(rule -1 (gen_bitcast r ty ty) r)
+(rule 0 (imm $F32 (u64_as_u32 c)) (pulley_fconst32 c))
+(rule 0 (imm $F64 c) (pulley_fconst64 c))
 
 ;;;; Instruction Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -161,13 +161,11 @@
 
 ;;;; Rules for `f32const`;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (f32const (u32_from_ieee32 x)))
-      (pulley_fconst32 x))
+(rule (lower (f32const (u32_from_ieee32 x))) (imm $F32 x))
 
 ;;;; Rules for `f64const`;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (f64const (u64_from_ieee64 x)))
-      (pulley_fconst64 x))
+(rule (lower (f64const (u64_from_ieee64 x))) (imm $F64 x))
 
 ;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This was originally added long ago and this brings the method up-to-date with the current pulley opcode set.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
