### PR TITLE
Enable pulley in `wasmtime-bench-api`

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 anyhow = { workspace = true }
 shuffling-allocator = { version = "1.1.1", optional = true }
 target-lexicon = { workspace = true }
-wasmtime = { workspace = true, default-features = true, features = ["winch"] }
+wasmtime = { workspace = true, default-features = true, features = ["winch", 'pulley'] }
 wasmtime-cli-flags = { workspace = true, default-features = true, features = [
     "cranelift",
 ] }


### PR DESCRIPTION
Makes it easier to compare Pulley runtime by-default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
