### PR TITLE
Remove float canonicalization from components

### DIFF
--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -503,7 +503,7 @@ fn floats() -> Result<()> {
             .call(&mut store, (CANON_32BIT_NAN | 1,))?
             .0
             .to_bits(),
-        CANON_32BIT_NAN
+        CANON_32BIT_NAN | 1
     );
     u32_to_f32.post_return(&mut store)?;
     assert_eq!(
@@ -511,18 +511,18 @@ fn floats() -> Result<()> {
             .call(&mut store, (CANON_64BIT_NAN | 1,))?
             .0
             .to_bits(),
-        CANON_64BIT_NAN,
+        CANON_64BIT_NAN | 1,
     );
     u64_to_f64.post_return(&mut store)?;
 
     assert_eq!(
         f32_to_u32.call(&mut store, (f32::from_bits(CANON_32BIT_NAN | 1),))?,
-        (CANON_32BIT_NAN,)
+        (CANON_32BIT_NAN | 1,)
     );
     f32_to_u32.post_return(&mut store)?;
     assert_eq!(
         f64_to_u64.call(&mut store, (f64::from_bits(CANON_64BIT_NAN | 1),))?,
-        (CANON_64BIT_NAN,)
+        (CANON_64BIT_NAN | 1,)
     );
     f64_to_u64.post_return(&mut store)?;
 
@@ -937,7 +937,10 @@ fn many_parameters() -> Result<()> {
     assert_eq!(i8::from_le_bytes(*actual.take_n::<1>()), input.0);
     actual.skip::<7>();
     assert_eq!(u64::from_le_bytes(*actual.take_n::<8>()), input.1);
-    assert_eq!(u32::from_le_bytes(*actual.take_n::<4>()), CANON_32BIT_NAN);
+    assert_eq!(
+        u32::from_le_bytes(*actual.take_n::<4>()),
+        CANON_32BIT_NAN | 1
+    );
     assert_eq!(u8::from_le_bytes(*actual.take_n::<1>()), input.3);
     actual.skip::<1>();
     assert_eq!(i16::from_le_bytes(*actual.take_n::<2>()), input.4);
@@ -1703,7 +1706,7 @@ fn expected() -> Result<()> {
     let ret = to_expected_s16_f32
         .call(&mut store, (1, CANON_32BIT_NAN | 1))?
         .0;
-    assert_eq!(ret.unwrap_err().to_bits(), CANON_32BIT_NAN);
+    assert_eq!(ret.unwrap_err().to_bits(), CANON_32BIT_NAN | 1);
     to_expected_s16_f32.post_return(&mut store)?;
     assert!(to_expected_s16_f32.call(&mut store, (2, 0)).is_err());
 


### PR DESCRIPTION
This was removed from the spec quite awhile back so this catches up the runtime to the spec where this is no longer required.

Closes #9826

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
