### PR TITLE
Test x86_64-apple-darwin on newer CI machines

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -81,9 +81,10 @@ const FULL_MATRIX = [
     "isa": "x64"
   },
   {
-    "os": "macos-13",
+    "os": macos,
     "name": "Test macOS x86_64",
     "filter": "macos-x64",
+    "target": "x86_64-apple-darwin",
   },
   {
     "os": macos,


### PR DESCRIPTION
This commit moves testing of x86_64-apple-darwin from `macos-13` macs to the `macos-14` image which is newer. The hope is that these newer images, being natively M1 machines, are faster to compile and less flaky. A number of CI builds recently have failed due to seeming CI issues with the older machines, so this'll hopefully keep the same amount of testing while improving robustness.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
