### PR TITLE
pulley: Fill out most remaining simd float ops

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -756,6 +756,9 @@
 (rule (lower (fcmp cc a b @ (value_type (ty_scalar_float ty))))
   (lower_fcmp ty cc a b))
 
+(rule 1 (lower (fcmp cc a b @ (value_type (ty_vec128 ty))))
+  (lower_vfcmp ty cc a b))
+
 (decl lower_fcmp (Type FloatCC Value Value) XReg)
 
 (rule (lower_fcmp $F32 (FloatCC.Equal) a b) (pulley_feq32 a b))
@@ -786,6 +789,32 @@
 (rule -1 (lower_fcmp ty cc a b)
   (if-let true (floatcc_unordered cc))
   (pulley_xbxor32_s8 (lower_fcmp ty (floatcc_complement cc) a b) 1))
+
+(decl lower_vfcmp (Type FloatCC Value Value) VReg)
+
+(rule (lower_vfcmp $F32X4 (FloatCC.Equal) a b) (pulley_veqf32x4 a b))
+(rule (lower_vfcmp $F64X2 (FloatCC.Equal) a b) (pulley_veqf64x2 a b))
+(rule (lower_vfcmp $F32X4 (FloatCC.NotEqual) a b) (pulley_vneqf32x4 a b))
+(rule (lower_vfcmp $F64X2 (FloatCC.NotEqual) a b) (pulley_vneqf64x2 a b))
+(rule (lower_vfcmp $F32X4 (FloatCC.LessThan) a b) (pulley_vltf32x4 a b))
+(rule (lower_vfcmp $F64X2 (FloatCC.LessThan) a b) (pulley_vltf64x2 a b))
+(rule (lower_vfcmp $F32X4 (FloatCC.LessThanOrEqual) a b) (pulley_vlteqf32x4 a b))
+(rule (lower_vfcmp $F64X2 (FloatCC.LessThanOrEqual) a b) (pulley_vlteqf64x2 a b))
+
+(rule (lower_vfcmp ty (FloatCC.Unordered) a b)
+  (pulley_vbor128
+    (lower_vfcmp ty (FloatCC.NotEqual) a a)
+    (lower_vfcmp ty (FloatCC.NotEqual) b b)))
+
+;; NB: Pulley doesn't have lowerings for `Ordered` or `Unordered*` `FloatCC`
+;; conditions as that's not needed by wasm at this time.
+
+;; Pulley doesn't have instructions for `>` and `>=`, so we have to reverse the
+;; operation.
+(rule (lower_vfcmp ty (FloatCC.GreaterThan) a b)
+  (lower_vfcmp ty (FloatCC.LessThan) b a))
+(rule (lower_vfcmp ty (FloatCC.GreaterThanOrEqual) a b)
+  (lower_vfcmp ty (FloatCC.LessThanOrEqual) b a))
 
 ;;;; Rules for `load` and friends ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1203,6 +1232,7 @@
       (pulley_vfloor32x4 a))
 (rule (lower (has_type $F64X2 (floor a)))
       (pulley_vfloor64x2 a))
+
 ;;;; Rules for `ceil` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (ceil a))) (pulley_fceil32 a))
@@ -1229,7 +1259,6 @@
       (pulley_vsqrt32x4 a))
 (rule (lower (has_type $F64X2 (sqrt a)))
       (pulley_vsqrt64x2 a))
-
 
 ;;;; Rules for `fneg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1407,7 +1436,7 @@
 (rule (lower (scalar_to_vector a @ (value_type $F64)))
   (pulley_vinsertf64 (pulley_vconst128 0) a 0))
 
-;;;; Rules for `shuffle` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Rules for `shuffle` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I8X16 (shuffle a b (u128_from_immediate mask))))
   (pulley_vshuffle a b mask))
@@ -1415,3 +1444,8 @@
 ;;;; Rules for `swizzle` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 1 (lower (has_type $I8X16 (swizzle a b))) (pulley_vswizzlei8x16 a b))
+
+;;;; Rules for `fma` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type $F32X4 (fma a b c))) (pulley_vfma32x4 a b c))
+(rule (lower (has_type $F64X2 (fma a b c))) (pulley_vfma64x2 a b c))

--- a/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
@@ -8,6 +8,10 @@ target x86_64 sse42 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %splat_f32x4_2(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd.clif
@@ -9,6 +9,10 @@ target x86_64 sse42 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 
 function %fadd_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-eq.clif
@@ -6,6 +6,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %simd_fcmp_eq_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ge.clif
@@ -6,6 +6,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %simd_fcmp_ge_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-gt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-gt.clif
@@ -6,6 +6,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %simd_fcmp_gt_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-le.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-le.clif
@@ -6,6 +6,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %simd_fcmp_le_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-lt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-lt.clif
@@ -6,6 +6,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %simd_fcmp_lt_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ne.clif
@@ -6,6 +6,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %simd_fcmp_ne_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-uno.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-uno.clif
@@ -6,6 +6,10 @@ target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %simd_fcmp_uno_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fdiv.clif
@@ -9,6 +9,10 @@ target x86_64 sse42 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 
 function %fdiv_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-floor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-floor.clif
@@ -9,6 +9,10 @@ target s390x
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %floor_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fma-neg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma-neg.clif
@@ -5,6 +5,10 @@ target aarch64
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 ;; This file is not enabled in the interpreter since SIMD fneg is currently broken
 ;; there.

--- a/cranelift/filetests/filetests/runtests/simd-fma.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma.clif
@@ -6,6 +6,10 @@ target aarch64
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fma_f32x4(f32x4, f32x4, f32x4) -> f32x4 {
 block0(v0: f32x4, v1: f32x4, v2: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
@@ -6,6 +6,10 @@ target x86_64 skylake
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fmin_pseudo_f32x4(f32x4, f32x4) -> f32x4 {
 block0(v0:f32x4, v1:f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fmul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmul.clif
@@ -8,6 +8,10 @@ target x86_64 sse42 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 
 function %fmul_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-fneg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fneg.clif
@@ -9,6 +9,10 @@ target x86_64 sse42 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %fneg_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fsub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fsub.clif
@@ -8,6 +8,10 @@ target x86_64 sse42 has_avx
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 
 function %fsub_f32x4(f32x4, f32x4) -> f32x4 {

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -31,7 +31,7 @@ pub trait WasmFloat {
     fn wasm_nearest(self) -> Self;
     fn wasm_minimum(self, other: Self) -> Self;
     fn wasm_maximum(self, other: Self) -> Self;
-    fn mul_add(self, b: Self, c: Self) -> Self;
+    fn wasm_mul_add(self, b: Self, c: Self) -> Self;
 }
 
 impl WasmFloat for f32 {
@@ -148,9 +148,11 @@ impl WasmFloat for f32 {
         }
     }
     #[inline]
-    fn mul_add(self, b: f32, c: f32) -> f32 {
+    fn wasm_mul_add(self, b: f32, c: f32) -> f32 {
+        // The MinGW implementation of `fma` differs from other platforms, so
+        // favor `libm` there instead.
         #[cfg(feature = "std")]
-        if true {
+        if !(cfg!(windows) && cfg!(target_env = "gnu")) {
             return self.mul_add(b, c);
         }
         libm::fmaf(self, b, c)
@@ -271,7 +273,7 @@ impl WasmFloat for f64 {
         }
     }
     #[inline]
-    fn mul_add(self, b: f64, c: f64) -> f64 {
+    fn wasm_mul_add(self, b: f64, c: f64) -> f64 {
         // The MinGW implementation of `fma` differs from other platforms, so
         // favor `libm` there instead.
         #[cfg(feature = "std")]

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -272,8 +272,10 @@ impl WasmFloat for f64 {
     }
     #[inline]
     fn mul_add(self, b: f64, c: f64) -> f64 {
+        // The MinGW implementation of `fma` differs from other platforms, so
+        // favor `libm` there instead.
         #[cfg(feature = "std")]
-        if true {
+        if !(cfg!(windows) && cfg!(target_env = "gnu")) {
             return self.mul_add(b, c);
         }
         libm::fma(self, b, c)

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1289,11 +1289,11 @@ pub mod relocs {
     }
 
     pub extern "C" fn fmaf32(a: f32, b: f32, c: f32) -> f32 {
-        wasmtime_math::WasmFloat::mul_add(a, b, c)
+        wasmtime_math::WasmFloat::wasm_mul_add(a, b, c)
     }
 
     pub extern "C" fn fmaf64(a: f64, b: f64, c: f64) -> f64 {
-        wasmtime_math::WasmFloat::mul_add(a, b, c)
+        wasmtime_math::WasmFloat::wasm_mul_add(a, b, c)
     }
 
     // This intrinsic is only used on x86_64 platforms as an implementation of

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -401,17 +401,9 @@ impl WastTest {
         // features in Pulley are implemented.
         if config.compiler == Compiler::CraneliftPulley {
             let unsupported = [
-                "misc_testsuite/simd/canonicalize-nan.wast",
-                "misc_testsuite/simd/issue_3327_bnot_lowering.wast",
                 "misc_testsuite/simd/v128-select.wast",
                 "spec_testsuite/proposals/relaxed-simd/i32x4_relaxed_trunc.wast",
-                "spec_testsuite/proposals/relaxed-simd/relaxed_madd_nmadd.wast",
-                "spec_testsuite/proposals/memory64/relaxed_madd_nmadd.wast",
                 "spec_testsuite/proposals/memory64/i32x4_relaxed_trunc.wast",
-                "spec_testsuite/simd_f32x4_cmp.wast",
-                "spec_testsuite/simd_f32x4_pmin_pmax.wast",
-                "spec_testsuite/simd_f64x2_cmp.wast",
-                "spec_testsuite/simd_f64x2_pmin_pmax.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f64x2.wast",
                 "spec_testsuite/simd_load.wast",

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -4681,4 +4681,114 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         self.state[operands.dst].set_u16x8(a);
         ControlFlow::Continue(())
     }
+
+    fn veqf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f32x4();
+        let b = self.state[operands.src2].get_f32x4();
+        let mut c = [0; 4];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a == b { u32::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u32x4(c);
+        ControlFlow::Continue(())
+    }
+
+    fn vneqf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f32x4();
+        let b = self.state[operands.src2].get_f32x4();
+        let mut c = [0; 4];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a != b { u32::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u32x4(c);
+        ControlFlow::Continue(())
+    }
+
+    fn vltf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f32x4();
+        let b = self.state[operands.src2].get_f32x4();
+        let mut c = [0; 4];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a < b { u32::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u32x4(c);
+        ControlFlow::Continue(())
+    }
+
+    fn vlteqf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f32x4();
+        let b = self.state[operands.src2].get_f32x4();
+        let mut c = [0; 4];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a <= b { u32::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u32x4(c);
+        ControlFlow::Continue(())
+    }
+
+    fn veqf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f64x2();
+        let b = self.state[operands.src2].get_f64x2();
+        let mut c = [0; 2];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a == b { u64::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u64x2(c);
+        ControlFlow::Continue(())
+    }
+
+    fn vneqf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f64x2();
+        let b = self.state[operands.src2].get_f64x2();
+        let mut c = [0; 2];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a != b { u64::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u64x2(c);
+        ControlFlow::Continue(())
+    }
+
+    fn vltf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f64x2();
+        let b = self.state[operands.src2].get_f64x2();
+        let mut c = [0; 2];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a < b { u64::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u64x2(c);
+        ControlFlow::Continue(())
+    }
+
+    fn vlteqf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f64x2();
+        let b = self.state[operands.src2].get_f64x2();
+        let mut c = [0; 2];
+        for ((a, b), c) in a.iter().zip(&b).zip(&mut c) {
+            *c = if a <= b { u64::MAX } else { 0 };
+        }
+        self.state[operands.dst].set_u64x2(c);
+        ControlFlow::Continue(())
+    }
+
+    fn vfma32x4(&mut self, dst: VReg, a: VReg, b: VReg, c: VReg) -> ControlFlow<Done> {
+        let mut a = self.state[a].get_f32x4();
+        let b = self.state[b].get_f32x4();
+        let c = self.state[c].get_f32x4();
+        for ((a, b), c) in a.iter_mut().zip(b).zip(c) {
+            *a = a.mul_add(b, c);
+        }
+        self.state[dst].set_f32x4(a);
+        ControlFlow::Continue(())
+    }
+
+    fn vfma64x2(&mut self, dst: VReg, a: VReg, b: VReg, c: VReg) -> ControlFlow<Done> {
+        let mut a = self.state[a].get_f64x2();
+        let b = self.state[b].get_f64x2();
+        let c = self.state[c].get_f64x2();
+        for ((a, b), c) in a.iter_mut().zip(b).zip(c) {
+            *a = a.mul_add(b, c);
+        }
+        self.state[dst].set_f64x2(a);
+        ControlFlow::Continue(())
+    }
 }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -4775,7 +4775,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         let b = self.state[b].get_f32x4();
         let c = self.state[c].get_f32x4();
         for ((a, b), c) in a.iter_mut().zip(b).zip(c) {
-            *a = a.mul_add(b, c);
+            *a = a.wasm_mul_add(b, c);
         }
         self.state[dst].set_f32x4(a);
         ControlFlow::Continue(())
@@ -4786,7 +4786,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         let b = self.state[b].get_f64x2();
         let c = self.state[c].get_f64x2();
         for ((a, b), c) in a.iter_mut().zip(b).zip(c) {
-            *a = a.mul_add(b, c);
+            *a = a.wasm_mul_add(b, c);
         }
         self.state[dst].set_f64x2(a);
         ControlFlow::Continue(())

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -1256,6 +1256,28 @@ macro_rules! for_each_extended_op {
             vavground8x16 = Vavground8x16 { operands: BinaryOperands<VReg> };
             /// `dst = (src1 + src2 + 1) // 2`
             vavground16x8 = Vavground16x8 { operands: BinaryOperands<VReg> };
+
+            /// `dst = src == dst`
+            veqf32x4 = VeqF32x4 { operands: BinaryOperands<VReg> };
+            /// `dst = src != dst`
+            vneqf32x4 = VneqF32x4 { operands: BinaryOperands<VReg> };
+            /// `dst = src < dst`
+            vltf32x4 = VltF32x4 { operands: BinaryOperands<VReg> };
+            /// `dst = src <= dst`
+            vlteqf32x4 = VlteqF32x4 { operands: BinaryOperands<VReg> };
+            /// `dst = src == dst`
+            veqf64x2 = VeqF64x2 { operands: BinaryOperands<VReg> };
+            /// `dst = src != dst`
+            vneqf64x2 = VneqF64x2 { operands: BinaryOperands<VReg> };
+            /// `dst = src < dst`
+            vltf64x2 = VltF64x2 { operands: BinaryOperands<VReg> };
+            /// `dst = src <= dst`
+            vlteqf64x2 = VlteqF64x2 { operands: BinaryOperands<VReg> };
+
+            /// `dst = ieee_fma(a, b, c)`
+            vfma32x4 = Vfma32x4 { dst: VReg, a: VReg, b: VReg, c: VReg };
+            /// `dst = ieee_fma(a, b, c)`
+            vfma64x2 = Vfma64x2 { dst: VReg, a: VReg, b: VReg, c: VReg };
         }
     };
 }


### PR DESCRIPTION
Get most simd/float-related tests passing. Mostly reusing preexisting scalar ops for the simd implementation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
