### PR TITLE
Enable introspecting pulley at runtime

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -382,8 +382,6 @@ wasmtime_config_cache_config_load(wasm_config_t *, const char *);
 
 #endif // WASMTIME_FEATURE_CACHE
 
-#ifdef WASMTIME_FEATURE_COMPILER
-
 /**
  * \brief Configures the target triple that this configuration will produce
  * machine code for.
@@ -397,6 +395,8 @@ wasmtime_config_cache_config_load(wasm_config_t *, const char *);
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.config
  */
 WASMTIME_CONFIG_PROP(wasmtime_error_t *, target, const char *)
+
+#ifdef WASMTIME_FEATURE_COMPILER
 
 /**
  * \brief Enables a target-specific flag in Cranelift.

--- a/crates/c-api/include/wasmtime/engine.h
+++ b/crates/c-api/include/wasmtime/engine.h
@@ -35,6 +35,12 @@ WASM_API_EXTERN wasm_engine_t *wasmtime_engine_clone(wasm_engine_t *engine);
  */
 WASM_API_EXTERN void wasmtime_engine_increment_epoch(wasm_engine_t *engine);
 
+/**
+ * \brief Returns whether this engine is using the Pulley interpreter to execute
+ * WebAssembly code.
+ */
+WASM_API_EXTERN bool wasmtime_engine_is_pulley(wasm_engine_t *engine);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -249,7 +249,6 @@ pub extern "C" fn wasmtime_config_native_unwind_info_set(c: &mut wasm_config_t, 
 }
 
 #[no_mangle]
-#[cfg(any(feature = "cranelift", feature = "winch"))]
 pub unsafe extern "C" fn wasmtime_config_target_set(
     c: &mut wasm_config_t,
     target: *const c_char,

--- a/crates/c-api/src/engine.rs
+++ b/crates/c-api/src/engine.rs
@@ -47,3 +47,8 @@ pub extern "C" fn wasmtime_engine_clone(engine: &wasm_engine_t) -> Box<wasm_engi
 pub extern "C" fn wasmtime_engine_increment_epoch(engine: &wasm_engine_t) {
     engine.engine.increment_epoch();
 }
+
+#[no_mangle]
+pub extern "C" fn wasmtime_engine_is_pulley(engine: &wasm_engine_t) -> bool {
+    engine.engine.is_pulley()
+}

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -568,10 +568,8 @@ impl CommonOptions {
             collector => config.collector(collector),
             _ => err,
         }
-        match_feature! {
-            ["cranelift" : &self.target]
-            target => config.target(target)?,
-            _ => err,
+        if let Some(target) = &self.target {
+            config.target(target)?;
         }
         match_feature! {
             ["cranelift" : self.codegen.cranelift_debug_verifier]

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -126,6 +126,7 @@ impl core::hash::Hash for ModuleVersionStrategy {
 pub struct Config {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     compiler_config: CompilerConfig,
+    target: Option<target_lexicon::Triple>,
     #[cfg(feature = "gc")]
     collector: Collector,
     profiling_strategy: ProfilingStrategy,
@@ -171,7 +172,6 @@ pub struct Config {
 #[derive(Debug, Clone)]
 struct CompilerConfig {
     strategy: Option<Strategy>,
-    target: Option<target_lexicon::Triple>,
     settings: HashMap<String, String>,
     flags: HashSet<String>,
     #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
@@ -185,7 +185,6 @@ impl CompilerConfig {
     fn new() -> Self {
         Self {
             strategy: Strategy::Auto.not_auto(),
-            target: None,
             settings: HashMap::new(),
             flags: HashSet::new(),
             #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
@@ -230,6 +229,7 @@ impl Config {
             tunables: ConfigTunables::default(),
             #[cfg(any(feature = "cranelift", feature = "winch"))]
             compiler_config: CompilerConfig::default(),
+            target: None,
             #[cfg(feature = "gc")]
             collector: Collector::default(),
             #[cfg(feature = "cache")]
@@ -305,9 +305,8 @@ impl Config {
     /// # Errors
     ///
     /// This method will error if the given target triple is not supported.
-    #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn target(&mut self, target: &str) -> Result<&mut Self> {
-        self.compiler_config.target =
+        self.target =
             Some(target_lexicon::Triple::from_str(target).map_err(|e| anyhow::anyhow!(e))?);
 
         Ok(self)
@@ -2053,10 +2052,10 @@ impl Config {
     }
 
     /// Returns the configured compiler target for this `Config`.
-    fn compiler_target(&self) -> target_lexicon::Triple {
+    pub(crate) fn compiler_target(&self) -> target_lexicon::Triple {
         // If a target is explicitly configured, always use that.
         #[cfg(any(feature = "cranelift", feature = "winch"))]
-        if let Some(target) = self.compiler_config.target.clone() {
+        if let Some(target) = self.target.clone() {
             return target;
         }
 
@@ -2256,7 +2255,7 @@ impl Config {
         // specified (which indicates no feature inference) and the target
         // matches the host.
         let target_for_builder =
-            if self.compiler_config.target.is_none() && target == target_lexicon::Triple::host() {
+            if self.target.is_none() && target == target_lexicon::Triple::host() {
                 None
             } else {
                 Some(target.clone())


### PR DESCRIPTION
This commit includes a few assorted changes to improve detection of whether Wasmtime is using Pulley at runtime:

* A new `Engine::is_pulley` API is added.
* A new `wasmtime_engine_is_pulley` C API is added.
* The `Config::target` method is now available regardless of compilation features.
* The `Engine::target` method now consults the `Config` to have the same fallback logic for when a target is not explicitly configured.

cc https://github.com/bytecodealliance/wasmtime/issues/1980#issuecomment-2557615804

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
