### PR TITLE
Don't forcibly enable `gc` feature with cli-flags crate

### DIFF
--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -18,7 +18,7 @@ clap = { workspace = true }
 file-per-thread-logger = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 rayon = { version = "1.5.0", optional = true }
-wasmtime = { workspace = true, features = ["gc"] }
+wasmtime = { workspace = true }
 humantime = { workspace = true }
 
 [features]

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -712,8 +712,10 @@ impl CommonOptions {
         if let Some(enable) = self.debug.address_map {
             config.generate_address_map(enable);
         }
-        if let Some(enable) = self.opts.memory_init_cow {
-            config.memory_init_cow(enable);
+        match_feature! {
+            ["signals-based-traps" : self.opts.memory_init_cow]
+            enable => config.memory_init_cow(enable),
+            _ => err,
         }
         match_feature! {
             ["signals-based-traps" : self.opts.signals_based_traps]


### PR DESCRIPTION
Helps keep the `gc` feature out of the "min" build.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
