### PR TITLE
Add aarch64-apple-ios to platform-check matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -553,6 +553,9 @@ jobs:
         - target: wasm32-wasip1
           os: ubuntu-latest
           test: cargo build --no-default-features --features compile,cranelift,all-arch
+        - target: aarch64-apple-ios
+          os: macos-latest
+          test: cargo build
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -556,6 +556,9 @@ jobs:
         - target: aarch64-apple-ios
           os: macos-latest
           test: cargo build
+          env:
+            IPHONEOS_DEPLOYMENT_TARGET: 13.0
+    env: ${{ matrix.env || fromJSON('{}') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/crates/asm-macros/src/lib.rs
+++ b/crates/asm-macros/src/lib.rs
@@ -9,7 +9,7 @@
 #![no_std]
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "macos")] {
+    if #[cfg(target_vendor = "apple")] {
         #[macro_export]
         macro_rules! asm_func {
             ($name:expr, $body:expr $(, $($args:tt)*)?) => {

--- a/crates/fiber/src/stackswitch/aarch64.rs
+++ b/crates/fiber/src/stackswitch/aarch64.rs
@@ -22,7 +22,7 @@ use super::wasmtime_fiber_start;
 use wasmtime_asm_macros::asm_func;
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "macos")] {
+    if #[cfg(target_vendor = "apple")] {
         macro_rules! paci1716 { () => ("pacib1716\n"); }
         macro_rules! pacisp { () => ("pacibsp\n"); }
         macro_rules! autisp { () => ("autibsp\n"); }

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -24,7 +24,7 @@ features = [
     "Win32_System_Diagnostics_Debug",
 ]
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "android"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_vendor = "apple", target_os = "freebsd", target_os = "android"))'.dependencies]
 libc = { workspace = true }
 
 [features]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -89,7 +89,7 @@ ittapi = { workspace = true, optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 memfd = { workspace = true, optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 mach2 = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mod.rs
@@ -12,7 +12,7 @@ pub mod unwind;
 #[cfg(feature = "signals-based-traps")]
 pub mod vm;
 
-#[cfg(all(feature = "signals-based-traps", target_os = "macos"))]
+#[cfg(all(feature = "signals-based-traps", target_vendor = "apple"))]
 pub mod machports;
 #[cfg(feature = "signals-based-traps")]
 pub mod signals;


### PR DESCRIPTION
This commit is somewhat of a rebase of #7506 to port most of it to `main`. I've left out any test-related changes since we're not testing anything just yet. I've also found that rustc now has `target_vendor = "apple"` to cover both macOS and iOS targets (and presumably other targets like tvOS as well if they get added)

Closes #7506

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
