### PR TITLE
bad markdown on winch/README.md

### DIFF
--- a/winch/README.md
+++ b/winch/README.md
@@ -25,7 +25,7 @@ Winch's primary goal is compilation performance, therefore only certain, very
 limited peephole optimations are applied.
 
 For more details on the original motivation and goals, refer to the [Bytecode
-Alliance RFC for Baseline Compilation in Wasmtime.](rfc).
+Alliance RFC for Baseline Compilation in Wasmtime.][rfc].
 
 [rfc]: https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-baseline-compilation.md
 


### PR DESCRIPTION
[Alliance RFC for Baseline Compilation in Wasmtime.](https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-baseline-compilation.md) doesn't link to the correct path in [winch/README.md](https://github.com/bytecodealliance/wasmtime/blob/main/winch/README.md), due to bad mardown.