### PR TITLE
typo-Update instructions.rs

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift/codegen/meta/src/cdsl/instructions.rs
@@ -421,7 +421,7 @@ fn verify_polymorphic(
 /// Verify that the use of TypeVars is consistent with `ctrl_typevar` as the controlling type
 /// variable.
 ///
-/// All polymorhic inputs must either be derived from `ctrl_typevar` or be independent free type
+/// All polymorphic inputs must either be derived from `ctrl_typevar` or be independent free type
 /// variables only used once.
 ///
 /// All polymorphic results must be derived from `ctrl_typevar`.


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `cranelift/codegen/meta/src/cdsl/instructions.rs:424`: "polymorhic" corrected to "polymorphic".

## Purpose
- Improved code clarity and ensured professionalism by fixing the typo.

