### PR TITLE
Make Pulley pass `simd_f32x4_arith.wast`

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -1157,14 +1157,14 @@
 
 (rule (lower (has_type $F32 (fsub a b))) (pulley_fsub32 a b))
 (rule (lower (has_type $F64 (fsub a b))) (pulley_fsub64 a b))
-(rule (lower (has_type $F32X4 (fsub a b))) (pulley_vsub32x4 a b))
+(rule (lower (has_type $F32X4 (fsub a b))) (pulley_vsubf32x4 a b))
 (rule (lower (has_type $F64X2 (fsub a b))) (pulley_vsubf64x2 a b))
 
 ;;;; Rules for `fmul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fmul a b))) (pulley_fmul32 a b))
 (rule (lower (has_type $F64 (fmul a b))) (pulley_fmul64 a b))
-(rule (lower (has_type $F32X4 (fmul a b))) (pulley_vmul32x4 a b))
+(rule (lower (has_type $F32X4 (fmul a b))) (pulley_vmulf32x4 a b))
 (rule (lower (has_type $F64X2 (fmul a b))) (pulley_vmulf64x2 a b))
 
 ;;;; Rules for `fdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -1157,12 +1157,14 @@
 
 (rule (lower (has_type $F32 (fsub a b))) (pulley_fsub32 a b))
 (rule (lower (has_type $F64 (fsub a b))) (pulley_fsub64 a b))
+(rule (lower (has_type $F32X4 (fsub a b))) (pulley_vsub32x4 a b))
 (rule (lower (has_type $F64X2 (fsub a b))) (pulley_vsubf64x2 a b))
 
 ;;;; Rules for `fmul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fmul a b))) (pulley_fmul32 a b))
 (rule (lower (has_type $F64 (fmul a b))) (pulley_fmul64 a b))
+(rule (lower (has_type $F32X4 (fmul a b))) (pulley_vmul32x4 a b))
 (rule (lower (has_type $F64X2 (fmul a b))) (pulley_vmulf64x2 a b))
 
 ;;;; Rules for `fdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1233,6 +1235,7 @@
 
 (rule (lower (has_type $F32 (fneg a))) (pulley_fneg32 a))
 (rule (lower (has_type $F64 (fneg a))) (pulley_fneg64 a))
+(rule (lower (has_type $F32X4 (fneg a))) (pulley_vnegf32x4 a))
 (rule (lower (has_type $F64X2 (fneg a))) (pulley_vnegf64x2 a))
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -408,7 +408,6 @@ impl WastTest {
                 "spec_testsuite/proposals/relaxed-simd/relaxed_madd_nmadd.wast",
                 "spec_testsuite/proposals/memory64/relaxed_madd_nmadd.wast",
                 "spec_testsuite/proposals/memory64/i32x4_relaxed_trunc.wast",
-                "spec_testsuite/simd_f32x4_arith.wast",
                 "spec_testsuite/simd_f32x4_cmp.wast",
                 "spec_testsuite/simd_f32x4_pmin_pmax.wast",
                 "spec_testsuite/simd_f64x2_cmp.wast",

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -2980,10 +2980,30 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn vsub32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_f32x4();
+        let b = self.state[operands.src2].get_f32x4();
+        for (a, b) in a.iter_mut().zip(b) {
+            *a = *a - b;
+        }
+        self.state[operands.dst].set_f32x4(a);
+        ControlFlow::Continue(())
+    }
+
     fn fmul32(&mut self, operands: BinaryOperands<FReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f32();
         let b = self.state[operands.src2].get_f32();
         self.state[operands.dst].set_f32(a * b);
+        ControlFlow::Continue(())
+    }
+
+    fn vmul32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_f32x4();
+        let b = self.state[operands.src2].get_f32x4();
+        for (a, b) in a.iter_mut().zip(b) {
+            *a = *a * b;
+        }
+        self.state[operands.dst].set_f32x4(a);
         ControlFlow::Continue(())
     }
 
@@ -3159,6 +3179,15 @@ impl ExtendedOpVisitor for Interpreter<'_> {
     fn fneg32(&mut self, dst: FReg, src: FReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f32();
         self.state[dst].set_f32(-a);
+        ControlFlow::Continue(())
+    }
+
+    fn vnegf32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
+        let mut a = self.state[src].get_f32x4();
+        for elem in a.iter_mut() {
+            *elem = -*elem;
+        }
+        self.state[dst].set_f32x4(a);
         ControlFlow::Continue(())
     }
 

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -2980,7 +2980,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
-    fn vsub32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+    fn vsubf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
         for (a, b) in a.iter_mut().zip(b) {
@@ -2997,7 +2997,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
-    fn vmul32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+    fn vmulf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
         for (a, b) in a.iter_mut().zip(b) {

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -812,11 +812,11 @@ macro_rules! for_each_extended_op {
             /// `low32(dst) = low32(src1) - low32(src2)`
             fsub32 = Fsub32 { operands: BinaryOperands<FReg> };
             /// `low128(dst) = low128(src1) - low128(src2)`
-            vsub32x4 = Vsub32x4 { operands: BinaryOperands<VReg> };
+            vsubf32x4 = Vsubf32x4 { operands: BinaryOperands<VReg> };
             /// `low32(dst) = low32(src1) * low32(src2)`
             fmul32 = Fmul32 { operands: BinaryOperands<FReg> };
             /// `low128(dst) = low128(src1) * low128(src2)`
-            vmul32x4 = Vmul32x4 { operands: BinaryOperands<VReg> };
+            vmulf32x4 = Vmulf32x4 { operands: BinaryOperands<VReg> };
             /// `low32(dst) = low32(src1) / low32(src2)`
             fdiv32 = Fdiv32 { operands: BinaryOperands<FReg> };
             /// `low128(dst) = low128(src1) / low128(src2)`

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -811,8 +811,12 @@ macro_rules! for_each_extended_op {
             fadd32 = Fadd32 { operands: BinaryOperands<FReg> };
             /// `low32(dst) = low32(src1) - low32(src2)`
             fsub32 = Fsub32 { operands: BinaryOperands<FReg> };
+            /// `low128(dst) = low128(src1) - low128(src2)`
+            vsub32x4 = Vsub32x4 { operands: BinaryOperands<VReg> };
             /// `low32(dst) = low32(src1) * low32(src2)`
             fmul32 = Fmul32 { operands: BinaryOperands<FReg> };
+            /// `low128(dst) = low128(src1) * low128(src2)`
+            vmul32x4 = Vmul32x4 { operands: BinaryOperands<VReg> };
             /// `low32(dst) = low32(src1) / low32(src2)`
             fdiv32 = Fdiv32 { operands: BinaryOperands<FReg> };
             /// `low128(dst) = low128(src1) / low128(src2)`
@@ -849,6 +853,8 @@ macro_rules! for_each_extended_op {
             vsqrt64x2 = Vsqrt64x2 { dst: VReg, src: VReg };
             /// `low32(dst) = -low32(src)`
             fneg32 = Fneg32 { dst: FReg, src: FReg };
+            /// `low128(dst) = -low128(src)`
+            vnegf32x4 = Vnegf32x4 { dst: VReg, src: VReg };
             /// `low32(dst) = |low32(src)|`
             fabs32 = Fabs32 { dst: FReg, src: FReg };
 


### PR DESCRIPTION
Helping towards issue #9783.

This PR makes Pulley pass `spec_testsuite/simd_f32x4_arith.wast`, by adding f32x4 instructions for subtraction, negation, multiplication, ~~and division~~ (division already got added by another PR).

Random notes:
- Added instructions placement and doc comments in `pulley/src/lib.rs` are based on what is done with `vtrunc32x4`.
- Added instructions implementation is based on `vmuli32x4`.
- How instructions are generally grouped together/ordered appears to vary, e.g. `ftrunc32`, `vtrunc32x4`, and `vtrunc64x2` are together, but `ftrunc64` isn't near there.
- It also appears inconsistent if a SIMD float instruction has an `f` at the end, e.g. `vtrunc32x4` vs. `vabsf32x4`.