### PR TITLE
feat: Implement simd_i32x4_arith2 for pulley

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -509,6 +509,7 @@
   (pulley_xmin32_u (zext32 a) (zext32 b)))
 (rule 1 (lower (has_type $I64 (umin a b))) (pulley_xmin64_u a b))
 (rule 1 (lower (has_type $I16X8 (umin a b))) (pulley_vmin16x8_u a b))
+(rule 1 (lower (has_type $I32X4 (umin a b))) (pulley_vmin32x4_u a b))
 
 ;;;; Rules for `smin` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -516,6 +517,7 @@
   (pulley_xmin32_s (sext32 a) (sext32 b)))
 (rule 1 (lower (has_type $I64 (smin a b))) (pulley_xmin64_s a b))
 (rule 1 (lower (has_type $I16X8 (smin a b))) (pulley_vmin16x8_s a b))
+(rule 1 (lower (has_type $I32X4 (smin a b))) (pulley_vmin32x4_s a b))
 
 ;;;; Rules for `umax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -523,6 +525,7 @@
   (pulley_xmax32_u (zext32 a) (zext32 b)))
 (rule 1 (lower (has_type $I64 (umax a b))) (pulley_xmax64_u a b))
 (rule 1 (lower (has_type $I16X8 (umax a b))) (pulley_vmax16x8_u a b))
+(rule 1 (lower (has_type $I32X4 (umax a b))) (pulley_vmax32x4_u a b))
 
 ;;;; Rules for `smax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -530,6 +533,7 @@
   (pulley_xmax32_s (sext32 a) (sext32 b)))
 (rule 1 (lower (has_type $I64 (smax a b))) (pulley_xmax64_s a b))
 (rule 1 (lower (has_type $I16X8 (smax a b))) (pulley_vmax16x8_s a b))
+(rule 1 (lower (has_type $I32X4 (smax a b))) (pulley_vmax32x4_s a b))
 
 ;;;; Rules for `bmask` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1239,6 +1243,7 @@
 (rule 0 (lower (has_type (fits_in_32 _) (iabs a))) (pulley_xabs32 (sext32 a)))
 (rule 1 (lower (has_type $I64 (iabs a))) (pulley_xabs64 a))
 (rule 1 (lower (has_type $I16X8 (iabs a))) (pulley_vabs16x8 a))
+(rule 1 (lower (has_type $I32X4 (iabs a))) (pulley_vabs32x4 a))
 
 ;;;; Rules for `splat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -423,7 +423,6 @@ impl WastTest {
                 "spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
                 "spec_testsuite/simd_i16x8_q15mulr_sat_s.wast",
                 "spec_testsuite/simd_i16x8_sat_arith.wast",
-                "spec_testsuite/simd_i32x4_arith2.wast",
                 "spec_testsuite/simd_i32x4_dot_i16x8.wast",
                 "spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -4263,6 +4263,26 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn vmin32x4_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_i32x4();
+        let b = self.state[operands.src2].get_i32x4();
+        for (a, b) in a.iter_mut().zip(&b) {
+            *a = (*a).min(*b);
+        }
+        self.state[operands.dst].set_i32x4(a);
+        ControlFlow::Continue(())
+    }
+
+    fn vmin32x4_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_u32x4();
+        let b = self.state[operands.src2].get_u32x4();
+        for (a, b) in a.iter_mut().zip(&b) {
+            *a = (*a).min(*b);
+        }
+        self.state[operands.dst].set_u32x4(a);
+        ControlFlow::Continue(())
+    }
+
     fn vmax16x8_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4283,9 +4303,35 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn vmax32x4_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_i32x4();
+        let b = self.state[operands.src2].get_i32x4();
+        for (a, b) in a.iter_mut().zip(&b) {
+            *a = (*a).max(*b);
+        }
+        self.state[operands.dst].set_i32x4(a);
+        ControlFlow::Continue(())
+    }
+
+    fn vmax32x4_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_u32x4();
+        let b = self.state[operands.src2].get_u32x4();
+        for (a, b) in a.iter_mut().zip(&b) {
+            *a = (*a).max(*b);
+        }
+        self.state[operands.dst].set_u32x4(a);
+        ControlFlow::Continue(())
+    }
+
     fn vabs16x8(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i16x8();
         self.state[dst].set_i16x8(a.map(|i| i.wrapping_abs()));
+        ControlFlow::Continue(())
+    }
+
+    fn vabs32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
+        let a = self.state[src].get_i32x4();
+        self.state[dst].set_i32x4(a.map(|i| i.wrapping_abs()));
         ControlFlow::Continue(())
     }
 

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -1164,8 +1164,19 @@ macro_rules! for_each_extended_op {
             /// `dst = max(src1, src2)` (unsigned)
             vmax16x8_u = Vmax16x8U { operands: BinaryOperands<VReg> };
 
+            /// `dst = min(src1, src2)` (signed)
+            vmin32x4_s = Vmin32x4S { operands: BinaryOperands<VReg> };
+            /// `dst = min(src1, src2)` (unsigned)
+            vmin32x4_u = Vmin32x4U { operands: BinaryOperands<VReg> };
+            /// `dst = max(src1, src2)` (signed)
+            vmax32x4_s = Vmax32x4S { operands: BinaryOperands<VReg> };
+            /// `dst = max(src1, src2)` (unsigned)
+            vmax32x4_u = Vmax32x4U { operands: BinaryOperands<VReg> };
+
             /// `dst = |src|`
             vabs16x8 = Vabs16x8 { dst: VReg, src: VReg };
+            /// `dst = |src|`
+            vabs32x4 = Vabs32x4 { dst: VReg, src: VReg };
 
             /// `dst = |src|`
             vabsf32x4 = Vabsf32x4 { dst: VReg, src: VReg };


### PR DESCRIPTION
Part of https://github.com/bytecodealliance/wasmtime/issues/9783

---

This PR adds the following instructions for pulley:

- vmin32x4_s
- vmin32x4_u 
- vmax32x4_s
- vmax32x4_u 
- vabs32x4

which helped pass the `simd_i32x4_arith2` test.