### PR TITLE
Fix incorrect frame code offset in coredump

### DIFF
--- a/crates/wasmtime/src/runtime/instantiate.rs
+++ b/crates/wasmtime/src/runtime/instantiate.rs
@@ -293,6 +293,12 @@ impl CompiledModule {
     pub fn has_address_map(&self) -> bool {
         !self.code_memory.address_map_data().is_empty()
     }
+
+    /// Returns the binary offset in the original wasm file to the start of the
+    /// code section.
+    pub fn code_section_offset(&self) -> u64 {
+        self.meta.code_section_offset
+    }
 }
 
 #[cfg(feature = "addr2line")]

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1118,6 +1118,20 @@ impl Module {
 
         Some(&info.stack_maps[index].stack_map)
     }
+
+    /// Converts an absolute binary offset into a relative to the code section
+    /// one. Useful for generating Wasm codedump.
+    ///
+    /// Panics if the provided `codeoffset` is before the code section.
+    pub(crate) fn get_relative_codeoffset(&self, codeoffset: u32) -> u32 {
+        let code_section_offset = self.inner.module.code_section_offset();
+
+        assert!(
+            (codeoffset as u64) >= code_section_offset,
+            "the codeoffset cannot be before the code section"
+        );
+        (codeoffset as u64 - code_section_offset) as u32
+    }
 }
 
 /// Describes a function for a given module.


### PR DESCRIPTION
Currently, coredump include incorrect code offsets, the generation relies on `func_offset()` which returns the instruction's offset relative to the function.

This change uses `module_offset()` to get the absolute code offset and, using a new method `get_relative_codeoffset`, converts the offset to be relative to the code section.

Also, the `name` property has been removed because it's misleading when displayed and not actually useful.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
