### PR TITLE
c-api: Enable debugger DWARF export for guest code

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -56,5 +56,6 @@ gc-drc = ["wasmtime/gc-drc"]
 gc-null = ["wasmtime/gc-null"]
 cranelift = ['wasmtime/cranelift']
 winch = ['wasmtime/winch']
+debug-builtins = ['wasmtime/debug-builtins']
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/artifact/Cargo.toml
+++ b/crates/c-api/artifact/Cargo.toml
@@ -38,6 +38,7 @@ default = [
   'gc-null',
   'cranelift',
   'winch',
+  'debug-builtins',
   # ... if you add a line above this be sure to change the other locations
   # marked WASMTIME_FEATURE_LIST
 ]
@@ -58,5 +59,6 @@ gc-drc = ["wasmtime-c-api/gc-drc"]
 gc-null = ["wasmtime-c-api/gc-null"]
 cranelift = ["wasmtime-c-api/cranelift"]
 winch = ["wasmtime-c-api/winch"]
+debug-builtins = ["wasmtime-c-api/debug-builtins"]
 # ... if you add a line above this be sure to read the comment at the end of
 # `default`

--- a/crates/c-api/build.rs
+++ b/crates/c-api/build.rs
@@ -19,6 +19,7 @@ const FEATURES: &[&str] = &[
     "GC_NULL",
     "CRANELIFT",
     "WINCH",
+    "DEBUG_BUILTINS",
 ];
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/cmake/features.cmake
+++ b/crates/c-api/cmake/features.cmake
@@ -43,5 +43,6 @@ feature(gc-null ON)
 feature(async ON)
 feature(cranelift ON)
 feature(winch ON)
+feature(debug-builtins ON)
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/include/wasmtime/conf.h.in
+++ b/crates/c-api/include/wasmtime/conf.h.in
@@ -25,6 +25,7 @@
 #cmakedefine WASMTIME_FEATURE_ASYNC
 #cmakedefine WASMTIME_FEATURE_CRANELIFT
 #cmakedefine WASMTIME_FEATURE_WINCH
+#cmakedefine WASMTIME_FEATURE_DEBUG_BUILTINS
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,8 @@ function(CREATE_TARGET TARGET TARGET_PATH)
 		target_compile_options(wasmtime-${TARGET} PRIVATE /W3)
 	endif()
 
+        target_compile_definitions(wasmtime-${TARGET} PRIVATE WASMTIME_TEST_ONLY)
+
 	set_target_properties(wasmtime-${TARGET} PROPERTIES
 		OUTPUT_NAME wasmtime-${TARGET}
 		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/$<0:>


### PR DESCRIPTION
In order to allow source level debugging of hosted webassembly code in C-based embeddings, we must enable the debug-builtins cargo feature when building the C api. This allows for embeddings of wasmtime in non-rust environments to benefit from the integration with [gdb/lldb's JIT debug interface](https://sourceware.org/gdb/current/onlinedocs/gdb.html/JIT-Interface.html).

Fixes #9909 

---

Tests: I have tested this manually per the notes in the linked issue, and have single-stepped through the code to confirm it is behaving as I expect (I basically did a side-by side step through with an equivalent rust program linked with the default settings and `wasmtime` cargo dependency).

For automated tests, I have a simple strategy: I can validate that the GDB structures are actually set up in the fib-debug/main.c. It's a little hacky so I've added as a second commit. The strategy is to validate the actual `__jit_debug_descriptor` that's created is non-NULL after instantiation. As these examples are used by other people, I have gated the code with a compile definition that's only set during the tests.

I have confirmed this test fails without my patch and passes with it.