### PR TITLE
Reword `LinearMemory` and `MemoryCreator` note in docs about being a new API

### DIFF
--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -669,8 +669,8 @@ impl Memory {
 /// guard page.  Additionally the safety concerns explained in ['Memory'], for
 /// accessing the memory apply here as well.
 ///
-/// Note that this is a relatively new and experimental feature and it is
-/// recommended to be familiar with wasmtime runtime code to use it.
+/// Note that this is a relatively advanced feature and it is recommended to be
+/// familiar with wasmtime runtime code to use it.
 pub unsafe trait LinearMemory: Send + Sync + 'static {
     /// Returns the number of allocated bytes which are accessible at this time.
     fn byte_size(&self) -> usize;
@@ -702,8 +702,8 @@ pub unsafe trait LinearMemory: Send + Sync + 'static {
 /// treated as owned by wasmtime instance, and any modification of them outside
 /// of wasmtime invoked routines is unsafe and may lead to corruption.
 ///
-/// Note that this is a relatively new and experimental feature and it is
-/// recommended to be familiar with wasmtime runtime code to use it.
+/// Note that this is a relatively advanced feature and it is recommended to be
+/// familiar with Wasmtime runtime code to use it.
 pub unsafe trait MemoryCreator: Send + Sync {
     /// Create a new `LinearMemory` object from the specified parameters.
     ///


### PR DESCRIPTION
The API is three and a half years old at this point. Not really new anymore. But still something that requires care to use well, so leaving the disclaimer in place, just adjusted for 2025.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
