### PR TITLE
feat: Implement simd_f64x2_arith for pulley

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -1157,17 +1157,20 @@
 
 (rule (lower (has_type $F32 (fsub a b))) (pulley_fsub32 a b))
 (rule (lower (has_type $F64 (fsub a b))) (pulley_fsub64 a b))
+(rule (lower (has_type $F64X2 (fsub a b))) (pulley_vsubf64x2 a b))
 
 ;;;; Rules for `fmul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fmul a b))) (pulley_fmul32 a b))
 (rule (lower (has_type $F64 (fmul a b))) (pulley_fmul64 a b))
+(rule (lower (has_type $F64X2 (fmul a b))) (pulley_vmulf64x2 a b))
 
 ;;;; Rules for `fdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fdiv a b))) (pulley_fdiv32 a b))
 (rule (lower (has_type $F64 (fdiv a b))) (pulley_fdiv64 a b))
 (rule (lower (has_type $F32X4 (fdiv a b))) (pulley_vdivf32x4 a b))
+(rule (lower (has_type $F64X2 (fdiv a b))) (pulley_vdivf64x2 a b))
 
 ;;;; Rules for `fmax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1230,6 +1233,7 @@
 
 (rule (lower (has_type $F32 (fneg a))) (pulley_fneg32 a))
 (rule (lower (has_type $F64 (fneg a))) (pulley_fneg64 a))
+(rule (lower (has_type $F64X2 (fneg a))) (pulley_vnegf64x2 a))
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -411,7 +411,6 @@ impl WastTest {
                 "spec_testsuite/simd_f32x4_arith.wast",
                 "spec_testsuite/simd_f32x4_cmp.wast",
                 "spec_testsuite/simd_f32x4_pmin_pmax.wast",
-                "spec_testsuite/simd_f64x2_arith.wast",
                 "spec_testsuite/simd_f64x2_cmp.wast",
                 "spec_testsuite/simd_f64x2_pmin_pmax.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -3007,6 +3007,19 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn vdivf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let a = self.state[operands.src1].get_f64x2();
+        let b = self.state[operands.src2].get_f64x2();
+        let mut result = [0.0f64; 2];
+
+        for i in 0..2 {
+            result[i] = a[i] / b[i];
+        }
+
+        self.state[operands.dst].set_f64x2(result);
+        ControlFlow::Continue(())
+    }
+
     fn fmaximum32(&mut self, operands: BinaryOperands<FReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f32();
         let b = self.state[operands.src2].get_f32();
@@ -3900,6 +3913,16 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn vsubf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_f64x2();
+        let b = self.state[operands.src2].get_f64x2();
+        for (a, b) in a.iter_mut().zip(b) {
+            *a = *a - b;
+        }
+        self.state[operands.dst].set_f64x2(a);
+        ControlFlow::Continue(())
+    }
+
     fn vmuli8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -3937,6 +3960,16 @@ impl ExtendedOpVisitor for Interpreter<'_> {
             *a = a.wrapping_mul(b);
         }
         self.state[operands.dst].set_i64x2(a);
+        ControlFlow::Continue(())
+    }
+
+    fn vmulf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
+        let mut a = self.state[operands.src1].get_f64x2();
+        let b = self.state[operands.src2].get_f64x2();
+        for (a, b) in a.iter_mut().zip(b) {
+            *a = *a * b;
+        }
+        self.state[operands.dst].set_f64x2(a);
         ControlFlow::Continue(())
     }
 
@@ -4364,6 +4397,12 @@ impl ExtendedOpVisitor for Interpreter<'_> {
     fn vneg64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i64x2();
         self.state[dst].set_i64x2(a.map(|i| i.wrapping_neg()));
+        ControlFlow::Continue(())
+    }
+
+    fn vnegf64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
+        let a = self.state[src].get_f64x2();
+        self.state[dst].set_f64x2(a.map(|i| -i));
         ControlFlow::Continue(())
     }
 

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -860,6 +860,8 @@ macro_rules! for_each_extended_op {
             fmul64 = Fmul64 { operands: BinaryOperands<FReg> };
             /// `dst = src1 / src2`
             fdiv64 = Fdiv64 { operands: BinaryOperands<FReg> };
+            /// `dst = src1 / src2`
+            vdivf64x2 = VDivF64x2 { operands: BinaryOperands<VReg> };
             /// `dst = ieee_maximum(src1, src2)`
             fmaximum64 = Fmaximum64 { operands: BinaryOperands<FReg> };
             /// `dst = ieee_minimum(src1, src2)`
@@ -1075,6 +1077,8 @@ macro_rules! for_each_extended_op {
             vsubi32x4 = VSubI32x4 { operands: BinaryOperands<VReg> };
             /// `dst = src1 - src2`
             vsubi64x2 = VSubI64x2 { operands: BinaryOperands<VReg> };
+            /// `dst = src1 - src2`
+            vsubf64x2 = VSubF64x2 { operands: BinaryOperands<VReg> };
 
             /// `dst = saturating_sub(src1, src2)`
             vsubi8x16_sat = VSubI8x16Sat { operands: BinaryOperands<VReg> };
@@ -1093,6 +1097,8 @@ macro_rules! for_each_extended_op {
             vmuli32x4 = VMulI32x4 { operands: BinaryOperands<VReg> };
             /// `dst = src1 * src2`
             vmuli64x2 = VMulI64x2 { operands: BinaryOperands<VReg> };
+            /// `dst = src1 * src2`
+            vmulf64x2 = VMulF64x2 { operands: BinaryOperands<VReg> };
 
             /// `dst = signed_saturate(src1 * src2 + (1 << (Q - 1)) >> Q)`
             vqmulrsi16x8 = VQmulrsI16x8 { operands: BinaryOperands<VReg> };
@@ -1183,6 +1189,8 @@ macro_rules! for_each_extended_op {
             vneg32x4 = Vneg32x4 { dst: VReg, src: VReg };
             /// `dst = -src`
             vneg64x2 = Vneg64x2 { dst: VReg, src: VReg };
+            /// `dst = -src`
+            vnegf64x2 = VnegF64x2 { dst: VReg, src: VReg };
 
             /// `dst = min(src1, src2)` (signed)
             vmin8x16_s = Vmin8x16S { operands: BinaryOperands<VReg> };


### PR DESCRIPTION
Part of https://github.com/bytecodealliance/wasmtime/issues/9783

This PR implemented the following f64x2 SIMD instructions and made the "spec_testsuite/simd_f64x2_arith.wast" tests pass.
- vsubf64x2
- vmulf64x2
- vdivf64x2
- vnegf64x2

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
