### PR TITLE
winch: Standardize method naming convention accross the assemblers

### DIFF
--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -260,7 +260,7 @@ impl Assembler {
     }
 
     /// Emit an unwind instruction.
-    pub fn emit_unwind_inst(&mut self, inst: UnwindInst) {
+    pub fn unwind_inst(&mut self, inst: UnwindInst) {
         self.emit(Inst::Unwind { inst })
     }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -73,7 +73,7 @@ impl Masm for MacroAssembler {
         self.asm.push_r(frame_pointer);
 
         if self.shared_flags.unwind_info() {
-            self.asm.emit_unwind_inst(UnwindInst::PushFrameRegs {
+            self.asm.unwind_inst(UnwindInst::PushFrameRegs {
                 offset_upward_to_caller_sp: Self::ABI::arg_base_offset().into(),
             })
         }
@@ -105,7 +105,7 @@ impl Masm for MacroAssembler {
 
         // Emit unwind info.
         if self.shared_flags.unwind_info() {
-            self.asm.emit_unwind_inst(UnwindInst::DefineNewFrame {
+            self.asm.unwind_inst(UnwindInst::DefineNewFrame {
                 offset_upward_to_caller_sp: Self::ABI::arg_base_offset().into(),
 
                 // The Winch calling convention has no callee-save registers, so nothing will be


### PR DESCRIPTION
The initial convention was to name all the methods after the instructions they represent (e.g., `fn mov_ir`). This convention has diverged over time, most noticeably in the AArch64 assembler.

The intention of this commit is primarily for bookkeeping purposes, in order to maintain a consistent naming convention.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
