### PR TITLE
jit module return code slice

### DIFF
--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -408,11 +408,7 @@ impl JITModule {
         }
     }
 
-    /// Returns the address of a finalized function.
-    ///
-    /// The pointer remains valid until either [`JITModule::free_memory`] is called or in the future
-    /// some way of deallocating this individual function is used.
-    pub fn get_finalized_function(&self, func_id: FuncId) -> *const u8 {
+    fn get_finalized_function_inner(&self, func_id: FuncId) -> &CompiledBlob {
         let info = &self.compiled_functions[func_id];
         assert!(
             !self.functions_to_finalize.iter().any(|x| *x == func_id),
@@ -420,7 +416,19 @@ impl JITModule {
         );
         info.as_ref()
             .expect("function must be compiled before it can be finalized")
-            .ptr
+    }
+
+    /// Returns the address of a finalized function.
+    ///
+    /// The pointer remains valid until either [`JITModule::free_memory`] is called or in the future
+    /// some way of deallocating this individual function is used.
+    pub fn get_finalized_function(&self, func_id: FuncId) -> *const u8 {
+        self.get_finalized_function_inner(func_id).ptr
+    }
+
+    /// Returns the bytes of a finalized function.
+    pub fn get_finalized_function_bytes(&self, func_id: FuncId) -> &[u8] {
+        self.get_finalized_function_inner(func_id).code()
     }
 
     /// Returns the address and size of a finalized data object.

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -20,6 +20,10 @@ pub(crate) struct CompiledBlob {
 unsafe impl Send for CompiledBlob {}
 
 impl CompiledBlob {
+    pub(crate) fn code(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.size) }
+    }
+
     pub(crate) fn perform_relocations(
         &self,
         get_address: impl Fn(&ModuleRelocTarget) -> *const u8,


### PR DESCRIPTION
It can be usefull to get the compiled function as a slice from a `JITModule`, for example, if one wants to disassemble it, to inspect the assembled code. It is currently possible to get pseudo assembly from the module context, by explicitely requesting `ctx.want_disasm`, but it is not very practical and it is not the _actual_ machine code.
