### PR TITLE
Bump Wasmtime to 30.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "29.0.0"
+version = "30.0.0"
 
 [[package]]
 name = "byteorder"
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -709,14 +709,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "cranelift-codegen-shared",
  "pulley-interpreter",
@@ -765,18 +765,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.116.0"
+version = "0.117.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1188,7 +1188,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3614,7 +3614,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.221.2",
@@ -3664,7 +3664,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4023,14 +4023,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4046,14 +4046,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4204,11 +4204,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "29.0.0"
+version = "30.0.0"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "object",
  "rustix",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4380,14 +4380,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-math"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "29.0.0"
+version = "30.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4402,7 +4402,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast-util"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -4545,7 +4545,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "29.0.0"
+version = "30.0.0"
 
 [[package]]
 name = "wast"
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4733,7 +4733,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "29.0.0"
+version = "30.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "29.0.0"
+version = "30.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -204,61 +204,61 @@ allow_attributes_without_reason = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.4.0" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=29.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "29.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=29.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=29.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=29.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=29.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=29.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=29.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=29.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=29.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=29.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=29.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "29.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=29.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "29.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "29.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "29.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "29.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=29.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=29.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=29.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=29.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=29.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=30.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "30.0.0", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=30.0.0" }
+wasmtime-cache = { path = "crates/cache", version = "=30.0.0" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=30.0.0" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=30.0.0" }
+wasmtime-winch = { path = "crates/winch", version = "=30.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=30.0.0" }
+wasmtime-explorer = { path = "crates/explorer", version = "=30.0.0" }
+wasmtime-fiber = { path = "crates/fiber", version = "=30.0.0" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=30.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=30.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "30.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=30.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "30.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "30.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "30.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "30.0.0" }
+wasmtime-component-util = { path = "crates/component-util", version = "=30.0.0" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=30.0.0" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=30.0.0" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=30.0.0" }
+wasmtime-slab = { path = "crates/slab", version = "=30.0.0" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=29.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=29.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=29.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=29.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=30.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=30.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=30.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=30.0.0", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=29.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=29.0.0" }
-wasmtime-math = { path = "crates/math", version = "=29.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=30.0.0" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=30.0.0" }
+wasmtime-math = { path = "crates/math", version = "=30.0.0" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=29.0.0" }
+pulley-interpreter = { path = 'pulley', version = "=30.0.0" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-codegen = { path = "cranelift/codegen", version = "0.116.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.116.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.116.0" }
-cranelift-native = { path = "cranelift/native", version = "0.116.0" }
-cranelift-module = { path = "cranelift/module", version = "0.116.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.116.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.116.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.117.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.117.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.117.0" }
+cranelift-native = { path = "cranelift/native", version = "0.117.0" }
+cranelift-module = { path = "cranelift/module", version = "0.117.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.117.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.117.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.116.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.116.0" }
+cranelift-object = { path = "cranelift/object", version = "0.117.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.117.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.116.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.116.0" }
-cranelift-control = { path = "cranelift/control", version = "0.116.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.116.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.117.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.117.0" }
+cranelift-control = { path = "cranelift/control", version = "0.117.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.117.0" }
 
-winch-codegen = { path = "winch/codegen", version = "=29.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=30.0.0" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 29.0.0
+## 30.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [29.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-29.0.0/RELEASES.md)
 * [28.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-28.0.0/RELEASES.md)
 * [27.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-27.0.0/RELEASES.md)
 * [26.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-26.0.0/RELEASES.md)

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.116.0"
+version = "0.117.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.116.0"
+version = "0.117.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.116.0"
+version = "0.117.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -24,7 +24,7 @@ features = ["all-arch"]
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.116.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.117.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -53,8 +53,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.116.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.116.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.117.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.117.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.116.0"
+version = "0.117.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,7 +16,7 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.116.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.117.0" }
 pulley-interpreter = { workspace = true, optional = true }
 
 [features]

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.116.0"
+version = "0.117.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.116.0"
+version = "0.117.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.116.0"
+version = "0.117.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.116.0"
+version = "0.117.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.116.0"
+version = "0.117.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.116.0"
+version = "0.117.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.116.0"
+version = "0.117.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.116.0"
+version = "0.117.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.116.0"
+version = "0.117.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.116.0"
+version = "0.117.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.116.0"
+version = "0.117.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.116.0"
+version = "0.117.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.116.0"
+version = "0.117.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,11 +206,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "29.0.0"
+#define WASMTIME_VERSION "30.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 29
+#define WASMTIME_VERSION_MAJOR 30
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -16,6 +20,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-bforest]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.115.0"
@@ -25,6 +33,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -32,6 +44,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-codegen]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.115.0"
@@ -41,6 +57,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -48,6 +68,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-control]]
 version = "0.115.0"
@@ -57,6 +81,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-control]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -64,6 +92,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-entity]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.115.0"
@@ -73,6 +105,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -80,6 +116,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.115.0"
@@ -89,6 +129,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -96,6 +140,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-jit]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-module]]
 version = "0.115.0"
@@ -105,6 +153,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-module]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-native]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -112,6 +164,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-native]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-native]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-object]]
 version = "0.115.0"
@@ -121,6 +177,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-object]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -128,6 +188,10 @@ audited_as = "0.113.1"
 [[unpublished.cranelift-reader]]
 version = "0.116.0"
 audited_as = "0.114.0"
+
+[[unpublished.cranelift-reader]]
+version = "0.117.0"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-serde]]
 version = "0.115.0"
@@ -137,6 +201,10 @@ audited_as = "0.113.1"
 version = "0.116.0"
 audited_as = "0.114.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.117.0"
+audited_as = "0.115.0"
+
 [[unpublished.pulley-interpreter]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -144,6 +212,10 @@ audited_as = "26.0.1"
 [[unpublished.pulley-interpreter]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasi-common]]
 version = "28.0.0"
@@ -153,6 +225,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasi-common]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -160,6 +236,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "28.0.0"
@@ -169,6 +249,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-cache]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -176,6 +260,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-cache]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-cache]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-cli]]
 version = "28.0.0"
@@ -185,6 +273,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-cli]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -192,6 +284,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-cli-flags]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-component-macro]]
 version = "28.0.0"
@@ -201,6 +297,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-component-macro]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-component-util]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -208,6 +308,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-component-util]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-component-util]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-cranelift]]
 version = "28.0.0"
@@ -217,6 +321,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-cranelift]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -224,6 +332,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-environ]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-explorer]]
 version = "28.0.0"
@@ -233,6 +345,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-explorer]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-fiber]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -240,6 +356,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-fiber]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-fiber]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "28.0.0"
@@ -249,6 +369,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -256,6 +380,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-slab]]
 version = "28.0.0"
@@ -265,6 +393,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-slab]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wasi]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -272,6 +404,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-wasi]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-wasi]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "28.0.0"
@@ -281,6 +417,10 @@ audited_as = "27.0.0"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -288,6 +428,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "28.0.0"
@@ -297,6 +441,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -304,6 +452,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "28.0.0"
@@ -313,6 +465,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -320,6 +476,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-wast]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-wast]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-winch]]
 version = "28.0.0"
@@ -329,6 +489,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-winch]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -336,6 +500,10 @@ audited_as = "26.0.1"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "28.0.0"
@@ -345,6 +513,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wiggle]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -352,6 +524,10 @@ audited_as = "26.0.1"
 [[unpublished.wiggle]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wiggle]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wiggle-generate]]
 version = "28.0.0"
@@ -361,6 +537,10 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -368,6 +548,10 @@ audited_as = "26.0.1"
 [[unpublished.wiggle-macro]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -380,6 +564,10 @@ audited_as = "26.0.1"
 [[unpublished.winch-codegen]]
 version = "29.0.0"
 audited_as = "27.0.0"
+
+[[unpublished.winch-codegen]]
+version = "30.0.0"
+audited_as = "28.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -585,104 +773,104 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.114.0"
-when = "2024-11-20"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -897,8 +1085,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1133,8 +1321,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1222,146 +1410,146 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-slab]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1385,20 +1573,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1417,8 +1605,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-29.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 29.0.0 to 30.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 29.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-29.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-29.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-29.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
