### PR TITLE
Clarify rebasing/merging guidelines in docs

### DIFF
--- a/docs/contributing-development-process.md
+++ b/docs/contributing-development-process.md
@@ -52,8 +52,15 @@ Once someone has reviewed your PR, it's easier for us if you _don't_ rebase it
 when making further changes. Instead, at that point we prefer that you make new
 commits on top of the already-reviewed work.
 
-That said, sometimes we may need to ask you to rebase for various technical
-reasons. If you need help doing that, please ask!
+That said rebasing (or merging from `main`) may still be required in situations
+such as:
+
+* Your PR has a merge conflict with the `main` branch.
+* CI on your PR is failing for unrelated reasons and a fix was applied to `main`
+  which needs to be picked up on your branch.
+* Other miscellaneous technical reasons may cause us to ask for a rebase.
+
+If you need help rebasing or merging, please ask!
 
 ### Review and merge
 


### PR DESCRIPTION
Indicate that a rebase is required if there's a merge conflict or CI issues for example. Inspired by discussion on #9897

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
