### PR TITLE
Add return code checking in CMakeList.txt in examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,7 +38,13 @@ function(CREATE_RUST_TEST EXAMPLE)
 	endif()
 endfunction()
 function(CREATE_RUST_WASM EXAMPLE TARGET)
-	execute_process(COMMAND cargo build -p example-${EXAMPLE}-wasm --target ${TARGET})
+	execute_process(
+        COMMAND cargo build -p example-${EXAMPLE}-wasm --target ${TARGET}
+        RESULT_VARIABLE CARGO_RESULT
+    )
+    if(NOT CARGO_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to build Rust WASM target: ${EXAMPLE} for ${TARGET}")
+    endif()
 endfunction()
 
 # Enable testing


### PR DESCRIPTION
This attempts to partially solve #9932, adding checking return code of the executed command `cargo build`, which can fail, for example, if a target has not been added.

I don't know whether there are similar cases somewhere else, in which the return code of an executed command is simply ignored.

In this file, however, when I asked Claude "are there anything else that will cause silent failures in this file", it says the following. I think what it says makes sense, but I don't know much about cmake, so I don't know if it's correct.
<details>
Yes, there are a few potential sources of silent failures in this CMake file:

1. The `create_rust_test` function also uses `cargo run` without checking return codes:
```cmake
function(CREATE_RUST_TEST EXAMPLE)
    # These tests might fail silently during test execution
    if(ARGC GREATER 1)
        add_test(NAME ${EXAMPLE}-rust COMMAND cargo run --example ${EXAMPLE} --features ${ARGV1} WORKING_DIRECTORY ../..)
    else()
        add_test(NAME ${EXAMPLE}-rust COMMAND cargo run --example ${EXAMPLE} WORKING_DIRECTORY ../..)
    endif()
endfunction()
```

2. The `add_subdirectory` command at the beginning might fail silently if the directory doesn't exist:
```cmake
add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../crates/c-api ${CMAKE_CURRENT_BINARY_DIR}/wasmtime)
```

3. In the `CREATE_TARGET` function, the linking against CoreFoundation on Apple platforms doesn't verify if the framework exists:
```cmake
if(APPLE)
    target_link_libraries(wasmtime-${TARGET} PRIVATE "-framework CoreFoundation")
endif()
```

To make the file more robust, you could:

1. Add existence checks for required directories and files
2. Add `REQUIRED` to framework findings
3. Set test properties to fail on non-zero return codes:

```cmake
function(CREATE_RUST_TEST EXAMPLE)
    if(ARGC GREATER 1)
        add_test(NAME ${EXAMPLE}-rust 
                COMMAND cargo run --example ${EXAMPLE} --features ${ARGV1}
                WORKING_DIRECTORY ../..)
    else()
        add_test(NAME ${EXAMPLE}-rust 
                COMMAND cargo run --example ${EXAMPLE}
                WORKING_DIRECTORY ../..)
    endif()
    # Make the test fail if cargo returns non-zero
    set_tests_properties(${EXAMPLE}-rust PROPERTIES WILL_FAIL FALSE)
endfunction()
```

Also, it's worth noting that the relative paths (`../..`) in `WORKING_DIRECTORY` could be fragile if the directory structure changes. It would be more robust to use absolute paths or CMake variables to reference directories.
</details>

