### PR TITLE
Clarify MSRV intent in contributor docs

### DIFF
--- a/docs/contributing-coding-guidelines.md
+++ b/docs/contributing-coding-guidelines.md
@@ -89,7 +89,7 @@ $ cargo clippy --workspace --all-targets
 Contributors are welcome to enable new lints and send PRs for this. Feel free to
 reach out if you're not sure about a lint as well.
 
-### Minimum Supported `rustc` Version
+### Minimum Supported `rustc` Version (MSRV)
 
 Wasmtime and Cranelift support the latest three stable releases of Rust. This
 means that if the latest version of Rust is 1.72.0 then Wasmtime supports Rust
@@ -102,6 +102,13 @@ periodically and the general repository does not depend on nightly features.
 
 Updating Wasmtime's MSRV is done by editing the `rust-version` field in the
 workspace root's `Cargo.toml`
+
+Note that this policy is subject to change over time (notably it might be
+extended to include more rustc versions). Current Wasmtime users don't require a
+larger MSRV window to justify the maintenance needed to have a larger window. If
+your use case requires a larger MSRV range though please feel free to contact
+maintainers to raise your use case (e.g. an issue, in a Wasmtime meeting, on
+Zulip, etc).
 
 ### Dependencies of Wasmtime
 


### PR DESCRIPTION
Currently we support 3 versions of rustc (current, current-1, and current-2). This is probably too small a window for someone out there on the internet so this commit adds a clarification with some rationale for the current policy as well as an olive branch for "please talk to us if you want a wider window". Basically I wanted to update this to explicitly declare intent that we're open to reconsidering this policy as necessary (without actually committing to any alternative policy yet).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
