### PR TITLE
Enable the memory64 proposal by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2023,6 +2023,7 @@ impl Config {
         features |= WasmFeatures::RELAXED_SIMD;
         features |= WasmFeatures::TAIL_CALL;
         features |= WasmFeatures::EXTENDED_CONST;
+        features |= WasmFeatures::MEMORY64;
         // NB: if you add a feature above this line please double-check
         // https://docs.wasmtime.dev/stability-wasm-proposals.html
         // to ensure all requirements are met and/or update the documentation

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -26,6 +26,7 @@ column is below.
 | [`threads`]              | ✅      | ✅    | ✅[^9]   | ❌[^3] | ✅  | ✅    |
 | [`tail-call`]            | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`extended-const`]       | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`memory64`]             | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 
 [^1]: The `component-model` proposal is not at phase 4 in the standardization
     process but it is still enabled-by-default in Wasmtime.
@@ -45,7 +46,6 @@ column is below.
 
 |  Proposal                | Phase 4 | Tests | Finished | Fuzzed | API | C API |
 |--------------------------|---------|-------|----------|--------|-----|-------|
-| [`memory64`]             | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`function-references`]  | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
 | [`gc`] [^6]              | ✅      | ✅    | ❌[^7]   | ❌     | ✅  | ❌    |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |


### PR DESCRIPTION
The memory64 proposal for WebAssembly moved to phase 4 early last November which was the final remaining blocker for enabling it in Wasmtime. I've gone ahead and enabled it here with all the other checkboxes being ticked such as:

* Tests - all spec tests are enabled and we have a few tests here and there for memory64 behavior throughout the unit test suite.

* Finished - this proposal's memory-facing bits have been done for quite some time and the final 64-bit table bits have been done for a bit now as well.

* Fuzzed - this is enabled in `wasm-smith` and additionally has custom fuzzing via the `memory_accesses` fuzzer.

* API - all APIs related to memory work with `u64` values to accommodate 64-bit memories and the 64-bit-ness is reflected in the type of memories.

* C API - the C API's functions for working with memories all reflect 64-bit indices like the Rust API.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
