### PR TITLE
Move gdbjit C helpers to a separate file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,6 +4364,7 @@ dependencies = [
 name = "wasmtime-jit-debug"
 version = "30.0.0"
 dependencies = [
+ "cc",
  "object",
  "rustix",
  "wasmtime-versioned-export-macros",

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -14,6 +14,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[build-dependencies]
+cc = { workspace = true }
+wasmtime-versioned-export-macros = { workspace = true }
+
 [dependencies]
 object = { workspace = true, optional = true }
 wasmtime-versioned-export-macros = { workspace = true }

--- a/crates/jit-debug/build.rs
+++ b/crates/jit-debug/build.rs
@@ -1,0 +1,17 @@
+use wasmtime_versioned_export_macros::versioned_suffix;
+
+fn main() {
+    if !cfg!(feature = "gdb_jit_int") {
+        return;
+    }
+
+    let mut build = cc::Build::new();
+    build.warnings(true);
+    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    build.define(&format!("CFG_TARGET_OS_{os}"), None);
+    build.define("VERSIONED_SUFFIX", Some(versioned_suffix!()));
+
+    println!("cargo:rerun-if-changed=gdbjit.c");
+    build.file("gdbjit.c");
+    build.compile("gdbjit-helpers");
+}

--- a/crates/jit-debug/gdbjit.c
+++ b/crates/jit-debug/gdbjit.c
@@ -1,0 +1,46 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#define CONCAT2(a, b) a##b
+#define CONCAT(a, b) CONCAT2(a, b)
+#define VERSIONED_SYMBOL(a) CONCAT(a, VERSIONED_SUFFIX)
+
+#ifdef CFG_TARGET_OS_windows
+// export required for external access.
+__declspec(dllexport)
+#else
+// Note the `weak` linkage here, though, which is intended to let other code
+// override this symbol if it's defined elsewhere, since this definition doesn't
+// matter.
+// Just in case cross-language LTO is enabled we set the `noinline` attribute
+// and also try to have some sort of side effect in this function with a dummy
+// `asm` statement.
+__attribute__((weak, noinline))
+#endif
+    void __jit_debug_register_code() {
+#ifndef CFG_TARGET_OS_windows
+  __asm__("");
+#endif
+}
+
+struct JITDescriptor {
+  uint32_t version_;
+  uint32_t action_flag_;
+  void *relevant_entry_;
+  void *first_entry_;
+};
+
+#ifdef CFG_TARGET_OS_windows
+// export required for external access.
+__declspec(dllexport)
+#else
+// Note the `weak` linkage here which is the same purpose as above. We want to
+// let other runtimes be able to override this since our own definition isn't
+// important.
+__attribute__((weak))
+#endif
+struct JITDescriptor __jit_debug_descriptor = {1, 0, NULL, NULL};
+
+struct JITDescriptor *VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)() {
+  return &__jit_debug_descriptor;
+}

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -101,6 +101,8 @@ impl Engine {
             // handlers, etc.
             #[cfg(all(feature = "signals-based-traps", not(miri)))]
             crate::runtime::vm::init_traps(config.macos_use_mach_ports);
+            #[cfg(feature = "debug-builtins")]
+            crate::runtime::vm::debug_builtins::init();
         }
 
         #[cfg(any(feature = "cranelift", feature = "winch"))]

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -101,8 +101,10 @@ impl Engine {
             // handlers, etc.
             #[cfg(all(feature = "signals-based-traps", not(miri)))]
             crate::runtime::vm::init_traps(config.macos_use_mach_ports);
-            #[cfg(feature = "debug-builtins")]
-            crate::runtime::vm::debug_builtins::init();
+            if !cfg!(miri) {
+                #[cfg(feature = "debug-builtins")]
+                crate::runtime::vm::debug_builtins::init();
+            }
         }
 
         #[cfg(any(feature = "cranelift", feature = "winch"))]

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -33,3 +33,18 @@ pub unsafe extern "C" fn set_vmctx_memory(vmctx_ptr: *mut VMContext) {
     // TODO multi-memory
     VMCTX_AND_MEMORY = (vmctx_ptr, 0);
 }
+
+/// A bit of a hack around various linkage things. The goal here is to force the
+/// `wasmtime_*` symbols defined in `helpers.c` to actually get exported. That
+/// means they need to be referenced for the linker to include them which is
+/// what this function does with trickery in C.
+pub fn init() {
+    extern "C" {
+        #[wasmtime_versioned_export_macros::versioned_link]
+        fn wasmtime_debug_builtins_init();
+    }
+
+    unsafe {
+        wasmtime_debug_builtins_init();
+    }
+}

--- a/crates/wasmtime/src/runtime/vm/helpers.c
+++ b/crates/wasmtime/src/runtime/vm/helpers.c
@@ -96,6 +96,17 @@ void VERSIONED_SYMBOL(set_vmctx_memory)(void *);
 DEBUG_BUILTIN_EXPORT void VERSIONED_SYMBOL(wasmtime_set_vmctx_memory)(void *p) {
   VERSIONED_SYMBOL(set_vmctx_memory)(p);
 }
+
+// Helper symbol called from Rust to force the above two functions to not get
+// stripped by the linker.
+void VERSIONED_SYMBOL(wasmtime_debug_builtins_init)() {
+#ifndef CFG_TARGET_OS_windows
+  void *volatile p;
+  p = (void *)&VERSIONED_SYMBOL(wasmtime_resolve_vmctx_memory_ptr);
+  p = (void *)&VERSIONED_SYMBOL(wasmtime_set_vmctx_memory);
+  (void)p;
+#endif
+}
 #endif // FEATURE_DEBUG_BUILTINS
 
 // For more information about this see `unix/unwind.rs` and the

--- a/crates/wasmtime/src/runtime/vm/helpers.c
+++ b/crates/wasmtime/src/runtime/vm/helpers.c
@@ -98,53 +98,6 @@ DEBUG_BUILTIN_EXPORT void VERSIONED_SYMBOL(wasmtime_set_vmctx_memory)(void *p) {
 }
 #endif // FEATURE_DEBUG_BUILTINS
 
-#ifdef CFG_TARGET_OS_windows
-// export required for external access.
-__declspec(dllexport)
-#else
-// Note the `weak` linkage here, though, which is intended to let other code
-// override this symbol if it's defined elsewhere, since this definition doesn't
-// matter.
-// Just in case cross-language LTO is enabled we set the `noinline` attribute
-// and also try to have some sort of side effect in this function with a dummy
-// `asm` statement.
-__attribute__((weak, noinline))
-#endif
-    void __jit_debug_register_code() {
-#ifndef CFG_TARGET_OS_windows
-  __asm__("");
-#ifdef FEATURE_DEBUG_BUILTINS
-  // Make sure these symbols do not get stripped by the compiler or linker.
-  void *volatile p;
-  p = (void *)&VERSIONED_SYMBOL(wasmtime_resolve_vmctx_memory_ptr);
-  p = (void *)&VERSIONED_SYMBOL(wasmtime_set_vmctx_memory);
-  (void)p;
-#endif // FEATURE_DEBUG_BUILTINS
-#endif
-}
-
-struct JITDescriptor {
-  uint32_t version_;
-  uint32_t action_flag_;
-  void *relevant_entry_;
-  void *first_entry_;
-};
-
-#ifdef CFG_TARGET_OS_windows
-// export required for external access.
-__declspec(dllexport)
-#else
-// Note the `weak` linkage here which is the same purpose as above. We want to
-// let other runtimes be able to override this since our own definition isn't
-// important.
-__attribute__((weak))
-#endif
-struct JITDescriptor __jit_debug_descriptor = {1, 0, NULL, NULL};
-
-struct JITDescriptor *VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)() {
-  return &__jit_debug_descriptor;
-}
-
 // For more information about this see `unix/unwind.rs` and the
 // `using_libunwind` function. The basic idea is that weak symbols aren't stable
 // in Rust so we use a bit of C to work around that.


### PR DESCRIPTION
This commit splits out the gdbjit-related helpers from `helpers.c` in Wasmtime to a separate C file built as part of the `wasmtime-jit-debug` crate. This'll help excise these helpers if gdbjit support is disabled at compile time and additionally brings them closer to the actual definition in the `wasmtime-jit-debug` crate.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
