### PR TITLE
Refactor CMake-based testing of examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,45 +6,52 @@ set(CMAKE_CXX_STANDARD 11)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../crates/c-api ${CMAKE_CURRENT_BINARY_DIR}/wasmtime)
 
 function(CREATE_TARGET TARGET TARGET_PATH)
-	add_executable(wasmtime-${TARGET} ${TARGET_PATH})
+  add_executable(wasmtime-${TARGET} ${TARGET_PATH})
 
-	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-		target_compile_options(wasmtime-${TARGET} PRIVATE -Wall -Wextra -Wno-deprecated-declarations)
-	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-		target_compile_options(wasmtime-${TARGET} PRIVATE /W3)
-	endif()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(wasmtime-${TARGET} PRIVATE -Wall -Wextra -Wno-deprecated-declarations)
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(wasmtime-${TARGET} PRIVATE /W3)
+  endif()
 
-        target_compile_definitions(wasmtime-${TARGET} PRIVATE WASMTIME_TEST_ONLY)
+  target_compile_definitions(wasmtime-${TARGET} PRIVATE WASMTIME_TEST_ONLY)
 
-	set_target_properties(wasmtime-${TARGET} PROPERTIES
-		OUTPUT_NAME wasmtime-${TARGET}
-		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/$<0:>
-		CXX_VISIBILITY_PRESET hidden
-		POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(wasmtime-${TARGET} PROPERTIES
+    OUTPUT_NAME wasmtime-${TARGET}
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/$<0:>
+    CXX_VISIBILITY_PRESET hidden
+    POSITION_INDEPENDENT_CODE ON)
 
-	target_include_directories(wasmtime-${TARGET} PUBLIC wasmtime)
-	target_link_libraries(wasmtime-${TARGET} PUBLIC wasmtime)
-	if(APPLE)
-		target_link_libraries(wasmtime-${TARGET} PRIVATE "-framework CoreFoundation")
-	endif()
-	add_test(NAME ${TARGET}-c COMMAND $<TARGET_FILE:wasmtime-${TARGET}> WORKING_DIRECTORY ../..)
+  target_include_directories(wasmtime-${TARGET} PUBLIC wasmtime)
+  target_link_libraries(wasmtime-${TARGET} PUBLIC wasmtime)
+  if(APPLE)
+    target_link_libraries(wasmtime-${TARGET} PRIVATE "-framework CoreFoundation")
+  endif()
+  add_test(NAME ${TARGET}-c COMMAND wasmtime-${TARGET} WORKING_DIRECTORY ../..)
 endfunction()
 
 function(CREATE_RUST_TEST EXAMPLE)
-	if(ARGC GREATER 1)
-		add_test(NAME ${EXAMPLE}-rust COMMAND cargo run --example ${EXAMPLE} --features ${ARGV1} WORKING_DIRECTORY ../..)
-	else()
-		add_test(NAME ${EXAMPLE}-rust COMMAND cargo run --example ${EXAMPLE} WORKING_DIRECTORY ../..)
-	endif()
+  if(ARGC GREATER 1)
+    add_test(NAME ${EXAMPLE}-rust COMMAND cargo run --example ${EXAMPLE} --features ${ARGV1} WORKING_DIRECTORY ../..)
+  else()
+    add_test(NAME ${EXAMPLE}-rust COMMAND cargo run --example ${EXAMPLE} WORKING_DIRECTORY ../..)
+  endif()
 endfunction()
 function(CREATE_RUST_WASM EXAMPLE TARGET)
-	execute_process(COMMAND cargo build -p example-${EXAMPLE}-wasm --target ${TARGET})
+  add_custom_target(${EXAMPLE}-wasm-${TARGET} ALL COMMAND cargo build -p example-${EXAMPLE}-wasm --target ${TARGET})
 endfunction()
 
 # Enable testing
 enable_testing()
 
-# Add all examples
+# Wasm files required by tests
+create_rust_wasm(fib-debug wasm32-unknown-unknown)
+create_rust_wasm(tokio wasm32-wasip1)
+create_rust_wasm(wasi wasm32-wasip1)
+create_rust_wasm(wasi wasm32-wasip2)
+create_rust_wasm(component wasm32-unknown-unknown)
+
+# C/C++ examples/tests
 create_target(anyref anyref.c)
 create_target(async async.cpp)
 create_target(externref externref.c)
@@ -61,13 +68,8 @@ create_target(serialize serialize.c)
 create_target(threads threads.c)
 create_target(wasip1 wasip1/main.c)
 
-# Add rust tests
+# Rust examples/tests
 create_rust_test(anyref)
-create_rust_wasm(fib-debug wasm32-unknown-unknown)
-create_rust_wasm(tokio wasm32-wasip1)
-create_rust_wasm(wasi wasm32-wasip1)
-create_rust_wasm(wasi wasm32-wasip2)
-create_rust_wasm(component wasm32-unknown-unknown)
 create_rust_test(epochs)
 create_rust_test(externref)
 create_rust_test(fib-debug)


### PR DESCRIPTION
* Replace hard tabs in file with `  `
* Move building of example executables to build-time instead of configure-time
* Move examples to being built as part of the "all" target
* Use a CMake shorthand for adding tests on executables generated

Closes #9932
Closes #9933

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
