### PR TITLE
pulley: Implement the wide-arithmetic proposal

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -215,6 +215,17 @@
   (if-let neg_u32 (u32_try_from_u64 neg_u64))
   neg_u32)
 
+;; 128-bit addition
+(rule 1 (lower (has_type $I128 (iadd a b)))
+  (let ((a ValueRegs a)
+        (b ValueRegs b))
+    (pulley_xadd128
+      (value_regs_get a 0)
+      (value_regs_get a 1)
+      (value_regs_get b 0)
+      (value_regs_get b 1))))
+
+;; vector addition
 (rule 1 (lower (has_type $I8X16 (iadd a b))) (pulley_vaddi8x16 a b))
 (rule 1 (lower (has_type $I16X8 (iadd a b))) (pulley_vaddi16x8 a b))
 (rule 1 (lower (has_type $I32X4 (iadd a b))) (pulley_vaddi32x4 a b))
@@ -260,6 +271,17 @@
   (if-let c (u8_from_negated_iconst b))
   (pulley_xadd64_u8 a c))
 
+;; 128-bit subtraction
+(rule 1 (lower (has_type $I128 (isub a b)))
+  (let ((a ValueRegs a)
+        (b ValueRegs b))
+    (pulley_xsub128
+      (value_regs_get a 0)
+      (value_regs_get a 1)
+      (value_regs_get b 0)
+      (value_regs_get b 1))))
+
+;; vector subtraction
 (rule 1 (lower (has_type $I8X16 (isub a b))) (pulley_vsubi8x16 a b))
 (rule 1 (lower (has_type $I16X8 (isub a b))) (pulley_vsubi16x8 a b))
 (rule 1 (lower (has_type $I32X4 (isub a b))) (pulley_vsubi32x4 a b))
@@ -286,6 +308,13 @@
 (rule 4 (lower (has_type $I64 (imul a (i8_from_iconst b))))
   (pulley_xmul64_s8 a b))
 
+;; 128-bit (or wide) multiplication
+(rule (lower (has_type $I128 (imul (uextend a) (uextend b))))
+  (pulley_xwidemul64_u (zext64 a) (zext64 b)))
+(rule (lower (has_type $I128 (imul (sextend a) (sextend b))))
+  (pulley_xwidemul64_s (sext64 a) (sext64 b)))
+
+;; vector multiplication
 (rule (lower (has_type $I8X16 (imul a b))) (pulley_vmuli8x16 a b))
 (rule (lower (has_type $I16X8 (imul a b))) (pulley_vmuli16x8 a b))
 (rule (lower (has_type $I32X4 (imul a b))) (pulley_vmuli32x4 a b))

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -304,13 +304,6 @@ impl Compiler {
                 if config.threads() {
                     return true;
                 }
-                // Unsupported proposals. Note that other proposals have partial
-                // support at this time (pulley is a work-in-progress) and so
-                // individual tests are listed below as "should fail" even if
-                // they're not covered in this list.
-                if config.wide_arithmetic() {
-                    return true;
-                }
             }
         }
 

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -996,6 +996,17 @@ impl Interpreter<'_> {
         }
         ControlFlow::Continue(())
     }
+
+    fn get_i128(&self, lo: XReg, hi: XReg) -> i128 {
+        let lo = self.state[lo].get_u64();
+        let hi = self.state[hi].get_i64();
+        i128::from(lo) | (i128::from(hi) << 64)
+    }
+
+    fn set_i128(&mut self, lo: XReg, hi: XReg, val: i128) {
+        self.state[lo].set_u64(val as u64);
+        self.state[hi].set_u64((val >> 64) as u64);
+    }
 }
 
 #[test]
@@ -4789,6 +4800,66 @@ impl ExtendedOpVisitor for Interpreter<'_> {
             *a = a.wasm_mul_add(b, c);
         }
         self.state[dst].set_f64x2(a);
+        ControlFlow::Continue(())
+    }
+
+    fn xadd128(
+        &mut self,
+        dst_lo: XReg,
+        dst_hi: XReg,
+        lhs_lo: XReg,
+        lhs_hi: XReg,
+        rhs_lo: XReg,
+        rhs_hi: XReg,
+    ) -> ControlFlow<Done> {
+        let lhs = self.get_i128(lhs_lo, lhs_hi);
+        let rhs = self.get_i128(rhs_lo, rhs_hi);
+        let result = lhs.wrapping_add(rhs);
+        self.set_i128(dst_lo, dst_hi, result);
+        ControlFlow::Continue(())
+    }
+
+    fn xsub128(
+        &mut self,
+        dst_lo: XReg,
+        dst_hi: XReg,
+        lhs_lo: XReg,
+        lhs_hi: XReg,
+        rhs_lo: XReg,
+        rhs_hi: XReg,
+    ) -> ControlFlow<Done> {
+        let lhs = self.get_i128(lhs_lo, lhs_hi);
+        let rhs = self.get_i128(rhs_lo, rhs_hi);
+        let result = lhs.wrapping_sub(rhs);
+        self.set_i128(dst_lo, dst_hi, result);
+        ControlFlow::Continue(())
+    }
+
+    fn xwidemul64_s(
+        &mut self,
+        dst_lo: XReg,
+        dst_hi: XReg,
+        lhs: XReg,
+        rhs: XReg,
+    ) -> ControlFlow<Done> {
+        let lhs = self.state[lhs].get_i64();
+        let rhs = self.state[rhs].get_i64();
+        let result = i128::from(lhs).wrapping_mul(i128::from(rhs));
+        self.set_i128(dst_lo, dst_hi, result);
+        ControlFlow::Continue(())
+    }
+
+    fn xwidemul64_u(
+        &mut self,
+        dst_lo: XReg,
+        dst_hi: XReg,
+        lhs: XReg,
+        rhs: XReg,
+    ) -> ControlFlow<Done> {
+        let lhs = self.state[lhs].get_u64();
+        let rhs = self.state[rhs].get_u64();
+        let result = u128::from(lhs).wrapping_mul(u128::from(rhs));
+        self.set_i128(dst_lo, dst_hi, result as i128);
         ControlFlow::Continue(())
     }
 }

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -1279,7 +1279,7 @@ macro_rules! for_each_extended_op {
             /// `dst = ieee_fma(a, b, c)`
             vfma64x2 = Vfma64x2 { dst: VReg, a: VReg, b: VReg, c: VReg };
 
-            /// `dst_lo:dst_hi = lhs_lo:lhs_hi + rhs_lo:rhs_hi`
+            /// `dst_hi:dst_lo = lhs_hi:lhs_lo + rhs_hi:rhs_lo`
             xadd128 = Xadd128 {
                 dst_lo: XReg,
                 dst_hi: XReg,
@@ -1288,7 +1288,7 @@ macro_rules! for_each_extended_op {
                 rhs_lo: XReg,
                 rhs_hi: XReg
             };
-            /// `dst_lo:dst_hi = lhs_lo:lhs_hi - rhs_lo:rhs_hi`
+            /// `dst_hi:dst_lo = lhs_hi:lhs_lo - rhs_hi:rhs_lo`
             xsub128 = Xsub128 {
                 dst_lo: XReg,
                 dst_hi: XReg,
@@ -1297,14 +1297,14 @@ macro_rules! for_each_extended_op {
                 rhs_lo: XReg,
                 rhs_hi: XReg
             };
-            /// `dst_lo:dst_hi = sext(lhs) * sext(rhs)`
+            /// `dst_hi:dst_lo = sext(lhs) * sext(rhs)`
             xwidemul64_s = Xwidemul64S {
                 dst_lo: XReg,
                 dst_hi: XReg,
                 lhs: XReg,
                 rhs: XReg
             };
-            /// `dst_lo:dst_hi = zext(lhs) * zext(rhs)`
+            /// `dst_hi:dst_lo = zext(lhs) * zext(rhs)`
             xwidemul64_u = Xwidemul64U {
                 dst_lo: XReg,
                 dst_hi: XReg,

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -1278,6 +1278,39 @@ macro_rules! for_each_extended_op {
             vfma32x4 = Vfma32x4 { dst: VReg, a: VReg, b: VReg, c: VReg };
             /// `dst = ieee_fma(a, b, c)`
             vfma64x2 = Vfma64x2 { dst: VReg, a: VReg, b: VReg, c: VReg };
+
+            /// `dst_lo:dst_hi = lhs_lo:lhs_hi + rhs_lo:rhs_hi`
+            xadd128 = Xadd128 {
+                dst_lo: XReg,
+                dst_hi: XReg,
+                lhs_lo: XReg,
+                lhs_hi: XReg,
+                rhs_lo: XReg,
+                rhs_hi: XReg
+            };
+            /// `dst_lo:dst_hi = lhs_lo:lhs_hi - rhs_lo:rhs_hi`
+            xsub128 = Xsub128 {
+                dst_lo: XReg,
+                dst_hi: XReg,
+                lhs_lo: XReg,
+                lhs_hi: XReg,
+                rhs_lo: XReg,
+                rhs_hi: XReg
+            };
+            /// `dst_lo:dst_hi = sext(lhs) * sext(rhs)`
+            xwidemul64_s = Xwidemul64S {
+                dst_lo: XReg,
+                dst_hi: XReg,
+                lhs: XReg,
+                rhs: XReg
+            };
+            /// `dst_lo:dst_hi = zext(lhs) * zext(rhs)`
+            xwidemul64_u = Xwidemul64U {
+                dst_lo: XReg,
+                dst_hi: XReg,
+                lhs: XReg,
+                rhs: XReg
+            };
         }
     };
 }


### PR DESCRIPTION
Add a few minor instructions/lowerings for the new operations added as part of the wide-arithmetic proposal. These are all part of the "extended" opcode set since they shouldn't be common and if they're performance critical you probably want a native backend instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
