### PR TITLE
Make module validation deterministic in case of multiple errors

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -154,9 +154,14 @@ impl Engine {
             #[cfg(feature = "parallel-compilation")]
             {
                 use rayon::prelude::*;
+                // If we collect into Result<Vec<B>, E> directly, the returned error is not
+                // deterministic, because any error could be returned early. So we first materialize
+                // all results in order and then return the first error deterministically, or Ok(_).
                 return input
                     .into_par_iter()
                     .map(|a| f(a))
+                    .collect::<Vec<Result<B, E>>>()
+                    .into_iter()
                     .collect::<Result<Vec<B>, E>>();
             }
         }

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -536,6 +536,7 @@ fn concurrent_type_modifications_and_checks(config: &mut Config) -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn validate_deterministic() {
     let mut faulty_wat = "(module ".to_string();
     for i in 0..1_000 {

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -539,7 +539,7 @@ fn concurrent_type_modifications_and_checks(config: &mut Config) -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn validate_deterministic() {
     let mut faulty_wat = "(module ".to_string();
-    for i in 0..1_000 {
+    for i in 0..100 {
         faulty_wat.push_str(&format!(
             "(func (export \"foo_{i}\") (result i64) (i64.add (i32.const 0) (i64.const 1)))"
         ));


### PR DESCRIPTION
If a Wasm binary is invalid in several ways, parallel compilation will return a non-deterministic result. We would like to get a deterministic result even in the presence of multiple errors. 

This PR addresses that by first materializing all validation results and then returning the first error, if any ('first' with regard to the order of the input vector).

The downside is that we cannot return early when an error is encountered. This slows down the validation for invalid binaries. Since that is not the happy path anyway, I propose to accept the slowdown.  

The provided test does not prove determinism, which is hard to do. But it gives _some_ confidence and ensures the behaviours of parallel and sequential compilation do not deviate. 