### PR TITLE
fix broken example includes for #9788

### DIFF
--- a/docs/examples-c-wasi.md
+++ b/docs/examples-c-wasi.md
@@ -17,5 +17,5 @@ This example shows off how to instantiate a wasm module using WASI imports.
 ## `wasi.c`
 
 ```c
-{{#include ../examples/wasi/main.c}}
+{{#include ../examples/wasip1/main.c}}
 ```

--- a/docs/examples-rust-wasi.md
+++ b/docs/examples-rust-wasi.md
@@ -34,7 +34,7 @@ This example shows adding and configuring the WASI imports to invoke the above W
 
 `main.rs`
 ```rust,ignore
-{{#include ../examples/wasi/main.rs}}
+{{#include ../examples/wasip2/main.rs}}
 ```
 
 ### Async example
@@ -48,7 +48,7 @@ This does not require any change to the WASIp2 component, it's just the WASIp2 A
 [`wasmtime-wasi`]: https://docs.rs/wasmtime-wasi/*/wasmtime_wasi/preview2/index.html
 
 ```rust,ignore
-{{#include ../examples/wasi-async/main.rs}}
+{{#include ../examples/wasip2-async/main.rs}}
 ```
 
 You can also [browse this source code online][code2] and clone the wasmtime


### PR DESCRIPTION
I think with the merge of #9788 yesterday the include statements of the new WASI examples were not quite spot on.

I'm not entirely sure if I got the right file paths to fix, but looking at the diff of #9788 I think they might be the right ones.

Running `mdbook build --open` to build the doc gave these errors:
```
2025-01-08 15:25:26 [INFO] (mdbook::book): Book building has started
2025-01-08 15:25:26 [ERROR] (mdbook::preprocess::links): Error updating "{{#include ../examples/wasi/main.rs}}", Could not read file for link {{#include ../examples/wasi/main.rs}} (/home/christian/repos/wasmtime/docs/./../examples/wasi/main.rs)
2025-01-08 15:25:26 [WARN] (mdbook::preprocess::links): Caused By: No such file or directory (os error 2)
2025-01-08 15:25:26 [ERROR] (mdbook::preprocess::links): Error updating "{{#include ../examples/wasi-async/main.rs}}", Could not read file for link {{#include ../examples/wasi-async/main.rs}} (/home/christian/repos/wasmtime/docs/./../examples/wasi-async/main.rs)
2025-01-08 15:25:26 [WARN] (mdbook::preprocess::links): Caused By: No such file or directory (os error 2)
2025-01-08 15:25:26 [ERROR] (mdbook::preprocess::links): Error updating "{{#include ../examples/wasi/main.c}}", Could not read file for link {{#include ../examples/wasi/main.c}} (/home/christian/repos/wasmtime/docs/./../examples/wasi/main.c)
2025-01-08 15:25:26 [WARN] (mdbook::preprocess::links): Caused By: No such file or directory (os error 2)
2025-01-08 15:25:26 [INFO] (mdbook::book): Running the html backend
2025-01-08 15:25:26 [INFO] (mdbook): Opening web browser
```
I changed the includes to those files:
- https://github.com/bytecodealliance/wasmtime/blob/main/examples/wasip2/main.rs
- https://github.com/bytecodealliance/wasmtime/blob/main/examples/wasip2-async/main.rs
- https://github.com/bytecodealliance/wasmtime/blob/main/examples/wasip1/main.c

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
