### PR TITLE
winch: Gracefully handle unsupported Wasm types

### DIFF
--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -5,6 +5,7 @@ use crate::{
     codegen::env::ptr_type_from_ptr_size,
     CallingConvention,
 };
+use anyhow::Result;
 use cranelift_codegen::ir::LibCall;
 use std::sync::Arc;
 use wasmtime_environ::{BuiltinFunctionIndex, PtrSize, VMOffsets, WasmValType};
@@ -154,109 +155,109 @@ macro_rules! declare_function_sig {
                 WasmValType::I32
             }
 
-            fn over_f64<A: ABI>(&self) -> ABISig {
+            fn over_f64<A: ABI>(&self) -> Result<ABISig> {
                 A::sig_from(&[self.f64()], &[self.f64()], &self.host_call_conv)
             }
 
-            fn over_f32<A: ABI>(&self) -> ABISig {
+            fn over_f32<A: ABI>(&self) -> Result<ABISig> {
                 A::sig_from(&[self.f64()], &[self.f64()], &self.host_call_conv)
             }
 
-            pub(crate) fn ceil_f32<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn ceil_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.ceil_f32.is_none() {
-                    let sig = self.over_f32::<A>();
+                    let sig = self.over_f32::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::CeilF32) });
                     self.ceil_f32 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.ceil_f32.as_ref().unwrap().clone()
+                Ok(self.ceil_f32.as_ref().unwrap().clone())
             }
 
-            pub(crate) fn ceil_f64<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn ceil_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.ceil_f64.is_none() {
-                    let sig = self.over_f64::<A>();
+                    let sig = self.over_f64::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::CeilF64) });
                     self.ceil_f64 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.ceil_f64.as_ref().unwrap().clone()
+                Ok(self.ceil_f64.as_ref().unwrap().clone())
             }
 
-            pub(crate) fn floor_f32<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn floor_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.floor_f32.is_none() {
-                    let sig = self.over_f32::<A>();
+                    let sig = self.over_f32::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::FloorF32) });
                     self.floor_f32 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.floor_f32.as_ref().unwrap().clone()
+                Ok(self.floor_f32.as_ref().unwrap().clone())
             }
 
-            pub(crate) fn floor_f64<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn floor_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.floor_f64.is_none() {
-                    let sig = self.over_f64::<A>();
+                    let sig = self.over_f64::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::FloorF64) });
                     self.floor_f64 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.floor_f64.as_ref().unwrap().clone()
+                Ok(self.floor_f64.as_ref().unwrap().clone())
             }
 
-            pub(crate) fn trunc_f32<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn trunc_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.trunc_f32.is_none() {
-                    let sig = self.over_f32::<A>();
+                    let sig = self.over_f32::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::TruncF32) });
                     self.trunc_f32 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.trunc_f32.as_ref().unwrap().clone()
+                Ok(self.trunc_f32.as_ref().unwrap().clone())
             }
 
-            pub(crate) fn trunc_f64<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn trunc_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.trunc_f64.is_none() {
-                    let sig = self.over_f64::<A>();
+                    let sig = self.over_f64::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::TruncF64) });
                     self.trunc_f64 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.trunc_f64.as_ref().unwrap().clone()
+                Ok(self.trunc_f64.as_ref().unwrap().clone())
             }
 
-            pub(crate) fn nearest_f32<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn nearest_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.nearest_f32.is_none() {
-                    let sig = self.over_f32::<A>();
+                    let sig = self.over_f32::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::NearestF32) });
                     self.nearest_f32 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.nearest_f32.as_ref().unwrap().clone()
+                Ok(self.nearest_f32.as_ref().unwrap().clone())
             }
 
-            pub(crate) fn nearest_f64<A: ABI>(&mut self) -> BuiltinFunction {
+            pub(crate) fn nearest_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
                 if self.nearest_f64.is_none() {
-                    let sig = self.over_f64::<A>();
+                    let sig = self.over_f64::<A>()?;
                     let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::NearestF64) });
                     self.nearest_f64 = Some(BuiltinFunction {
                         inner,
                     });
                 }
-                self.nearest_f64.as_ref().unwrap().clone()
+                Ok(self.nearest_f64.as_ref().unwrap().clone())
             }
 
             $(
                 $( #[ $attr ] )*
-                pub(crate) fn $name<A: ABI, P: PtrSize>(&mut self) -> BuiltinFunction {
+                pub(crate) fn $name<A: ABI, P: PtrSize>(&mut self) -> Result<BuiltinFunction> {
                     if self.$name.is_none() {
                         let params = vec![ $(self.$param() ),* ];
                         let result = vec![ $(self.$result() )?];
-                        let sig = A::sig_from(&params, &result, &self.wasm_call_conv);
+                        let sig = A::sig_from(&params, &result, &self.wasm_call_conv)?;
                         let index = BuiltinFunctionIndex::$name();
                         let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::builtin(index) });
                         self.$name = Some(BuiltinFunction {
@@ -264,7 +265,7 @@ macro_rules! declare_function_sig {
                         });
                     }
 
-                    self.$name.as_ref().unwrap().clone()
+                    Ok(self.$name.as_ref().unwrap().clone())
                 }
              )*
         }

--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -91,7 +91,7 @@ impl FnCall {
     ) -> Result<()> {
         let (kind, callee_context) = Self::lower(env, context.vmoffsets, &callee, context, masm)?;
 
-        let sig = env.callee_sig::<M::ABI>(&callee);
+        let sig = env.callee_sig::<M::ABI>(&callee)?;
         context.spill(masm)?;
         let ret_area = Self::make_ret_area(&sig, masm)?;
         let arg_stack_space = sig.params_stack_size();
@@ -142,11 +142,11 @@ impl FnCall {
         match callee {
             Callee::Builtin(b) => Ok(Self::lower_builtin(env, b)),
             Callee::FuncRef(_) => {
-                Self::lower_funcref(env.callee_sig::<M::ABI>(callee), ptr, context, masm)
+                Self::lower_funcref(env.callee_sig::<M::ABI>(callee)?, ptr, context, masm)
             }
             Callee::Local(i) => Ok(Self::lower_local(env, *i)),
             Callee::Import(i) => {
-                let sig = env.callee_sig::<M::ABI>(callee);
+                let sig = env.callee_sig::<M::ABI>(callee)?;
                 Self::lower_import(*i, sig, context, masm, vmoffsets)
             }
         }

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -16,6 +16,8 @@ use wasmtime_environ::{
     TypeIndex, VMOffsets, WasmHeapType, WasmValType,
 };
 
+use anyhow::Result;
+
 #[derive(Debug, Clone, Copy)]
 pub struct GlobalData {
     /// The offset of the global.
@@ -302,32 +304,37 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
         self.table_access_spectre_mitigation
     }
 
-    pub(crate) fn callee_sig<'b, A>(&'b mut self, callee: &'b Callee) -> &'b ABISig
+    pub(crate) fn callee_sig<'b, A>(&'b mut self, callee: &'b Callee) -> Result<&'b ABISig>
     where
         A: ABI,
     {
         match callee {
             Callee::Local(idx) | Callee::Import(idx) => {
-                let types = self.translation.get_types();
-                let types = types.as_ref();
-                let ty = types[types.core_function_at(idx.as_u32())].unwrap_func();
-                let val = || {
+                if self.resolved_callees.contains_key(idx) {
+                    Ok(self.resolved_callees.get(idx).unwrap())
+                } else {
+                    let types = self.translation.get_types();
+                    let types = types.as_ref();
+                    let ty = types[types.core_function_at(idx.as_u32())].unwrap_func();
                     let converter = TypeConverter::new(self.translation, self.types);
                     let ty = converter.convert_func_type(&ty);
-                    wasm_sig::<A>(&ty)
-                };
-                self.resolved_callees.entry(*idx).or_insert_with(val)
+                    let sig = wasm_sig::<A>(&ty)?;
+                    self.resolved_callees.insert(*idx, sig);
+                    Ok(self.resolved_callees.get(idx).unwrap())
+                }
             }
             Callee::FuncRef(idx) => {
-                let val = || {
+                if self.resolved_sigs.contains_key(idx) {
+                    Ok(self.resolved_sigs.get(idx).unwrap())
+                } else {
                     let sig_index = self.translation.module.types[*idx];
                     let ty = self.types[sig_index].unwrap_func();
-                    let sig = wasm_sig::<A>(ty);
-                    sig
-                };
-                self.resolved_sigs.entry(*idx).or_insert_with(val)
+                    let sig = wasm_sig::<A>(ty)?;
+                    self.resolved_sigs.insert(*idx, sig);
+                    Ok(self.resolved_sigs.get(idx).unwrap())
+                }
             }
-            Callee::Builtin(b) => b.sig(),
+            Callee::Builtin(b) => Ok(b.sig()),
         }
     }
 

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -548,7 +548,7 @@ where
         let builtin = self
             .env
             .builtins
-            .table_get_lazy_init_func_ref::<M::ABI, M::Ptr>();
+            .table_get_lazy_init_func_ref::<M::ABI, M::Ptr>()?;
 
         // Request the builtin's  result register and use it to hold the table
         // element value. We preemptively spill and request this register to
@@ -1016,7 +1016,7 @@ where
             return Ok(());
         }
 
-        let out_of_fuel = self.env.builtins.out_of_gas::<M::ABI, M::Ptr>();
+        let out_of_fuel = self.env.builtins.out_of_gas::<M::ABI, M::Ptr>()?;
         let fuel_reg = self.context.without::<Result<Reg>, M, _>(
             &out_of_fuel.sig().regs,
             self.masm,
@@ -1084,7 +1084,7 @@ where
         // The continuation branch if the current epoch hasn't reached the
         // configured deadline.
         let cont = self.masm.get_label()?;
-        let new_epoch = self.env.builtins.new_epoch::<M::ABI, M::Ptr>();
+        let new_epoch = self.env.builtins.new_epoch::<M::ABI, M::Ptr>()?;
 
         // Checks for runtime limits (e.g., fuel, epoch) are special since they
         // require inserting arbitrary function calls and control flow.

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -167,14 +167,16 @@ mod tests {
         WasmValType::{self, *},
     };
 
+    use anyhow::Result;
+
     #[test]
-    fn xreg_abi_sig() {
+    fn xreg_abi_sig() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [I32, I64, I32, I64, I32, I32, I64, I32, I64].into(),
             [].into(),
         );
 
-        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), I32, regs::xreg(0));
@@ -186,16 +188,17 @@ mod tests {
         match_reg_arg(params.get(6).unwrap(), I64, regs::xreg(6));
         match_reg_arg(params.get(7).unwrap(), I32, regs::xreg(7));
         match_stack_arg(params.get(8).unwrap(), I64, 0);
+        Ok(())
     }
 
     #[test]
-    fn vreg_abi_sig() {
+    fn vreg_abi_sig() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, F64, F32, F64, F32, F32, F64, F32, F64].into(),
             [].into(),
         );
 
-        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), F32, regs::vreg(0));
@@ -207,16 +210,17 @@ mod tests {
         match_reg_arg(params.get(6).unwrap(), F64, regs::vreg(6));
         match_reg_arg(params.get(7).unwrap(), F32, regs::vreg(7));
         match_stack_arg(params.get(8).unwrap(), F64, 0);
+        Ok(())
     }
 
     #[test]
-    fn mixed_abi_sig() {
+    fn mixed_abi_sig() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, I32, I64, F64, I32, F32, F64, F32, F64].into(),
             [].into(),
         );
 
-        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), F32, regs::vreg(0));
@@ -228,16 +232,17 @@ mod tests {
         match_reg_arg(params.get(6).unwrap(), F64, regs::vreg(3));
         match_reg_arg(params.get(7).unwrap(), F32, regs::vreg(4));
         match_reg_arg(params.get(8).unwrap(), F64, regs::vreg(5));
+        Ok(())
     }
 
     #[test]
-    fn int_abi_sig_multi_returns() {
+    fn int_abi_sig_multi_returns() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [I32, I64, I32, I64, I32, I32].into(),
             [I32, I32, I32].into(),
         );
 
-        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
         let results = sig.results;
 
@@ -251,16 +256,17 @@ mod tests {
         match_stack_arg(results.get(0).unwrap(), I32, 4);
         match_stack_arg(results.get(1).unwrap(), I32, 0);
         match_reg_arg(results.get(2).unwrap(), I32, regs::xreg(0));
+        Ok(())
     }
 
     #[test]
-    fn mixed_abi_sig_multi_returns() {
+    fn mixed_abi_sig_multi_returns() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, I32, I64, F64, I32].into(),
             [I32, F32, I32, F32, I64].into(),
         );
 
-        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = Aarch64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
         let results = sig.results;
 
@@ -275,6 +281,7 @@ mod tests {
         match_stack_arg(results.get(2).unwrap(), I32, 4);
         match_stack_arg(results.get(3).unwrap(), F32, 0);
         match_reg_arg(results.get(4).unwrap(), I64, regs::xreg(0));
+        Ok(())
     }
 
     #[track_caller]

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -1,7 +1,9 @@
 use super::regs;
 use crate::abi::{align_to, ABIOperand, ABIParams, ABIResults, ABISig, ParamsOrReturns, ABI};
+use crate::codegen::CodeGenError;
 use crate::isa::{reg::Reg, CallingConvention};
 use crate::RegIndexEnv;
+use anyhow::{bail, Result};
 use wasmtime_environ::{WasmHeapType, WasmRefType, WasmValType};
 
 #[derive(Default)]
@@ -29,14 +31,14 @@ impl ABI for Aarch64ABI {
         params: &[WasmValType],
         returns: &[WasmValType],
         call_conv: &CallingConvention,
-    ) -> ABISig {
+    ) -> Result<ABISig> {
         assert!(call_conv.is_apple_aarch64() || call_conv.is_default());
         // The first element tracks the general purpose register index, capped at 7 (x0-x7).
         // The second element tracks the floating point register index, capped at 7 (v0-v7).
         // Follows
         // https://github.com/ARM-software/abi-aa/blob/2021Q1/aapcs64/aapcs64.rst#64parameter-passing
         let mut params_index_env = RegIndexEnv::with_limits_per_class(8, 8);
-        let results = Self::abi_results(returns, call_conv);
+        let results = Self::abi_results(returns, call_conv)?;
         let params =
             ABIParams::from::<_, Self>(params, 0, results.on_stack(), |ty, stack_offset| {
                 Self::to_abi_operand(
@@ -46,12 +48,12 @@ impl ABI for Aarch64ABI {
                     call_conv,
                     ParamsOrReturns::Params,
                 )
-            });
+            })?;
 
-        ABISig::new(*call_conv, params, results)
+        Ok(ABISig::new(*call_conv, params, results))
     }
 
-    fn abi_results(returns: &[WasmValType], call_conv: &CallingConvention) -> ABIResults {
+    fn abi_results(returns: &[WasmValType], call_conv: &CallingConvention) -> Result<ABIResults> {
         assert!(call_conv.is_apple_aarch64() || call_conv.is_default());
         // Use absolute count for results given that for Winch's
         // default CallingConvention only one register is used for results
@@ -112,7 +114,7 @@ impl Aarch64ABI {
         index_env: &mut RegIndexEnv,
         call_conv: &CallingConvention,
         params_or_returns: ParamsOrReturns,
-    ) -> (ABIOperand, u32) {
+    ) -> Result<(ABIOperand, u32)> {
         let (reg, ty) = match wasm_arg {
             ty @ (WasmValType::I32 | WasmValType::I64) => {
                 (index_env.next_gpr().map(regs::xreg), ty)
@@ -122,7 +124,7 @@ impl Aarch64ABI {
                 (index_env.next_fpr().map(regs::vreg), ty)
             }
 
-            ty => unreachable!("Unsupported argument type {:?}", ty),
+            _ => bail!(CodeGenError::unsupported_wasm_type()),
         };
 
         let ty_size = <Self as ABI>::sizeof(wasm_arg);
@@ -145,9 +147,9 @@ impl Aarch64ABI {
             };
             (arg, next_stack)
         };
-        reg.map_or_else(default, |reg| {
+        Ok(reg.map_or_else(default, |reg| {
             (ABIOperand::reg(reg, *ty, ty_size as u32), stack_offset)
-        })
+        }))
     }
 }
 

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -97,7 +97,7 @@ impl TargetIsa for Aarch64 {
         let mut body = body.get_binary_reader();
         let mut masm = Aarch64Masm::new(pointer_bytes, self.shared_flags.clone())?;
         let stack = Stack::new();
-        let abi_sig = wasm_sig::<abi::Aarch64ABI>(sig);
+        let abi_sig = wasm_sig::<abi::Aarch64ABI>(sig)?;
 
         let env = FuncEnv::new(
             &vmoffsets,

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -282,17 +282,20 @@ mod tests {
         abi::{ABIOperand, ABI},
         isa::{reg::Reg, x64::regs, CallingConvention},
     };
+
+    use anyhow::Result;
+
     use wasmtime_environ::{
         WasmFuncType,
         WasmValType::{self, *},
     };
 
     #[test]
-    fn int_abi_sig() {
+    fn int_abi_sig() -> Result<()> {
         let wasm_sig =
             WasmFuncType::new([I32, I64, I32, I64, I32, I32, I64, I32].into(), [].into());
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), I32, regs::rdi());
@@ -303,16 +306,17 @@ mod tests {
         match_reg_arg(params.get(5).unwrap(), I32, regs::r9());
         match_stack_arg(params.get(6).unwrap(), I64, 0);
         match_stack_arg(params.get(7).unwrap(), I32, 8);
+        Ok(())
     }
 
     #[test]
-    fn int_abi_sig_multi_returns() {
+    fn int_abi_sig_multi_returns() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [I32, I64, I32, I64, I32, I32, I64, I32].into(),
             [I32, I32, I32].into(),
         );
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
         let results = sig.results;
 
@@ -328,16 +332,17 @@ mod tests {
         match_stack_arg(results.get(0).unwrap(), I32, 4);
         match_stack_arg(results.get(1).unwrap(), I32, 0);
         match_reg_arg(results.get(2).unwrap(), I32, regs::rax());
+        Ok(())
     }
 
     #[test]
-    fn float_abi_sig() {
+    fn float_abi_sig() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, F64, F32, F64, F32, F32, F64, F32, F64].into(),
             [].into(),
         );
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), F32, regs::xmm0());
@@ -349,16 +354,17 @@ mod tests {
         match_reg_arg(params.get(6).unwrap(), F64, regs::xmm6());
         match_reg_arg(params.get(7).unwrap(), F32, regs::xmm7());
         match_stack_arg(params.get(8).unwrap(), F64, 0);
+        Ok(())
     }
 
     #[test]
-    fn vector_abi_sig() {
+    fn vector_abi_sig() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [V128, V128, V128, V128, V128, V128, V128, V128, V128, V128].into(),
             [].into(),
         );
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), V128, regs::xmm0());
@@ -371,28 +377,30 @@ mod tests {
         match_reg_arg(params.get(7).unwrap(), V128, regs::xmm7());
         match_stack_arg(params.get(8).unwrap(), V128, 0);
         match_stack_arg(params.get(9).unwrap(), V128, 16);
+        Ok(())
     }
 
     #[test]
-    fn vector_abi_sig_multi_returns() {
+    fn vector_abi_sig_multi_returns() -> Result<()> {
         let wasm_sig = WasmFuncType::new([].into(), [V128, V128, V128].into());
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let results = sig.results;
 
         match_stack_arg(results.get(0).unwrap(), V128, 16);
         match_stack_arg(results.get(1).unwrap(), V128, 0);
         match_reg_arg(results.get(2).unwrap(), V128, regs::xmm0());
+        Ok(())
     }
 
     #[test]
-    fn mixed_abi_sig() {
+    fn mixed_abi_sig() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, I32, I64, F64, I32, F32, F64, F32, F64].into(),
             [].into(),
         );
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::Default)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), F32, regs::xmm0());
@@ -404,16 +412,17 @@ mod tests {
         match_reg_arg(params.get(6).unwrap(), F64, regs::xmm3());
         match_reg_arg(params.get(7).unwrap(), F32, regs::xmm4());
         match_reg_arg(params.get(8).unwrap(), F64, regs::xmm5());
+        Ok(())
     }
 
     #[test]
-    fn system_v_call_conv() {
+    fn system_v_call_conv() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, I32, I64, F64, I32, F32, F64, F32, F64].into(),
             [].into(),
         );
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::SystemV);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::SystemV)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), F32, regs::xmm0());
@@ -425,16 +434,17 @@ mod tests {
         match_reg_arg(params.get(6).unwrap(), F64, regs::xmm3());
         match_reg_arg(params.get(7).unwrap(), F32, regs::xmm4());
         match_reg_arg(params.get(8).unwrap(), F64, regs::xmm5());
+        Ok(())
     }
 
     #[test]
-    fn fastcall_call_conv() {
+    fn fastcall_call_conv() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, I32, I64, F64, I32, F32, F64, F32, F64].into(),
             [].into(),
         );
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::WindowsFastcall);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::WindowsFastcall)?;
         let params = sig.params;
 
         match_reg_arg(params.get(0).unwrap(), F32, regs::xmm0());
@@ -443,16 +453,17 @@ mod tests {
         match_reg_arg(params.get(3).unwrap(), F64, regs::xmm3());
         match_stack_arg(params.get(4).unwrap(), I32, 32);
         match_stack_arg(params.get(5).unwrap(), F32, 40);
+        Ok(())
     }
 
     #[test]
-    fn fastcall_call_conv_multi_returns() {
+    fn fastcall_call_conv_multi_returns() -> Result<()> {
         let wasm_sig = WasmFuncType::new(
             [F32, I32, I64, F64, I32, F32, F64, F32, F64].into(),
             [I32, F32, I32, F32, I64].into(),
         );
 
-        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::WindowsFastcall);
+        let sig = X64ABI::sig(&wasm_sig, &CallingConvention::WindowsFastcall)?;
         let params = sig.params;
         let results = sig.results;
 
@@ -470,6 +481,7 @@ mod tests {
         match_stack_arg(results.get(2).unwrap(), I32, 4);
         match_stack_arg(results.get(3).unwrap(), F32, 8);
         match_stack_arg(results.get(4).unwrap(), I64, 12);
+        Ok(())
     }
 
     #[track_caller]

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -107,7 +107,7 @@ impl TargetIsa for X64 {
         )?;
         let stack = Stack::new();
 
-        let abi_sig = wasm_sig::<abi::X64ABI>(sig);
+        let abi_sig = wasm_sig::<abi::X64ABI>(sig)?;
 
         let env = FuncEnv::new(
             &vmoffsets,

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -477,7 +477,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.floor_f32::<M::ABI>();
+                let builtin = env.builtins.floor_f32::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -490,7 +490,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.floor_f64::<M::ABI>();
+                let builtin = env.builtins.floor_f64::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -503,7 +503,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.ceil_f32::<M::ABI>();
+                let builtin = env.builtins.ceil_f32::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -516,7 +516,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.ceil_f64::<M::ABI>();
+                let builtin = env.builtins.ceil_f64::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -529,7 +529,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.nearest_f32::<M::ABI>();
+                let builtin = env.builtins.nearest_f32::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -542,7 +542,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.nearest_f64::<M::ABI>();
+                let builtin = env.builtins.nearest_f64::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -555,7 +555,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.trunc_f32::<M::ABI>();
+                let builtin = env.builtins.trunc_f32::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -568,7 +568,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.trunc_f64::<M::ABI>();
+                let builtin = env.builtins.trunc_f64::<M::ABI>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -1434,7 +1434,7 @@ where
             .stack
             .insert_many(at, &[table.try_into()?, elem.try_into()?]);
 
-        let builtin = self.env.builtins.table_init::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.table_init::<M::ABI, M::Ptr>()?;
         FnCall::emit::<M>(
             &mut self.env,
             self.masm,
@@ -1450,7 +1450,7 @@ where
             .stack
             .insert_many(at, &[dst.try_into()?, src.try_into()?]);
 
-        let builtin = self.env.builtins.table_copy::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.table_copy::<M::ABI, M::Ptr>()?;
         FnCall::emit::<M>(
             &mut self.env,
             self.masm,
@@ -1475,7 +1475,7 @@ where
         let table_index = TableIndex::from_u32(table);
         let table_ty = self.env.table(table_index);
         let builtin = match table_ty.ref_type.heap_type {
-            WasmHeapType::Func => self.env.builtins.table_grow_func_ref::<M::ABI, M::Ptr>(),
+            WasmHeapType::Func => self.env.builtins.table_grow_func_ref::<M::ABI, M::Ptr>()?,
             _ => bail!(CodeGenError::unsupported_wasm_type()),
         };
 
@@ -1517,7 +1517,7 @@ where
             CodeGenError::unsupported_wasm_type()
         );
 
-        let builtin = self.env.builtins.table_fill_func_ref::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.table_fill_func_ref::<M::ABI, M::Ptr>()?;
 
         let at = self.context.stack.ensure_index_at(3)?;
 
@@ -1567,7 +1567,7 @@ where
     }
 
     fn visit_elem_drop(&mut self, index: u32) -> Self::Output {
-        let elem_drop = self.env.builtins.elem_drop::<M::ABI, M::Ptr>();
+        let elem_drop = self.env.builtins.elem_drop::<M::ABI, M::Ptr>()?;
         self.context.stack.extend([index.try_into()?]);
         FnCall::emit::<M>(
             &mut self.env,
@@ -1583,7 +1583,7 @@ where
         self.context
             .stack
             .insert_many(at, &[mem.try_into()?, data_index.try_into()?]);
-        let builtin = self.env.builtins.memory_init::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.memory_init::<M::ABI, M::Ptr>()?;
         FnCall::emit::<M>(
             &mut self.env,
             self.masm,
@@ -1607,7 +1607,7 @@ where
         let at = self.context.stack.ensure_index_at(4)?;
         self.context.stack.insert_many(at, &[dst_mem.try_into()?]);
 
-        let builtin = self.env.builtins.memory_copy::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.memory_copy::<M::ABI, M::Ptr>()?;
 
         FnCall::emit::<M>(
             &mut self.env,
@@ -1623,7 +1623,7 @@ where
 
         self.context.stack.insert_many(at, &[mem.try_into()?]);
 
-        let builtin = self.env.builtins.memory_fill::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.memory_fill::<M::ABI, M::Ptr>()?;
         FnCall::emit::<M>(
             &mut self.env,
             self.masm,
@@ -1646,7 +1646,7 @@ where
         self.context.stack.extend([mem.try_into()?]);
 
         let heap = self.env.resolve_heap(MemoryIndex::from_u32(mem));
-        let builtin = self.env.builtins.memory32_grow::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.memory32_grow::<M::ABI, M::Ptr>()?;
         FnCall::emit::<M>(
             &mut self.env,
             self.masm,
@@ -1674,7 +1674,7 @@ where
     fn visit_data_drop(&mut self, data_index: u32) -> Self::Output {
         self.context.stack.extend([data_index.try_into()?]);
 
-        let builtin = self.env.builtins.data_drop::<M::ABI, M::Ptr>();
+        let builtin = self.env.builtins.data_drop::<M::ABI, M::Ptr>()?;
         FnCall::emit::<M>(
             &mut self.env,
             self.masm,
@@ -1748,7 +1748,7 @@ where
 
         let top = {
             let top = self.context.without::<Result<TypedReg>, M, _>(
-                frame.results::<M>().regs(),
+                frame.results::<M>()?.regs(),
                 self.masm,
                 |ctx, masm| ctx.pop_to_reg(masm, None),
             )??;
@@ -1783,7 +1783,7 @@ where
         // Emit instructions to balance the machine stack if the frame has
         // a different offset.
         let current_sp_offset = self.masm.sp_offset()?;
-        let results_size = frame.results::<M>().size();
+        let results_size = frame.results::<M>()?.size();
         let state = frame.stack_state();
         let (label, cmp, needs_cleanup) = if current_sp_offset > state.target_offset {
             (self.masm.get_label()?, IntCmpKind::Eq, true)
@@ -1829,7 +1829,7 @@ where
 
         let default_index = control_index(targets.default(), self.control_frames.len())?;
         let default_frame = &mut self.control_frames[default_index];
-        let default_result = default_frame.results::<M>();
+        let default_result = default_frame.results::<M>()?;
 
         let (index, tmp) = {
             let index_and_tmp = self.context.without::<Result<(TypedReg, _)>, M, _>(


### PR DESCRIPTION
Follow-up to https://github.com/bytecodealliance/wasmtime/pull/9851

Prior to this commit, Winch's ABI layer would panic on unsupported Wasm types, i.e., `v128`, `externref`.

This commit ensures that a recoverable error is returned in case an unsupported type is found in a function signature.

This change is particularly helpful to start running spec tests for aarch64.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
