### PR TITLE
Remove usage of `gen` as an identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,11 @@ unused_import_braces = 'warn'
 unused-lifetimes = 'warn'
 unused-macro-rules = 'warn'
 
+# Lints that are part of the `rust-2024-compatibility` group. This group is a
+# bit too noisy to enable wholesale but some selective items are ones we want to
+# opt-in to.
+keyword_idents_2024 = 'warn'
+
 # Don't warn about unknown cfgs for pulley
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -697,7 +697,7 @@ impl LinearizeDfg<'_> {
         &mut self,
         key: K,
         map: impl Fn(&mut Self) -> &mut HashMap<K, V>,
-        gen: impl FnOnce(&mut Self, K) -> T,
+        generate: impl FnOnce(&mut Self, K) -> T,
         init: impl FnOnce(V, T) -> GlobalInitializer,
     ) -> V
     where
@@ -707,7 +707,7 @@ impl LinearizeDfg<'_> {
         if let Some(val) = map(self).get(&key) {
             return *val;
         }
-        let tmp = gen(self, key);
+        let tmp = generate(self, key);
         let index = V::new(map(self).len());
         self.initializers.push(init(index, tmp));
         let prev = map(self).insert(key, index);

--- a/crates/fuzzing/src/single_module_fuzzer.rs
+++ b/crates/fuzzing/src/single_module_fuzzer.rs
@@ -311,10 +311,10 @@ mod tests {
             let mutate = mutate::<u32>;
             let run2 = run_config::<(u32, u32)>;
 
-            if let Ok((module, known_valid)) = execute(&buf[..seed_size], run1, gen) {
+            if let Ok((module, known_valid)) = execute(&buf[..seed_size], run1, generate) {
                 assert_eq!(known_valid, KnownValid::Yes);
-                let new_size = mutate(&mut buf, seed_size, max_size, gen, noop_mutate);
-                if let Ok((module2, known_valid)) = execute(&buf[..new_size], run2, gen) {
+                let new_size = mutate(&mut buf, seed_size, max_size, generate, noop_mutate);
+                if let Ok((module2, known_valid)) = execute(&buf[..new_size], run2, generate) {
                     assert_eq!(known_valid, KnownValid::No);
                     compares += 1;
                     if module != module2 {
@@ -340,7 +340,7 @@ mod tests {
             Ok((data.to_vec(), known_valid))
         }
 
-        fn gen<T>(_: &mut T, u: &mut Unstructured<'_>) -> Result<(Vec<u8>, KnownValid)>
+        fn generate<T>(_: &mut T, u: &mut Unstructured<'_>) -> Result<(Vec<u8>, KnownValid)>
         where
             T: for<'a> Arbitrary<'a>,
         {

--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -68,13 +68,13 @@ impl<T, const L: u32, const H: u32> VecInRange<T, L, H> {
     fn new<'a>(
         input: &mut Unstructured<'a>,
         fuel: &mut u32,
-        gen: impl Fn(&mut Unstructured<'a>, &mut u32) -> arbitrary::Result<T>,
+        generate: impl Fn(&mut Unstructured<'a>, &mut u32) -> arbitrary::Result<T>,
     ) -> arbitrary::Result<Self> {
         let mut ret = Vec::new();
         input.arbitrary_loop(Some(L), Some(H), |input| {
             if *fuel > 0 {
                 *fuel = *fuel - 1;
-                ret.push(gen(input, fuel)?);
+                ret.push(generate(input, fuel)?);
                 Ok(std::ops::ControlFlow::Continue(()))
             } else {
                 Ok(std::ops::ControlFlow::Break(()))

--- a/crates/wasi-common/src/sync/mod.rs
+++ b/crates/wasi-common/src/sync/mod.rs
@@ -131,7 +131,7 @@ impl WasiCtxBuilder {
 
 pub fn random_ctx() -> Box<dyn RngCore + Send + Sync> {
     let mut rng = cap_rand::thread_rng(cap_rand::ambient_authority());
-    Box::new(cap_rand::rngs::StdRng::from_seed(rng.gen()))
+    Box::new(cap_rand::rngs::StdRng::from_seed(rng.r#gen()))
 }
 
 #[cfg(feature = "wasmtime")]

--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -86,7 +86,7 @@ impl WasiCtxBuilder {
         // `thread_rng()`, so that it's not guessable from the insecure_random
         // API.
         let insecure_random_seed =
-            cap_rand::thread_rng(cap_rand::ambient_authority()).gen::<u128>();
+            cap_rand::thread_rng(cap_rand::ambient_authority()).r#gen::<u128>();
         Self {
             stdin: Box::new(pipe::ClosedInputStream),
             stdout: Box::new(pipe::SinkOutputStream),

--- a/crates/wasi/src/random.rs
+++ b/crates/wasi/src/random.rs
@@ -54,5 +54,5 @@ mod test {
 pub fn thread_rng() -> Box<dyn RngCore + Send> {
     use cap_rand::{Rng, SeedableRng};
     let mut rng = cap_rand::thread_rng(cap_rand::ambient_authority());
-    Box::new(cap_rand::rngs::StdRng::from_seed(rng.gen()))
+    Box::new(cap_rand::rngs::StdRng::from_seed(rng.r#gen()))
 }

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -355,15 +355,15 @@ struct TableSlot {
 pub struct HostResourceIndex(u64);
 
 impl HostResourceIndex {
-    fn new(idx: u32, gen: u32) -> HostResourceIndex {
-        HostResourceIndex(u64::from(idx) | (u64::from(gen) << 32))
+    fn new(idx: u32, generation: u32) -> HostResourceIndex {
+        HostResourceIndex(u64::from(idx) | (u64::from(generation) << 32))
     }
 
     fn index(&self) -> u32 {
         u32::try_from(self.0 & 0xffffffff).unwrap()
     }
 
-    fn gen(&self) -> u32 {
+    fn generation(&self) -> u32 {
         u32::try_from(self.0 >> 32).unwrap()
     }
 }
@@ -453,7 +453,7 @@ impl<'a> HostResourceTables<'a> {
         // situation the operation that this is guarding will return a more
         // precise error, such as a lift operation.
         if let Some(actual) = actual {
-            if actual.generation != idx.gen() {
+            if actual.generation != idx.generation() {
                 bail!("host-owned resource is being used with the wrong type");
             }
         }

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -41,7 +41,7 @@ mod component {
             seed.parse::<u64>()
                 .with_context(|| anyhow!("expected u64 in WASMTIME_FUZZ_SEED"))?
         } else {
-            StdRng::from_entropy().gen()
+            StdRng::from_entropy().r#gen()
         };
 
         eprintln!(
@@ -62,7 +62,7 @@ mod component {
 
         // First generate a set of type to select from.
         for _ in 0..TYPE_COUNT {
-            let ty = gen(&mut rng, |u| {
+            let ty = generate(&mut rng, |u| {
                 // Only discount fuel if the generation was successful,
                 // otherwise we'll get more random data and try again.
                 let mut fuel = type_fuel;
@@ -80,7 +80,7 @@ mod component {
         // Next generate a set of static API test cases driven by the above
         // types.
         for index in 0..TEST_CASE_COUNT {
-            let (case, rust_params, rust_results) = gen(&mut rng, |u| {
+            let (case, rust_params, rust_results) = generate(&mut rng, |u| {
                 let mut params = Vec::new();
                 let mut results = Vec::new();
                 let mut rust_params = TokenStream::new();
@@ -173,14 +173,14 @@ mod component {
         Ok(())
     }
 
-    fn gen<T>(
+    fn generate<T>(
         rng: &mut StdRng,
         mut f: impl FnMut(&mut Unstructured<'_>) -> arbitrary::Result<T>,
     ) -> Result<T> {
         let mut bytes = Vec::new();
         loop {
             let count = rng.gen_range(1000..2000);
-            bytes.extend(iter::repeat_with(|| rng.gen::<u8>()).take(count));
+            bytes.extend(iter::repeat_with(|| rng.r#gen::<u8>()).take(count));
 
             match f(&mut Unstructured::new(&bytes)) {
                 Ok(ret) => break Ok(ret),


### PR DESCRIPTION
This commit is a start to some preparation for the Rust 2024 edition for Wasmtime and this workspace. The `rust-2024-compatibility` lint group in rustc, currently off-by-default, is intended to assist with migrating code to prepare for the 2024 edition. Some of those lints though are, in my opinion, far too noisy to be turned on so this PR doesn't turn on the whole group. Instead though I plan on enabling individual lints over time in our `Cargo.toml` before the 2024 edition is enabled. This should hopefully provide a relatively smooth and less churn-y path to enabling the 2024 edition in the future.

The first lint enabled here in this commit is the `keyword_idents_2024` lint which warns against usage of identifiers that will become keywords in the 2024 edition. The only one affecting Wasmtime is the `gen` identifier (soon to be keyword) and we had quite a few instances of it. Where possible I've renamed to `generator` or `generate` or `generated` but when used as methods from upstream crate traits (e.g. `RngCore::gen`) we're forced to use `r#gen`. The `rand` crate will be updated in 0.9.0 to avoid this keyword so this shouldn't be permanent.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
