### PR TITLE
Use `&raw` from Rust 1.82

### DIFF
--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -270,7 +270,7 @@ impl Descriptors {
             if len >= (*table).len() {
                 return Err(wasi::ERRNO_NOMEM);
             }
-            core::ptr::addr_of_mut!((*table)[len]).write(desc);
+            (&raw mut (*table)[len]).write(desc);
             self.table_len.set(u16::try_from(len + 1).trapping_unwrap());
             Ok(Fd::from(u32::try_from(len).trapping_unwrap()))
         }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -334,11 +334,11 @@ macro_rules! map_maybe_uninit {
                 use $crate::MaybeUninitExt;
 
                 let m: &mut core::mem::MaybeUninit<_> = $maybe_uninit;
-                // Note the usage of `addr_of_mut!` here which is an attempt to "stay
+                // Note the usage of `&raw` here which is an attempt to "stay
                 // safe" here where we never accidentally create `&mut T` where `T` is
                 // actually uninitialized, hopefully appeasing the Rust unsafe
                 // guidelines gods.
-                m.map(|p| core::ptr::addr_of_mut!((*p)$($field)*))
+                m.map(|p| &raw mut (*p)$($field)*)
             }
         }
     })

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1834,7 +1834,7 @@ impl StoreOpaque {
 
         Some(AsyncCx {
             current_suspend: self.async_state.current_suspend.get(),
-            current_poll_cx: unsafe { core::ptr::addr_of_mut!((*poll_cx_box_ptr).future_context) },
+            current_poll_cx: unsafe { &raw mut (*poll_cx_box_ptr).future_context },
             track_pkey_context_switch: self.pkey.is_some(),
         })
     }

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -228,7 +228,7 @@ impl ComponentInstance {
     }
 
     fn vmctx(&self) -> *mut VMComponentContext {
-        let addr = core::ptr::addr_of!(self.vmctx);
+        let addr = &raw const self.vmctx;
         Strict::with_addr(self.vmctx_self_reference.as_ptr(), Strict::addr(addr))
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -644,7 +644,7 @@ impl Instance {
         // today so the `sptr` crate is used. This crate provides the extension
         // trait `Strict` but the method names conflict with the nightly methods
         // so a different syntax is used to invoke methods here.
-        let addr = ptr::addr_of!(self.vmctx);
+        let addr = &raw const self.vmctx;
         Strict::with_addr(self.vmctx_self_reference.as_ptr(), Strict::addr(addr))
     }
 
@@ -1067,7 +1067,7 @@ impl Instance {
 
     /// Get a locally-defined memory.
     pub fn get_defined_memory(&mut self, index: DefinedMemoryIndex) -> *mut Memory {
-        ptr::addr_of_mut!(self.memories[index].1)
+        &raw mut self.memories[index].1
     }
 
     /// Do a `memory.copy`
@@ -1287,20 +1287,20 @@ impl Instance {
             }
         }
 
-        ptr::addr_of_mut!(self.tables[idx].1)
+        &raw mut self.tables[idx].1
     }
 
     /// Get a table by index regardless of whether it is locally-defined or an
     /// imported, foreign table.
     pub(crate) fn get_table(&mut self, table_index: TableIndex) -> *mut Table {
         self.with_defined_table_index_and_instance(table_index, |idx, instance| {
-            ptr::addr_of_mut!(instance.tables[idx].1)
+            &raw mut instance.tables[idx].1
         })
     }
 
     /// Get a locally-defined table.
     pub(crate) fn get_defined_table(&mut self, index: DefinedTableIndex) -> *mut Table {
-        ptr::addr_of_mut!(self.tables[index].1)
+        &raw mut self.tables[index].1
     }
 
     pub(crate) fn with_defined_table_index_and_instance<R>(

--- a/examples/min-platform/embedding/src/allocator.rs
+++ b/examples/min-platform/embedding/src/allocator.rs
@@ -74,7 +74,7 @@ unsafe impl dlmalloc::Allocator for MyAllocator {
                 (ptr::null_mut(), 0, 0)
             } else {
                 INITIAL_HEAP_ALLOCATED = true;
-                (ptr::addr_of_mut!(INITIAL_HEAP).cast(), INITIAL_HEAP_SIZE, 0)
+                ((&raw mut INITIAL_HEAP).cast(), INITIAL_HEAP_SIZE, 0)
             }
         }
     }


### PR DESCRIPTION
This commit leverages #9956 to use the `&raw` syntax for creating raw pointers instead of using the `ptr::addr_of!` macro.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
