### PR TITLE
Remove `#![deny(warnings)]` from `wasmtime-environ`

### DIFF
--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -3,7 +3,7 @@
 //! the translation the base addresses of regions of memory that will hold the globals, tables and
 //! linear memories.
 
-#![deny(missing_docs, warnings)]
+#![deny(missing_docs)]
 #![warn(clippy::cast_sign_loss)]
 #![no_std]
 


### PR DESCRIPTION
Looks like this accidentally snuck in in #9696 but in general we want to avoid `#![deny(warnings)]` because our CI is where warnings are promoted to errors.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
