### PR TITLE
Enable some more 2024 migration lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,10 @@ unused-macro-rules = 'warn'
 # bit too noisy to enable wholesale but some selective items are ones we want to
 # opt-in to.
 keyword_idents_2024 = 'warn'
+deprecated-safe-2024 = 'warn'
+rust-2024-guarded-string-incompatible-syntax = 'warn'
+rust-2024-prelude-collisions = 'warn'
+rust-2024-incompatible-pat = 'warn'
 
 # Don't warn about unknown cfgs for pulley
 [workspace.lints.rust.unexpected_cfgs]

--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -1262,11 +1262,7 @@ impl DataFlowGraph {
         {
             // We update the position of the old last arg.
             let mut last_arg_data = ValueData::from(self.values[last_arg_val]);
-            if let ValueData::Param {
-                num: ref mut old_num,
-                ..
-            } = &mut last_arg_data
-            {
+            if let ValueData::Param { num: old_num, .. } = &mut last_arg_data {
                 *old_num = num;
                 self.values[last_arg_val] = last_arg_data.into();
             } else {
@@ -1295,7 +1291,7 @@ impl DataFlowGraph {
                 .unwrap()];
             let mut data = ValueData::from(*packed);
             match &mut data {
-                ValueData::Param { ref mut num, .. } => {
+                ValueData::Param { num, .. } => {
                     *num -= 1;
                     *packed = data.into();
                 }

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -307,9 +307,7 @@ impl InstructionData {
     /// `br_table` returns the empty slice.
     pub fn branch_destination<'a>(&'a self, jump_tables: &'a ir::JumpTables) -> &'a [BlockCall] {
         match self {
-            Self::Jump {
-                ref destination, ..
-            } => std::slice::from_ref(destination),
+            Self::Jump { destination, .. } => std::slice::from_ref(destination),
             Self::Brif { blocks, .. } => blocks.as_slice(),
             Self::BranchTable { table, .. } => jump_tables.get(*table).unwrap().all_branches(),
             _ => {
@@ -327,10 +325,7 @@ impl InstructionData {
         jump_tables: &'a mut ir::JumpTables,
     ) -> &'a mut [BlockCall] {
         match self {
-            Self::Jump {
-                ref mut destination,
-                ..
-            } => std::slice::from_mut(destination),
+            Self::Jump { destination, .. } => std::slice::from_mut(destination),
             Self::Brif { blocks, .. } => blocks.as_mut_slice(),
             Self::BranchTable { table, .. } => {
                 jump_tables.get_mut(*table).unwrap().all_branches_mut()

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -965,15 +965,15 @@ impl<'a> FactContext<'a> {
                 },
                 Fact::DynamicRange {
                     bit_width: bw_dynamic,
-                    min: ref min_dynamic,
-                    max: ref max_dynamic,
+                    min: min_dynamic,
+                    max: max_dynamic,
                 },
             )
             | (
                 Fact::DynamicRange {
                     bit_width: bw_dynamic,
-                    min: ref min_dynamic,
-                    max: ref max_dynamic,
+                    min: min_dynamic,
+                    max: max_dynamic,
                 },
                 Fact::Range {
                     bit_width: bw_static,
@@ -1070,16 +1070,16 @@ impl<'a> FactContext<'a> {
                 },
                 Fact::DynamicMem {
                     ty,
-                    min: ref min_dynamic,
-                    max: ref max_dynamic,
+                    min: min_dynamic,
+                    max: max_dynamic,
                     nullable,
                 },
             )
             | (
                 Fact::DynamicMem {
                     ty,
-                    min: ref min_dynamic,
-                    max: ref max_dynamic,
+                    min: min_dynamic,
+                    max: max_dynamic,
                     nullable,
                 },
                 Fact::Range {

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1036,12 +1036,12 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
     fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo<()>) -> SmallVec<[Inst; 2]> {
         let mut insts = SmallVec::new();
-        match &dest {
-            &CallDest::ExtName(ref name, RelocDistance::Near) => {
+        match dest {
+            CallDest::ExtName(name, RelocDistance::Near) => {
                 let info = Box::new(info.map(|()| name.clone()));
                 insts.push(Inst::Call { info });
             }
-            &CallDest::ExtName(ref name, RelocDistance::Far) => {
+            CallDest::ExtName(name, RelocDistance::Far) => {
                 insts.push(Inst::LoadExtName {
                     rd: tmp,
                     name: Box::new(name.clone()),
@@ -1050,7 +1050,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 let info = Box::new(info.map(|()| tmp.to_reg()));
                 insts.push(Inst::CallInd { info });
             }
-            &CallDest::Reg(reg) => {
+            CallDest::Reg(reg) => {
                 let info = Box::new(info.map(|()| *reg));
                 insts.push(Inst::CallInd { info });
             }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -558,11 +558,11 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo<()>) -> SmallVec<[Self::I; 2]> {
         let mut insts = SmallVec::new();
         match &dest {
-            &CallDest::ExtName(ref name, RelocDistance::Near) => {
+            CallDest::ExtName(name, RelocDistance::Near) => {
                 let info = Box::new(info.map(|()| name.clone()));
                 insts.push(Inst::Call { info })
             }
-            &CallDest::ExtName(ref name, RelocDistance::Far) => {
+            CallDest::ExtName(name, RelocDistance::Far) => {
                 insts.push(Inst::LoadExtName {
                     rd: tmp,
                     name: Box::new(name.clone()),
@@ -571,7 +571,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 let info = Box::new(info.map(|()| tmp.to_reg()));
                 insts.push(Inst::CallInd { info });
             }
-            &CallDest::Reg(reg) => {
+            CallDest::Reg(reg) => {
                 let info = Box::new(info.map(|()| *reg));
                 insts.push(Inst::CallInd { info });
             }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -1588,8 +1588,8 @@ impl Inst {
                 eew,
                 to,
                 from,
-                ref mask,
-                ref vstate,
+                mask,
+                vstate,
                 ..
             } => {
                 let base = format_vec_amode(from);
@@ -1602,8 +1602,8 @@ impl Inst {
                 eew,
                 to,
                 from,
-                ref mask,
-                ref vstate,
+                mask,
+                vstate,
                 ..
             } => {
                 let dst = format_vec_amode(to);

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -505,7 +505,7 @@ impl PrettyPrint for Amode {
                 pretty_print_reg(index.to_reg(), 8),
                 1 << shift
             ),
-            Amode::RipRelative { ref target } => format!("label{}(%rip)", target.get()),
+            Amode::RipRelative { target } => format!("label{}(%rip)", target.get()),
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -4517,7 +4517,7 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::ElfTlsGetAddr { ref symbol, dst } => {
+        Inst::ElfTlsGetAddr { symbol, dst } => {
             let dst = dst.to_reg().to_reg();
             debug_assert_eq!(dst, regs::rax());
 
@@ -4546,7 +4546,7 @@ pub(crate) fn emit(
             sink.put4(0); // offset
         }
 
-        Inst::MachOTlsGetAddr { ref symbol, dst } => {
+        Inst::MachOTlsGetAddr { symbol, dst } => {
             let dst = dst.to_reg().to_reg();
             debug_assert_eq!(dst, regs::rax());
 
@@ -4562,11 +4562,7 @@ pub(crate) fn emit(
             sink.put1(0x17);
         }
 
-        Inst::CoffTlsGetAddr {
-            ref symbol,
-            dst,
-            tmp,
-        } => {
+        Inst::CoffTlsGetAddr { symbol, dst, tmp } => {
             let dst = dst.to_reg().to_reg();
             debug_assert_eq!(dst, regs::rax());
 
@@ -4619,7 +4615,7 @@ pub(crate) fn emit(
             sink.put4(0); // offset
         }
 
-        Inst::Unwind { ref inst } => {
+        Inst::Unwind { inst } => {
             sink.add_unwind(inst.clone());
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1923,21 +1923,17 @@ impl PrettyPrint for Inst {
 
             Inst::Ud2 { trap_code } => format!("ud2 {trap_code}"),
 
-            Inst::ElfTlsGetAddr { ref symbol, dst } => {
+            Inst::ElfTlsGetAddr { symbol, dst } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 format!("{dst} = elf_tls_get_addr {symbol:?}")
             }
 
-            Inst::MachOTlsGetAddr { ref symbol, dst } => {
+            Inst::MachOTlsGetAddr { symbol, dst } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 format!("{dst} = macho_tls_get_addr {symbol:?}")
             }
 
-            Inst::CoffTlsGetAddr {
-                ref symbol,
-                dst,
-                tmp,
-            } => {
+            Inst::CoffTlsGetAddr { symbol, dst, tmp } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let tmp = tmp.to_reg().to_reg();
 

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -147,7 +147,7 @@ pub(crate) fn check(
             dst,
             ..
         } => match <&RegMemImm>::from(src2) {
-            RegMemImm::Mem { ref addr } => {
+            RegMemImm::Mem { addr } => {
                 let loaded = check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 check_output(ctx, vcode, dst.to_writable_reg(), &[], |_vcode| {
                     clamp_range(ctx, 64, size.to_bits().into(), loaded)
@@ -175,7 +175,7 @@ pub(crate) fn check(
             dst,
             ..
         } => match <&RegMem>::from(src2) {
-            RegMem::Mem { ref addr } => {
+            RegMem::Mem { addr } => {
                 let loaded = check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 check_output(ctx, vcode, dst.to_writable_reg(), &[], |_vcode| {
                     clamp_range(ctx, 64, size.to_bits().into(), loaded)
@@ -203,7 +203,7 @@ pub(crate) fn check(
         | Inst::UnaryRmRImmVex {
             size, ref src, dst, ..
         } => match <&RegMem>::from(src) {
-            RegMem::Mem { ref addr } => {
+            RegMem::Mem { addr } => {
                 check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 check_output(ctx, vcode, dst.to_writable_reg(), &[], |_vcode| {
                     clamp_range(ctx, 64, size.to_bits().into(), None)
@@ -224,7 +224,7 @@ pub(crate) fn check(
             ..
         } => {
             match <&RegMem>::from(divisor) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -237,7 +237,7 @@ pub(crate) fn check(
             dst, ref divisor, ..
         } => {
             match <&RegMem>::from(divisor) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8, 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -262,7 +262,7 @@ pub(crate) fn check(
             ..
         } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -273,7 +273,7 @@ pub(crate) fn check(
         }
         Inst::Mul8 { dst, ref src2, .. } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8, 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -288,7 +288,7 @@ pub(crate) fn check(
             ..
         } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -303,7 +303,7 @@ pub(crate) fn check(
             ..
         } => {
             match <&RegMem>::from(src1) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -351,7 +351,7 @@ pub(crate) fn check(
                         clamp_range(ctx, 64, from_bytes * 8, Some(src.clone()))
                     })
                 }
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     let loaded = check_load(
                         ctx,
                         Some(dst.to_writable_reg()),
@@ -397,7 +397,7 @@ pub(crate) fn check(
             dst,
         } => {
             match <&RegMem>::from(src) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, ext_mode.src_type(), 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -437,7 +437,7 @@ pub(crate) fn check(
 
         Inst::XmmRmiReg { dst, ref src2, .. } => {
             match <&RegMemImm>::from(src2) {
-                RegMemImm::Mem { ref addr } => {
+                RegMemImm::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8X16, 128)?;
                 }
                 _ => {}
@@ -465,7 +465,7 @@ pub(crate) fn check(
                 }
                 Ok(())
             }
-            RegMemImm::Mem { ref addr } => {
+            RegMemImm::Mem { addr } => {
                 if let Some(rhs) = check_load(ctx, None, addr, vcode, size.to_type(), 64)? {
                     let lhs = get_fact_or_default(vcode, src1.to_reg(), 64);
                     state.cmp_flags = Some((lhs, rhs));
@@ -498,7 +498,7 @@ pub(crate) fn check(
             cc,
             ..
         } => match <&RegMem>::from(consequent) {
-            RegMem::Mem { ref addr } => {
+            RegMem::Mem { addr } => {
                 check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
                 Ok(())
             }
@@ -533,7 +533,7 @@ pub(crate) fn check(
         Inst::XmmCmove { dst, .. } => ensure_no_fact(vcode, dst.to_writable_reg().to_reg()),
 
         Inst::Push64 { ref src } => match <&RegMemImm>::from(src) {
-            RegMemImm::Mem { ref addr } => {
+            RegMemImm::Mem { addr } => {
                 check_load(ctx, None, addr, vcode, I64, 64)?;
                 Ok(())
             }
@@ -553,7 +553,7 @@ pub(crate) fn check(
             dst, src: ref src2, ..
         } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8X16, 128)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -568,7 +568,7 @@ pub(crate) fn check(
             ..
         } => {
             match <&RegMem>::from(src) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, F32, 32)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -582,7 +582,7 @@ pub(crate) fn check(
             ..
         } => {
             match <&RegMem>::from(src) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, F64, 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -610,7 +610,7 @@ pub(crate) fn check(
             ..
         } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8X16, 128)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -655,7 +655,7 @@ pub(crate) fn check(
             };
 
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, ty, size)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -665,7 +665,7 @@ pub(crate) fn check(
 
         Inst::XmmRmiRVex { dst, ref src2, .. } => {
             match <&RegMemImm>::from(src2) {
-                RegMemImm::Mem { ref addr } => {
+                RegMemImm::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8X16, 128)?;
                 }
                 RegMemImm::Reg { .. } | RegMemImm::Imm { .. } => {}
@@ -675,7 +675,7 @@ pub(crate) fn check(
 
         Inst::XmmVexPinsr { dst, ref src2, .. } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I64, 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -691,7 +691,7 @@ pub(crate) fn check(
 
         Inst::GprToXmmVex { dst, ref src, .. } | Inst::GprToXmm { dst, ref src, .. } => {
             match <&RegMem>::from(src) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I64, 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -731,7 +731,7 @@ pub(crate) fn check(
         Inst::CvtIntToFloat { dst, ref src2, .. }
         | Inst::CvtIntToFloatVex { dst, ref src2, .. } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I64, 64)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -783,7 +783,7 @@ pub(crate) fn check(
             ref src1, ref src2, ..
         } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8X16, 128)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -799,7 +799,7 @@ pub(crate) fn check(
             ..
         } if op.has_scalar_src2() => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(
                         ctx,
                         None,
@@ -816,7 +816,7 @@ pub(crate) fn check(
 
         Inst::XmmRmRImm { dst, ref src2, .. } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I8X16, 128)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -828,7 +828,7 @@ pub(crate) fn check(
             ref src1, ref src2, ..
         } => {
             match <&RegMem>::from(src2) {
-                RegMem::Mem { ref addr } => {
+                RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, F32, 32)?;
                 }
                 RegMem::Reg { .. } => {}
@@ -852,7 +852,7 @@ pub(crate) fn check(
         Inst::ReturnCallUnknown { .. } => Ok(()),
 
         Inst::CallUnknown { ref info } => match <&RegMem>::from(&info.dest) {
-            RegMem::Mem { ref addr } => {
+            RegMem::Mem { addr } => {
                 check_load(ctx, None, addr, vcode, I64, 64)?;
                 Ok(())
             }
@@ -861,7 +861,7 @@ pub(crate) fn check(
         Inst::JmpUnknown {
             target: ref dest, ..
         } => match <&RegMem>::from(dest) {
-            RegMem::Mem { ref addr } => {
+            RegMem::Mem { addr } => {
                 check_load(ctx, None, addr, vcode, I64, 64)?;
                 Ok(())
             }

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
 
     fn eat_sym_str(&mut self, s: &str) -> Result<bool> {
         self.eat(|tok| match tok {
-            Token::Symbol(ref tok_s) if tok_s == s => true,
+            Token::Symbol(tok_s) if tok_s == s => true,
             _ => false,
         })
         .map(|token| token.is_some())

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -2245,7 +2245,7 @@ impl TermEnv {
                         ..
                     } => {}
                     TermKind::Decl {
-                        extractor_kind: Some(ExtractorKind::InternalExtractor { ref template }),
+                        extractor_kind: Some(ExtractorKind::InternalExtractor { template }),
                         ..
                     } => {
                         if self.expand_internal_extractors {

--- a/cranelift/jit/src/memory.rs
+++ b/cranelift/jit/src/memory.rs
@@ -252,7 +252,7 @@ impl Memory {
         let iter = self.allocations[self.already_protected..].iter();
 
         #[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
-        return iter.filter(|&PtrLen { ref map, len, .. }| *len != 0 && map.is_some());
+        return iter.filter(|&PtrLen { map, len, .. }| *len != 0 && map.is_some());
 
         #[cfg(any(target_os = "windows", not(feature = "selinux-fix")))]
         return iter.filter(|&PtrLen { len, .. }| *len != 0);

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -55,7 +55,9 @@ pub fn run(options: &Options) -> Result<()> {
         anyhow::bail!("compilation requires a target isa");
     };
 
-    std::env::set_var("RUST_BACKTRACE", "0"); // Disable backtraces to reduce verbosity
+    unsafe {
+        std::env::set_var("RUST_BACKTRACE", "0"); // Disable backtraces to reduce verbosity
+    }
 
     for (func, _) in test_file.functions {
         let (orig_block_count, orig_inst_count) = (block_count(&func), inst_count(&func));

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -532,7 +532,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     ) -> Result<types::Prestat, Error> {
         let table = self.table();
         let dir_entry: Arc<DirEntry> = table.get(u32::from(fd)).map_err(|_| Error::badf())?;
-        if let Some(ref preopen) = dir_entry.preopen_path() {
+        if let Some(preopen) = dir_entry.preopen_path() {
             let path_str = preopen.to_str().ok_or_else(|| Error::not_supported())?;
             let pr_name_len = u32::try_from(path_str.as_bytes().len())?;
             Ok(types::Prestat::Dir(types::PrestatDir { pr_name_len }))
@@ -550,7 +550,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
     ) -> Result<(), Error> {
         let table = self.table();
         let dir_entry: Arc<DirEntry> = table.get(u32::from(fd)).map_err(|_| Error::not_dir())?;
-        if let Some(ref preopen) = dir_entry.preopen_path() {
+        if let Some(preopen) = dir_entry.preopen_path() {
             let path_bytes = preopen
                 .to_str()
                 .ok_or_else(|| Error::not_supported())?

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -509,7 +509,7 @@ impl HostOutputStream for FileOutputStream {
             .await
         {
             Ok(nwritten) => {
-                if let FileOutputMode::Position(ref mut p) = &mut self.mode {
+                if let FileOutputMode::Position(p) = &mut self.mode {
                     *p += nwritten as u64;
                 }
                 self.state = OutputState::Ready;
@@ -571,7 +571,7 @@ impl Subscribe for FileOutputStream {
         if let OutputState::Waiting(task) = &mut self.state {
             self.state = match task.await {
                 Ok(nwritten) => {
-                    if let FileOutputMode::Position(ref mut p) = &mut self.mode {
+                    if let FileOutputMode::Position(p) = &mut self.mode {
                         *p += nwritten as u64;
                     }
                     OutputState::Ready

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -715,7 +715,7 @@ macro_rules! impl_wasm_params {
 
             #[inline]
             fn vmgcref_pointing_to_object_count(&self) -> usize {
-                let ($(ref $t,)*) = self;
+                let ($($t,)*) = self;
                 0 $(
                     + $t.is_vmgcref_and_points_to_object() as usize
                 )*


### PR DESCRIPTION
Most don't produce many warnings except for `rust-2024-incompatible-pat` which required removal of a number of `ref` and `ref mut` keywords throughout the workspace.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
