### PR TITLE
Enable `missing-unsafe-on-extern` lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -936,7 +936,7 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: cargo install cbindgen --vers "^0.26" --locked
+    - run: cargo install cbindgen --vers "^0.27" --locked
     - run: rustup target add x86_64-unknown-none
     - run: ./build.sh x86_64-unknown-none
       working-directory: ./examples/min-platform

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ deprecated-safe-2024 = 'warn'
 rust-2024-guarded-string-incompatible-syntax = 'warn'
 rust-2024-prelude-collisions = 'warn'
 rust-2024-incompatible-pat = 'warn'
+missing-unsafe-on-extern = 'warn'
 
 # Don't warn about unknown cfgs for pulley
 [workspace.lints.rust.unexpected_cfgs]

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -111,11 +111,11 @@ impl TestFileCompiler {
         // final binary doesn't link in `libm`.
         #[cfg(unix)]
         {
-            extern "C" {
-                fn ceilf(f: f32) -> f32;
+            unsafe extern "C" {
+                safe fn ceilf(f: f32) -> f32;
             }
             let f = 1.2_f32;
-            assert_eq!(f.ceil(), unsafe { ceilf(f) });
+            assert_eq!(f.ceil(), ceilf(f));
         }
 
         let module = JITModule::new(builder);

--- a/crates/fiber/src/stackswitch.rs
+++ b/crates/fiber/src/stackswitch.rs
@@ -23,7 +23,7 @@ cfg_if::cfg_if! {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     #[wasmtime_versioned_export_macros::versioned_link]
     pub(crate) fn wasmtime_fiber_init(
         top_of_stack: *mut u8,

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -371,7 +371,7 @@ mod asan {
 
     // These intrinsics are provided by the address sanitizer runtime. Their C
     // signatures were translated into Rust-isms here with `Option` and `&mut`.
-    extern "C" {
+    unsafe extern "C" {
         fn __sanitizer_start_switch_fiber(
             private_asan_pointer_save: Option<&mut *mut u8>,
             bottom: *const u8,

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -64,7 +64,7 @@ struct StartState {
 
 const FIBER_FLAG_FLOAT_SWITCH: u32 = 1;
 
-extern "C" {
+unsafe extern "C" {
     #[wasmtime_versioned_export_macros::versioned_link]
     fn wasmtime_fiber_get_current() -> *mut c_void;
 }

--- a/crates/jit-debug/src/gdb_jit_int.rs
+++ b/crates/jit-debug/src/gdb_jit_int.rs
@@ -27,7 +27,7 @@ struct JITDescriptor {
     first_entry: *mut JITCodeEntry,
 }
 
-extern "C" {
+unsafe extern "C" {
     #[versioned_link]
     fn wasmtime_jit_debug_descriptor() -> *mut JITDescriptor;
     fn __jit_debug_register_code();

--- a/crates/test-programs/src/bin/preview2_adapter_badfd.rs
+++ b/crates/test-programs/src/bin/preview2_adapter_badfd.rs
@@ -1,6 +1,6 @@
 fn main() {
     #[link(wasm_import_module = "wasi_snapshot_preview1")]
-    extern "C" {
+    unsafe extern "C" {
         #[cfg_attr(target_arch = "wasm32", link_name = "adapter_open_badfd")]
         fn adapter_open_badfd(fd: *mut u32) -> wasi::Errno;
 

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -150,7 +150,7 @@ pub struct Descriptors {
 
 #[cfg(not(feature = "proxy"))]
 #[link(wasm_import_module = "wasi:filesystem/preopens@0.2.2")]
-extern "C" {
+unsafe extern "C" {
     #[link_name = "get-directories"]
     fn wasi_filesystem_get_directories(rval: *mut PreopenList);
 }

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -457,7 +457,7 @@ impl BumpAlloc {
 
 #[cfg(not(feature = "proxy"))]
 #[link(wasm_import_module = "wasi:cli/environment@0.2.3")]
-extern "C" {
+unsafe extern "C" {
     #[link_name = "get-arguments"]
     fn wasi_cli_get_arguments(rval: *mut WasmStrList);
     #[link_name = "get-environment"]
@@ -2156,7 +2156,7 @@ pub unsafe extern "C" fn poll_oneoff(
         }
 
         #[link(wasm_import_module = "wasi:io/poll@0.2.3")]
-        extern "C" {
+        unsafe extern "C" {
             #[link_name = "poll"]
             fn poll_import(pollables: *const Pollable, len: usize, rval: *mut ReadyList);
         }
@@ -2731,7 +2731,7 @@ enum AllocationState {
 }
 
 #[expect(improper_ctypes, reason = "types behind pointers")]
-extern "C" {
+unsafe extern "C" {
     fn get_state_ptr() -> *mut State;
     fn set_state_ptr(state: *mut State);
     fn get_allocation_state() -> AllocationState;
@@ -2764,7 +2764,7 @@ impl State {
     #[cold]
     fn new() -> *mut State {
         #[link(wasm_import_module = "__main_module__")]
-        extern "C" {
+        unsafe extern "C" {
             fn cabi_realloc(
                 old_ptr: *mut u8,
                 old_len: usize,

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -114,12 +114,12 @@ pub mod bindings {
     }
 }
 
-#[export_name = "wasi:cli/run@0.2.3#run"]
+#[unsafe(export_name = "wasi:cli/run@0.2.3#run")]
 #[cfg(feature = "command")]
-pub unsafe extern "C" fn run() -> u32 {
+pub extern "C" fn run() -> u32 {
     #[link(wasm_import_module = "__main_module__")]
-    extern "C" {
-        fn _start();
+    unsafe extern "C" {
+        safe fn _start();
     }
     _start();
     0

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn set_vmctx_memory(vmctx_ptr: *mut VMContext) {
 /// means they need to be referenced for the linker to include them which is
 /// what this function does with trickery in C.
 pub fn init() {
-    extern "C" {
+    unsafe extern "C" {
         #[wasmtime_versioned_export_macros::versioned_link]
         fn wasmtime_debug_builtins_init();
     }

--- a/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
@@ -52,7 +52,7 @@ pub type wasmtime_trap_handler_t =
 #[cfg(feature = "signals-based-traps")]
 pub enum wasmtime_memory_image {}
 
-extern "C" {
+unsafe extern "C" {
     /// Creates a new virtual memory mapping of the `size` specified with
     /// protection bits specified in `prot_flags`.
     ///

--- a/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
@@ -1,7 +1,7 @@
 use crate::vm::VMContext;
 
 #[link(name = "wasmtime-helpers")]
-extern "C" {
+unsafe extern "C" {
     #[wasmtime_versioned_export_macros::versioned_link]
     #[allow(improper_ctypes)]
     pub fn wasmtime_setjmp(

--- a/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
             false
         }
     } else {
-        extern "C" {
+        unsafe extern "C" {
             // libunwind import
             fn __register_frame(fde: *const u8);
             fn __deregister_frame(fde: *const u8);

--- a/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
@@ -8,7 +8,7 @@ use windows_sys::Win32::System::Diagnostics::Debug::*;
 use windows_sys::Win32::System::Kernel::*;
 
 #[link(name = "wasmtime-helpers")]
-extern "C" {
+unsafe extern "C" {
     #[wasmtime_versioned_export_macros::versioned_link]
     #[allow(improper_ctypes)]
     pub fn wasmtime_setjmp(

--- a/examples/min-platform/embedding/wasmtime-platform.h
+++ b/examples/min-platform/embedding/wasmtime-platform.h
@@ -23,7 +23,7 @@
 #ifndef _WASMTIME_PLATFORM_H
 #define _WASMTIME_PLATFORM_H
 
-/* Generated with cbindgen:0.26.0 */
+/* Generated with cbindgen:0.27.0 */
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -288,7 +288,7 @@ extern uint8_t *wasmtime_tls_get(void);
 extern void wasmtime_tls_set(uint8_t *ptr);
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
-#endif /* _WASMTIME_PLATFORM_H */
+#endif  /* _WASMTIME_PLATFORM_H */


### PR DESCRIPTION
This'll be a hard error in the 2024 edition so go ahead and opt-in to it now to ease our future transition.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
