### PR TITLE
Enable `unsafe-attr-outside-unsafe` 2024 edition lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ unused-macro-rules = 'warn'
 # bit too noisy to enable wholesale but some selective items are ones we want to
 # opt-in to.
 keyword_idents_2024 = 'warn'
+unsafe-attr-outside-unsafe = 'warn'
 deprecated-safe-2024 = 'warn'
 rust-2024-guarded-string-incompatible-syntax = 'warn'
 rust-2024-prelude-collisions = 'warn'

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -265,7 +265,7 @@ impl WasmBenchConfig {
 /// that contains the engine's initialized state, and `0` is returned. On
 /// failure, a non-zero status code is returned and `out_bench_ptr` is left
 /// untouched.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_bench_create(
     config: WasmBenchConfig,
     out_bench_ptr: *mut *mut c_void,
@@ -347,7 +347,7 @@ pub extern "C" fn wasm_bench_create(
 }
 
 /// Free the engine state allocated by this library.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_bench_free(state: *mut c_void) {
     assert!(!state.is_null());
     unsafe {
@@ -356,7 +356,7 @@ pub extern "C" fn wasm_bench_free(state: *mut c_void) {
 }
 
 /// Compile the Wasm benchmark module.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_bench_compile(
     state: *mut c_void,
     wasm_bytes: *const u8,
@@ -369,7 +369,7 @@ pub extern "C" fn wasm_bench_compile(
 }
 
 /// Instantiate the Wasm benchmark module.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_bench_instantiate(state: *mut c_void) -> ExitCode {
     let state = unsafe { (state as *mut BenchState).as_mut().unwrap() };
     let result = state.instantiate().context("failed to instantiate");
@@ -377,7 +377,7 @@ pub extern "C" fn wasm_bench_instantiate(state: *mut c_void) -> ExitCode {
 }
 
 /// Execute the Wasm benchmark module.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_bench_execute(state: *mut c_void) -> ExitCode {
     let state = unsafe { (state as *mut BenchState).as_mut().unwrap() };
     let result = state.execute().context("failed to execute");

--- a/crates/c-api-macros/src/lib.rs
+++ b/crates/c-api-macros/src/lib.rs
@@ -26,7 +26,7 @@ pub fn declare_own(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     (quote! {
         #[doc = #docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #delete(_: Box<#ty>) {}
     })
     .into()
@@ -48,7 +48,7 @@ pub fn declare_ty(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         wasmtime_c_api_macros::declare_own!(#ty);
 
         #[doc = #docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #copy(src: &#ty) -> Box<#ty> {
             Box::new(src.clone())
         }
@@ -96,27 +96,27 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         wasmtime_c_api_macros::declare_ty!(#ty);
 
         #[doc = #same_docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #same(_a: &#ty, _b: &#ty) -> bool {
             eprintln!("`{}` is not implemented", stringify!(#same));
             std::process::abort();
         }
 
         #[doc = #get_host_info_docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #get_host_info(a: &#ty) -> *mut std::os::raw::c_void {
             std::ptr::null_mut()
         }
 
         #[doc = #set_host_info_docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #set_host_info(a: &#ty, info: *mut std::os::raw::c_void) {
             eprintln!("`{}` is not implemented", stringify!(#set_host_info));
             std::process::abort();
         }
 
         #[doc = #set_host_info_final_docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #set_host_info_final(
             a: &#ty,
             info: *mut std::os::raw::c_void,
@@ -127,14 +127,14 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
 
         #[doc = #as_ref_docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #as_ref(a: &#ty) -> Box<crate::wasm_ref_t> {
             eprintln!("`{}` is not implemented", stringify!(#as_ref));
             std::process::abort();
         }
 
         #[doc = #as_ref_const_docs]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern fn #as_ref_const(a: &#ty) -> Box<crate::wasm_ref_t> {
             eprintln!("`{}` is not implemented", stringify!(#as_ref_const));
             std::process::abort();

--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -18,17 +18,17 @@ use crate::{
     WASMTIME_I32,
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_async_support_set(c: &mut wasm_config_t, enable: bool) {
     c.config.async_support(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_async_stack_size_set(c: &mut wasm_config_t, size: usize) {
     c.config.async_stack_size(size);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_epoch_deadline_async_yield_and_update(
     mut store: WasmtimeStoreContextMut<'_>,
     delta: u64,
@@ -36,7 +36,7 @@ pub extern "C" fn wasmtime_context_epoch_deadline_async_yield_and_update(
     store.epoch_deadline_async_yield_and_update(delta);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_fuel_async_yield_interval(
     mut store: WasmtimeStoreContextMut<'_>,
     interval: Option<NonZeroU64>,
@@ -194,10 +194,10 @@ pub struct wasmtime_call_future_t<'a> {
     underlying: Pin<Box<dyn Future<Output = ()> + 'a>>,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_call_future_delete(_future: Box<wasmtime_call_future_t>) {}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_call_future_poll(future: &mut wasmtime_call_future_t) -> bool {
     let w = futures::task::noop_waker_ref();
     match future.underlying.as_mut().poll(&mut Context::from_waker(w)) {
@@ -242,7 +242,7 @@ async fn do_func_call_async(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_func_call_async<'a>(
     store: WasmtimeStoreContextMut<'a>,
     func: &'a Func,
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn wasmtime_func_call_async<'a>(
     Box::new(wasmtime_call_future_t { underlying: fut })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_define_async_func(
     linker: &mut wasmtime_linker_t,
     module: *const u8,
@@ -308,7 +308,7 @@ async fn do_linker_instantiate_async(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_linker_instantiate_async<'a>(
     linker: &'a wasmtime_linker_t,
     store: WasmtimeStoreContextMut<'a>,
@@ -342,7 +342,7 @@ async fn do_instance_pre_instantiate_async(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_instance_pre_instantiate_async<'a>(
     instance_pre: &'a wasmtime_instance_pre_t,
     store: WasmtimeStoreContextMut<'a>,
@@ -438,7 +438,7 @@ unsafe impl StackCreator for CHostStackCreator {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_config_host_stack_creator_set(
     c: &mut wasm_config_t,
     creator: &wasmtime_stack_creator_t,

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -42,50 +42,50 @@ pub enum wasmtime_profiling_strategy_t {
     WASMTIME_PROFILING_STRATEGY_PERFMAP,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_config_new() -> Box<wasm_config_t> {
     Box::new(wasm_config_t {
         config: Config::default(),
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_debug_info_set(c: &mut wasm_config_t, enable: bool) {
     c.config.debug_info(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_consume_fuel_set(c: &mut wasm_config_t, enable: bool) {
     c.config.consume_fuel(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_epoch_interruption_set(c: &mut wasm_config_t, enable: bool) {
     c.config.epoch_interruption(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_max_wasm_stack_set(c: &mut wasm_config_t, size: usize) {
     c.config.max_wasm_stack(size);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(feature = "threads")]
 pub extern "C" fn wasmtime_config_wasm_threads_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_threads(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_tail_call_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_tail_call(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_reference_types_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_reference_types(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_function_references_set(
     c: &mut wasm_config_t,
     enable: bool,
@@ -93,22 +93,22 @@ pub extern "C" fn wasmtime_config_wasm_function_references_set(
     c.config.wasm_function_references(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_gc_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_gc(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_simd_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_simd(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_relaxed_simd_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_relaxed_simd(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_relaxed_simd_deterministic_set(
     c: &mut wasm_config_t,
     enable: bool,
@@ -116,27 +116,27 @@ pub extern "C" fn wasmtime_config_wasm_relaxed_simd_deterministic_set(
     c.config.relaxed_simd_deterministic(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_bulk_memory_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_bulk_memory(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_multi_value_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_multi_value(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_multi_memory_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_multi_memory(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_memory64_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_memory64(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub extern "C" fn wasmtime_config_strategy_set(
     c: &mut wasm_config_t,
@@ -149,13 +149,13 @@ pub extern "C" fn wasmtime_config_strategy_set(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(feature = "parallel-compilation")]
 pub extern "C" fn wasmtime_config_parallel_compilation_set(c: &mut wasm_config_t, enable: bool) {
     c.config.parallel_compilation(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub extern "C" fn wasmtime_config_cranelift_debug_verifier_set(
     c: &mut wasm_config_t,
@@ -164,7 +164,7 @@ pub extern "C" fn wasmtime_config_cranelift_debug_verifier_set(
     c.config.cranelift_debug_verifier(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub extern "C" fn wasmtime_config_cranelift_nan_canonicalization_set(
     c: &mut wasm_config_t,
@@ -173,7 +173,7 @@ pub extern "C" fn wasmtime_config_cranelift_nan_canonicalization_set(
     c.config.cranelift_nan_canonicalization(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub extern "C" fn wasmtime_config_cranelift_opt_level_set(
     c: &mut wasm_config_t,
@@ -187,7 +187,7 @@ pub extern "C" fn wasmtime_config_cranelift_opt_level_set(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_profiler_set(
     c: &mut wasm_config_t,
     strategy: wasmtime_profiling_strategy_t,
@@ -201,7 +201,7 @@ pub extern "C" fn wasmtime_config_profiler_set(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(feature = "cache")]
 pub unsafe extern "C" fn wasmtime_config_cache_config_load(
     c: &mut wasm_config_t,
@@ -220,22 +220,22 @@ pub unsafe extern "C" fn wasmtime_config_cache_config_load(
     )
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_memory_may_move_set(c: &mut wasm_config_t, enable: bool) {
     c.config.memory_may_move(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_memory_reservation_set(c: &mut wasm_config_t, size: u64) {
     c.config.memory_reservation(size);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
     c.config.memory_guard_size(size);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_memory_reservation_for_growth_set(
     c: &mut wasm_config_t,
     size: u64,
@@ -243,12 +243,12 @@ pub extern "C" fn wasmtime_config_memory_reservation_for_growth_set(
     c.config.memory_reservation_for_growth(size);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_native_unwind_info_set(c: &mut wasm_config_t, enabled: bool) {
     c.config.native_unwind_info(enabled);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_config_target_set(
     c: &mut wasm_config_t,
     target: *const c_char,
@@ -257,12 +257,12 @@ pub unsafe extern "C" fn wasmtime_config_target_set(
     handle_result(c.config.target(target), |_cfg| {})
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_macos_use_mach_ports_set(c: &mut wasm_config_t, enabled: bool) {
     c.config.macos_use_mach_ports(enabled);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub unsafe extern "C" fn wasmtime_config_cranelift_flag_enable(
     c: &mut wasm_config_t,
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn wasmtime_config_cranelift_flag_enable(
     c.config.cranelift_flag_enable(flag);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub unsafe extern "C" fn wasmtime_config_cranelift_flag_set(
     c: &mut wasm_config_t,
@@ -421,7 +421,7 @@ unsafe impl MemoryCreator for CHostMemoryCreator {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_config_host_memory_creator_set(
     c: &mut wasm_config_t,
     creator: &wasmtime_memory_creator_t,
@@ -435,12 +435,12 @@ pub unsafe extern "C" fn wasmtime_config_host_memory_creator_set(
     }));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_memory_init_cow_set(c: &mut wasm_config_t, enable: bool) {
     c.config.memory_init_cow(enable);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_wide_arithmetic_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_wide_arithmetic(enable);
 }

--- a/crates/c-api/src/engine.rs
+++ b/crates/c-api/src/engine.rs
@@ -9,7 +9,7 @@ pub struct wasm_engine_t {
 
 wasmtime_c_api_macros::declare_own!(wasm_engine_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
     // Enable the `env_logger` crate since this is as good a place as any to
     // support some "top level initialization" for the C API. Almost all support
@@ -27,7 +27,7 @@ pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_engine_new_with_config(c: Box<wasm_config_t>) -> Box<wasm_engine_t> {
     #[cfg(feature = "logging")]
     drop(env_logger::try_init());
@@ -38,17 +38,17 @@ pub extern "C" fn wasm_engine_new_with_config(c: Box<wasm_config_t>) -> Box<wasm
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_engine_clone(engine: &wasm_engine_t) -> Box<wasm_engine_t> {
     Box::new(engine.clone())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_engine_increment_epoch(engine: &wasm_engine_t) {
     engine.engine.increment_epoch();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_engine_is_pulley(engine: &wasm_engine_t) -> bool {
     engine.engine.is_pulley()
 }

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -20,7 +20,7 @@ impl Into<Error> for wasmtime_error_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_error_new(
     msg: *const std::ffi::c_char,
 ) -> Option<Box<wasmtime_error_t>> {
@@ -48,12 +48,12 @@ pub(crate) fn bad_utf8() -> Option<Box<wasmtime_error_t>> {
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_error_message(error: &wasmtime_error_t, message: &mut wasm_name_t) {
     message.set_buffer(format!("{:?}", error.error).into_bytes());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_error_exit_status(raw: &wasmtime_error_t, status: &mut i32) -> bool {
     #[cfg(feature = "wasi")]
     if let Some(exit) = raw.error.downcast_ref::<wasmtime_wasi::I32Exit>() {
@@ -67,7 +67,7 @@ pub extern "C" fn wasmtime_error_exit_status(raw: &wasmtime_error_t, status: &mu
     false
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_error_wasm_trace<'a>(
     raw: &'a wasmtime_error_t,
     out: &mut wasm_frame_vec_t<'a>,

--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -13,7 +13,7 @@ pub struct wasm_extern_t {
 
 wasmtime_c_api_macros::declare_ref!(wasm_extern_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
     match e.which {
         Extern::Func(_) => crate::WASM_EXTERN_FUNC,
@@ -26,49 +26,49 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
     Box::new(wasm_externtype_t::from_extern_type(
         e.which.ty(&e.store.context()),
     ))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_func(e: &wasm_extern_t) -> Option<&wasm_func_t> {
     wasm_func_t::try_from(e)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_func_t> {
     wasm_extern_as_func(e)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_global(e: &wasm_extern_t) -> Option<&wasm_global_t> {
     wasm_global_t::try_from(e)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm_global_t> {
     wasm_extern_as_global(e)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_table(e: &wasm_extern_t) -> Option<&wasm_table_t> {
     wasm_table_t::try_from(e)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_table_t> {
     wasm_extern_as_table(e)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_memory(e: &wasm_extern_t) -> Option<&wasm_memory_t> {
     wasm_memory_t::try_from(e)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_extern_as_memory_const(e: &wasm_extern_t) -> Option<&wasm_memory_t> {
     wasm_extern_as_memory(e)
 }
@@ -147,12 +147,12 @@ impl From<Extern> for wasmtime_extern_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_extern_delete(e: &mut ManuallyDrop<wasmtime_extern_t>) {
     ManuallyDrop::drop(e);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_extern_type(
     store: WasmtimeStoreContext<'_>,
     e: &wasmtime_extern_t,

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -91,7 +91,7 @@ unsafe fn create_function(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_new(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn wasm_func_new(
     create_function(store, ty, move |params, results| callback(params, results))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_new_with_env(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,
@@ -131,7 +131,7 @@ pub(crate) fn translate_args<'a>(
     (a, b)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_call(
     func: &mut wasm_func_t,
     args: *const wasm_val_vec_t,
@@ -177,27 +177,27 @@ fn error_from_panic(panic: Box<dyn Any + Send>) -> Error {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t> {
     Box::new(wasm_functype_t::new(f.func().ty(f.ext.store.context())))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.ext.store.context()).params().len()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_result_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.ext.store.context()).results().len()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_func_as_extern(f: &mut wasm_func_t) -> &mut wasm_extern_t {
     &mut (*f).ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_func_as_extern_const(f: &wasm_func_t) -> &wasm_extern_t {
     &(*f).ext
 }
@@ -237,7 +237,7 @@ pub type wasmtime_func_unchecked_callback_t = extern "C" fn(
     usize,
 ) -> Option<Box<wasm_trap_t>>;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_func_new(
     store: WasmtimeStoreContextMut<'_>,
     ty: &wasm_functype_t,
@@ -307,7 +307,7 @@ pub(crate) unsafe fn c_callback_to_rust_fn(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_func_new_unchecked(
     store: WasmtimeStoreContextMut<'_>,
     ty: &wasm_functype_t,
@@ -337,7 +337,7 @@ pub(crate) unsafe fn c_unchecked_callback_to_rust_fn(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_func_call(
     mut store: WasmtimeStoreContextMut<'_>,
     func: &Func,
@@ -383,7 +383,7 @@ pub unsafe extern "C" fn wasmtime_func_call(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_func_call_unchecked(
     store: WasmtimeStoreContextMut<'_>,
     func: &Func,
@@ -407,7 +407,7 @@ fn store_err(err: Error, trap_ret: &mut *mut wasm_trap_t) -> Option<Box<wasmtime
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_func_type(
     store: WasmtimeStoreContext<'_>,
     func: &Func,
@@ -415,14 +415,14 @@ pub extern "C" fn wasmtime_func_type(
     Box::new(wasm_functype_t::new(func.ty(store)))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_caller_context<'a>(
     caller: &'a mut wasmtime_caller_t,
 ) -> WasmtimeStoreContextMut<'a> {
     caller.caller.as_context_mut()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_caller_export_get(
     caller: &mut wasmtime_caller_t,
     name: *const u8,
@@ -441,7 +441,7 @@ pub unsafe extern "C" fn wasmtime_caller_export_get(
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_func_from_raw(
     store: WasmtimeStoreContextMut<'_>,
     raw: *mut c_void,
@@ -450,7 +450,7 @@ pub unsafe extern "C" fn wasmtime_func_from_raw(
     *func = Func::from_raw(store, raw).unwrap();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_func_to_raw(
     store: WasmtimeStoreContextMut<'_>,
     func: &Func,

--- a/crates/c-api/src/global.rs
+++ b/crates/c-api/src/global.rs
@@ -29,7 +29,7 @@ impl wasm_global_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_global_new(
     store: &mut wasm_store_t,
     gt: &wasm_globaltype_t,
@@ -46,23 +46,23 @@ pub unsafe extern "C" fn wasm_global_new(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_global_as_extern(g: &mut wasm_global_t) -> &mut wasm_extern_t {
     &mut g.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern_t {
     &g.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globaltype_t> {
     let globaltype = g.global().ty(&g.ext.store.context());
     Box::new(wasm_globaltype_t::new(globaltype))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeUninit<wasm_val_t>) {
     let global = g.global();
     crate::initialize(
@@ -71,13 +71,13 @@ pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeU
     );
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_global_set(g: &mut wasm_global_t, val: &wasm_val_t) {
     let global = g.global();
     drop(global.set(g.ext.store.context_mut(), val.val()));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_global_new(
     mut store: WasmtimeStoreContextMut<'_>,
     gt: &wasm_globaltype_t,
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn wasmtime_global_new(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_global_type(
     store: WasmtimeStoreContext<'_>,
     global: &Global,
@@ -100,7 +100,7 @@ pub extern "C" fn wasmtime_global_type(
     Box::new(wasm_globaltype_t::new(global.ty(store)))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_global_get(
     store: WasmtimeStoreContextMut<'_>,
     global: &Global,
@@ -111,7 +111,7 @@ pub extern "C" fn wasmtime_global_get(
     crate::initialize(val, wasmtime_val_t::from_val(&mut scope, gval))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_global_set(
     mut store: WasmtimeStoreContextMut<'_>,
     global: &Global,

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -19,7 +19,7 @@ impl wasm_instance_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_instance_new(
     store: &mut wasm_store_t,
     wasm_module: &wasm_module_t,
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn wasm_instance_new(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_instance_exports(
     instance: &mut wasm_instance_t,
     out: &mut wasm_extern_vec_t,
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn wasm_instance_exports(
     );
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_instance_new(
     store: WasmtimeStoreContextMut<'_>,
     module: &wasmtime_module_t,
@@ -109,7 +109,7 @@ pub(crate) fn handle_instantiate(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_instance_export_get(
     store: WasmtimeStoreContextMut<'_>,
     instance: &Instance,
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn wasmtime_instance_export_get(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_instance_export_nth(
     store: WasmtimeStoreContextMut<'_>,
     instance: &Instance,
@@ -156,11 +156,11 @@ pub struct wasmtime_instance_pre_t {
     pub(crate) underlying: InstancePre<WasmtimeStoreData>,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_instance_pre_delete(_instance_pre: Box<wasmtime_instance_pre_t>) {
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_instance_pre_instantiate(
     instance_pre: &wasmtime_instance_pre_t,
     store: WasmtimeStoreContextMut<'_>,
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn wasmtime_instance_pre_instantiate(
     handle_instantiate(result, instance_ptr, trap_ptr)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_instance_pre_module(
     instance_pre: &wasmtime_instance_pre_t,
 ) -> Box<wasmtime_module_t> {

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -15,21 +15,21 @@ pub struct wasmtime_linker_t {
 
 wasmtime_c_api_macros::declare_own!(wasmtime_linker_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_linker_new(engine: &wasm_engine_t) -> Box<wasmtime_linker_t> {
     Box::new(wasmtime_linker_t {
         linker: Linker::new(&engine.engine),
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_linker_clone(linker: &wasmtime_linker_t) -> Box<wasmtime_linker_t> {
     Box::new(wasmtime_linker_t {
         linker: linker.linker.clone(),
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_linker_allow_shadowing(
     linker: &mut wasmtime_linker_t,
     allow_shadowing: bool,
@@ -48,7 +48,7 @@ macro_rules! to_str {
 
 pub(crate) use to_str;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_define(
     linker: &mut wasmtime_linker_t,
     store: WasmtimeStoreContext<'_>,
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn wasmtime_linker_define(
     handle_result(linker.define(&store, module, name, item), |_linker| ())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_define_func(
     linker: &mut wasmtime_linker_t,
     module: *const u8,
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_func(
     handle_result(linker.linker.func_new(module, name, ty, cb), |_linker| ())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_define_func_unchecked(
     linker: &mut wasmtime_linker_t,
     module: *const u8,
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_func_unchecked(
 }
 
 #[cfg(feature = "wasi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_linker_define_wasi(
     linker: &mut wasmtime_linker_t,
 ) -> Option<Box<wasmtime_error_t>> {
@@ -119,7 +119,7 @@ pub extern "C" fn wasmtime_linker_define_wasi(
     )
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_define_instance(
     linker: &mut wasmtime_linker_t,
     store: WasmtimeStoreContextMut<'_>,
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_instance(
     handle_result(linker.instance(store, name, *instance), |_linker| ())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_linker_instantiate(
     linker: &wasmtime_linker_t,
     store: WasmtimeStoreContextMut<'_>,
@@ -144,7 +144,7 @@ pub extern "C" fn wasmtime_linker_instantiate(
     super::instance::handle_instantiate(result, instance_ptr, trap_ptr)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_instantiate_pre(
     linker: &wasmtime_linker_t,
     module: &wasmtime_module_t,
@@ -157,7 +157,7 @@ pub unsafe extern "C" fn wasmtime_linker_instantiate_pre(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_module(
     linker: &mut wasmtime_linker_t,
     store: WasmtimeStoreContextMut<'_>,
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn wasmtime_linker_module(
     handle_result(linker.module(store, name, &module.module), |_linker| ())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_get_default(
     linker: &wasmtime_linker_t,
     store: WasmtimeStoreContextMut<'_>,
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn wasmtime_linker_get_default(
     handle_result(linker.get_default(store, name), |f| *func = f)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_linker_get(
     linker: &wasmtime_linker_t,
     store: WasmtimeStoreContextMut<'_>,

--- a/crates/c-api/src/memory.rs
+++ b/crates/c-api/src/memory.rs
@@ -31,7 +31,7 @@ impl wasm_memory_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_new(
     store: &mut wasm_store_t,
     mt: &wasm_memorytype_t,
@@ -45,38 +45,38 @@ pub unsafe extern "C" fn wasm_memory_new(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_memory_as_extern(m: &mut wasm_memory_t) -> &mut wasm_extern_t {
     &mut m.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern_t {
     &m.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memorytype_t> {
     let ty = m.memory().ty(m.ext.store.context());
     Box::new(wasm_memorytype_t::new(ty))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
     m.memory().data_ptr(m.ext.store.context())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
     m.memory().data_size(m.ext.store.context())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_pages_t {
     u32::try_from(m.memory().size(m.ext.store.context())).unwrap()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_grow(
     m: &mut wasm_memory_t,
     delta: wasm_memory_pages_t,
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn wasm_memory_grow(
     memory.grow(&mut store, u64::from(delta)).is_ok()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memory_new(
     store: WasmtimeStoreContextMut<'_>,
     ty: &wasm_memorytype_t,
@@ -95,7 +95,7 @@ pub extern "C" fn wasmtime_memory_new(
     handle_result(Memory::new(store, ty.ty().ty.clone()), |mem| *ret = mem)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memory_type(
     store: WasmtimeStoreContext<'_>,
     mem: &Memory,
@@ -103,12 +103,12 @@ pub extern "C" fn wasmtime_memory_type(
     Box::new(wasm_memorytype_t::new(mem.ty(store)))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memory_data(store: WasmtimeStoreContext<'_>, mem: &Memory) -> *const u8 {
     mem.data(store).as_ptr()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memory_data_size(
     store: WasmtimeStoreContext<'_>,
     mem: &Memory,
@@ -116,12 +116,12 @@ pub extern "C" fn wasmtime_memory_data_size(
     mem.data(store).len()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memory_size(store: WasmtimeStoreContext<'_>, mem: &Memory) -> u64 {
     mem.size(store)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memory_grow(
     store: WasmtimeStoreContextMut<'_>,
     mem: &Memory,

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -28,7 +28,7 @@ pub struct wasm_shared_module_t {
 
 wasmtime_c_api_macros::declare_own!(wasm_shared_module_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub unsafe extern "C" fn wasm_module_new(
     store: &mut wasm_store_t,
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn wasm_module_new(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub unsafe extern "C" fn wasm_module_validate(
     store: &mut wasm_store_t,
@@ -76,24 +76,24 @@ fn fill_imports(module: &Module, out: &mut wasm_importtype_vec_t) {
     out.set_buffer(imports);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exporttype_vec_t) {
     fill_exports(&module.module, out);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_importtype_vec_t) {
     fill_imports(&module.module, out);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_module_t> {
     Box::new(wasm_shared_module_t {
         module: module.module.clone(),
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_module_obtain(
     store: &mut wasm_store_t,
     shared_module: &wasm_shared_module_t,
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn wasm_module_obtain(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub extern "C" fn wasm_module_serialize(module: &wasm_module_t, ret: &mut wasm_byte_vec_t) {
     if let Ok(buf) = module.module.serialize() {
@@ -114,7 +114,7 @@ pub extern "C" fn wasm_module_serialize(module: &wasm_module_t, ret: &mut wasm_b
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_module_deserialize(
     store: &mut wasm_store_t,
     binary: &wasm_byte_vec_t,
@@ -132,7 +132,7 @@ pub struct wasmtime_module_t {
 
 wasmtime_c_api_macros::declare_own!(wasmtime_module_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub unsafe extern "C" fn wasmtime_module_new(
     engine: &wasm_engine_t,
@@ -148,12 +148,12 @@ pub unsafe extern "C" fn wasmtime_module_new(
     )
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_module_clone(module: &wasmtime_module_t) -> Box<wasmtime_module_t> {
     Box::new(module.clone())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_module_exports(
     module: &wasmtime_module_t,
     out: &mut wasm_exporttype_vec_t,
@@ -161,7 +161,7 @@ pub extern "C" fn wasmtime_module_exports(
     fill_exports(&module.module, out);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_module_imports(
     module: &wasmtime_module_t,
     out: &mut wasm_importtype_vec_t,
@@ -169,7 +169,7 @@ pub extern "C" fn wasmtime_module_imports(
     fill_imports(&module.module, out);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub unsafe extern "C" fn wasmtime_module_validate(
     engine: &wasm_engine_t,
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn wasmtime_module_validate(
     handle_result(Module::validate(&engine.engine, binary), |()| {})
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 pub extern "C" fn wasmtime_module_serialize(
     module: &wasmtime_module_t,
@@ -189,7 +189,7 @@ pub extern "C" fn wasmtime_module_serialize(
     handle_result(module.module.serialize(), |buf| ret.set_buffer(buf))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_module_image_range(
     module: &wasmtime_module_t,
     start: &mut *const u8,
@@ -200,7 +200,7 @@ pub extern "C" fn wasmtime_module_image_range(
     *end = range.end;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_module_deserialize(
     engine: &wasm_engine_t,
     bytes: *const u8,
@@ -213,7 +213,7 @@ pub unsafe extern "C" fn wasmtime_module_deserialize(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_module_deserialize_file(
     engine: &wasm_engine_t,
     path: *const c_char,

--- a/crates/c-api/src/profiling.rs
+++ b/crates/c-api/src/profiling.rs
@@ -16,7 +16,7 @@ pub struct wasmtime_guestprofiler_modules_t<'a> {
     module: &'a wasmtime_module_t,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_guestprofiler_new(
     module_name: &wasm_name_t,
     interval_nanos: u64,
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn wasmtime_guestprofiler_new(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_guestprofiler_sample(
     guestprofiler: &mut wasmtime_guestprofiler_t,
     store: &wasmtime_store_t,
@@ -51,7 +51,7 @@ pub extern "C" fn wasmtime_guestprofiler_sample(
         .sample(&store.store, Duration::from_nanos(delta_nanos));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_guestprofiler_finish(
     guestprofiler: Box<wasmtime_guestprofiler_t>,
     out: &mut wasm_byte_vec_t,

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -35,28 +35,28 @@ pub(crate) fn ref_to_val(r: &wasm_ref_t) -> Val {
     Val::from(r.r.clone())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t>> {
     r.map(|r| Box::new(r.clone()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>) -> bool {
     // We need a store to determine whether these are the same reference or not.
     abort("wasm_ref_same")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_void {
     std::ptr::null_mut()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut c_void) {
     abort("wasm_ref_set_host_info")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
     _ref: Option<&wasm_ref_t>,
     _info: *mut c_void,
@@ -65,108 +65,108 @@ pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
     abort("wasm_ref_set_host_info_with_finalizer")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_extern(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_extern_t> {
     abort("wasm_ref_as_extern")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_extern_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_extern_t> {
     abort("wasm_ref_as_extern_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_foreign(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_foreign_t> {
     abort("wasm_ref_as_foreign")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_foreign_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_foreign_t> {
     abort("wasm_ref_as_foreign_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_func(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_func_t> {
     abort("wasm_ref_as_func")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_func_t> {
     abort("wasm_ref_as_func_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_global(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_global_t> {
     abort("wasm_ref_as_global")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_global_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_global_t> {
     abort("wasm_ref_as_global_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_instance(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_instance_t> {
     abort("wasm_ref_as_instance")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_instance_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_instance_t> {
     abort("wasm_ref_as_instance_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_memory(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_memory_t> {
     abort("wasm_ref_as_memory")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_memory_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_memory_t> {
     abort("wasm_ref_as_memory_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_module(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_module_t> {
     abort("wasm_ref_as_module")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_module_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_module_t> {
     abort("wasm_ref_as_module_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_table(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_table_t> {
     abort("wasm_ref_as_table")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_table_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_table_t> {
     abort("wasm_ref_as_table_const")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_trap(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_trap_t> {
     abort("wasm_ref_as_trap")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_ref_as_trap_const(_ref: Option<&wasm_ref_t>) -> Option<&crate::wasm_trap_t> {
     abort("wasm_ref_as_trap_const")
 }
@@ -177,7 +177,7 @@ pub struct wasm_foreign_t {}
 
 wasmtime_c_api_macros::declare_ref!(wasm_foreign_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_foreign_t> {
     abort("wasm_foreign_new")
 }
@@ -229,7 +229,7 @@ macro_rules! ref_wrapper {
 ref_wrapper!(AnyRef => wasmtime_anyref_t);
 ref_wrapper!(ExternRef => wasmtime_externref_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_clone(
     cx: WasmtimeStoreContextMut<'_>,
     anyref: Option<&wasmtime_anyref_t>,
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn wasmtime_anyref_clone(
     crate::initialize(out, anyref.into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_unroot(
     cx: WasmtimeStoreContextMut<'_>,
     val: Option<&mut MaybeUninit<wasmtime_anyref_t>>,
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn wasmtime_anyref_unroot(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_to_raw(
     cx: WasmtimeStoreContextMut<'_>,
     val: Option<&wasmtime_anyref_t>,
@@ -259,7 +259,7 @@ pub unsafe extern "C" fn wasmtime_anyref_to_raw(
         .unwrap_or_default()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_from_raw(
     cx: WasmtimeStoreContextMut<'_>,
     raw: u32,
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn wasmtime_anyref_from_raw(
     crate::initialize(val, anyref.into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_anyref_from_i31(
     cx: WasmtimeStoreContextMut<'_>,
     val: u32,
@@ -283,7 +283,7 @@ pub extern "C" fn wasmtime_anyref_from_i31(
     crate::initialize(out, Some(anyref).into())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_i31_get_u(
     cx: WasmtimeStoreContextMut<'_>,
     anyref: Option<&wasmtime_anyref_t>,
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn wasmtime_anyref_i31_get_u(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_i31_get_s(
     cx: WasmtimeStoreContextMut<'_>,
     anyref: Option<&wasmtime_anyref_t>,
@@ -321,7 +321,7 @@ pub unsafe extern "C" fn wasmtime_anyref_i31_get_s(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_externref_new(
     cx: WasmtimeStoreContextMut<'_>,
     data: *mut c_void,
@@ -338,7 +338,7 @@ pub extern "C" fn wasmtime_externref_new(
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_data(
     cx: WasmtimeStoreContextMut<'_>,
     externref: Option<&wasmtime_externref_t>,
@@ -352,7 +352,7 @@ pub unsafe extern "C" fn wasmtime_externref_data(
         .unwrap_or(ptr::null_mut())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_clone(
     cx: WasmtimeStoreContextMut<'_>,
     externref: Option<&wasmtime_externref_t>,
@@ -362,7 +362,7 @@ pub unsafe extern "C" fn wasmtime_externref_clone(
     crate::initialize(out, externref.into());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_unroot(
     cx: WasmtimeStoreContextMut<'_>,
     val: Option<&mut MaybeUninit<wasmtime_externref_t>>,
@@ -372,7 +372,7 @@ pub unsafe extern "C" fn wasmtime_externref_unroot(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_to_raw(
     cx: WasmtimeStoreContextMut<'_>,
     val: Option<&wasmtime_externref_t>,
@@ -382,7 +382,7 @@ pub unsafe extern "C" fn wasmtime_externref_to_raw(
         .unwrap_or_default()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_from_raw(
     cx: WasmtimeStoreContextMut<'_>,
     raw: u32,

--- a/crates/c-api/src/sharedmemory.rs
+++ b/crates/c-api/src/sharedmemory.rs
@@ -6,7 +6,7 @@ type wasmtime_sharedmemory_t = SharedMemory;
 
 wasmtime_c_api_macros::declare_own!(wasmtime_sharedmemory_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(feature = "threads")]
 pub extern "C" fn wasmtime_sharedmemory_new(
     engine: &crate::wasm_engine_t,
@@ -19,38 +19,38 @@ pub extern "C" fn wasmtime_sharedmemory_new(
     )
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_sharedmemory_clone(
     mem: &wasmtime_sharedmemory_t,
 ) -> Box<wasmtime_sharedmemory_t> {
     Box::new(mem.clone())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_sharedmemory_type(
     mem: &wasmtime_sharedmemory_t,
 ) -> Box<wasm_memorytype_t> {
     Box::new(wasm_memorytype_t::new(mem.ty()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_sharedmemory_data(
     mem: &wasmtime_sharedmemory_t,
 ) -> *const UnsafeCell<u8> {
     mem.data().as_ptr()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_sharedmemory_data_size(mem: &wasmtime_sharedmemory_t) -> usize {
     mem.data().len()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_sharedmemory_size(mem: &wasmtime_sharedmemory_t) -> u64 {
     mem.size()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_sharedmemory_grow(
     mem: &wasmtime_sharedmemory_t,
     delta: u64,

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -48,7 +48,7 @@ pub struct wasm_store_t {
 
 wasmtime_c_api_macros::declare_own!(wasm_store_t);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_store_new(engine: &wasm_engine_t) -> Box<wasm_store_t> {
     let engine = &engine.engine;
     let store = Store::new(engine, ());
@@ -97,7 +97,7 @@ pub struct WasmtimeStoreData {
     pub store_limits: StoreLimits,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_store_new(
     engine: &wasm_engine_t,
     data: *mut c_void,
@@ -122,7 +122,7 @@ pub type wasmtime_update_deadline_kind_t = u8;
 pub const WASMTIME_UPDATE_DEADLINE_CONTINUE: wasmtime_update_deadline_kind_t = 0;
 pub const WASMTIME_UPDATE_DEADLINE_YIELD: wasmtime_update_deadline_kind_t = 1;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_store_epoch_deadline_callback(
     store: &mut wasmtime_store_t,
     func: extern "C" fn(
@@ -159,14 +159,14 @@ pub extern "C" fn wasmtime_store_epoch_deadline_callback(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_store_context(
     store: &mut wasmtime_store_t,
 ) -> WasmtimeStoreContextMut<'_> {
     store.store.as_context_mut()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_store_limiter(
     store: &mut wasmtime_store_t,
     memory_size: i64,
@@ -195,12 +195,12 @@ pub extern "C" fn wasmtime_store_limiter(
     store.store.limiter(|data| &mut data.store_limits);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_get_data(store: WasmtimeStoreContext<'_>) -> *mut c_void {
     store.data().foreign.data
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_set_data(
     mut store: WasmtimeStoreContextMut<'_>,
     data: *mut c_void,
@@ -209,7 +209,7 @@ pub extern "C" fn wasmtime_context_set_data(
 }
 
 #[cfg(feature = "wasi")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_set_wasi(
     mut context: WasmtimeStoreContextMut<'_>,
     wasi: Box<crate::wasi_config_t>,
@@ -219,12 +219,12 @@ pub extern "C" fn wasmtime_context_set_wasi(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_gc(mut context: WasmtimeStoreContextMut<'_>) {
     context.gc();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_set_fuel(
     mut store: WasmtimeStoreContextMut<'_>,
     fuel: u64,
@@ -232,7 +232,7 @@ pub extern "C" fn wasmtime_context_set_fuel(
     crate::handle_result(store.set_fuel(fuel), |()| {})
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_get_fuel(
     store: WasmtimeStoreContext<'_>,
     fuel: &mut u64,
@@ -242,7 +242,7 @@ pub extern "C" fn wasmtime_context_get_fuel(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_set_epoch_deadline(
     mut store: WasmtimeStoreContextMut<'_>,
     ticks_beyond_current: u64,

--- a/crates/c-api/src/table.rs
+++ b/crates/c-api/src/table.rs
@@ -37,7 +37,7 @@ fn option_wasm_ref_t_to_ref(r: Option<&wasm_ref_t>, table_ty: &TableType) -> Ref
         .unwrap_or_else(|| Ref::null(table_ty.element().heap_type()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_table_new(
     store: &mut wasm_store_t,
     tt: &wasm_tabletype_t,
@@ -54,14 +54,14 @@ pub unsafe extern "C" fn wasm_table_new(
     }))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype_t> {
     let table = t.table();
     let store = t.ext.store.context();
     Box::new(wasm_tabletype_t::new(table.ty(&store)))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_table_get(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn wasm_table_get(
     wasm_ref_t::new(r)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_table_set(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -84,14 +84,14 @@ pub unsafe extern "C" fn wasm_table_set(
         .is_ok()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t {
     let table = t.table();
     let store = t.ext.store.context();
     u32::try_from(table.size(&store)).unwrap()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_table_grow(
     t: &mut wasm_table_t,
     delta: wasm_table_size_t,
@@ -104,17 +104,17 @@ pub unsafe extern "C" fn wasm_table_grow(
         .is_ok()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_table_as_extern(t: &mut wasm_table_t) -> &mut wasm_extern_t {
     &mut t.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_table_as_extern_const(t: &wasm_table_t) -> &wasm_extern_t {
     &t.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_table_new(
     mut store: WasmtimeStoreContextMut<'_>,
     tt: &wasm_tabletype_t,
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn wasmtime_table_new(
     )
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_table_type(
     store: WasmtimeStoreContext<'_>,
     table: &Table,
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn wasmtime_table_type(
     Box::new(wasm_tabletype_t::new(table.ty(store)))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_table_get(
     store: WasmtimeStoreContextMut<'_>,
     table: &Table,
@@ -156,7 +156,7 @@ pub extern "C" fn wasmtime_table_get(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_table_set(
     mut store: WasmtimeStoreContextMut<'_>,
     table: &Table,
@@ -173,12 +173,12 @@ pub unsafe extern "C" fn wasmtime_table_set(
     )
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_table_size(store: WasmtimeStoreContext<'_>, table: &Table) -> u64 {
     table.size(store)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_table_grow(
     mut store: WasmtimeStoreContextMut<'_>,
     table: &Table,

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -41,7 +41,7 @@ wasmtime_c_api_macros::declare_own!(wasm_frame_t);
 
 pub type wasm_message_t = wasm_name_t;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_trap_new(
     _store: &wasm_store_t,
     message: &wasm_message_t,
@@ -56,7 +56,7 @@ pub extern "C" fn wasm_trap_new(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_trap_new(message: *const u8, len: usize) -> Box<wasm_trap_t> {
     let bytes = crate::slice_from_raw_parts(message, len);
     let message = String::from_utf8_lossy(&bytes);
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn wasmtime_trap_new(message: *const u8, len: usize) -> Bo
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t) {
     let mut buffer = Vec::new();
     buffer.extend_from_slice(format!("{:?}", trap.error).as_bytes());
@@ -74,7 +74,7 @@ pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t
     out.set_buffer(buffer);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_trap_origin(raw: &wasm_trap_t) -> Option<Box<wasm_frame_t<'_>>> {
     let trace = match raw.error.downcast_ref::<WasmBacktrace>() {
         Some(trap) => trap,
@@ -92,7 +92,7 @@ pub extern "C" fn wasm_trap_origin(raw: &wasm_trap_t) -> Option<Box<wasm_frame_t
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_trap_trace<'a>(raw: &'a wasm_trap_t, out: &mut wasm_frame_vec_t<'a>) {
     error_trace(&raw.error, out)
 }
@@ -115,7 +115,7 @@ pub(crate) fn error_trace<'a>(error: &'a Error, out: &mut wasm_frame_vec_t<'a>) 
     out.set_buffer(vec);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_trap_code(raw: &wasm_trap_t, code: &mut u8) -> bool {
     let trap = match raw.error.downcast_ref::<Trap>() {
         Some(trap) => trap,
@@ -140,12 +140,12 @@ pub extern "C" fn wasmtime_trap_code(raw: &wasm_trap_t, code: &mut u8) -> bool {
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_frame_func_index(frame: &wasm_frame_t<'_>) -> u32 {
     frame.trace.frames()[frame.idx].func_index()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_frame_func_name<'a>(
     frame: &'a wasm_frame_t<'_>,
 ) -> Option<&'a wasm_name_t> {
@@ -159,7 +159,7 @@ pub extern "C" fn wasmtime_frame_func_name<'a>(
         .as_ref()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_frame_module_name<'a>(
     frame: &'a wasm_frame_t<'_>,
 ) -> Option<&'a wasm_name_t> {
@@ -174,26 +174,26 @@ pub extern "C" fn wasmtime_frame_module_name<'a>(
         .as_ref()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_frame_func_offset(frame: &wasm_frame_t<'_>) -> usize {
     frame.trace.frames()[frame.idx]
         .func_offset()
         .unwrap_or(usize::MAX)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wasm_instance_t {
     unimplemented!("wasm_frame_instance")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_frame_module_offset(frame: &wasm_frame_t<'_>) -> usize {
     frame.trace.frames()[frame.idx]
         .module_offset()
         .unwrap_or(usize::MAX)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_frame_copy<'a>(frame: &wasm_frame_t<'a>) -> Box<wasm_frame_t<'a>> {
     Box::new(frame.clone())
 }

--- a/crates/c-api/src/types/export.rs
+++ b/crates/c-api/src/types/export.rs
@@ -23,7 +23,7 @@ impl wasm_exporttype_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_exporttype_new(
     name: &mut wasm_name_t,
     ty: Box<wasm_externtype_t>,
@@ -33,13 +33,13 @@ pub extern "C" fn wasm_exporttype_new(
     Some(Box::new(wasm_exporttype_t::new(name, ty.which.clone())))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
     et.name_cache
         .get_or_init(|| wasm_name_t::from_name(et.name.clone()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     et.type_cache
         .get_or_init(|| wasm_externtype_t::from_cextern_type(et.ty.clone()))

--- a/crates/c-api/src/types/extern.rs
+++ b/crates/c-api/src/types/extern.rs
@@ -48,7 +48,7 @@ impl wasm_externtype_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkind_t {
     match &et.which {
         CExternType::Func(_) => WASM_EXTERN_FUNC,
@@ -58,54 +58,54 @@ pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkin
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_functype(et: &wasm_externtype_t) -> Option<&wasm_functype_t> {
     wasm_externtype_as_functype_const(et)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_functype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_functype_t> {
     wasm_functype_t::try_from(et)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_globaltype(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_globaltype_t> {
     wasm_externtype_as_globaltype_const(et)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_globaltype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_globaltype_t> {
     wasm_globaltype_t::try_from(et)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_tabletype(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_tabletype_t> {
     wasm_externtype_as_tabletype_const(et)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_tabletype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_tabletype_t> {
     wasm_tabletype_t::try_from(et)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_memorytype(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_memorytype_t> {
     wasm_externtype_as_memorytype_const(et)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_externtype_as_memorytype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_memorytype_t> {

--- a/crates/c-api/src/types/func.rs
+++ b/crates/c-api/src/types/func.rs
@@ -140,7 +140,7 @@ impl CFuncType {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_functype_new(
     params: &mut wasm_valtype_vec_t,
     results: &mut wasm_valtype_vec_t,
@@ -158,7 +158,7 @@ pub extern "C" fn wasm_functype_new(
     Box::new(wasm_functype_t::lazy(params, results))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     let ft = ft.ty();
     ft.params_cache.get_or_init(|| {
@@ -170,7 +170,7 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     let ft = ft.ty();
     ft.returns_cache.get_or_init(|| {
@@ -182,12 +182,12 @@ pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_v
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_functype_as_externtype(ty: &wasm_functype_t) -> &wasm_externtype_t {
     &ty.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_functype_as_externtype_const(ty: &wasm_functype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c-api/src/types/global.rs
+++ b/crates/c-api/src/types/global.rs
@@ -52,7 +52,7 @@ impl CGlobalType {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_globaltype_new(
     ty: Box<wasm_valtype_t>,
     mutability: wasm_mutability_t,
@@ -67,7 +67,7 @@ pub extern "C" fn wasm_globaltype_new(
     Some(Box::new(wasm_globaltype_t::new(ty)))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_globaltype_content(gt: &wasm_globaltype_t) -> &wasm_valtype_t {
     let gt = gt.ty();
     gt.content_cache.get_or_init(|| wasm_valtype_t {
@@ -75,7 +75,7 @@ pub extern "C" fn wasm_globaltype_content(gt: &wasm_globaltype_t) -> &wasm_valty
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mutability_t {
     use wasmtime::Mutability::*;
     let gt = gt.ty();
@@ -85,12 +85,12 @@ pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mut
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_globaltype_as_externtype(ty: &wasm_globaltype_t) -> &wasm_externtype_t {
     &ty.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_globaltype_as_externtype_const(
     ty: &wasm_globaltype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c-api/src/types/import.rs
+++ b/crates/c-api/src/types/import.rs
@@ -27,7 +27,7 @@ impl wasm_importtype_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_importtype_new(
     module: &mut wasm_name_t,
     name: &mut wasm_name_t,
@@ -44,19 +44,19 @@ pub extern "C" fn wasm_importtype_new(
     )))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t {
     it.module_cache
         .get_or_init(|| wasm_name_t::from_name(it.module.clone()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
     it.name_cache
         .get_or_init(|| wasm_name_t::from_name(it.name.to_string()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     it.type_cache
         .get_or_init(|| wasm_externtype_t::from_cextern_type(it.ty.clone()))

--- a/crates/c-api/src/types/memory.rs
+++ b/crates/c-api/src/types/memory.rs
@@ -48,7 +48,7 @@ impl CMemoryType {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memorytype_t> {
     Box::new(wasm_memorytype_t::new(MemoryType::new(
         limits.min,
@@ -56,7 +56,7 @@ pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memory
     )))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> &wasm_limits_t {
     let mt = mt.ty();
     mt.limits_cache.get_or_init(|| wasm_limits_t {
@@ -65,7 +65,7 @@ pub extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> &wasm_limits
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memorytype_new(
     minimum: u64,
     maximum_specified: bool,
@@ -90,12 +90,12 @@ pub extern "C" fn wasmtime_memorytype_new(
     ))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memorytype_minimum(mt: &wasm_memorytype_t) -> u64 {
     mt.ty().ty.minimum()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memorytype_maximum(mt: &wasm_memorytype_t, out: &mut u64) -> bool {
     match mt.ty().ty.maximum() {
         Some(max) => {
@@ -106,22 +106,22 @@ pub extern "C" fn wasmtime_memorytype_maximum(mt: &wasm_memorytype_t, out: &mut 
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memorytype_is64(mt: &wasm_memorytype_t) -> bool {
     mt.ty().ty.is_64()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_memorytype_isshared(mt: &wasm_memorytype_t) -> bool {
     mt.ty().ty.is_shared()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_memorytype_as_externtype(ty: &wasm_memorytype_t) -> &wasm_externtype_t {
     &ty.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_memorytype_as_externtype_const(
     ty: &wasm_memorytype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c-api/src/types/table.rs
+++ b/crates/c-api/src/types/table.rs
@@ -49,7 +49,7 @@ impl CTableType {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_tabletype_new(
     ty: Box<wasm_valtype_t>,
     limits: &wasm_limits_t,
@@ -62,7 +62,7 @@ pub extern "C" fn wasm_tabletype_new(
     ))))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype_t {
     let tt = tt.ty();
     tt.element_cache.get_or_init(|| wasm_valtype_t {
@@ -70,7 +70,7 @@ pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_tabletype_limits(tt: &wasm_tabletype_t) -> &wasm_limits_t {
     let tt = tt.ty();
     tt.limits_cache.get_or_init(|| wasm_limits_t {
@@ -79,12 +79,12 @@ pub extern "C" fn wasm_tabletype_limits(tt: &wasm_tabletype_t) -> &wasm_limits_t
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_tabletype_as_externtype(ty: &wasm_tabletype_t) -> &wasm_externtype_t {
     &ty.ext
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_tabletype_as_externtype_const(ty: &wasm_tabletype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c-api/src/types/val.rs
+++ b/crates/c-api/src/types/val.rs
@@ -16,14 +16,14 @@ pub const WASM_F64: wasm_valkind_t = 3;
 pub const WASM_EXTERNREF: wasm_valkind_t = 128;
 pub const WASM_FUNCREF: wasm_valkind_t = 129;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> {
     Box::new(wasm_valtype_t {
         ty: into_valtype(kind),
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasm_valtype_kind(vt: &wasm_valtype_t) -> wasm_valkind_t {
     from_valtype(&vt.ty)
 }

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -122,12 +122,12 @@ impl wasm_val_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source: &wasm_val_t) {
     crate::initialize(out, source.clone());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_val_delete(val: *mut wasm_val_t) {
     ptr::drop_in_place(val);
 }
@@ -294,7 +294,7 @@ impl wasmtime_val_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_val_unroot(
     cx: WasmtimeStoreContextMut<'_>,
     val: &mut MaybeUninit<wasmtime_val_t>,
@@ -315,7 +315,7 @@ pub unsafe extern "C" fn wasmtime_val_unroot(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_val_clone(
     cx: WasmtimeStoreContextMut<'_>,
     src: &wasmtime_val_t,

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -103,18 +103,18 @@ macro_rules! declare_vecs {
             }
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn $empty(out: &mut $name) {
             out.size = 0;
             out.data = ptr::null_mut();
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn $uninit(out: &mut $name, size: usize) {
             out.set_buffer(vec![Default::default(); size]);
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $new $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             size: usize,
@@ -124,7 +124,7 @@ macro_rules! declare_vecs {
             out.set_buffer(vec);
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn $copy $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             src: &$name $(<$lt>)?,
@@ -132,7 +132,7 @@ macro_rules! declare_vecs {
             out.set_buffer(src.as_slice().to_vec());
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn $delete $(<$lt>)? (out: &mut $name $(<$lt>)?) {
             out.take();
         }

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -37,14 +37,14 @@ impl wasi_config_t {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasi_config_new() -> Box<wasi_config_t> {
     Box::new(wasi_config_t {
         builder: WasiCtxBuilder::new(),
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_set_argv(
     config: &mut wasi_config_t,
     argc: usize,
@@ -60,12 +60,12 @@ pub unsafe extern "C" fn wasi_config_set_argv(
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasi_config_inherit_argv(config: &mut wasi_config_t) {
     config.builder.inherit_args();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_set_env(
     config: &mut wasi_config_t,
     envc: usize,
@@ -89,12 +89,12 @@ pub unsafe extern "C" fn wasi_config_set_env(
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasi_config_inherit_env(config: &mut wasi_config_t) {
     config.builder.inherit_env();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_set_stdin_file(
     config: &mut wasi_config_t,
     path: *const c_char,
@@ -112,7 +112,7 @@ pub unsafe extern "C" fn wasi_config_set_stdin_file(
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_set_stdin_bytes(
     config: &mut wasi_config_t,
     binary: &mut wasm_byte_vec_t,
@@ -122,12 +122,12 @@ pub unsafe extern "C" fn wasi_config_set_stdin_bytes(
     config.builder.stdin(binary);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasi_config_inherit_stdin(config: &mut wasi_config_t) {
     config.builder.inherit_stdin();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_set_stdout_file(
     config: &mut wasi_config_t,
     path: *const c_char,
@@ -142,12 +142,12 @@ pub unsafe extern "C" fn wasi_config_set_stdout_file(
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasi_config_inherit_stdout(config: &mut wasi_config_t) {
     config.builder.inherit_stdout();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_set_stderr_file(
     config: &mut wasi_config_t,
     path: *const c_char,
@@ -162,12 +162,12 @@ pub unsafe extern "C" fn wasi_config_set_stderr_file(
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn wasi_config_inherit_stderr(config: &mut wasi_config_t) {
     config.builder.inherit_stderr();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_preopen_dir(
     config: &mut wasi_config_t,
     path: *const c_char,

--- a/crates/c-api/src/wat2wasm.rs
+++ b/crates/c-api/src/wat2wasm.rs
@@ -1,6 +1,6 @@
 use crate::{bad_utf8, handle_result, wasm_byte_vec_t, wasmtime_error_t};
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_wat2wasm(
     wat: *const u8,
     wat_len: usize,

--- a/crates/test-programs/src/bin/api_reactor.rs
+++ b/crates/test-programs/src/bin/api_reactor.rs
@@ -1,3 +1,8 @@
+#![expect(
+    unsafe_attr_outside_unsafe,
+    reason = "needs fixes in upstream wit-bindgen to satisfy this lint"
+)]
+
 use std::sync::{Mutex, MutexGuard};
 
 wit_bindgen::generate!({

--- a/crates/test-programs/src/bin/cli_export_cabi_realloc.rs
+++ b/crates/test-programs/src/bin/cli_export_cabi_realloc.rs
@@ -1,7 +1,7 @@
 //! `wit-component` handles modules which export `cabi_realloc` in a special way, using it instead of `memory.grow`
 //! to allocate the adapter stack, hence this test.
 
-#[export_name = "cabi_realloc"]
+#[unsafe(export_name = "cabi_realloc")]
 unsafe extern "C" fn cabi_realloc(
     old_ptr: *mut u8,
     old_len: usize,

--- a/crates/versioned-export-macros/src/lib.rs
+++ b/crates/versioned-export-macros/src/lib.rs
@@ -24,7 +24,7 @@ pub fn versioned_export(
     let export_name = versioned_lit_str(&function.sig.ident);
     function
         .attrs
-        .push(syn::parse_quote! { #[export_name = #export_name] });
+        .push(syn::parse_quote! { #[unsafe(export_name = #export_name)] });
 
     function.to_token_stream().into()
 }

--- a/crates/wasi-preview1-component-adapter/build.rs
+++ b/crates/wasi-preview1-component-adapter/build.rs
@@ -33,7 +33,7 @@ fn main() {
 ///     "
 /// );
 ///
-/// #[no_mangle]
+/// #[unsafe(no_mangle)]
 /// extern "C" fn get_state_ptr() -> *mut u8 {
 ///     unsafe {
 ///         let ret: *mut u8;
@@ -48,7 +48,7 @@ fn main() {
 ///     }
 /// }
 ///
-/// #[no_mangle]
+/// #[unsafe(no_mangle)]
 /// extern "C" fn set_state_ptr(val: *mut u8) {
 ///     unsafe {
 ///         std::arch::asm!(

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -114,7 +114,7 @@ pub mod bindings {
     }
 }
 
-#[export_name = "wasi:cli/run@0.2.3#run"]
+#[unsafe(export_name = "wasi:cli/run@0.2.3#run")]
 #[cfg(feature = "command")]
 pub unsafe extern "C" fn run() -> u32 {
     #[link(wasm_import_module = "__main_module__")]

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -167,7 +167,7 @@ impl<T, E> TrappingUnwrap<T> for Result<T, E> {
 /// This is intended for use by `wasi-libc` during its incremental transition
 /// from WASI Preview 1 to Preview 2.  It will use this function to reserve
 /// descriptors for its own use, valid only for use with libc functions.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn adapter_open_badfd(fd: *mut u32) -> Errno {
     State::with(|state| {
         *fd = state.descriptors_mut().open(Descriptor::Bad)?;
@@ -176,12 +176,12 @@ pub unsafe extern "C" fn adapter_open_badfd(fd: *mut u32) -> Errno {
 }
 
 /// Close a descriptor previously opened using `adapter_open_badfd`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn adapter_close_badfd(fd: u32) -> Errno {
     State::with(|state| state.descriptors_mut().close(fd))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn reset_adapter_state() {
     let state = get_state_ptr();
     if !state.is_null() {
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn reset_adapter_state() {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cabi_import_realloc(
     old_ptr: *mut u8,
     old_size: usize,
@@ -466,7 +466,7 @@ extern "C" {
 
 /// Read command-line argument data.
 /// The size of the array should match that returned by `args_sizes_get`
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn args_get(argv: *mut *mut u8, argv_buf: *mut u8) -> Errno {
     State::with(|state| {
         #[cfg(not(feature = "proxy"))]
@@ -501,7 +501,7 @@ pub unsafe extern "C" fn args_get(argv: *mut *mut u8, argv_buf: *mut u8) -> Errn
 }
 
 /// Return command-line argument data sizes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn args_sizes_get(argc: *mut Size, argv_buf_size: *mut Size) -> Errno {
     State::with(|state| {
         #[cfg(feature = "proxy")]
@@ -542,7 +542,7 @@ pub unsafe extern "C" fn args_sizes_get(argc: *mut Size, argv_buf_size: *mut Siz
 
 /// Read environment variable data.
 /// The sizes of the buffers should match that returned by `environ_sizes_get`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn environ_get(environ: *mut *const u8, environ_buf: *mut u8) -> Errno {
     State::with(|state| {
         #[cfg(not(feature = "proxy"))]
@@ -580,7 +580,7 @@ pub unsafe extern "C" fn environ_get(environ: *mut *const u8, environ_buf: *mut 
 }
 
 /// Return environment variable data sizes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn environ_sizes_get(
     environc: *mut Size,
     environ_buf_size: *mut Size,
@@ -636,7 +636,7 @@ pub unsafe extern "C" fn environ_sizes_get(
 /// Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks,
 /// return `errno::inval`.
 /// Note: This is similar to `clock_getres` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn clock_res_get(id: Clockid, resolution: &mut Timestamp) -> Errno {
     match id {
         CLOCKID_MONOTONIC => {
@@ -660,7 +660,7 @@ pub extern "C" fn clock_res_get(id: Clockid, resolution: &mut Timestamp) -> Errn
 
 /// Return the time value of a clock.
 /// Note: This is similar to `clock_gettime` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn clock_time_get(
     id: Clockid,
     _precision: Timestamp,
@@ -688,7 +688,7 @@ pub unsafe extern "C" fn clock_time_get(
 
 /// Provide file advisory information on a file descriptor.
 /// Note: This is similar to `posix_fadvise` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_advise(
     fd: Fd,
     offset: Filesize,
@@ -716,7 +716,7 @@ pub unsafe extern "C" fn fd_advise(
 
 /// Force the allocation of space in a file.
 /// Note: This is similar to `posix_fallocate` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_allocate(fd: Fd, _offset: Filesize, _len: Filesize) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -731,7 +731,7 @@ pub unsafe extern "C" fn fd_allocate(fd: Fd, _offset: Filesize, _len: Filesize) 
 
 /// Close a file descriptor.
 /// Note: This is similar to `close` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_close(fd: Fd) -> Errno {
     State::with(|state| {
         if let Descriptor::Bad = state.descriptors().get(fd)? {
@@ -753,7 +753,7 @@ pub unsafe extern "C" fn fd_close(fd: Fd) -> Errno {
 
 /// Synchronize the data of a file to disk.
 /// Note: This is similar to `fdatasync` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_datasync(fd: Fd) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -767,7 +767,7 @@ pub unsafe extern "C" fn fd_datasync(fd: Fd) -> Errno {
 
 /// Get the attributes of a file descriptor.
 /// Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_fdstat_get(fd: Fd, stat: *mut Fdstat) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -891,7 +891,7 @@ pub unsafe extern "C" fn fd_fdstat_get(fd: Fd, stat: *mut Fdstat) -> Errno {
 
 /// Adjust the flags associated with a file descriptor.
 /// Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_fdstat_set_flags(fd: Fd, flags: Fdflags) -> Errno {
     // Only support changing the NONBLOCK or APPEND flags.
     if flags & !(FDFLAGS_NONBLOCK | FDFLAGS_APPEND) != 0 {
@@ -920,7 +920,7 @@ pub unsafe extern "C" fn fd_fdstat_set_flags(fd: Fd, flags: Fdflags) -> Errno {
 }
 
 /// Does not do anything if `fd` corresponds to a valid descriptor and returns [`wasi::ERRNO_BADF`] otherwise.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_fdstat_set_rights(
     fd: Fd,
     _fs_rights_base: Rights,
@@ -936,7 +936,7 @@ pub unsafe extern "C" fn fd_fdstat_set_rights(
 }
 
 /// Return the attributes of an open file.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_filestat_get(fd: Fd, buf: *mut Filestat) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -986,7 +986,7 @@ pub unsafe extern "C" fn fd_filestat_get(fd: Fd, buf: *mut Filestat) -> Errno {
 
 /// Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
 /// Note: This is similar to `ftruncate` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_filestat_set_size(fd: Fd, size: Filesize) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -1016,7 +1016,7 @@ fn systimespec(set: bool, ts: Timestamp, now: bool) -> Result<filesystem::NewTim
 
 /// Adjust the timestamps of an open file or directory.
 /// Note: This is similar to `futimens` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_filestat_set_times(
     fd: Fd,
     atim: Timestamp,
@@ -1045,7 +1045,7 @@ pub unsafe extern "C" fn fd_filestat_set_times(
 
 /// Read from a file descriptor, without using and updating the file descriptor's offset.
 /// Note: This is similar to `preadv` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_pread(
     fd: Fd,
     mut iovs_ptr: *const Iovec,
@@ -1088,7 +1088,7 @@ pub unsafe extern "C" fn fd_pread(
 }
 
 /// Return a description of the given preopened file descriptor.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_prestat_get(fd: Fd, buf: *mut Prestat) -> Errno {
     if !matches!(
         get_allocation_state(),
@@ -1133,7 +1133,7 @@ pub unsafe extern "C" fn fd_prestat_get(fd: Fd, buf: *mut Prestat) -> Errno {
 }
 
 /// Return a description of the given preopened file descriptor.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_prestat_dir_name(fd: Fd, path: *mut u8, path_max_len: Size) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -1160,7 +1160,7 @@ pub unsafe extern "C" fn fd_prestat_dir_name(fd: Fd, path: *mut u8, path_max_len
 
 /// Write to a file descriptor, without using and updating the file descriptor's offset.
 /// Note: This is similar to `pwritev` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_pwrite(
     fd: Fd,
     mut iovs_ptr: *const Ciovec,
@@ -1205,7 +1205,7 @@ pub unsafe extern "C" fn fd_pwrite(
 
 /// Read from a file descriptor.
 /// Note: This is similar to `readv` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_read(
     fd: Fd,
     mut iovs_ptr: *const Iovec,
@@ -1292,7 +1292,7 @@ fn stream_error_to_errno(err: streams::Error) -> Errno {
 /// truncating the last directory entry. This allows the caller to grow its
 /// read buffer size in case it's too small to fit a single large directory
 /// entry, or skip the oversized directory entry.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(feature = "proxy")]
 pub unsafe extern "C" fn fd_readdir(
     fd: Fd,
@@ -1304,7 +1304,7 @@ pub unsafe extern "C" fn fd_readdir(
     wasi::ERRNO_NOTSUP
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(not(feature = "proxy"))]
 pub unsafe extern "C" fn fd_readdir(
     fd: Fd,
@@ -1538,14 +1538,14 @@ pub unsafe extern "C" fn fd_readdir(
 /// thread at the same time.
 /// This function provides a way to atomically renumber file descriptors, which
 /// would disappear if `dup2()` were to be removed entirely.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_renumber(fd: Fd, to: Fd) -> Errno {
     State::with(|state| state.descriptors_mut().renumber(fd, to))
 }
 
 /// Move the offset of a file descriptor.
 /// Note: This is similar to `lseek` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_seek(
     fd: Fd,
     offset: Filedelta,
@@ -1590,7 +1590,7 @@ pub unsafe extern "C" fn fd_seek(
 
 /// Synchronize the data and metadata of a file to disk.
 /// Note: This is similar to `fsync` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_sync(fd: Fd) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -1604,7 +1604,7 @@ pub unsafe extern "C" fn fd_sync(fd: Fd) -> Errno {
 
 /// Return the current offset of a file descriptor.
 /// Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_tell(fd: Fd, offset: *mut Filesize) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -1618,7 +1618,7 @@ pub unsafe extern "C" fn fd_tell(fd: Fd, offset: *mut Filesize) -> Errno {
 
 /// Write to a file descriptor.
 /// Note: This is similar to `writev` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_write(
     fd: Fd,
     mut iovs_ptr: *const Ciovec,
@@ -1691,7 +1691,7 @@ pub unsafe extern "C" fn fd_write(
 
 /// Create a directory.
 /// Note: This is similar to `mkdirat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_create_directory(
     fd: Fd,
     path_ptr: *const u8,
@@ -1711,7 +1711,7 @@ pub unsafe extern "C" fn path_create_directory(
 
 /// Return the attributes of a file or directory.
 /// Note: This is similar to `stat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_filestat_get(
     fd: Fd,
     flags: Lookupflags,
@@ -1746,7 +1746,7 @@ pub unsafe extern "C" fn path_filestat_get(
 
 /// Adjust the timestamps of a file or directory.
 /// Note: This is similar to `utimensat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_filestat_set_times(
     fd: Fd,
     flags: Lookupflags,
@@ -1782,7 +1782,7 @@ pub unsafe extern "C" fn path_filestat_set_times(
 
 /// Create a hard link.
 /// Note: This is similar to `linkat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_link(
     old_fd: Fd,
     old_flags: Lookupflags,
@@ -1814,7 +1814,7 @@ pub unsafe extern "C" fn path_link(
 /// is error-prone in multi-threaded contexts. The returned file descriptor is
 /// guaranteed to be less than 2**31.
 /// Note: This is similar to `openat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_open(
     fd: Fd,
     dirflags: Lookupflags,
@@ -1872,7 +1872,7 @@ pub unsafe extern "C" fn path_open(
 
 /// Read the contents of a symbolic link.
 /// Note: This is similar to `readlinkat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_readlink(
     fd: Fd,
     path_ptr: *const u8,
@@ -1924,7 +1924,7 @@ pub unsafe extern "C" fn path_readlink(
 /// Remove a directory.
 /// Return `errno::notempty` if the directory is not empty.
 /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_remove_directory(
     fd: Fd,
     path_ptr: *const u8,
@@ -1944,7 +1944,7 @@ pub unsafe extern "C" fn path_remove_directory(
 
 /// Rename a file or directory.
 /// Note: This is similar to `renameat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_rename(
     old_fd: Fd,
     old_path_ptr: *const u8,
@@ -1969,7 +1969,7 @@ pub unsafe extern "C" fn path_rename(
 
 /// Create a symbolic link.
 /// Note: This is similar to `symlinkat` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_symlink(
     old_path_ptr: *const u8,
     old_path_len: usize,
@@ -1993,7 +1993,7 @@ pub unsafe extern "C" fn path_symlink(
 /// Unlink a file.
 /// Return `errno::isdir` if the path refers to a directory.
 /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_unlink_file(fd: Fd, path_ptr: *const u8, path_len: usize) -> Errno {
     cfg_filesystem_available! {
         let path = slice::from_raw_parts(path_ptr, path_len);
@@ -2037,7 +2037,7 @@ impl Drop for Pollables {
 }
 
 /// Concurrently poll for the occurrence of a set of events.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn poll_oneoff(
     r#in: *const Subscription,
     out: *mut Event,
@@ -2266,7 +2266,7 @@ pub unsafe extern "C" fn poll_oneoff(
 /// Terminate the process normally. An exit code of 0 indicates successful
 /// termination of the program. The meanings of other values is dependent on
 /// the environment.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn proc_exit(rval: Exitcode) -> ! {
     #[cfg(feature = "proxy")]
     {
@@ -2282,14 +2282,14 @@ pub unsafe extern "C" fn proc_exit(rval: Exitcode) -> ! {
 
 /// Send a signal to the process of the calling thread.
 /// Note: This is similar to `raise` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn proc_raise(_sig: Signal) -> Errno {
     unreachable!()
 }
 
 /// Temporarily yield execution of the calling thread.
 /// Note: This is similar to `sched_yield` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sched_yield() -> Errno {
     // TODO: This is not yet covered in Preview2.
 
@@ -2302,7 +2302,7 @@ pub unsafe extern "C" fn sched_yield() -> Errno {
 /// This function may execute slowly, so when large mounts of random data are
 /// required, it's advisable to use this function to seed a pseudo-random
 /// number generator, rather than to provide the random data directly.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn random_get(buf: *mut u8, buf_len: Size) -> Errno {
     if matches!(
         get_allocation_state(),
@@ -2327,7 +2327,7 @@ pub unsafe extern "C" fn random_get(buf: *mut u8, buf_len: Size) -> Errno {
 
 /// Accept a new incoming connection.
 /// Note: This is similar to `accept` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sock_accept(_fd: Fd, _flags: Fdflags, _connection: *mut Fd) -> Errno {
     unreachable!()
 }
@@ -2335,7 +2335,7 @@ pub unsafe extern "C" fn sock_accept(_fd: Fd, _flags: Fdflags, _connection: *mut
 /// Receive a message from a socket.
 /// Note: This is similar to `recv` in POSIX, though it also supports reading
 /// the data into multiple buffers in the manner of `readv`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sock_recv(
     _fd: Fd,
     _ri_data_ptr: *const Iovec,
@@ -2350,7 +2350,7 @@ pub unsafe extern "C" fn sock_recv(
 /// Send a message on a socket.
 /// Note: This is similar to `send` in POSIX, though it also supports writing
 /// the data from multiple buffers in the manner of `writev`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sock_send(
     _fd: Fd,
     _si_data_ptr: *const Ciovec,
@@ -2363,7 +2363,7 @@ pub unsafe extern "C" fn sock_send(
 
 /// Shut down socket send and receive channels.
 /// Note: This is similar to `shutdown` in POSIX.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn sock_shutdown(_fd: Fd, _how: Sdflags) -> Errno {
     unreachable!()
 }

--- a/examples/fib-debug/wasm/fib.rs
+++ b/examples/fib-debug/wasm/fib.rs
@@ -1,4 +1,4 @@
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn fib(n: u32) -> u32 {
     let mut a = 1;
     let mut b = 1;

--- a/examples/min-platform/embedding/cbindgen.toml
+++ b/examples/min-platform/embedding/cbindgen.toml
@@ -13,7 +13,7 @@ header = """
 //
 // Embedders are expected to implement the symbols defined in this header file.
 // These symbols can be defined either in C/C++ or in Rust (using
-// `#[no_mangle]`).
+// `#[unsafe(no_mangle)]`).
 //
 // Note that there are some `#define`s here which can be added before this
 // header file is included to indicate how Wasmtime was built. This corresponds

--- a/examples/min-platform/embedding/src/lib.rs
+++ b/examples/min-platform/embedding/src/lib.rs
@@ -15,7 +15,7 @@ mod panic;
 /// This takes a number of parameters which are the precompiled module AOT
 /// images that are run for each of the various tests below. The first parameter
 /// is also where to put an error string, if any, if anything fails.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn run(
     error_buf: *mut u8,
     error_size: usize,

--- a/examples/min-platform/embedding/wasmtime-platform.h
+++ b/examples/min-platform/embedding/wasmtime-platform.h
@@ -7,7 +7,7 @@
 //
 // Embedders are expected to implement the symbols defined in this header file.
 // These symbols can be defined either in C/C++ or in Rust (using
-// `#[no_mangle]`).
+// `#[unsafe(no_mangle)]`).
 //
 // Note that there are some `#define`s here which can be added before this
 // header file is included to indicate how Wasmtime was built. This corresponds


### PR DESCRIPTION
This commit enables the `unsafe-attr-outside-unsafe` lint in rustc used in transitioning to the 2024 edition. This requires that the `#[no_mangle]` attribute is replaced in favor of `#[unsafe(no_mangle)]`. This mostly affects the C API of wasmtime and most of the changes here are a simple search/replace.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
