### PR TITLE
Enable `impl-trait-overcaptures` 2024 transition lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ rust-2024-guarded-string-incompatible-syntax = 'warn'
 rust-2024-prelude-collisions = 'warn'
 rust-2024-incompatible-pat = 'warn'
 missing-unsafe-on-extern = 'warn'
+impl-trait-overcaptures = 'warn'
 
 # Don't warn about unknown cfgs for pulley
 [workspace.lints.rust.unexpected_cfgs]

--- a/cranelift/codegen/meta/src/gen_settings.rs
+++ b/cranelift/codegen/meta/src/gen_settings.rs
@@ -76,7 +76,7 @@ fn gen_iterator(group: &SettingGroup, fmt: &mut Formatter) {
     fmtln!(fmt, "impl Flags {");
     fmt.indent(|fmt| {
         fmt.doc_comment("Iterates the setting values.");
-        fmtln!(fmt, "pub fn iter(&self) -> impl Iterator<Item = Value> {");
+        fmtln!(fmt, "pub fn iter(&self) -> impl Iterator<Item = Value> + use<'_>{");
         fmt.indent(|fmt| {
             fmtln!(fmt, "let mut bytes = [0; {}];", group.settings_size);
             fmtln!(fmt, "bytes.copy_from_slice(&self.bytes[0..{}]);", group.settings_size);

--- a/cranelift/codegen/meta/src/gen_settings.rs
+++ b/cranelift/codegen/meta/src/gen_settings.rs
@@ -76,7 +76,7 @@ fn gen_iterator(group: &SettingGroup, fmt: &mut Formatter) {
     fmtln!(fmt, "impl Flags {");
     fmt.indent(|fmt| {
         fmt.doc_comment("Iterates the setting values.");
-        fmtln!(fmt, "pub fn iter(&self) -> impl Iterator<Item = Value> + use<'_>{");
+        fmtln!(fmt, "pub fn iter(&self) -> impl Iterator<Item = Value> + use<> {");
         fmt.indent(|fmt| {
             fmtln!(fmt, "let mut bytes = [0; {}];", group.settings_size);
             fmtln!(fmt, "bytes.copy_from_slice(&self.bytes[0..{}]);", group.settings_size);

--- a/cranelift/codegen/meta/src/pulley.rs
+++ b/cranelift/codegen/meta/src/pulley.rs
@@ -47,7 +47,7 @@ enum Operand<'a> {
 }
 
 impl Inst<'_> {
-    fn operands(&self) -> impl Iterator<Item = Operand<'_>> {
+    fn operands(&self) -> impl Iterator<Item = Operand<'_>> + use<'_> {
         self.fields
             .iter()
             .map(|(name, ty)| match (*name, *ty) {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -211,7 +211,7 @@ impl<T> IsaBuilder<T> {
     }
 
     /// Iterates the available settings in the builder.
-    pub fn iter(&self) -> impl Iterator<Item = settings::Setting> {
+    pub fn iter(&self) -> impl Iterator<Item = settings::Setting> + use<T> {
         self.setup.iter()
     }
 

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -167,7 +167,7 @@ impl Builder {
     }
 
     /// Iterates the available settings in the builder.
-    pub fn iter(&self) -> impl Iterator<Item = Setting> {
+    pub fn iter(&self) -> impl Iterator<Item = Setting> + use<> {
         let template = self.template;
 
         template.descriptors.iter().map(move |d| {

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -147,7 +147,7 @@ impl<'a> Compilation<'a> {
     /// compilation.
     ///
     /// Each function is additionally accompanied with its module index.
-    fn indexes(&self) -> impl Iterator<Item = (StaticModuleIndex, DefinedFuncIndex)> + '_ {
+    fn indexes(&self) -> impl Iterator<Item = (StaticModuleIndex, DefinedFuncIndex)> + use<'_> {
         self.translations
             .iter()
             .flat_map(|(i, t)| t.module.defined_func_indices().map(move |j| (i, j)))

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -747,7 +747,7 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
         }
     }
 
-    pub fn into_ranges(self) -> impl Iterator<Item = CachedValueLabelRange> {
+    pub fn into_ranges(self) -> impl Iterator<Item = CachedValueLabelRange> + use<> {
         // Ranges with not-enough labels are discarded.
         let processed_labels_len = self.processed_labels.len();
         self.ranges

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -244,7 +244,7 @@ impl CompiledExpression {
         addr_tr: &'a AddressTransform,
         frame_info: Option<&'a FunctionFrameInfo>,
         isa: &'a dyn TargetIsa,
-    ) -> impl Iterator<Item = Result<(write::Address, u64, write::Expression)>> + 'a {
+    ) -> impl Iterator<Item = Result<(write::Address, u64, write::Expression)>> + use<'a> {
         enum BuildWithLocalsResult<'a> {
             Empty,
             Simple(

--- a/crates/environ/src/compile/module_types.rs
+++ b/crates/environ/src/compile/module_types.rs
@@ -308,7 +308,7 @@ impl ModuleTypesBuilder {
     pub fn rec_group_elements(
         &self,
         rec_group: ModuleInternedRecGroupIndex,
-    ) -> impl ExactSizeIterator<Item = ModuleInternedTypeIndex> {
+    ) -> impl ExactSizeIterator<Item = ModuleInternedTypeIndex> + use<> {
         self.types.rec_group_elements(rec_group)
     }
 

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -3069,13 +3069,14 @@ impl<'a> Source<'a> {
 
 impl<'a> Destination<'a> {
     /// Same as `Source::record_field_srcs` but for destinations.
-    fn record_field_dsts<'b>(
+    fn record_field_dsts<'b, I>(
         &'b self,
         types: &'b ComponentTypesBuilder,
-        fields: impl IntoIterator<Item = InterfaceType> + 'b,
-    ) -> impl Iterator<Item = Destination<'b>> + 'b
+        fields: I,
+    ) -> impl Iterator<Item = Destination<'b>> + use<'b, I>
     where
         'a: 'b,
+        I: IntoIterator<Item = InterfaceType> + 'b,
     {
         let mut offset = 0;
         fields.into_iter().map(move |ty| match self {

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -537,7 +537,7 @@ impl Module {
 
     /// Returns an iterator over all of the defined function indices in this
     /// module.
-    pub fn defined_func_indices(&self) -> impl Iterator<Item = DefinedFuncIndex> {
+    pub fn defined_func_indices(&self) -> impl Iterator<Item = DefinedFuncIndex> + use<> {
         (0..self.functions.len() - self.num_imported_funcs).map(|i| DefinedFuncIndex::new(i))
     }
 

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -41,7 +41,7 @@ impl ModuleTypes {
     pub fn rec_group_elements(
         &self,
         rec_group: ModuleInternedRecGroupIndex,
-    ) -> impl ExactSizeIterator<Item = ModuleInternedTypeIndex> {
+    ) -> impl ExactSizeIterator<Item = ModuleInternedTypeIndex> + use<> {
         let range = &self.rec_groups[rec_group];
         (range.start.as_u32()..range.end.as_u32()).map(|i| ModuleInternedTypeIndex::from_u32(i))
     }

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -165,7 +165,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
 async fn double_echo(
     incoming_request: IncomingRequest,
     url: &Url,
-) -> Result<(impl Future<Output = Result<()>>, IncomingResponse)> {
+) -> Result<(impl Future<Output = Result<()>> + use<>, IncomingResponse)> {
     let outgoing_request = OutgoingRequest::new(Fields::new());
 
     outgoing_request

--- a/crates/wasi/src/pipe.rs
+++ b/crates/wasi/src/pipe.rs
@@ -364,7 +364,7 @@ mod test {
         assert_eq!(bs.len(), 0);
     }
 
-    async fn finite_async_reader(contents: &[u8]) -> impl AsyncRead + Send + 'static {
+    async fn finite_async_reader(contents: &[u8]) -> impl AsyncRead + Send + 'static + use<> {
         let (r, mut w) = simplex(contents.len());
         w.write_all(contents).await.unwrap();
         r

--- a/crates/wasmtime/src/runtime/component/resource_table.rs
+++ b/crates/wasmtime/src/runtime/component/resource_table.rs
@@ -306,7 +306,7 @@ impl ResourceTable {
     pub fn iter_children<T>(
         &self,
         parent: &Resource<T>,
-    ) -> Result<impl Iterator<Item = &(dyn Any + Send)>, ResourceTableError>
+    ) -> Result<impl Iterator<Item = &(dyn Any + Send)> + use<'_, T>, ResourceTableError>
     where
         T: 'static,
     {

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -263,7 +263,7 @@ impl Global {
     /// Even if the same underlying global definition is added to the
     /// `StoreData` multiple times and becomes multiple `wasmtime::Global`s,
     /// this hash key will be consistent across all of these globals.
-    pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq {
+    pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
         store[self.0].definition as usize
     }
 }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -432,7 +432,7 @@ impl Table {
     /// `StoreData` multiple times and becomes multiple `wasmtime::Table`s,
     /// this hash key will be consistent across all of these tables.
     #[allow(dead_code)] // Not used yet, but added for consistency.
-    pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq {
+    pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<'_> {
         store[self.0].definition as usize
     }
 }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1579,7 +1579,7 @@ impl Func {
     /// multiple times and becomes multiple `wasmtime::Func`s, this hash key
     /// will be consistent across all of these functions.
     #[allow(dead_code)] // Not used yet, but added for consistency.
-    pub(crate) fn hash_key(&self, store: &mut StoreOpaque) -> impl core::hash::Hash + Eq {
+    pub(crate) fn hash_key(&self, store: &mut StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
         self.vm_func_ref(store).as_ptr() as usize
     }
 }

--- a/crates/wasmtime/src/runtime/gc/disabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/arrayref.rs
@@ -41,7 +41,7 @@ impl ArrayRef {
     pub fn elems<'a, T: 'a>(
         &self,
         _store: impl Into<StoreContextMut<'a, T>>,
-    ) -> Result<impl ExactSizeIterator<Item = Val> + 'a> {
+    ) -> Result<impl ExactSizeIterator<Item = Val> + 'a + '_> {
         match *self {}
         Ok([].into_iter())
     }

--- a/crates/wasmtime/src/runtime/gc/disabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/structref.rs
@@ -37,7 +37,7 @@ impl StructRef {
     pub fn fields<'a, T: 'a>(
         &self,
         _store: impl Into<StoreContextMut<'a, T>>,
-    ) -> Result<impl ExactSizeIterator<Item = Val> + 'a> {
+    ) -> Result<impl ExactSizeIterator<Item = Val> + 'a + '_> {
         match *self {}
         Ok([].into_iter())
     }

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -651,7 +651,7 @@ impl Memory {
     /// Even if the same underlying memory definition is added to the
     /// `StoreData` multiple times and becomes multiple `wasmtime::Memory`s,
     /// this hash key will be consistent across all of these memories.
-    pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq {
+    pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
         store[self.0].definition as usize
     }
 }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -103,7 +103,7 @@ impl StoreData {
         true
     }
 
-    pub fn iter<T>(&self) -> impl ExactSizeIterator<Item = Stored<T>>
+    pub fn iter<T>(&self) -> impl ExactSizeIterator<Item = Stored<T>> + use<T>
     where
         T: StoredData,
     {

--- a/crates/wiggle/test-helpers/src/lib.rs
+++ b/crates/wiggle/test-helpers/src/lib.rs
@@ -174,7 +174,7 @@ impl MemArea {
     }
 
     /// Enumerate all memareas of size `len` inside a given area
-    fn inside(&self, len: u32) -> impl Iterator<Item = MemArea> {
+    fn inside(&self, len: u32) -> impl Iterator<Item = MemArea> + use<'_> {
         let end: i64 = self.len as i64 - len as i64;
         let start = self.ptr;
         (0..end).into_iter().map(move |v| MemArea {

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -72,12 +72,15 @@ impl Vm {
     ///
     /// Returns either the resulting values, or the PC at which a trap was
     /// raised.
-    pub unsafe fn call<'a>(
+    pub unsafe fn call<'a, T>(
         &'a mut self,
         func: NonNull<u8>,
         args: &[Val],
-        rets: impl IntoIterator<Item = RegType> + 'a,
-    ) -> DoneReason<impl Iterator<Item = Val> + 'a> {
+        rets: T,
+    ) -> DoneReason<impl Iterator<Item = Val> + use<'a, T>>
+    where
+        T: IntoIterator<Item = RegType> + 'a,
+    {
         self.call_start(args);
 
         match self.call_run(func) {

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -105,7 +105,7 @@ fn run_all(testsuite_dir: &str, extra_flags: &[&str], ignore: &[&str]) -> Result
     clean_garbage(testsuite_dir)
 }
 
-fn list_files<F>(testsuite_dir: &str, filter: F) -> impl Iterator<Item = PathBuf>
+fn list_files<F>(testsuite_dir: &str, filter: F) -> impl Iterator<Item = PathBuf> + use<F>
 where
     F: FnMut(&DirEntry) -> bool,
 {


### PR DESCRIPTION
This lint detects cases where returning `impl Trait` will work differently in 2024 than in the current 2021 edition. Ambiguities are resolved with `use<..>` syntax stabilized in Rust 1.82.0 to mean the same thing in both editions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
