### PR TITLE
Enable fuzzing for Pulley & Winch

### DIFF
--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -26,7 +26,7 @@ target-lexicon = { workspace = true }
 tempfile = "3.3.0"
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
-wasmtime = { workspace = true, features = ['default', 'winch', 'gc', 'memory-protection-keys', 'signals-based-traps'] }
+wasmtime = { workspace = true, features = ['default', 'winch', 'gc', 'memory-protection-keys', 'signals-based-traps', 'pulley'] }
 wasmtime-wast = { workspace = true, features = ['component-model'] }
 wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1222,7 +1222,7 @@ mod tests {
     ) -> bool {
         let mut rng = SmallRng::seed_from_u64(0);
         let mut buf = vec![0; 2048];
-        let n = 2000;
+        let n = 3000;
         for _ in 0..n {
             rng.fill_bytes(&mut buf);
             let mut u = Unstructured::new(&buf);

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -245,9 +245,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn smoke_cranelift() {
+    fn smoke_cranelift_native() {
         crate::oracles::engine::smoke_test_engine(|u, config| {
-            WasmtimeEngine::new(u, config, CompilerStrategy::Cranelift)
+            WasmtimeEngine::new(u, config, CompilerStrategy::CraneliftNative)
+        })
+    }
+
+    #[test]
+    fn smoke_cranelift_pulley() {
+        crate::oracles::engine::smoke_test_engine(|u, config| {
+            WasmtimeEngine::new(u, config, CompilerStrategy::CraneliftPulley)
         })
     }
 

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -40,8 +40,9 @@ impl WasmtimeEngine {
 impl DiffEngine for WasmtimeEngine {
     fn name(&self) -> &'static str {
         match self.config.wasmtime.compiler_strategy {
-            CompilerStrategy::Cranelift => "wasmtime",
+            CompilerStrategy::CraneliftNative => "wasmtime",
             CompilerStrategy::Winch => "winch",
+            CompilerStrategy::CraneliftPulley => "pulley",
         }
     }
 

--- a/crates/fuzzing/src/oracles/engine.rs
+++ b/crates/fuzzing/src/oracles/engine.rs
@@ -16,7 +16,16 @@ pub fn build(
     config: &mut Config,
 ) -> arbitrary::Result<Option<Box<dyn DiffEngine>>> {
     let engine: Box<dyn DiffEngine> = match name {
-        "wasmtime" => Box::new(WasmtimeEngine::new(u, config, CompilerStrategy::Cranelift)?),
+        "wasmtime" => Box::new(WasmtimeEngine::new(
+            u,
+            config,
+            CompilerStrategy::CraneliftNative,
+        )?),
+        "pulley" => Box::new(WasmtimeEngine::new(
+            u,
+            config,
+            CompilerStrategy::CraneliftPulley,
+        )?),
         "wasmi" => Box::new(WasmiEngine::new(config)),
 
         #[cfg(target_arch = "x86_64")]

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -38,7 +38,7 @@ fuzz_target!(|data: &[u8]| {
         // environment variables.
         let allowed_engines = build_allowed_env_list(
             parse_env_list("ALLOWED_ENGINES"),
-            &["wasmtime", "wasmi", "spec", "v8", "winch"],
+            &["wasmtime", "wasmi", "spec", "v8", "winch", "pulley"],
         );
         let allowed_modules = build_allowed_env_list(
             parse_env_list("ALLOWED_MODULES"),
@@ -201,6 +201,7 @@ struct RuntimeStats {
     spec: AtomicUsize,
     wasmtime: AtomicUsize,
     winch: AtomicUsize,
+    pulley: AtomicUsize,
 
     // Counters for which style of module is chosen
     wasm_smith_modules: AtomicUsize,
@@ -218,6 +219,7 @@ impl RuntimeStats {
             spec: AtomicUsize::new(0),
             wasmtime: AtomicUsize::new(0),
             winch: AtomicUsize::new(0),
+            pulley: AtomicUsize::new(0),
             wasm_smith_modules: AtomicUsize::new(0),
             single_instruction_modules: AtomicUsize::new(0),
         }
@@ -241,14 +243,18 @@ impl RuntimeStats {
         let wasmi = self.wasmi.load(SeqCst);
         let wasmtime = self.wasmtime.load(SeqCst);
         let winch = self.winch.load(SeqCst);
-        let total = v8 + spec + wasmi + wasmtime + winch;
+        let pulley = self.pulley.load(SeqCst);
+        let total = v8 + spec + wasmi + wasmtime + winch + pulley;
         println!(
-            "\twasmi: {:.02}%, spec: {:.02}%, wasmtime: {:.02}%, v8: {:.02}%, winch: {:.02}%",
+            "\twasmi: {:.02}%, spec: {:.02}%, wasmtime: {:.02}%, v8: {:.02}%, \
+             winch: {:.02}, \
+             pulley: {:.02}%",
             wasmi as f64 / total as f64 * 100f64,
             spec as f64 / total as f64 * 100f64,
             wasmtime as f64 / total as f64 * 100f64,
             v8 as f64 / total as f64 * 100f64,
             winch as f64 / total as f64 * 100f64,
+            pulley as f64 / total as f64 * 100f64,
         );
 
         let wasm_smith = self.wasm_smith_modules.load(SeqCst);
@@ -268,6 +274,7 @@ impl RuntimeStats {
             "spec" => self.spec.fetch_add(1, SeqCst),
             "v8" => self.v8.fetch_add(1, SeqCst),
             "winch" => self.winch.fetch_add(1, SeqCst),
+            "pulley" => self.pulley.fetch_add(1, SeqCst),
             _ => return,
         };
     }


### PR DESCRIPTION
This commit refactors the `wasmtime-fuzzing` crate to enable fuzzing the Pulley interpreter and the Winch compiler more often. Winch has been feature-complete for much of wasm for a good amount of time now and Pulley now supports many wasm proposals as well. Both strategies have wasm proposals that are still disabled, however.

I've run fuzzers for a bit locally and haven't turned up too too much, but I'm sure OSS-Fuzz will chastise me and tell me all the places I'm forgetting to add various configs and tweaks.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
