### PR TITLE
pulley: Fix a panic in using a return pointer

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -454,16 +454,7 @@ where
                 // `info.dest.args` to be handled differently during register
                 // allocation.
                 let mut args = SmallVec::new();
-                if cfg!(debug_assertions) {
-                    let xargs = info
-                        .uses
-                        .iter()
-                        .filter_map(|a| XReg::new(a.preg))
-                        .collect::<Vec<_>>();
-                    for window in xargs.windows(2) {
-                        assert!(window[0] < window[1]);
-                    }
-                }
+                info.uses.sort_by_key(|arg| arg.preg);
                 info.uses.retain(|arg| {
                     if arg.preg != x0() && arg.preg != x1() && arg.preg != x2() && arg.preg != x3()
                     {

--- a/tests/misc_testsuite/many-results.wast
+++ b/tests/misc_testsuite/many-results.wast
@@ -1,0 +1,49 @@
+(module
+  (func (export "f")
+    (result
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32
+    )
+
+    i32.const 0
+    i32.const 1
+    i32.const 2
+    i32.const 3
+    i32.const 4
+    i32.const 5
+    i32.const 6
+    i32.const 7
+    i32.const 8
+    i32.const 9
+    i32.const 10
+    i32.const 11
+    i32.const 12
+    i32.const 13
+    i32.const 14
+    i32.const 15
+    i32.const 16
+  )
+)
+
+(assert_return (invoke "f")
+  (i32.const 0)
+  (i32.const 1)
+  (i32.const 2)
+  (i32.const 3)
+  (i32.const 4)
+  (i32.const 5)
+  (i32.const 6)
+  (i32.const 7)
+  (i32.const 8)
+  (i32.const 9)
+  (i32.const 10)
+  (i32.const 11)
+  (i32.const 12)
+  (i32.const 13)
+  (i32.const 14)
+  (i32.const 15)
+  (i32.const 16)
+)


### PR DESCRIPTION
This fixes a panic in the pulley backend introduced in #9874 which comes up when using a return pointer on call instructions. This would shuffle the `uses` list of registers to not be sorted like the assertion was expecting. The fix in this commit is to just go ahead and sort the list of `uses` to ensure that registers are peeled off in order.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
