### PR TITLE
Update `Config::wasm_simd` docs

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -880,9 +880,8 @@ impl Config {
     /// as the `v128` type and all of its operators being in a module. Note that
     /// this does not enable the [relaxed simd proposal].
     ///
-    /// On x86_64 platforms note that enabling this feature requires SSE 4.2 and
-    /// below to be available on the target platform. Compilation will fail if
-    /// the compile target does not include SSE 4.2.
+    /// **Note**: On x86_64 platforms the base CPU feature requirement for this
+    /// SIMD is SSE2.
     ///
     /// This is `true` by default.
     ///

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -880,8 +880,8 @@ impl Config {
     /// as the `v128` type and all of its operators being in a module. Note that
     /// this does not enable the [relaxed simd proposal].
     ///
-    /// **Note**: On x86_64 platforms the base CPU feature requirement for this
-    /// SIMD is SSE2.
+    /// **Note**: On x86_64 platforms the base CPU feature requirement for SIMD
+    /// is SSE2.
     ///
     /// This is `true` by default.
     ///


### PR DESCRIPTION


To reflect that the base CPU feature requirement on x86_64 is SSE2



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
