### PR TITLE
[DWARF] Add logging to range building

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -15,6 +15,7 @@ use crate::settings as shared_settings;
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
+use std::string::String;
 use target_lexicon::{Aarch64Architecture, Architecture, OperatingSystem, Triple};
 
 // New backend:
@@ -212,6 +213,10 @@ impl TargetIsa for AArch64Backend {
         // and continue to the next instruction.
         cs.set_skipdata(true)?;
         Ok(cs)
+    }
+
+    fn pretty_print_reg(&self, reg: Reg, _size: u8) -> String {
+        inst::regs::pretty_print_reg(reg)
     }
 
     fn has_native_fma(&self) -> bool {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -46,7 +46,6 @@
 use crate::dominator_tree::DominatorTree;
 pub use crate::isa::call_conv::CallConv;
 
-use crate::flowgraph;
 use crate::ir::{self, Function, Type};
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::{systemv::RegisterMappingError, UnwindInfoKind};
@@ -55,10 +54,12 @@ use crate::settings;
 use crate::settings::Configurable;
 use crate::settings::SetResult;
 use crate::CodegenResult;
+use crate::{flowgraph, Reg};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use cranelift_control::ControlPlane;
+use std::string::String;
 use target_lexicon::{triple, Architecture, PointerWidth, Triple};
 
 // This module is made public here for benchmarking purposes. No guarantees are
@@ -372,6 +373,10 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
         Err(capstone::Error::UnsupportedArch)
     }
+
+    /// Return the string representation of "reg" accessed as "size" bytes.
+    /// The returned string will match the usual disassemly view of "reg".
+    fn pretty_print_reg(&self, reg: Reg, size: u8) -> String;
 
     /// Returns whether this ISA has a native fused-multiply-and-add instruction
     /// for floats.

--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -21,6 +21,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use cranelift_control::ControlPlane;
+use std::string::String;
 use target_lexicon::{Architecture, Triple};
 
 pub use settings::Flags as PulleyFlags;
@@ -213,6 +214,10 @@ where
 
     fn function_alignment(&self) -> FunctionAlignment {
         inst::InstAndKind::<P>::function_alignment()
+    }
+
+    fn pretty_print_reg(&self, reg: crate::Reg, _size: u8) -> String {
+        format!("{reg:?}")
     }
 
     fn has_native_fma(&self) -> bool {

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -14,6 +14,7 @@ use crate::{ir, CodegenError};
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
+use std::string::String;
 use target_lexicon::{Architecture, Triple};
 mod abi;
 pub(crate) mod inst;
@@ -189,6 +190,11 @@ impl TargetIsa for Riscv64Backend {
         // of stopping on invalid bytes.
         cs.set_skipdata(true)?;
         Ok(cs)
+    }
+
+    fn pretty_print_reg(&self, reg: Reg, _size: u8) -> String {
+        // TODO-RISC-V: implement proper register pretty-printing.
+        format!("{reg:?}")
     }
 
     fn has_native_fma(&self) -> bool {

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -15,6 +15,7 @@ use crate::settings as shared_settings;
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
+use std::string::String;
 use target_lexicon::{Architecture, Triple};
 
 // New backend:
@@ -172,6 +173,10 @@ impl TargetIsa for S390xBackend {
         cs.set_skipdata(true)?;
 
         Ok(cs)
+    }
+
+    fn pretty_print_reg(&self, reg: Reg, _size: u8) -> String {
+        inst::regs::pretty_print_reg(reg)
     }
 
     fn has_native_fma(&self) -> bool {

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -19,6 +19,7 @@ use crate::{Final, MachBufferFinalized};
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
+use std::string::String;
 use target_lexicon::Triple;
 
 mod abi;
@@ -156,6 +157,10 @@ impl TargetIsa for X64Backend {
             .syntax(arch::x86::ArchSyntax::Att)
             .detail(true)
             .build()
+    }
+
+    fn pretty_print_reg(&self, reg: Reg, size: u8) -> String {
+        inst::regs::pretty_print_reg(reg, size)
     }
 
     fn has_native_fma(&self) -> bool {

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -1,12 +1,18 @@
 use super::address_transform::AddressTransform;
+use super::dbi_log;
+use crate::debug::transform::debug_transform_logging::{
+    dbi_log_enabled, log_get_value_loc, log_get_value_name, log_get_value_ranges,
+};
 use crate::debug::ModuleMemoryOffset;
 use crate::translate::get_vmctx_value_label;
 use anyhow::{Context, Error, Result};
+use core::fmt;
 use cranelift_codegen::ir::ValueLabel;
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::LabelValueLoc;
 use cranelift_codegen::ValueLabelsRanges;
 use gimli::{write, Expression, Operation, Reader, ReaderOffset};
+use itertools::Itertools;
 use std::cmp::PartialEq;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -296,7 +302,7 @@ impl CompiledExpression {
 
         // Some locals are present, preparing and divided ranges based on the scope
         // and frame_info data.
-        let mut ranges_builder = ValueLabelRangesBuilder::new(scope, addr_tr, frame_info);
+        let mut ranges_builder = ValueLabelRangesBuilder::new(scope, addr_tr, frame_info, isa);
         for p in self.parts.iter() {
             match p {
                 CompiledExpressionPart::Code(_)
@@ -651,7 +657,36 @@ struct CachedValueLabelRange {
     label_location: HashMap<ValueLabel, LabelValueLoc>,
 }
 
+struct BuiltRangeSummary<'a> {
+    range: &'a CachedValueLabelRange,
+    isa: &'a dyn TargetIsa,
+}
+
+impl<'a> fmt::Debug for BuiltRangeSummary<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let range = self.range;
+        write!(f, "[")?;
+        let mut is_first = true;
+        for (value, value_loc) in &range.label_location {
+            if !is_first {
+                write!(f, ", ")?;
+            } else {
+                is_first = false;
+            }
+            write!(
+                f,
+                "{:?}:{:?}",
+                log_get_value_name(*value),
+                log_get_value_loc(*value_loc, self.isa)
+            )?;
+        }
+        write!(f, "]@[{}..{})", range.start, range.end)?;
+        Ok(())
+    }
+}
+
 struct ValueLabelRangesBuilder<'a, 'b> {
+    isa: &'a dyn TargetIsa,
     ranges: Vec<CachedValueLabelRange>,
     frame_info: Option<&'a FunctionFrameInfo<'b>>,
     processed_labels: HashSet<ValueLabel>,
@@ -662,6 +697,7 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
         scope: &[(u64, u64)], // wasm ranges
         addr_tr: &'a AddressTransform,
         frame_info: Option<&'a FunctionFrameInfo<'b>>,
+        isa: &'a dyn TargetIsa,
     ) -> Self {
         let mut ranges = Vec::new();
         for (wasm_start, wasm_end) in scope {
@@ -675,7 +711,17 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
             }
         }
         ranges.sort_unstable_by(|a, b| a.start.cmp(&b.start));
+
+        dbi_log!(
+            "Building ranges for values in scope: {}\n{:?}",
+            ranges
+                .iter()
+                .map(|r| format!("[{}..{})", r.start, r.end))
+                .join(" "),
+            log_get_value_ranges(frame_info.map(|f| f.value_ranges), isa)
+        );
         ValueLabelRangesBuilder {
+            isa,
             ranges,
             frame_info,
             processed_labels: HashSet::new(),
@@ -686,6 +732,7 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
         if self.processed_labels.contains(&label) {
             return;
         }
+        dbi_log!("Intersecting with {:?}", log_get_value_name(label));
         self.processed_labels.insert(label);
 
         let value_ranges = match self.frame_info.and_then(|fi| fi.value_ranges.get(&label)) {
@@ -750,9 +797,23 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
     pub fn into_ranges(self) -> impl Iterator<Item = CachedValueLabelRange> {
         // Ranges with not-enough labels are discarded.
         let processed_labels_len = self.processed_labels.len();
-        self.ranges
-            .into_iter()
-            .filter(move |r| r.label_location.len() == processed_labels_len)
+        let is_valid_range =
+            move |r: &CachedValueLabelRange| r.label_location.len() == processed_labels_len;
+
+        if dbi_log_enabled!() {
+            dbi_log!("Built ranges:");
+            for range in self.ranges.iter().filter(|r| is_valid_range(*r)) {
+                dbi_log!(
+                    "{:?}",
+                    BuiltRangeSummary {
+                        range,
+                        isa: self.isa
+                    }
+                );
+            }
+            dbi_log!("");
+        }
+        self.ranges.into_iter().filter(is_valid_range)
     }
 }
 
@@ -801,7 +862,9 @@ mod tests {
         FunctionFrameInfo, JumpTargetMarker, ValueLabel, ValueLabelsRanges,
     };
     use crate::CompiledFunctionMetadata;
+    use cranelift_codegen::{isa::lookup, settings::Flags};
     use gimli::{constants, Encoding, EndianSlice, Expression, RunTimeEndian};
+    use target_lexicon::triple;
     use wasmtime_environ::FilePos;
 
     macro_rules! dw_op {
@@ -1222,6 +1285,10 @@ mod tests {
         use super::ValueLabelRangesBuilder;
         use crate::debug::ModuleMemoryOffset;
 
+        let isa = lookup(triple!("x86_64"))
+            .expect("expect x86_64 ISA")
+            .finish(Flags::new(cranelift_codegen::settings::builder()))
+            .expect("Creating ISA");
         let addr_tr = create_mock_address_transform();
         let (value_ranges, value_labels) = create_mock_value_ranges();
         let fi = FunctionFrameInfo {
@@ -1230,7 +1297,7 @@ mod tests {
         };
 
         // No value labels, testing if entire function range coming through.
-        let builder = ValueLabelRangesBuilder::new(&[(10, 20)], &addr_tr, Some(&fi));
+        let builder = ValueLabelRangesBuilder::new(&[(10, 20)], &addr_tr, Some(&fi), isa.as_ref());
         let ranges = builder.into_ranges().collect::<Vec<_>>();
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].func_index, 0);
@@ -1238,7 +1305,8 @@ mod tests {
         assert_eq!(ranges[0].end, 30);
 
         // Two labels (val0@0..25 and val1@5..30), their common lifetime intersect at 5..25.
-        let mut builder = ValueLabelRangesBuilder::new(&[(10, 20)], &addr_tr, Some(&fi));
+        let mut builder =
+            ValueLabelRangesBuilder::new(&[(10, 20)], &addr_tr, Some(&fi), isa.as_ref());
         builder.process_label(value_labels.0);
         builder.process_label(value_labels.1);
         let ranges = builder.into_ranges().collect::<Vec<_>>();
@@ -1248,7 +1316,8 @@ mod tests {
 
         // Adds val2 with complex lifetime @0..10 and @20..30 to the previous test, and
         // also narrows range.
-        let mut builder = ValueLabelRangesBuilder::new(&[(11, 17)], &addr_tr, Some(&fi));
+        let mut builder =
+            ValueLabelRangesBuilder::new(&[(11, 17)], &addr_tr, Some(&fi), isa.as_ref());
         builder.process_label(value_labels.0);
         builder.process_label(value_labels.1);
         builder.process_label(value_labels.2);


### PR DESCRIPTION
This helps one gain insight into how and why variables ranges end up as they do. #9900 is an example of an investigation using this code.

Sample output:
```asm
Building ranges for values in scope: [0..186)
L#0   : %r13@[49..68)
L#2   : %rbx@[59..68) %rbx@[72..145)
L#5   : %rax@[100..105)
L#8   : %rax@[116..121)
L#11  : %rax@[132..142)
L#12  : %r9@[137..142)
L#13  : %rax@[142..157)
VMCTX : %rdi@[49..100) %r14@[100..157)    
Intersecting with L#2    
Intersecting with VMCTX    
Built ranges:    
[L#2:%rbx, VMCTX:%rdi]@[59..68)    
[L#2:%rbx, VMCTX:%rdi]@[72..100)    
[L#2:%rbx, VMCTX:%r14]@[100..145)    
```