### PR TITLE
Winch atomic loads x64

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1972,7 +1972,6 @@ impl Config {
             Some(Strategy::Winch) => {
                 let mut unsupported = WasmFeatures::GC
                     | WasmFeatures::FUNCTION_REFERENCES
-                    | WasmFeatures::THREADS
                     | WasmFeatures::RELAXED_SIMD
                     | WasmFeatures::TAIL_CALL
                     | WasmFeatures::GC_TYPES;
@@ -1985,6 +1984,7 @@ impl Config {
                         // winch on aarch64 but this helps gate most spec tests
                         // by default which otherwise currently cause panics.
                         unsupported |= WasmFeatures::REFERENCE_TYPES;
+                        unsupported |= WasmFeatures::THREADS
                     }
 
                     // Winch doesn't support other non-x64 architectures at this

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -286,7 +286,6 @@ impl Compiler {
             // Cranelift has quite yet.
             Compiler::Winch => {
                 if config.gc()
-                    || config.threads()
                     || config.tail_call()
                     || config.function_references()
                     || config.gc()
@@ -511,6 +510,17 @@ impl WastTest {
                 "spec_testsuite/simd_store32_lane.wast",
                 "spec_testsuite/simd_store64_lane.wast",
                 "spec_testsuite/simd_store8_lane.wast",
+                // thread related failures
+                "proposals/threads/atomic.wast",
+                "misc_testsuite/threads/MP_wait.wast",
+                "misc_testsuite/threads/load-store-alignment.wast",
+                "misc_testsuite/threads/MP_atomic.wast",
+                "misc_testsuite/threads/SB_atomic.wast",
+                "misc_testsuite/threads/wait_notify.wast",
+                "misc_testsuite/threads/LB_atomic.wast",
+                "misc_testsuite/threads/atomics_wait_address.wast",
+                "misc_testsuite/threads/atomics_notify.wast",
+                "misc_testsuite/threads/load-store-alignment.wast",
             ];
 
             if unsupported.iter().any(|part| self.path.ends_with(part)) {

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (param $foo i32) (result i32)
+        (i32.atomic.load
+          (local.get $foo))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x47
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rcx
+;;       addq    %rax, %rcx
+;;       movl    (%rcx), %eax
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   47: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (param $foo i32) (result i32)
+        (i32.atomic.load16_u
+          (local.get $foo))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x49
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rcx
+;;       addq    %rax, %rcx
+;;       movzwq  (%rcx), %rax
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   49: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load8_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load8_u.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (memory (data "\00\00\00\00\00\00\f4\7f"))
+
+  (func (result i32)
+        (i32.atomic.load8_u (i32.const 0))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x42
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
+;;       addq    %rax, %rcx
+;;       movzbq  (%rcx), %rax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   42: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (memory (data "\00\00\00\00\00\00\f4\7f"))
+
+  (func (result i64)
+        (i64.atomic.load
+          (i32.const 0))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x41
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
+;;       addq    %rax, %rcx
+;;       movq    (%rcx), %rax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   41: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (memory (data "\00\00\00\00\00\00\f4\7f"))
+
+  (func (result i64)
+        (i64.atomic.load16_u
+          (i32.const 0))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x42
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
+;;       addq    %rax, %rcx
+;;       movzwq  (%rcx), %rax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   42: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (memory (data "\00\00\00\00\00\00\f4\7f"))
+
+  (func (result i64)
+        (i64.atomic.load32_u
+          (i32.const 0))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x40
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
+;;       addq    %rax, %rcx
+;;       movl    (%rcx), %eax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   40: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load8_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load8_u.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (memory (data "\00\00\00\00\00\00\f4\7f"))
+
+  (func (result i64)
+        (i64.atomic.load8_u
+          (i32.const 0))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x42
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
+;;       addq    %rax, %rcx
+;;       movzbq  (%rcx), %rax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   42: ud2

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -254,36 +254,36 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
             Occupied(entry) => *entry.get(),
             Vacant(entry) => {
                 let (import_from, base_offset, current_length_offset) =
-                match self.translation.module.defined_memory_index(index) {
-                    Some(defined) => {
-                        if is_shared {
-                            (
-                                Some(self.vmoffsets.vmctx_vmmemory_pointer(defined)),
-                                self.vmoffsets.ptr.vmmemory_definition_base().into(),
-                                self.vmoffsets
-                                    .ptr
-                                    .vmmemory_definition_current_length()
-                                    .into(),
-                            )
-                        } else {
-                            let owned = self.translation.module.owned_memory_index(defined);
-                            (
-                                None,
-                                self.vmoffsets.vmctx_vmmemory_definition_base(owned),
-                                self.vmoffsets
-                                    .vmctx_vmmemory_definition_current_length(owned),
-                            )
+                    match self.translation.module.defined_memory_index(index) {
+                        Some(defined) => {
+                            if is_shared {
+                                (
+                                    Some(self.vmoffsets.vmctx_vmmemory_pointer(defined)),
+                                    self.vmoffsets.ptr.vmmemory_definition_base().into(),
+                                    self.vmoffsets
+                                        .ptr
+                                        .vmmemory_definition_current_length()
+                                        .into(),
+                                )
+                            } else {
+                                let owned = self.translation.module.owned_memory_index(defined);
+                                (
+                                    None,
+                                    self.vmoffsets.vmctx_vmmemory_definition_base(owned),
+                                    self.vmoffsets
+                                        .vmctx_vmmemory_definition_current_length(owned),
+                                )
+                            }
                         }
-                    }
-                    None => (
-                        Some(self.vmoffsets.vmctx_vmmemory_import_from(index)),
-                        self.vmoffsets.ptr.vmmemory_definition_base().into(),
-                        self.vmoffsets
-                            .ptr
-                            .vmmemory_definition_current_length()
-                            .into(),
-                    ),
-                };
+                        None => (
+                            Some(self.vmoffsets.vmctx_vmmemory_import_from(index)),
+                            self.vmoffsets.ptr.vmmemory_definition_base().into(),
+                            self.vmoffsets
+                                .ptr
+                                .vmmemory_definition_current_length()
+                                .into(),
+                        ),
+                    };
 
                 let memory = &self.translation.module.memories[index];
 

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -54,7 +54,7 @@ pub struct HeapData {
     pub offset: u32,
     /// The offset to the current length field.
     pub current_length_offset: u32,
-    /// If the WebAssembly memory is imported, this field contains the offset to locate the
+    /// If the WebAssembly memory is imported or shared, this field contains the offset to locate the
     /// base of the heap.
     pub import_from: Option<u32>,
     /// The memory type this heap is associated with.

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -879,7 +879,8 @@ where
 
             let src = self.masm.address_at_reg(addr, 0)?;
             if atomic {
-                self.masm.wasm_load_atomic(src, writable!(dst), size, sextend)?;
+                self.masm
+                    .wasm_load_atomic(src, writable!(dst), size, sextend)?;
             } else {
                 self.masm.wasm_load(src, writable!(dst), size, sextend)?;
             }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -871,7 +871,13 @@ impl Masm for MacroAssembler {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
 
-    fn wasm_load_atomic(&mut self, _src: Self::Address, _dst: WritableReg, _size: OperandSize, _sextend: Option<ExtendKind>) {
+    fn wasm_load_atomic(
+        &mut self,
+        _src: Self::Address,
+        _dst: WritableReg,
+        _size: OperandSize,
+        _sextend: Option<ExtendKind>,
+    ) -> Result<()> {
         todo!()
     }
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -870,6 +870,10 @@ impl Masm for MacroAssembler {
         let _ = (context, kind);
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
+
+    fn wasm_load_atomic(&mut self, _src: Self::Address, _dst: WritableReg, _size: OperandSize, _sextend: Option<ExtendKind>) {
+        todo!()
+    }
 }
 
 impl MacroAssembler {

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1219,9 +1219,8 @@ impl Masm for MacroAssembler {
         size: OperandSize,
         kind: Option<ExtendKind>,
     ) {
-        // The x86-64 architecture guarantee that a load
-        // operation will never be reodered with any memory operation appearing after it. Therefore
-        // loads are equivalent to their non-atomic counterparts.
+        // The guarantees of the x86-64 memory model ensure that `SeqCst`
+        // loads are equivalent to normal loads.
         self.wasm_load(src, dst, size, kind);
     }
 }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1212,7 +1212,13 @@ impl Masm for MacroAssembler {
         Ok(())
     }
 
-    fn wasm_load_atomic(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize, kind: Option<ExtendKind>) {
+    fn wasm_load_atomic(
+        &mut self,
+        src: Self::Address,
+        dst: WritableReg,
+        size: OperandSize,
+        kind: Option<ExtendKind>,
+    ) {
         // The x86-64 architecture guarantee that a load
         // operation will never be reodered with any memory operation appearing after it. Therefore
         // loads are equivalent to their non-atomic counterparts.

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1211,6 +1211,13 @@ impl Masm for MacroAssembler {
 
         Ok(())
     }
+
+    fn wasm_load_atomic(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize, kind: Option<ExtendKind>) {
+        // The x86-64 architecture guarantee that a load
+        // operation will never be reodered with any memory operation appearing after it. Therefore
+        // loads are equivalent to their non-atomic counterparts.
+        self.wasm_load(src, dst, size, kind);
+    }
 }
 
 impl MacroAssembler {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1134,5 +1134,5 @@ pub(crate) trait MacroAssembler {
     /// instruction (e.g. x64) so full access to `CodeGenContext` is provided.
     fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind);
 
-    fn wasm_load_atomic(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize, sextend: Option<ExtendKind>);
+    fn wasm_load_atomic(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize, sextend: Option<ExtendKind>) -> Result<()>;
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1132,6 +1132,7 @@ pub(crate) trait MacroAssembler {
     ///
     /// Note that some platforms require special handling of registers in this
     /// instruction (e.g. x64) so full access to `CodeGenContext` is provided.
-    fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind)
-        -> Result<()>;
+    fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind);
+
+    fn wasm_load_atomic(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize, sextend: Option<ExtendKind>);
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -38,6 +38,14 @@ impl RemKind {
     }
 }
 
+#[derive(Copy, Clone)]
+pub(crate) enum MemOpKind {
+    /// An atomic memory operation with SeqCst memory ordering.
+    Atomic,
+    /// A memory operation with no memory ordering constraint.
+    Normal,
+}
+
 #[derive(Eq, PartialEq)]
 pub(crate) enum MulWideKind {
     Signed,
@@ -646,7 +654,8 @@ pub(crate) trait MacroAssembler {
         src: Self::Address,
         dst: WritableReg,
         size: OperandSize,
-        kind: Option<ExtendKind>,
+        ext_kind: Option<ExtendKind>,
+        op_kind: MemOpKind,
     ) -> Result<()>;
 
     /// Alias for `MacroAssembler::load` with the operand size corresponding
@@ -1134,12 +1143,4 @@ pub(crate) trait MacroAssembler {
     /// instruction (e.g. x64) so full access to `CodeGenContext` is provided.
     fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind)
         -> Result<()>;
-
-    fn wasm_load_atomic(
-        &mut self,
-        src: Self::Address,
-        dst: WritableReg,
-        size: OperandSize,
-        sextend: Option<ExtendKind>,
-    ) -> Result<()>;
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1132,7 +1132,14 @@ pub(crate) trait MacroAssembler {
     ///
     /// Note that some platforms require special handling of registers in this
     /// instruction (e.g. x64) so full access to `CodeGenContext` is provided.
-    fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind);
+    fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind)
+        -> Result<()>;
 
-    fn wasm_load_atomic(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize, sextend: Option<ExtendKind>) -> Result<()>;
+    fn wasm_load_atomic(
+        &mut self,
+        src: Self::Address,
+        dst: WritableReg,
+        size: OperandSize,
+        sextend: Option<ExtendKind>,
+    ) -> Result<()>;
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -256,6 +256,7 @@ macro_rules! def_unsupported {
     (emit I32AtomicLoad8U $($rest:tt)*) => {};
     (emit I32AtomicLoad16U $($rest:tt)*) => {};
     (emit I32AtomicLoad $($rest:tt)*) => {};
+    (emit I64AtomicLoad8U $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2154,6 +2155,9 @@ where
         self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S32, None);
     }
 
+    fn visit_i64_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S8, None);
+    }
     wasmparser::for_each_visit_operator!(def_unsupported);
 }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -259,6 +259,7 @@ macro_rules! def_unsupported {
     (emit I64AtomicLoad8U $($rest:tt)*) => {};
     (emit I64AtomicLoad16U $($rest:tt)*) => {};
     (emit I64AtomicLoad32U $($rest:tt)*) => {};
+    (emit I64AtomicLoad $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2168,6 +2169,11 @@ where
     fn visit_i64_atomic_load32_u(&mut self, memarg: wasmparser::MemArg) {
         self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S32, None);
     }
+
+    fn visit_i64_atomic_load(&mut self, memarg: wasmparser::MemArg) {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S64, None);
+    }
+
     wasmparser::for_each_visit_operator!(def_unsupported);
 }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -258,6 +258,7 @@ macro_rules! def_unsupported {
     (emit I32AtomicLoad $($rest:tt)*) => {};
     (emit I64AtomicLoad8U $($rest:tt)*) => {};
     (emit I64AtomicLoad16U $($rest:tt)*) => {};
+    (emit I64AtomicLoad32U $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2162,6 +2163,10 @@ where
 
     fn visit_i64_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) {
         self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S16, None);
+    }
+
+    fn visit_i64_atomic_load32_u(&mut self, memarg: wasmparser::MemArg) {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S32, None);
     }
     wasmparser::for_each_visit_operator!(def_unsupported);
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -9,8 +9,8 @@ use crate::codegen::{
     control_index, Callee, CodeGen, CodeGenError, ControlStackFrame, Emission, FnCall,
 };
 use crate::masm::{
-    DivKind, ExtendKind, FloatCmpKind, IntCmpKind, MacroAssembler, MemMoveDirection, MulWideKind,
-    OperandSize, RegImm, RemKind, RoundingMode, SPOffset, ShiftKind, TruncKind,
+    DivKind, ExtendKind, FloatCmpKind, IntCmpKind, MacroAssembler, MemMoveDirection, MemOpKind,
+    MulWideKind, OperandSize, RegImm, RemKind, RoundingMode, SPOffset, ShiftKind, TruncKind,
 };
 
 use crate::reg::{writable, Reg};
@@ -1928,7 +1928,13 @@ where
     }
 
     fn visit_i32_load(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::I32, OperandSize::S32, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I32,
+            OperandSize::S32,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i32_load8_s(&mut self, memarg: MemArg) -> Self::Output {
@@ -1937,11 +1943,18 @@ where
             WasmValType::I32,
             OperandSize::S8,
             Some(ExtendKind::I32Extend8S),
+            MemOpKind::Normal,
         )
     }
 
     fn visit_i32_load8_u(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::I32, OperandSize::S8, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I32,
+            OperandSize::S8,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i32_load16_s(&mut self, memarg: MemArg) -> Self::Output {
@@ -1950,11 +1963,18 @@ where
             WasmValType::I32,
             OperandSize::S16,
             Some(ExtendKind::I32Extend16S),
+            MemOpKind::Normal,
         )
     }
 
     fn visit_i32_load16_u(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::I32, OperandSize::S16, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I32,
+            OperandSize::S16,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i32_store(&mut self, memarg: MemArg) -> Self::Output {
@@ -1975,15 +1995,28 @@ where
             WasmValType::I64,
             OperandSize::S8,
             Some(ExtendKind::I64Extend8S),
+            MemOpKind::Normal,
         )
     }
 
     fn visit_i64_load8_u(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::I64, OperandSize::S8, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S8,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i64_load16_u(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::I64, OperandSize::S16, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S16,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i64_load16_s(&mut self, memarg: MemArg) -> Self::Output {
@@ -1992,11 +2025,18 @@ where
             WasmValType::I64,
             OperandSize::S16,
             Some(ExtendKind::I64Extend16S),
+            MemOpKind::Normal,
         )
     }
 
     fn visit_i64_load32_u(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::I64, OperandSize::S32, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S32,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i64_load32_s(&mut self, memarg: MemArg) -> Self::Output {
@@ -2005,11 +2045,18 @@ where
             WasmValType::I64,
             OperandSize::S32,
             Some(ExtendKind::I64Extend32S),
+            MemOpKind::Normal,
         )
     }
 
     fn visit_i64_load(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::I64, OperandSize::S64, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S64,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i64_store(&mut self, memarg: MemArg) -> Self::Output {
@@ -2029,7 +2076,13 @@ where
     }
 
     fn visit_f32_load(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::F32, OperandSize::S32, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::F32,
+            OperandSize::S32,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_f32_store(&mut self, memarg: MemArg) -> Self::Output {
@@ -2037,7 +2090,13 @@ where
     }
 
     fn visit_f64_load(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::F64, OperandSize::S64, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::F64,
+            OperandSize::S64,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_f64_store(&mut self, memarg: MemArg) -> Self::Output {
@@ -2147,31 +2206,73 @@ where
     }
 
     fn visit_i32_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S8, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I32,
+            OperandSize::S8,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_i32_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S16, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I32,
+            OperandSize::S16,
+            None,
+            MemOpKind::Atomic,
+        )
     }
 
     fn visit_i32_atomic_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S32, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I32,
+            OperandSize::S32,
+            None,
+            MemOpKind::Atomic,
+        )
     }
 
     fn visit_i64_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S8, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S8,
+            None,
+            MemOpKind::Atomic,
+        )
     }
 
     fn visit_i64_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S16, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S16,
+            None,
+            MemOpKind::Atomic,
+        )
     }
 
     fn visit_i64_atomic_load32_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S32, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S32,
+            None,
+            MemOpKind::Atomic,
+        )
     }
 
     fn visit_i64_atomic_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S64, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::I64,
+            OperandSize::S64,
+            None,
+            MemOpKind::Atomic,
+        )
     }
 
     wasmparser::for_each_visit_operator!(def_unsupported);
@@ -2188,7 +2289,13 @@ where
     }
 
     fn visit_v128_load(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_load(&memarg, WasmValType::V128, OperandSize::S128, None)
+        self.emit_wasm_load(
+            &memarg,
+            WasmValType::V128,
+            OperandSize::S128,
+            None,
+            MemOpKind::Normal,
+        )
     }
 
     fn visit_v128_store(&mut self, memarg: MemArg) -> Self::Output {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -2146,32 +2146,32 @@ where
         self.masm.mul_wide(&mut self.context, MulWideKind::Unsigned)
     }
 
-    fn visit_i32_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S8, None);
+    fn visit_i32_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S8, None)
     }
 
-    fn visit_i32_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S16, None);
+    fn visit_i32_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S16, None)
     }
 
-    fn visit_i32_atomic_load(&mut self, memarg: wasmparser::MemArg) {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S32, None);
+    fn visit_i32_atomic_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S32, None)
     }
 
-    fn visit_i64_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S8, None);
+    fn visit_i64_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S8, None)
     }
 
-    fn visit_i64_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S16, None);
+    fn visit_i64_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S16, None)
     }
 
-    fn visit_i64_atomic_load32_u(&mut self, memarg: wasmparser::MemArg) {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S32, None);
+    fn visit_i64_atomic_load32_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S32, None)
     }
 
-    fn visit_i64_atomic_load(&mut self, memarg: wasmparser::MemArg) {
-        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S64, None);
+    fn visit_i64_atomic_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S64, None)
     }
 
     wasmparser::for_each_visit_operator!(def_unsupported);

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -253,6 +253,7 @@ macro_rules! def_unsupported {
     (emit I64Sub128 $($rest:tt)*) => {};
     (emit I64MulWideS $($rest:tt)*) => {};
     (emit I64MulWideU $($rest:tt)*) => {};
+    (emit I32AtomicLoad8U $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2139,7 +2140,12 @@ where
         self.masm.mul_wide(&mut self.context, MulWideKind::Unsigned)
     }
 
+    fn visit_i32_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S8, None);
+    }
+
     wasmparser::for_each_visit_operator!(def_unsupported);
+
 }
 
 impl<'a, 'translation, 'data, M> VisitSimdOperator<'a>

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -257,6 +257,7 @@ macro_rules! def_unsupported {
     (emit I32AtomicLoad16U $($rest:tt)*) => {};
     (emit I32AtomicLoad $($rest:tt)*) => {};
     (emit I64AtomicLoad8U $($rest:tt)*) => {};
+    (emit I64AtomicLoad16U $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2157,6 +2158,10 @@ where
 
     fn visit_i64_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) {
         self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S8, None);
+    }
+
+    fn visit_i64_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I64, OperandSize::S16, None);
     }
     wasmparser::for_each_visit_operator!(def_unsupported);
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -254,6 +254,7 @@ macro_rules! def_unsupported {
     (emit I64MulWideS $($rest:tt)*) => {};
     (emit I64MulWideU $($rest:tt)*) => {};
     (emit I32AtomicLoad8U $($rest:tt)*) => {};
+    (emit I32AtomicLoad16U $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2142,6 +2143,10 @@ where
 
     fn visit_i32_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) {
         self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S8, None);
+    }
+
+    fn visit_i32_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S16, None);
     }
 
     wasmparser::for_each_visit_operator!(def_unsupported);

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -255,6 +255,7 @@ macro_rules! def_unsupported {
     (emit I64MulWideU $($rest:tt)*) => {};
     (emit I32AtomicLoad8U $($rest:tt)*) => {};
     (emit I32AtomicLoad16U $($rest:tt)*) => {};
+    (emit I32AtomicLoad $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2149,8 +2150,11 @@ where
         self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S16, None);
     }
 
-    wasmparser::for_each_visit_operator!(def_unsupported);
+    fn visit_i32_atomic_load(&mut self, memarg: wasmparser::MemArg) {
+        self.emit_wasm_load_atomic(&memarg, WasmValType::I32, OperandSize::S32, None);
+    }
 
+    wasmparser::for_each_visit_operator!(def_unsupported);
 }
 
 impl<'a, 'translation, 'data, M> VisitSimdOperator<'a>


### PR DESCRIPTION
this PR enable the thread feature for x64 in Winch, and implements atomic loads. This includes:
- `i32.atomic.load8_u`
- `i32.atomic.load16_u`
- `i32.atomic.load`
- `i64.atomic.load8_u`
- `i64.atomic.load16_u`
- `i64.atomic.load32_u`
- `i64.atomic.load`

It also enabled shared memory for winch.

https://github.com/bytecodealliance/wasmtime/issues/9734

reopened from https://github.com/bytecodealliance/wasmtime/pull/9954 because the branch was wrong