### PR TITLE
ISLE: fix more glitches in BNF

### DIFF
--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1533,7 +1533,7 @@ The grammar accepted by the parser is as follows:
        | "(" "form" <form> ")"
        | "(" "instantiate" <instantiation> ")"
 
-<spec> ::= "(" <ident> <ident>* <provide> [ <require> ] ")"
+<spec> ::= "(" <ident> <ident>* ")" <provide> [ <require> ]
 <provide> ::= "(" "provide" <spec-expr>* ")"
 <require> ::= "(" "require" <spec-expr>* ")"
 

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1554,6 +1554,7 @@ The grammar accepted by the parser is as follows:
 
 <spec-expr> ::= <int>
               | <spec-bv>
+              | "result"
               | "true" | "false"
               | <ident>
               | "(" "switch" <spec-expr> <spec-pair>* ")"

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1472,7 +1472,7 @@ The grammar accepted by the parser is as follows:
 
 <ident> ::= <ident-start> <ident-cont>*
 <const-ident> ::= "$" <ident-cont>*
-<ident-start> ::= <any non-whitespace character other than "-", "0".."9", "(", ")" or ";">
+<ident-start> ::= <any non-whitespace character other than "-", "0".."9", "(", ")", ";" or "$">
 <ident-cont>  ::= <any non-whitespace character other than "(", ")", ";" or "@">
 
 <type-body> ::= "(" "primitive" <ident> ")"

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1554,7 +1554,6 @@ The grammar accepted by the parser is as follows:
 
 <spec-expr> ::= <int>
               | <spec-bv>
-              | "result"
               | "true" | "false"
               | <ident>
               | "(" "switch" <spec-expr> <spec-pair>* ")"

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1561,6 +1561,9 @@ The grammar accepted by the parser is as follows:
               | "(" <ident> ")"
               | "(" ")"
 
+<spec-bv> ::= "#b" [ "+" | "-" ] ("0".."1")+
+            | "#x" [ "+" | "-" ] ("0".."9" | "A".."F" | "a".."f")+
+
 <spec-pair> ::= "(" <spec-expr> <spec-expr> ")"
 
 <spec-op> ::= "and" | "not" | "or" | "=>"

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1544,7 +1544,7 @@ The grammar accepted by the parser is as follows:
 <model-ty> ::= "Bool"
              | "Int"
              | "Unit"
-             | "(" "bv" <int> ")"
+             | "(" "bv" [ <int> ] ")"
 
 <model-variant> ::= "(" <ident> [ <spec-expr> ] ")"
 

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1527,6 +1527,7 @@ The grammar accepted by the parser is as follows:
 ```
 
 ## Reference: ISLE Language Grammar verification extensions
+
 ```bnf
 <def> += "(" "spec" <spec> ")"
        | "(" "model" <model> ")"
@@ -1545,7 +1546,7 @@ The grammar accepted by the parser is as follows:
              | "Unit"
              | "(" "bv" <int> ")"
 
-<model-variant> ::= "(" <ident> [ <spec-expr> ]  ")"
+<model-variant> ::= "(" <ident> [ <spec-expr> ] ")"
 
 <form> ::= <ident> <signature>*
 
@@ -1571,7 +1572,7 @@ The grammar accepted by the parser is as follows:
             | "bvnot" | "bvand" | "bvor" | "bvxor"
             | "bvneg" | "bvadd" | "bvsub" | "bvmul"
             | "bvudiv" | "bvurem" | "bvsdiv" | "bvsrem"
-            | "bvshl" | "bvlshr| | "bvashr"
+            | "bvshl" | "bvlshr" | "bvashr"
             | "bvsaddo" | "subs"
             | "bvule" | "bvult" | "bvugt" | "bvuge"
             | "bvsle" | "bvslt" | "bvsgt" | "bvsge"

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1472,7 +1472,7 @@ The grammar accepted by the parser is as follows:
 
 <ident> ::= <ident-start> <ident-cont>*
 <const-ident> ::= "$" <ident-cont>*
-<ident-start> ::= <any non-whitespace character other than "-", "0".."9", "(", ")", ";" or "$">
+<ident-start> ::= <any non-whitespace character other than "-", "0".."9", "(", ")", ";", "#" or "$">
 <ident-cont>  ::= <any non-whitespace character other than "(", ")", ";" or "@">
 
 <type-body> ::= "(" "primitive" <ident> ")"

--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1549,7 +1549,7 @@ The grammar accepted by the parser is as follows:
 
 <form> ::= <ident> <signature>*
 
-<instantiation> ::= <ident> "(" <signature>* ")"
+<instantiation> ::= <ident> <signature>*
                   | <ident> <ident>
 
 <spec-expr> ::= <int>


### PR DESCRIPTION
Address some issues in BNF
* \<ident\> overlapped with \<const-ident\>
* `(spec (signature ...))` should be `(spec (signature) ...)`
* spec expression def. missing `result`