### PR TITLE
fix: `no_std` timing module

### DIFF
--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -287,7 +287,7 @@ mod disabled {
         }
     }
 
-    pub fn start_pass(_pass: Pass) -> Box<dyn Any> {
+    pub(crate) fn start_pass(_pass: Pass) -> Box<dyn Any> {
         Box::new(())
     }
 }


### PR DESCRIPTION
This change moves code around in the `cranelift` `timing` module so that it compiles on `no_std` targets where `thread_local` isn't available.