### PR TITLE
fix: `no_std` fix use without `unwind`

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -193,6 +193,7 @@ where
         })
     }
 
+    #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
         _result: &crate::CompiledCode,

--- a/cranelift/codegen/src/isa/unwind.rs
+++ b/cranelift/codegen/src/isa/unwind.rs
@@ -15,6 +15,7 @@ pub mod winx64;
 pub mod winarm64;
 
 /// CFA-based unwind information used on SystemV.
+#[cfg(feature = "unwind")]
 pub type CfaUnwindInfo = systemv::UnwindInfo;
 
 /// Expected unwind info type.

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -28,6 +28,7 @@ mod lower;
 mod pcc;
 pub mod settings;
 
+#[cfg(feature = "unwind")]
 pub use inst::unwind::systemv::create_cie;
 
 /// An X64 backend.
@@ -184,6 +185,7 @@ impl TargetIsa for X64Backend {
 }
 
 /// Emit unwind info for an x86 target.
+#[cfg(feature = "unwind")]
 pub fn emit_unwind_info(
     buffer: &MachBufferFinalized<Final>,
     kind: crate::isa::unwind::UnwindInfoKind,

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1064,8 +1064,14 @@ impl<I: VCodeInst> VCode<I> {
         }
 
         self.monotonize_inst_offsets(&mut inst_offsets[..], func_body_len);
+
+        #[cfg(feature = "unwind")]
         let value_labels_ranges =
             self.compute_value_labels_ranges(regalloc, &inst_offsets[..], func_body_len);
+        // when unwind information is disabled, ValueLabelsRanges are meaningless anyway
+        #[cfg(not(feature = "unwind"))]
+        let value_labels_ranges = ValueLabelsRanges::default();
+
         let frame_size = self.abi.frame_size();
 
         EmitResult {
@@ -1121,6 +1127,7 @@ impl<I: VCodeInst> VCode<I> {
         }
     }
 
+    #[cfg(feature = "unwind")]
     fn compute_value_labels_ranges(
         &self,
         regalloc: &regalloc2::Output,
@@ -1159,11 +1166,8 @@ impl<I: VCodeInst> VCode<I> {
                 let slot_offset = self.abi.get_spillslot_offset(slot);
                 let slot_base_to_caller_sp_offset = self.abi.slot_base_to_caller_sp_offset();
 
-                #[cfg(feature = "unwind")]
                 let caller_sp_to_cfa_offset =
                     crate::isa::unwind::systemv::caller_sp_to_cfa_offset();
-                #[cfg(not(feature = "unwind"))]
-                let caller_sp_to_cfa_offset = 0; // TODO is this right?
 
                 // NOTE: this is a negative offset because it's relative to the caller's SP
                 let cfa_to_sp_offset =

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1158,8 +1158,13 @@ impl<I: VCodeInst> VCode<I> {
                 let slot = alloc.as_stack().unwrap();
                 let slot_offset = self.abi.get_spillslot_offset(slot);
                 let slot_base_to_caller_sp_offset = self.abi.slot_base_to_caller_sp_offset();
+
+                #[cfg(feature = "unwind")]
                 let caller_sp_to_cfa_offset =
                     crate::isa::unwind::systemv::caller_sp_to_cfa_offset();
+                #[cfg(not(feature = "unwind"))]
+                let caller_sp_to_cfa_offset = 0; // TODO is this right?
+
                 // NOTE: this is a negative offset because it's relative to the caller's SP
                 let cfa_to_sp_offset =
                     -((slot_base_to_caller_sp_offset + caller_sp_to_cfa_offset) as i64);


### PR DESCRIPTION
As part of no_std support in cranelift this PR fixes uses of the `isa/unwind` module through `cranelift` so that `cranelift` can be compiled with the `unwind` feature (which depends on `stdlib` through `gimli`) disabled.