### PR TITLE
Fix some more minor 2024 edition things

### DIFF
--- a/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
+++ b/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
@@ -205,11 +205,11 @@ pub mod _1_world_imports;
 ///     // ...
 /// }
 ///
-/// # mod rand { pub fn thread_rng() -> G { G } pub struct G; impl G { pub fn gen(&self) -> u32 { 0 } } }
+/// # mod rand { pub fn thread_rng() -> G { G } pub struct G; impl G { pub fn r#gen(&self) -> u32 { 0 } } }
 /// // Note that the trait here is per-interface and within a submodule now.
 /// impl my::project::host::Host for MyState {
 ///     fn gen_random_integer(&mut self) -> u32 {
-///         rand::thread_rng().gen()
+///         rand::thread_rng().r#gen()
 ///     }
 ///
 ///     fn sha256(&mut self, bytes: Vec<u8>) -> String {

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -116,35 +116,43 @@ impl std::error::Error for MemoryAccessError {}
 ///     // First and foremost, any borrow can be invalidated at any time via the
 ///     // `Memory::grow` function. This can relocate memory which causes any
 ///     // previous pointer to be possibly invalid now.
-///     let pointer: &u8 = &*mem.data_ptr(&store);
-///     mem.grow(&mut *store, 1)?; // invalidates `pointer`!
-///     // println!("{}", *pointer); // FATAL: use-after-free
+///     unsafe {
+///         let pointer: &u8 = &*mem.data_ptr(&store);
+///         mem.grow(&mut *store, 1)?; // invalidates `pointer`!
+///         // println!("{}", *pointer); // FATAL: use-after-free
+///     }
 ///
 ///     // Note that the use-after-free also applies to slices, whether they're
 ///     // slices of bytes or strings.
-///     let mem_slice = std::slice::from_raw_parts(
-///         mem.data_ptr(&store),
-///         mem.data_size(&store),
-///     );
-///     let slice: &[u8] = &mem_slice[0x100..0x102];
-///     mem.grow(&mut *store, 1)?; // invalidates `slice`!
-///     // println!("{:?}", slice); // FATAL: use-after-free
+///     unsafe {
+///         let mem_slice = std::slice::from_raw_parts(
+///             mem.data_ptr(&store),
+///             mem.data_size(&store),
+///         );
+///         let slice: &[u8] = &mem_slice[0x100..0x102];
+///         mem.grow(&mut *store, 1)?; // invalidates `slice`!
+///         // println!("{:?}", slice); // FATAL: use-after-free
+///     }
 ///
 ///     // The `Memory` type may be stored in other locations, so if you hand
 ///     // off access to the `Store` then those locations may also call
 ///     // `Memory::grow` or similar, so it's not enough to just audit code for
 ///     // calls to `Memory::grow`.
-///     let pointer: &u8 = &*mem.data_ptr(&store);
-///     some_other_function(store); // may invalidate `pointer` through use of `store`
-///     // println!("{:?}", pointer); // FATAL: maybe a use-after-free
+///     unsafe {
+///         let pointer: &u8 = &*mem.data_ptr(&store);
+///         some_other_function(store); // may invalidate `pointer` through use of `store`
+///         // println!("{:?}", pointer); // FATAL: maybe a use-after-free
+///     }
 ///
 ///     // An especially subtle aspect of accessing a wasm instance's memory is
 ///     // that you need to be extremely careful about aliasing. Anyone at any
 ///     // time can call `data_unchecked()` or `data_unchecked_mut()`, which
 ///     // means you can easily have aliasing mutable references:
-///     let ref1: &u8 = &*mem.data_ptr(&store).add(0x100);
-///     let ref2: &mut u8 = &mut *mem.data_ptr(&store).add(0x100);
-///     // *ref2 = *ref1; // FATAL: violates Rust's aliasing rules
+///     unsafe {
+///         let ref1: &u8 = &*mem.data_ptr(&store).add(0x100);
+///         let ref2: &mut u8 = &mut *mem.data_ptr(&store).add(0x100);
+///         // *ref2 = *ref1; // FATAL: violates Rust's aliasing rules
+///     }
 ///
 ///     Ok(())
 /// }

--- a/crates/wiggle/test-helpers/src/lib.rs
+++ b/crates/wiggle/test-helpers/src/lib.rs
@@ -174,7 +174,7 @@ impl MemArea {
     }
 
     /// Enumerate all memareas of size `len` inside a given area
-    fn inside(&self, len: u32) -> impl Iterator<Item = MemArea> + use<'_> {
+    fn inside(&self, len: u32) -> impl Iterator<Item = MemArea> + use<> {
         let end: i64 = self.len as i64 - len as i64;
         let start = self.ptr;
         (0..end).into_iter().map(move |v| MemArea {


### PR DESCRIPTION
* Fix some doctests to be compatible with the 2024 edition.
* Fix a `use<...>` that's an error in the 2024 edition but works in the 2021 edition.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
