### PR TITLE
Fix some clippy warnings in the 2024 edition

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -23,7 +23,7 @@ impl test_programs::proxy::exports::wasi::http::incoming_handler::Guest for T {
         );
 
         assert!(req_hdrs.delete(&header).is_err());
-        assert!(req_hdrs.append(&header, &b"no".to_vec()).is_err());
+        assert!(req_hdrs.append(&header, b"no").is_err());
 
         assert!(
             !req_hdrs.has(&header),
@@ -31,7 +31,7 @@ impl test_programs::proxy::exports::wasi::http::incoming_handler::Guest for T {
         );
 
         assert!(
-            !req_hdrs.has(&"host".to_owned()),
+            !req_hdrs.has("host"),
             "forbidden host header present in incoming request"
         );
 

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
@@ -3,48 +3,39 @@ use test_programs::wasi::http::types::{HeaderError, Headers, OutgoingRequest};
 fn main() {
     let hdrs = Headers::new();
     assert!(matches!(
-        hdrs.append(&"malformed header name".to_owned(), &b"ok value".to_vec()),
+        hdrs.append("malformed header name", b"ok value"),
+        Err(HeaderError::InvalidSyntax)
+    ));
+
+    assert!(matches!(hdrs.append("ok-header-name", b"ok value"), Ok(())));
+
+    assert!(matches!(
+        hdrs.append("ok-header-name", b"bad\nvalue"),
         Err(HeaderError::InvalidSyntax)
     ));
 
     assert!(matches!(
-        hdrs.append(&"ok-header-name".to_owned(), &b"ok value".to_vec()),
-        Ok(())
-    ));
-
-    assert!(matches!(
-        hdrs.append(&"ok-header-name".to_owned(), &b"bad\nvalue".to_vec()),
-        Err(HeaderError::InvalidSyntax)
-    ));
-
-    assert!(matches!(
-        hdrs.append(&"Connection".to_owned(), &b"keep-alive".to_vec()),
+        hdrs.append("Connection", b"keep-alive"),
         Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
-        hdrs.append(&"Keep-Alive".to_owned(), &b"stuff".to_vec()),
+        hdrs.append("Keep-Alive", b"stuff"),
         Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
-        hdrs.append(&"Host".to_owned(), &b"example.com".to_vec()),
+        hdrs.append("Host", b"example.com"),
         Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
-        hdrs.append(
-            &"custom-forbidden-header".to_owned(),
-            &b"keep-alive".to_vec()
-        ),
+        hdrs.append("curbidden-header", b"keep-alive"),
         Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
-        hdrs.append(
-            &"Custom-Forbidden-Header".to_owned(),
-            &b"keep-alive".to_vec()
-        ),
+        hdrs.append("Curbidden-Header", b"keep-alive"),
         Err(HeaderError::Forbidden)
     ));
 
@@ -67,17 +58,17 @@ fn main() {
     let hdrs = req.headers();
 
     assert!(matches!(
-        hdrs.set(&"Content-Length".to_owned(), &[b"10".to_vec()]),
+        hdrs.set("Content-Length", &[b"10".to_vec()]),
         Err(HeaderError::Immutable),
     ));
 
     assert!(matches!(
-        hdrs.append(&"Content-Length".to_owned(), &b"10".to_vec()),
+        hdrs.append("Content-Length", b"10"),
         Err(HeaderError::Immutable),
     ));
 
     assert!(matches!(
-        hdrs.delete(&"Content-Length".to_owned()),
+        hdrs.delete("Content-Length"),
         Err(HeaderError::Immutable),
     ));
 }


### PR DESCRIPTION
Not sure why these aren't firing on the 2021 edition, but I figured I'd just roll with it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
