### PR TITLE
Improve some logging in the differential fuzzer

### DIFF
--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -44,7 +44,7 @@ impl DiffEngine for SpecInterpreter {
         Ok(Box::new(SpecInstance { instance }))
     }
 
-    fn assert_error_match(&self, trap: &Trap, err: &Error) {
+    fn assert_error_match(&self, err: &Error, trap: &Trap) {
         // TODO: implement this for the spec interpreter
         let _ = (trap, err);
     }

--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -78,7 +78,7 @@ impl DiffEngine for V8Engine {
         }))
     }
 
-    fn assert_error_match(&self, wasmtime: &Trap, err: &Error) {
+    fn assert_error_match(&self, err: &Error, wasmtime: &Trap) {
         let v8 = err.to_string();
         let wasmtime_msg = wasmtime.to_string();
         let verify_wasmtime = |msg: &str| {

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -78,10 +78,10 @@ impl DiffEngine for WasmiEngine {
         Ok(Box::new(WasmiInstance { store, instance }))
     }
 
-    fn assert_error_match(&self, trap: &Trap, err: &Error) {
-        match self.trap_code(err) {
-            Some(code) => assert_eq!(wasmi_to_wasmtime_trap_code(code), *trap),
-            None => panic!("unexpected wasmi error {err:?}"),
+    fn assert_error_match(&self, lhs: &Error, rhs: &Trap) {
+        match self.trap_code(lhs) {
+            Some(code) => assert_eq!(wasmi_to_wasmtime_trap_code(code), *rhs),
+            None => panic!("unexpected wasmi error {lhs:?}"),
         }
     }
 

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -52,11 +52,11 @@ impl DiffEngine for WasmtimeEngine {
         Ok(Box::new(instance))
     }
 
-    fn assert_error_match(&self, trap: &Trap, err: &Error) {
-        let trap2 = err
+    fn assert_error_match(&self, lhs: &Error, rhs: &Trap) {
+        let lhs = lhs
             .downcast_ref::<Trap>()
-            .expect(&format!("not a trap: {err:?}"));
-        assert_eq!(trap, trap2, "{trap}\nis not equal to\n{trap2}");
+            .expect(&format!("not a trap: {lhs:?}"));
+        assert_eq!(lhs, rhs, "{lhs}\nis not equal to\n{rhs}");
     }
 
     fn is_stack_overflow(&self, err: &Error) -> bool {

--- a/crates/fuzzing/src/oracles/engine.rs
+++ b/crates/fuzzing/src/oracles/engine.rs
@@ -50,7 +50,7 @@ pub trait DiffEngine {
 
     /// Tests that the wasmtime-originating `trap` matches the error this engine
     /// generated.
-    fn assert_error_match(&self, trap: &Trap, err: &Error);
+    fn assert_error_match(&self, err: &Error, trap: &Trap);
 
     /// Returns whether the error specified from this engine might be stack
     /// overflow.


### PR DESCRIPTION
Clearly show "lhs" and "rhs" more often and then also swap the order of the arguments in `assert_error_match` to match the "lhs" and "rhs" terminology of the original execution.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
