### PR TITLE
pulley: Add special instructions for `dst = 0` and 1

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -368,6 +368,9 @@
 ;; Lower a constant into a register.
 (decl imm (Type u64) Reg)
 
+(rule 4 (imm (ty_int _) 0) (pulley_xzero))
+(rule 5 (imm (ty_int _) 1) (pulley_xone))
+
 ;; If a value can fit into 8 bits, then prioritize that.
 (rule 3 (imm (ty_int _) x)
       (if-let y (i8_try_from_u64 x))

--- a/cranelift/filetests/filetests/isa/pulley32/br_table.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/br_table.clif
@@ -40,7 +40,7 @@ block5(v5: i32):
 ;   xconst8 x5, 2
 ;   jump label7
 ; block5:
-;   xconst8 x5, 1
+;   xone x5
 ;   jump label7
 ; block6:
 ;   xconst8 x5, 4
@@ -55,14 +55,14 @@ block5(v5: i32):
 ; 0x1d    // target = 0x27
 ; 0x19    // target = 0x27
 ; 0xd    // target = 0x1f
-; 0x21    // target = 0x37
+; 0x20    // target = 0x36
 ; jump 0xd    // target = 0x27
 ; xconst8 x5, 3
-; jump 0x18    // target = 0x3a
+; jump 0x17    // target = 0x39
 ; xconst8 x5, 2
-; jump 0x10    // target = 0x3a
-; xconst8 x5, 1
-; jump 0x8    // target = 0x3a
+; jump 0xf    // target = 0x39
+; xone x5
+; jump 0x8    // target = 0x39
 ; xconst8 x5, 4
 ; xadd32 x0, x0, x5
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley32/brif-icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif-icmp.clif
@@ -19,15 +19,15 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xeq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xeq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -50,15 +50,15 @@ block2:
 ; block0:
 ;   br_if_xneq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xneq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -81,15 +81,15 @@ block2:
 ; block0:
 ;   br_if_xult32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xult32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xult32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -112,15 +112,15 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xulteq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xulteq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -143,15 +143,15 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslt32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -174,15 +174,15 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslteq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslteq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -205,15 +205,15 @@ block2:
 ; block0:
 ;   br_if_xult32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xult32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xult32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -236,15 +236,15 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xulteq32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xulteq32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -267,15 +267,15 @@ block2:
 ; block0:
 ;   br_if_xslt32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslt32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -298,15 +298,15 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslteq32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslteq32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -330,15 +330,15 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xeq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xeq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley32/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/brif.clif
@@ -19,18 +19,18 @@ block2:
 ;   zext8 x4, x0
 ;   br_if32 x4, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
 ; zext8 x4, x0
-; br_if32 x4, 0xa    // target = 0xd
-; xconst8 x0, 0
+; br_if32 x4, 0x9    // target = 0xc
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_i16(i16) -> i8 {
@@ -51,18 +51,18 @@ block2:
 ;   zext16 x4, x0
 ;   br_if32 x4, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
 ; zext16 x4, x0
-; br_if32 x4, 0xa    // target = 0xd
-; xconst8 x0, 0
+; br_if32 x4, 0x9    // target = 0xc
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_i32(i32) -> i8 {
@@ -82,17 +82,17 @@ block2:
 ; block0:
 ;   br_if32 x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if32 x0, 0xa    // target = 0xa
-; xconst8 x0, 0
+; br_if32 x0, 0x9    // target = 0x9
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_i64(i64) -> i8 {
@@ -112,17 +112,17 @@ block2:
 ; block0:
 ;   br_if_xneq64_i32 x0, 0, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq64_i8 x0, 0, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xneq64_i8 x0, 0, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i8(i8, i8) -> i8 {
@@ -147,10 +147,10 @@ block2:
 ;   zext8 x8, x10
 ;   br_if32 x8, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
@@ -158,10 +158,10 @@ block2:
 ; zext8 x8, x1
 ; xeq32 x10, x6, x8
 ; zext8 x8, x10
-; br_if32 x8, 0xa    // target = 0x16
-; xconst8 x0, 0
+; br_if32 x8, 0x9    // target = 0x15
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i16(i16, i16) -> i8 {
@@ -186,10 +186,10 @@ block2:
 ;   zext8 x8, x10
 ;   br_if32 x8, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
@@ -197,10 +197,10 @@ block2:
 ; zext16 x8, x1
 ; xneq32 x10, x6, x8
 ; zext8 x8, x10
-; br_if32 x8, 0xa    // target = 0x16
-; xconst8 x0, 0
+; br_if32 x8, 0x9    // target = 0x15
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i32(i32, i32) -> i8 {
@@ -221,17 +221,17 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xslt32 x0, x1, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i64(i64, i64) -> i8 {
@@ -252,17 +252,17 @@ block2:
 ; block0:
 ;   br_if_xulteq64 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xulteq64 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xulteq64 x1, x0, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i32_imm(i32) -> i8 {
@@ -283,17 +283,17 @@ block2:
 ; block0:
 ;   br_if_xslt32_i32 x0, 10, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32_i8 x0, 10, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xslt32_i8 x0, 10, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i32_imm_big(i32) -> i8 {
@@ -314,17 +314,17 @@ block2:
 ; block0:
 ;   br_if_xslt32_i32 x0, 88888, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32_i32 x0, 88888, 0xe    // target = 0xe
-; xconst8 x0, 0
+; br_if_xslt32_i32 x0, 88888, 0xd    // target = 0xd
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i64_imm(i64) -> i8 {
@@ -345,17 +345,17 @@ block2:
 ; block0:
 ;   br_if_xslt64_i32 x0, 10, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt64_i8 x0, 10, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xslt64_i8 x0, 10, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i64_imm_big(i64) -> i8 {
@@ -376,15 +376,16 @@ block2:
 ; block0:
 ;   br_if_xslt64_i32 x0, 88888, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt64_i32 x0, 88888, 0xe    // target = 0xe
-; xconst8 x0, 0
+; br_if_xslt64_i32 x0, 88888, 0xd    // target = 0xd
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
+

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -15,17 +15,17 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xconst8 x2, 0
+;   xzero x2
 ;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xconst8 x0, 1
+;   xone x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xconst8 x2, 0
-; call1 x2, 0x0    // target = 0x4
-; xconst8 x0, 1
+; xzero x2
+; call1 x2, 0x0    // target = 0x3
+; xone x0
 ; pop_frame
 ; ret
 
@@ -42,17 +42,17 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xconst8 x2, 0
+;   xzero x2
 ;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xconst8 x0, 1
+;   xone x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xconst8 x2, 0
-; call1 x2, 0x0    // target = 0x4
-; xconst8 x0, 1
+; xzero x2
+; call1 x2, 0x0    // target = 0x3
+; xone x0
 ; pop_frame
 ; ret
 
@@ -71,8 +71,8 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xconst8 x3, 0
-;   xconst8 x4, 1
+;   xzero x3
+;   xone x4
 ;   xconst8 x5, 2
 ;   xconst8 x6, 3
 ;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p3i), XReg(p4i), XReg(p5i), XReg(p6i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
@@ -81,11 +81,11 @@ block0:
 ;
 ; Disassembled:
 ; push_frame
-; xconst8 x3, 0
-; xconst8 x4, 1
+; xzero x3
+; xone x4
 ; xconst8 x5, 2
 ; xconst8 x6, 3
-; call4 x3, x4, x5, x6, 0x0    // target = 0xd
+; call4 x3, x4, x5, x6, 0x0    // target = 0xb
 ; pop_frame
 ; ret
 
@@ -131,7 +131,7 @@ block0:
 ; VCode:
 ;   push_frame_save 48, {}
 ; block0:
-;   xconst8 x15, 0
+;   xzero x15
 ;   xstore64 OutgoingArg(0), x15 // flags =  notrap aligned
 ;   xstore64 OutgoingArg(8), x15 // flags =  notrap aligned
 ;   xstore64 OutgoingArg(16), x15 // flags =  notrap aligned
@@ -155,7 +155,7 @@ block0:
 ;
 ; Disassembled:
 ; push_frame_save 48, 
-; xconst8 x15, 0
+; xzero x15
 ; xstore64le_offset8 sp, 0, x15
 ; xstore64le_offset8 sp, 8, x15
 ; xstore64le_offset8 sp, 16, x15
@@ -173,7 +173,7 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call4 x15, x15, x15, x15, 0x0    // target = 0x45
+; call4 x15, x15, x15, x15, 0x0    // target = 0x44
 ; pop_frame_restore 48, 
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/jump.clif
@@ -22,19 +22,19 @@ block3(v3: i8):
 ;   zext8 x5, x0
 ;   br_if32 x5, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   jump label3
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   jump label3
 ; block3:
 ;   ret
 ;
 ; Disassembled:
 ; zext8 x5, x0
-; br_if32 x5, 0xe    // target = 0x11
-; xconst8 x0, 0
-; jump 0x8    // target = 0x14
-; xconst8 x0, 1
+; br_if32 x5, 0xd    // target = 0x10
+; xzero x0
+; jump 0x7    // target = 0x12
+; xone x0
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/trap.clif
@@ -104,7 +104,7 @@ block2:
 ; block0:
 ;   br_if_xneq64_i32 x0, 0, label2; jump label1
 ; block1:
-;   xconst8 x4, 0
+;   xzero x4
 ;   trap_if_xneq64_i32 x4, 0 // code = TrapCode(1)
 ;   ret
 ; block2:
@@ -113,12 +113,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq64_i8 x0, 0, 0x12    // target = 0x12
-; xconst8 x4, 0
-; br_if_xneq64_i8 x4, 0, 0x13    // target = 0x1d
+; br_if_xneq64_i8 x0, 0, 0x11    // target = 0x11
+; xzero x4
+; br_if_xneq64_i8 x4, 0, 0x13    // target = 0x1c
 ; ret
 ; xconst8 x6, 42
-; br_if_xneq64_i8 x6, 0, 0xb    // target = 0x20
+; br_if_xneq64_i8 x6, 0, 0xb    // target = 0x1f
 ; ret
 ; trap
 ; trap
@@ -142,7 +142,7 @@ block2:
 ; block0:
 ;   br_if_xneq64_i32 x0, 0, label2; jump label1
 ; block1:
-;   xconst8 x4, 0
+;   xzero x4
 ;   trap_if_xeq64_i32 x4, 0 // code = TrapCode(1)
 ;   ret
 ; block2:
@@ -151,12 +151,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq64_i8 x0, 0, 0x12    // target = 0x12
-; xconst8 x4, 0
-; br_if_xeq64_i8 x4, 0, 0x13    // target = 0x1d
+; br_if_xneq64_i8 x0, 0, 0x11    // target = 0x11
+; xzero x4
+; br_if_xeq64_i8 x4, 0, 0x13    // target = 0x1c
 ; ret
 ; xconst8 x6, 42
-; br_if_xeq64_i8 x6, 0, 0xb    // target = 0x20
+; br_if_xeq64_i8 x6, 0, 0xb    // target = 0x1f
 ; ret
 ; trap
 ; trap

--- a/cranelift/filetests/filetests/isa/pulley64/br_table.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/br_table.clif
@@ -40,7 +40,7 @@ block5(v5: i32):
 ;   xconst8 x5, 2
 ;   jump label7
 ; block5:
-;   xconst8 x5, 1
+;   xone x5
 ;   jump label7
 ; block6:
 ;   xconst8 x5, 4
@@ -55,14 +55,14 @@ block5(v5: i32):
 ; 0x1d    // target = 0x27
 ; 0x19    // target = 0x27
 ; 0xd    // target = 0x1f
-; 0x21    // target = 0x37
+; 0x20    // target = 0x36
 ; jump 0xd    // target = 0x27
 ; xconst8 x5, 3
-; jump 0x18    // target = 0x3a
+; jump 0x17    // target = 0x39
 ; xconst8 x5, 2
-; jump 0x10    // target = 0x3a
-; xconst8 x5, 1
-; jump 0x8    // target = 0x3a
+; jump 0xf    // target = 0x39
+; xone x5
+; jump 0x8    // target = 0x39
 ; xconst8 x5, 4
 ; xadd32 x0, x0, x5
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley64/brif-icmp.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif-icmp.clif
@@ -19,15 +19,15 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xeq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xeq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -50,15 +50,15 @@ block2:
 ; block0:
 ;   br_if_xneq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xneq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -81,15 +81,15 @@ block2:
 ; block0:
 ;   br_if_xult32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xult32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xult32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -112,15 +112,15 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xulteq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xulteq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -143,15 +143,15 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslt32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -174,15 +174,15 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslteq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslteq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -205,15 +205,15 @@ block2:
 ; block0:
 ;   br_if_xult32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xult32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xult32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -236,15 +236,15 @@ block2:
 ; block0:
 ;   br_if_xulteq32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xulteq32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xulteq32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -267,15 +267,15 @@ block2:
 ; block0:
 ;   br_if_xslt32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslt32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -298,15 +298,15 @@ block2:
 ; block0:
 ;   br_if_xslteq32 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslteq32 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xslteq32 x1, x0, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret
@@ -330,15 +330,15 @@ block2:
 ; block0:
 ;   br_if_xeq32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ; block2:
 ;   xconst8 x0, 2
 ;   ret
 ;
 ; Disassembled:
-; br_if_xeq32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 1
+; br_if_xeq32 x0, x1, 0xa    // target = 0xa
+; xone x0
 ; ret
 ; xconst8 x0, 2
 ; ret

--- a/cranelift/filetests/filetests/isa/pulley64/brif.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/brif.clif
@@ -19,18 +19,18 @@ block2:
 ;   zext8 x4, x0
 ;   br_if32 x4, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
 ; zext8 x4, x0
-; br_if32 x4, 0xa    // target = 0xd
-; xconst8 x0, 0
+; br_if32 x4, 0x9    // target = 0xc
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_i16(i16) -> i8 {
@@ -51,18 +51,18 @@ block2:
 ;   zext16 x4, x0
 ;   br_if32 x4, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
 ; zext16 x4, x0
-; br_if32 x4, 0xa    // target = 0xd
-; xconst8 x0, 0
+; br_if32 x4, 0x9    // target = 0xc
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_i32(i32) -> i8 {
@@ -82,17 +82,17 @@ block2:
 ; block0:
 ;   br_if32 x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if32 x0, 0xa    // target = 0xa
-; xconst8 x0, 0
+; br_if32 x0, 0x9    // target = 0x9
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_i64(i64) -> i8 {
@@ -112,17 +112,17 @@ block2:
 ; block0:
 ;   br_if_xneq64_i32 x0, 0, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq64_i8 x0, 0, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xneq64_i8 x0, 0, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i8(i8, i8) -> i8 {
@@ -147,10 +147,10 @@ block2:
 ;   zext8 x8, x10
 ;   br_if32 x8, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
@@ -158,10 +158,10 @@ block2:
 ; zext8 x8, x1
 ; xeq32 x10, x6, x8
 ; zext8 x8, x10
-; br_if32 x8, 0xa    // target = 0x16
-; xconst8 x0, 0
+; br_if32 x8, 0x9    // target = 0x15
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i16(i16, i16) -> i8 {
@@ -186,10 +186,10 @@ block2:
 ;   zext8 x8, x10
 ;   br_if32 x8, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
@@ -197,10 +197,10 @@ block2:
 ; zext16 x8, x1
 ; xneq32 x10, x6, x8
 ; zext8 x8, x10
-; br_if32 x8, 0xa    // target = 0x16
-; xconst8 x0, 0
+; br_if32 x8, 0x9    // target = 0x15
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i32(i32, i32) -> i8 {
@@ -221,17 +221,17 @@ block2:
 ; block0:
 ;   br_if_xslt32 x0, x1, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xslt32 x0, x1, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xslt32 x0, x1, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 
 function %brif_icmp_i64(i64, i64) -> i8 {
@@ -252,16 +252,16 @@ block2:
 ; block0:
 ;   br_if_xulteq64 x1, x0, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   ret
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   ret
 ;
 ; Disassembled:
-; br_if_xulteq64 x1, x0, 0xb    // target = 0xb
-; xconst8 x0, 0
+; br_if_xulteq64 x1, x0, 0xa    // target = 0xa
+; xzero x0
 ; ret
-; xconst8 x0, 1
+; xone x0
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -15,17 +15,17 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xconst8 x2, 0
+;   xzero x2
 ;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xconst8 x0, 1
+;   xone x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xconst8 x2, 0
-; call1 x2, 0x0    // target = 0x4
-; xconst8 x0, 1
+; xzero x2
+; call1 x2, 0x0    // target = 0x3
+; xone x0
 ; pop_frame
 ; ret
 
@@ -42,17 +42,17 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xconst8 x2, 0
+;   xzero x2
 ;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, preg: p0i }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
-;   xconst8 x0, 1
+;   xone x0
 ;   pop_frame
 ;   ret
 ;
 ; Disassembled:
 ; push_frame
-; xconst8 x2, 0
-; call1 x2, 0x0    // target = 0x4
-; xconst8 x0, 1
+; xzero x2
+; call1 x2, 0x0    // target = 0x3
+; xone x0
 ; pop_frame
 ; ret
 
@@ -71,8 +71,8 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   xconst8 x3, 0
-;   xconst8 x4, 1
+;   xzero x3
+;   xone x4
 ;   xconst8 x5, 2
 ;   xconst8 x6, 3
 ;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p3i), XReg(p4i), XReg(p5i), XReg(p6i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0 }
@@ -81,11 +81,11 @@ block0:
 ;
 ; Disassembled:
 ; push_frame
-; xconst8 x3, 0
-; xconst8 x4, 1
+; xzero x3
+; xone x4
 ; xconst8 x5, 2
 ; xconst8 x6, 3
-; call4 x3, x4, x5, x6, 0x0    // target = 0xd
+; call4 x3, x4, x5, x6, 0x0    // target = 0xb
 ; pop_frame
 ; ret
 
@@ -131,7 +131,7 @@ block0:
 ; VCode:
 ;   push_frame_save 48, {}
 ; block0:
-;   xconst8 x15, 0
+;   xzero x15
 ;   xstore64 OutgoingArg(0), x15 // flags =  notrap aligned
 ;   xstore64 OutgoingArg(8), x15 // flags =  notrap aligned
 ;   xstore64 OutgoingArg(16), x15 // flags =  notrap aligned
@@ -155,7 +155,7 @@ block0:
 ;
 ; Disassembled:
 ; push_frame_save 48, 
-; xconst8 x15, 0
+; xzero x15
 ; xstore64le_offset8 sp, 0, x15
 ; xstore64le_offset8 sp, 8, x15
 ; xstore64le_offset8 sp, 16, x15
@@ -173,7 +173,7 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call4 x15, x15, x15, x15, 0x0    // target = 0x45
+; call4 x15, x15, x15, x15, 0x0    // target = 0x44
 ; pop_frame_restore 48, 
 ; ret
 
@@ -333,7 +333,7 @@ block0:
 ; VCode:
 ;   push_frame_save 64, {}
 ; block0:
-;   xconst8 x15, 0
+;   xzero x15
 ;   xstore64 OutgoingArg(0), x15 // flags =  notrap aligned
 ;   xstore64 OutgoingArg(8), x15 // flags =  notrap aligned
 ;   xstore64 OutgoingArg(16), x15 // flags =  notrap aligned
@@ -359,7 +359,7 @@ block0:
 ;
 ; Disassembled:
 ; push_frame_save 64, 
-; xconst8 x15, 0
+; xzero x15
 ; xstore64le_offset8 sp, 0, x15
 ; xstore64le_offset8 sp, 8, x15
 ; xstore64le_offset8 sp, 16, x15
@@ -379,7 +379,7 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call4 x15, x15, x15, x15, 0x0    // target = 0x4d
+; call4 x15, x15, x15, x15, 0x0    // target = 0x4c
 ; pop_frame_restore 64, 
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/jump.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/jump.clif
@@ -22,19 +22,19 @@ block3(v3: i8):
 ;   zext8 x5, x0
 ;   br_if32 x5, label2; jump label1
 ; block1:
-;   xconst8 x0, 0
+;   xzero x0
 ;   jump label3
 ; block2:
-;   xconst8 x0, 1
+;   xone x0
 ;   jump label3
 ; block3:
 ;   ret
 ;
 ; Disassembled:
 ; zext8 x5, x0
-; br_if32 x5, 0xe    // target = 0x11
-; xconst8 x0, 0
-; jump 0x8    // target = 0x14
-; xconst8 x0, 1
+; br_if32 x5, 0xd    // target = 0x10
+; xzero x0
+; jump 0x7    // target = 0x12
+; xone x0
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/trap.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/trap.clif
@@ -104,7 +104,7 @@ block2:
 ; block0:
 ;   br_if_xneq64_i32 x0, 0, label2; jump label1
 ; block1:
-;   xconst8 x4, 0
+;   xzero x4
 ;   trap_if_xneq64_i32 x4, 0 // code = TrapCode(1)
 ;   ret
 ; block2:
@@ -113,12 +113,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq64_i8 x0, 0, 0x12    // target = 0x12
-; xconst8 x4, 0
-; br_if_xneq64_i8 x4, 0, 0x13    // target = 0x1d
+; br_if_xneq64_i8 x0, 0, 0x11    // target = 0x11
+; xzero x4
+; br_if_xneq64_i8 x4, 0, 0x13    // target = 0x1c
 ; ret
 ; xconst8 x6, 42
-; br_if_xneq64_i8 x6, 0, 0xb    // target = 0x20
+; br_if_xneq64_i8 x6, 0, 0xb    // target = 0x1f
 ; ret
 ; trap
 ; trap
@@ -142,7 +142,7 @@ block2:
 ; block0:
 ;   br_if_xneq64_i32 x0, 0, label2; jump label1
 ; block1:
-;   xconst8 x4, 0
+;   xzero x4
 ;   trap_if_xeq64_i32 x4, 0 // code = TrapCode(1)
 ;   ret
 ; block2:
@@ -151,12 +151,12 @@ block2:
 ;   ret
 ;
 ; Disassembled:
-; br_if_xneq64_i8 x0, 0, 0x12    // target = 0x12
-; xconst8 x4, 0
-; br_if_xeq64_i8 x4, 0, 0x13    // target = 0x1d
+; br_if_xneq64_i8 x0, 0, 0x11    // target = 0x11
+; xzero x4
+; br_if_xeq64_i8 x4, 0, 0x13    // target = 0x1c
 ; ret
 ; xconst8 x6, 42
-; br_if_xeq64_i8 x6, 0, 0xb    // target = 0x20
+; br_if_xeq64_i8 x6, 0, 0xb    // target = 0x1f
 ; ret
 ; trap
 ; trap

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1398,6 +1398,16 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    fn xzero(&mut self, dst: XReg) -> ControlFlow<Done> {
+        self.state[dst].set_i64(0);
+        ControlFlow::Continue(())
+    }
+
+    fn xone(&mut self, dst: XReg) -> ControlFlow<Done> {
+        self.state[dst].set_i64(1);
+        ControlFlow::Continue(())
+    }
+
     fn xconst16(&mut self, dst: XReg, imm: i16) -> ControlFlow<Done> {
         self.state[dst].set_i64(i64::from(imm));
         ControlFlow::Continue(())

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -247,6 +247,10 @@ macro_rules! for_each_op {
             /// Move between `x` registers.
             xmov = Xmov { dst: XReg, src: XReg };
 
+            /// Set `dst = 0`
+            xzero = Xzero { dst: XReg };
+            /// Set `dst = 1`
+            xone = Xone { dst: XReg };
             /// Set `dst = sign_extend(imm8)`.
             xconst8 = Xconst8 { dst: XReg, imm: i8 };
             /// Set `dst = sign_extend(imm16)`.

--- a/tests/disas/pulley/br_table.wat
+++ b/tests/disas/pulley/br_table.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       push_frame
 ;;       br_table32 x2, 3
-;;       0x11    // target = 0x18
+;;       0x10    // target = 0x17
 ;;       0x8    // target = 0x13
-;;       0xe    // target = 0x1d
-;;   13: xconst8 x0, 1
+;;       0xd    // target = 0x1c
+;;   13: xone x0
 ;;       pop_frame
 ;;       ret
-;;   18: xconst8 x0, 2
-;;   1b: pop_frame
-;;   1c: ret
-;;   1d: xconst8 x0, 0
-;;   20: pop_frame
-;;   21: ret
+;;   17: xconst8 x0, 2
+;;   1a: pop_frame
+;;   1b: ret
+;;   1c: xzero x0
+;;   1e: pop_frame
+;;   1f: ret

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -14,5 +14,5 @@
 ;;       br_if_xulteq64 x6, x7, 0x9    // target = 0x1a
 ;;   18: pop_frame
 ;;       ret
-;;   1a: call 0x9f    // target = 0xb9
+;;   1a: call 0x9c    // target = 0xb6
 ;;   1f: jump 0xfffffffffffffff9    // target = 0x18

--- a/tests/disas/pulley/memory-inbounds.wat
+++ b/tests/disas/pulley/memory-inbounds.wat
@@ -88,16 +88,16 @@
 ;;
 ;; wasm[0]::function[8]::maybe_inbounds_v2:
 ;;       push_frame
-;;       xconst8 x7, 0
+;;       xzero x7
 ;;       xconst32 x8, 131072
 ;;       xadd64_uoverflow_trap x7, x7, x8
 ;;       xload64le_offset8 x8, x0, 104
-;;       br_if_xult64 x8, x7, 0x14    // target = 0x27
-;;   1a: xload64le_offset8 x8, x0, 96
+;;       br_if_xult64 x8, x7, 0x14    // target = 0x26
+;;   19: xload64le_offset8 x8, x0, 96
 ;;       xload32le_offset32 x0, x8, 131068
 ;;       pop_frame
 ;;       ret
-;;   27: trap
+;;   26: trap
 ;;
 ;; wasm[0]::function[9]::never_inbounds:
 ;;       push_frame


### PR DESCRIPTION
This commit adds a special instruction for setting a register to the value 0 or the value 1. This extends to the full width of the register and accounts for the majority of all `xconst` instructions found in `spidermonkey.cwasm`. It's not a major size decrease, but helps a bit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
