### PR TITLE
winch: x64 atomic stores

### DIFF
--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -488,11 +488,9 @@ impl WastTest {
                 "spec_testsuite/simd_store8_lane.wast",
                 // thread related failures
                 "proposals/threads/atomic.wast",
-                "misc_testsuite/threads/load-store-alignment.wast",
                 "misc_testsuite/threads/wait_notify.wast",
                 "misc_testsuite/threads/atomics_wait_address.wast",
                 "misc_testsuite/threads/atomics_notify.wast",
-                "misc_testsuite/threads/load-store-alignment.wast",
             ];
 
             if unsupported.iter().any(|part| self.path.ends_with(part)) {

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -488,12 +488,8 @@ impl WastTest {
                 "spec_testsuite/simd_store8_lane.wast",
                 // thread related failures
                 "proposals/threads/atomic.wast",
-                "misc_testsuite/threads/MP_wait.wast",
                 "misc_testsuite/threads/load-store-alignment.wast",
-                "misc_testsuite/threads/MP_atomic.wast",
-                "misc_testsuite/threads/SB_atomic.wast",
                 "misc_testsuite/threads/wait_notify.wast",
-                "misc_testsuite/threads/LB_atomic.wast",
                 "misc_testsuite/threads/atomics_wait_address.wast",
                 "misc_testsuite/threads/atomics_notify.wast",
                 "misc_testsuite/threads/load-store-alignment.wast",

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
@@ -13,22 +13,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x55
+;;       ja      0x58
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
+;;       movl    %eax, %r11d
 ;;       andl    $3, %r11d
 ;;       cmpl    $0, %r11d
-;;       jne     0x57
-;;   43: movq    0x58(%r14), %r11
+;;       jne     0x5a
+;;   46: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
-;;   57: ud2
+;;   58: ud2
+;;   5a: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
@@ -13,23 +13,22 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x57
+;;       ja      0x55
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
-;;       andl    $3, %eax
-;;       cmpl    $0, %eax
-;;       jne     0x59
-;;   41: movl    0xc(%rsp), %eax
-;;       movq    0x58(%r14), %r11
+;;       andl    $3, %r11d
+;;       cmpl    $0, %r11d
+;;       jne     0x57
+;;   43: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   55: ud2
 ;;   57: ud2
-;;   59: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
@@ -13,13 +13,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x47
+;;       ja      0x57
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
+;;       andl    $3, %eax
+;;       cmpl    $0, %eax
+;;       jne     0x59
+;;   41: movl    0xc(%rsp), %eax
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
@@ -27,4 +31,5 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   47: ud2
+;;   57: ud2
+;;   59: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
@@ -13,23 +13,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x58
+;;       ja      0x57
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
-;;       movl    %eax, %r11d
-;;       andl    $3, %r11d
-;;       cmpl    $0, %r11d
-;;       jne     0x5a
-;;   46: movq    0x58(%r14), %r11
+;;       andl    $3, %eax
+;;       cmpl    $0, %eax
+;;       jne     0x59
+;;   41: movl    0xc(%rsp), %eax
+;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   58: ud2
-;;   5a: ud2
+;;   57: ud2
+;;   59: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
@@ -13,23 +13,22 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5b
+;;       ja      0x59
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
-;;       andw    $1, %ax
-;;       cmpw    $0, %ax
-;;       jne     0x5d
-;;   43: movl    0xc(%rsp), %eax
-;;       movq    0x58(%r14), %r11
+;;       andw    $1, %r11w
+;;       cmpw    $0, %r11w
+;;       jne     0x5b
+;;   45: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   59: ud2
 ;;   5b: ud2
-;;   5d: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
@@ -13,23 +13,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5c
+;;       ja      0x5b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
-;;       movl    %eax, %r11d
-;;       andw    $1, %r11w
-;;       cmpw    $0, %r11w
-;;       jne     0x5e
-;;   48: movq    0x58(%r14), %r11
+;;       andw    $1, %ax
+;;       cmpw    $0, %ax
+;;       jne     0x5d
+;;   43: movl    0xc(%rsp), %eax
+;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5c: ud2
-;;   5e: ud2
+;;   5b: ud2
+;;   5d: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
@@ -13,13 +13,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x49
+;;       ja      0x5b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
+;;       andw    $1, %ax
+;;       cmpw    $0, %ax
+;;       jne     0x5d
+;;   43: movl    0xc(%rsp), %eax
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
@@ -27,4 +31,5 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   49: ud2
+;;   5b: ud2
+;;   5d: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
@@ -13,22 +13,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x59
+;;       ja      0x5c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
+;;       movl    %eax, %r11d
 ;;       andw    $1, %r11w
 ;;       cmpw    $0, %r11w
-;;       jne     0x5b
-;;   45: movq    0x58(%r14), %r11
+;;       jne     0x5e
+;;   48: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   59: ud2
-;;   5b: ud2
+;;   5c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
@@ -14,21 +14,20 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x4f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       andq    $7, %rax
-;;       cmpq    $0, %rax
-;;       jne     0x56
-;;   3f: movl    $0, %eax
-;;       movq    0x60(%r14), %rcx
+;;       andq    $7, %r11
+;;       cmpq    $0, %r11
+;;       jne     0x51
+;;   3f: movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movq    (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: ud2
+;;   4f: ud2
+;;   51: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
@@ -14,20 +14,21 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4f
+;;       ja      0x52
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
+;;       movq    %rax, %r11
 ;;       andq    $7, %r11
 ;;       cmpq    $0, %r11
-;;       jne     0x51
-;;   3f: movq    0x60(%r14), %rcx
+;;       jne     0x54
+;;   42: movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movq    (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4f: ud2
-;;   51: ud2
+;;   52: ud2
+;;   54: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
@@ -14,16 +14,21 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x41
+;;       ja      0x54
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
+;;       andq    $7, %rax
+;;       cmpq    $0, %rax
+;;       jne     0x56
+;;   3f: movl    $0, %eax
 ;;       movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movq    (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   41: ud2
+;;   54: ud2
+;;   56: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
@@ -14,21 +14,21 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x52
+;;       ja      0x54
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       movq    %rax, %r11
-;;       andq    $7, %r11
-;;       cmpq    $0, %r11
-;;       jne     0x54
-;;   42: movq    0x60(%r14), %rcx
+;;       andq    $7, %rax
+;;       cmpq    $0, %rax
+;;       jne     0x56
+;;   3f: movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movq    (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
 ;;   54: ud2
+;;   56: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
@@ -14,16 +14,21 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x42
+;;       ja      0x55
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
+;;       andw    $1, %ax
+;;       cmpw    $0, %ax
+;;       jne     0x57
+;;   3f: movl    $0, %eax
 ;;       movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   42: ud2
+;;   55: ud2
+;;   57: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
@@ -20,11 +20,11 @@
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       movl    %eax, %r11d
-;;       andw    $1, %r11w
-;;       cmpw    $0, %r11w
+;;       andw    $1, %ax
+;;       cmpw    $0, %ax
 ;;       jne     0x57
-;;   44: movq    0x60(%r14), %rcx
+;;   3f: movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x10, %rsp

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
@@ -14,20 +14,21 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x52
+;;       ja      0x55
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
+;;       movl    %eax, %r11d
 ;;       andw    $1, %r11w
 ;;       cmpw    $0, %r11w
-;;       jne     0x54
-;;   41: movq    0x60(%r14), %rcx
+;;       jne     0x57
+;;   44: movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
-;;   54: ud2
+;;   55: ud2
+;;   57: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
@@ -14,21 +14,20 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x55
+;;       ja      0x52
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       andw    $1, %ax
-;;       cmpw    $0, %ax
-;;       jne     0x57
-;;   3f: movl    $0, %eax
-;;       movq    0x60(%r14), %rcx
+;;       andw    $1, %r11w
+;;       cmpw    $0, %r11w
+;;       jne     0x54
+;;   41: movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
-;;   57: ud2
+;;   52: ud2
+;;   54: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
@@ -14,16 +14,21 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x40
+;;       ja      0x51
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
+;;       andl    $3, %eax
+;;       cmpl    $0, %eax
+;;       jne     0x53
+;;   3d: movl    $0, %eax
 ;;       movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   40: ud2
+;;   51: ud2
+;;   53: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
@@ -14,21 +14,20 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x51
+;;       ja      0x4e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       andl    $3, %eax
-;;       cmpl    $0, %eax
-;;       jne     0x53
-;;   3d: movl    $0, %eax
-;;       movq    0x60(%r14), %rcx
+;;       andl    $3, %r11d
+;;       cmpl    $0, %r11d
+;;       jne     0x50
+;;   3f: movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   51: ud2
-;;   53: ud2
+;;   4e: ud2
+;;   50: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
@@ -20,11 +20,11 @@
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       movl    %eax, %r11d
-;;       andl    $3, %r11d
-;;       cmpl    $0, %r11d
+;;       andl    $3, %eax
+;;       cmpl    $0, %eax
 ;;       jne     0x53
-;;   42: movq    0x60(%r14), %rcx
+;;   3d: movl    $0, %eax
+;;       movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x10, %rsp

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
@@ -14,20 +14,21 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4e
+;;       ja      0x51
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
+;;       movl    %eax, %r11d
 ;;       andl    $3, %r11d
 ;;       cmpl    $0, %r11d
-;;       jne     0x50
-;;   3f: movq    0x60(%r14), %rcx
+;;       jne     0x53
+;;   42: movq    0x60(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4e: ud2
-;;   50: ud2
+;;   51: ud2
+;;   53: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
@@ -11,13 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4b
+;;       ja      0x5c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
+;;       andl    $3, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x5e
+;;   42: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
@@ -26,4 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4b: ud2
+;;   5c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (i32.atomic.store (i32.const 0) (i32.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0x2a, %eax
+;;       movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movl    %eax, (%rdx)
+;;       mfence
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   4b: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
@@ -11,18 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5c
+;;       ja      0x59
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x5e
-;;   42: movl    $0, %ecx
-;;       movq    0x58(%r14), %r11
+;;       andl    $3, %r11d
+;;       cmpl    $0, %r11d
+;;       jne     0x5b
+;;   44: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movl    %eax, (%rdx)
@@ -30,5 +29,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5c: ud2
-;;   5e: ud2
+;;   59: ud2
+;;   5b: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
@@ -11,17 +11,18 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x59
+;;       ja      0x5c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
+;;       movl    %ecx, %r11d
 ;;       andl    $3, %r11d
 ;;       cmpl    $0, %r11d
-;;       jne     0x5b
-;;   44: movq    0x58(%r14), %r11
+;;       jne     0x5e
+;;   47: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movl    %eax, (%rdx)
@@ -29,5 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   59: ud2
-;;   5b: ud2
+;;   5c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store.wat
@@ -18,11 +18,11 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       movl    %ecx, %r11d
-;;       andl    $3, %r11d
-;;       cmpl    $0, %r11d
+;;       andl    $3, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x5e
-;;   47: movq    0x58(%r14), %r11
+;;   42: movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movl    %eax, (%rdx)

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
@@ -18,11 +18,11 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       movl    %ecx, %r11d
-;;       andw    $1, %r11w
-;;       cmpw    $0, %r11w
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
 ;;       jne     0x61
-;;   49: movq    0x58(%r14), %r11
+;;   44: movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movw    %ax, (%rdx)

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (i32.atomic.store16 (i32.const 0) (i32.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4c
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0x2a, %eax
+;;       movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movw    %ax, (%rdx)
+;;       mfence
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   4c: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
@@ -11,17 +11,18 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5c
+;;       ja      0x5f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
+;;       movl    %ecx, %r11d
 ;;       andw    $1, %r11w
 ;;       cmpw    $0, %r11w
-;;       jne     0x5e
-;;   46: movq    0x58(%r14), %r11
+;;       jne     0x61
+;;   49: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movw    %ax, (%rdx)
@@ -29,5 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5c: ud2
-;;   5e: ud2
+;;   5f: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
@@ -11,13 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4c
+;;       ja      0x5f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
+;;       jne     0x61
+;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
@@ -26,4 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4c: ud2
+;;   5f: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
@@ -11,18 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x5c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x61
-;;   44: movl    $0, %ecx
-;;       movq    0x58(%r14), %r11
+;;       andw    $1, %r11w
+;;       cmpw    $0, %r11w
+;;       jne     0x5e
+;;   46: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movw    %ax, (%rdx)
@@ -30,5 +29,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
-;;   61: ud2
+;;   5c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store8.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store8.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (i32.atomic.store8 (i32.const 0) (i32.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0x2a, %eax
+;;       movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movb    %al, (%rdx)
+;;       mfence
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   4b: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
@@ -11,13 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4e
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
+;;       andq    $7, %rcx
+;;       cmpq    $0, %rcx
+;;       jne     0x63
+;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
@@ -26,4 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4e: ud2
+;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
@@ -11,18 +11,18 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       movq    %rcx, %r11
-;;       andq    $7, %r11
-;;       cmpq    $0, %r11
-;;       jne     0x61
-;;   49: movq    0x58(%r14), %r11
+;;       andq    $7, %rcx
+;;       cmpq    $0, %rcx
+;;       jne     0x63
+;;   46: movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movq    %rax, (%rdx)
@@ -30,5 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
 ;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
@@ -11,17 +11,18 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5c
+;;       ja      0x5f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
+;;       movq    %rcx, %r11
 ;;       andq    $7, %r11
 ;;       cmpq    $0, %r11
-;;       jne     0x5e
-;;   46: movq    0x58(%r14), %r11
+;;       jne     0x61
+;;   49: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movq    %rax, (%rdx)
@@ -29,5 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5c: ud2
-;;   5e: ud2
+;;   5f: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
@@ -11,18 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x61
+;;       ja      0x5c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x63
-;;   46: movl    $0, %ecx
-;;       movq    0x58(%r14), %r11
+;;       andq    $7, %r11
+;;       cmpq    $0, %r11
+;;       jne     0x5e
+;;   46: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movq    %rax, (%rdx)
@@ -30,5 +29,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   61: ud2
-;;   63: ud2
+;;   5c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (i64.atomic.store (i32.const 0) (i64.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4e
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x2a, %rax
+;;       movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movq    %rax, (%rdx)
+;;       mfence
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   4e: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
@@ -11,18 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x61
+;;       ja      0x5e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x63
-;;   46: movl    $0, %ecx
-;;       movq    0x58(%r14), %r11
+;;       andw    $1, %r11w
+;;       cmpw    $0, %r11w
+;;       jne     0x60
+;;   48: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movw    %ax, (%rdx)
@@ -30,5 +29,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   61: ud2
-;;   63: ud2
+;;   5e: ud2
+;;   60: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
@@ -18,11 +18,11 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       movl    %ecx, %r11d
-;;       andw    $1, %r11w
-;;       cmpw    $0, %r11w
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
 ;;       jne     0x63
-;;   4b: movq    0x58(%r14), %r11
+;;   46: movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movw    %ax, (%rdx)

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
@@ -11,17 +11,18 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
+;;       movl    %ecx, %r11d
 ;;       andw    $1, %r11w
 ;;       cmpw    $0, %r11w
-;;       jne     0x60
-;;   48: movq    0x58(%r14), %r11
+;;       jne     0x63
+;;   4b: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movw    %ax, (%rdx)
@@ -29,5 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
-;;   60: ud2
+;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (i64.atomic.store16 (i32.const 0) (i64.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4e
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x2a, %rax
+;;       movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movw    %ax, (%rdx)
+;;       mfence
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   4e: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
@@ -11,13 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4e
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
+;;       jne     0x63
+;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
@@ -26,4 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4e: ud2
+;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
@@ -18,11 +18,11 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       movl    %ecx, %r11d
-;;       andl    $3, %r11d
-;;       cmpl    $0, %r11d
+;;       andl    $3, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x60
-;;   49: movq    0x58(%r14), %r11
+;;   44: movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movl    %eax, (%rdx)

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
@@ -11,18 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x5b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x60
-;;   44: movl    $0, %ecx
-;;       movq    0x58(%r14), %r11
+;;       andl    $3, %r11d
+;;       cmpl    $0, %r11d
+;;       jne     0x5d
+;;   46: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movl    %eax, (%rdx)
@@ -30,5 +29,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
-;;   60: ud2
+;;   5b: ud2
+;;   5d: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
@@ -11,17 +11,18 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5b
+;;       ja      0x5e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
+;;       movl    %ecx, %r11d
 ;;       andl    $3, %r11d
 ;;       cmpl    $0, %r11d
-;;       jne     0x5d
-;;   46: movq    0x58(%r14), %r11
+;;       jne     0x60
+;;   49: movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       movl    %eax, (%rdx)
@@ -29,5 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5b: ud2
-;;   5d: ud2
+;;   5e: ud2
+;;   60: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (i64.atomic.store32 (i32.const 0) (i64.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4d
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x2a, %rax
+;;       movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movl    %eax, (%rdx)
+;;       mfence
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   4d: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store32.wat
@@ -11,13 +11,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4d
+;;       ja      0x5e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
+;;       andl    $3, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x60
+;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
@@ -26,4 +30,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   4d: ud2
+;;   5e: ud2
+;;   60: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store8.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store8.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module 
+  (import "env" "memory" (memory 1 1 shared))
+  (func (i64.atomic.store8 (i32.const 0) (i64.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4d
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x2a, %rax
+;;       movl    $0, %ecx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movb    %al, (%rdx)
+;;       mfence
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   4d: ud2

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -873,7 +873,7 @@ where
         let addr = self.emit_compute_heap_address(&arg, size)?;
         if let Some(addr) = addr {
             self.masm
-                .wasm_store(src.reg.into(), self.masm.address_at_reg(addr, 0)?, size)?;
+                .wasm_store(src.reg.into(), self.masm.address_at_reg(addr, 0)?, size, MemOpKind::Normal)?;
 
             self.context.free_reg(addr);
         }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -845,12 +845,12 @@ where
         Ok(addr)
     }
 
+    /// Emit checks to ensure that the address at `memarg` is correctly aligned for `size`.
     fn check_align(&mut self, memarg: &MemArg, size: OperandSize) -> Result<()> {
         if size.bytes() > 1 {
             let addr = *self.context.stack.peek().unwrap();
             let tmp = self.context.any_gpr(self.masm)?;
-            self.context
-                .move_val_to_reg(&addr, tmp, self.masm)?;
+            self.context.move_val_to_reg(&addr, tmp, self.masm)?;
             if memarg.offset != 0 {
                 self.masm.add(
                     writable!(tmp),
@@ -866,8 +866,7 @@ where
                 size,
             )?;
 
-            self.masm
-                .cmp(tmp, RegImm::Imm(Imm::i64(0)), size)?;
+            self.masm.cmp(tmp, RegImm::Imm(Imm::i64(0)), size)?;
             self.masm.trapif(IntCmpKind::Ne, TRAP_HEAP_MISALIGNED)?;
 
             self.context.free_reg(tmp);

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -868,12 +868,21 @@ where
     }
 
     /// Emit a WebAssembly store.
-    pub fn emit_wasm_store(&mut self, arg: &MemArg, size: OperandSize, op_kind: MemOpKind) -> Result<()> {
+    pub fn emit_wasm_store(
+        &mut self,
+        arg: &MemArg,
+        size: OperandSize,
+        op_kind: MemOpKind,
+    ) -> Result<()> {
         let src = self.context.pop_to_reg(self.masm, None)?;
         let addr = self.emit_compute_heap_address(&arg, size)?;
         if let Some(addr) = addr {
-            self.masm
-                .wasm_store(src.reg.into(), self.masm.address_at_reg(addr, 0)?, size, op_kind)?;
+            self.masm.wasm_store(
+                src.reg.into(),
+                self.masm.address_at_reg(addr, 0)?,
+                size,
+                op_kind,
+            )?;
 
             self.context.free_reg(addr);
         }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -868,12 +868,12 @@ where
     }
 
     /// Emit a WebAssembly store.
-    pub fn emit_wasm_store(&mut self, arg: &MemArg, size: OperandSize) -> Result<()> {
+    pub fn emit_wasm_store(&mut self, arg: &MemArg, size: OperandSize, op_kind: MemOpKind) -> Result<()> {
         let src = self.context.pop_to_reg(self.masm, None)?;
         let addr = self.emit_compute_heap_address(&arg, size)?;
         if let Some(addr) = addr {
             self.masm
-                .wasm_store(src.reg.into(), self.masm.address_at_reg(addr, 0)?, size, MemOpKind::Normal)?;
+                .wasm_store(src.reg.into(), self.masm.address_at_reg(addr, 0)?, size, op_kind)?;
 
             self.context.free_reg(addr);
         }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -3,7 +3,8 @@ use crate::{
     codegen::BlockSig,
     isa::reg::{writable, Reg},
     masm::{
-        Imm, IntCmpKind, LoadKind, MacroAssembler, MemOpKind, OperandSize, RegImm, SPOffset, ShiftKind, TrapCode
+        Imm, IntCmpKind, LoadKind, MacroAssembler, MemOpKind, OperandSize, RegImm, SPOffset,
+        ShiftKind, TrapCode,
     },
     stack::TypedReg,
 };

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -175,9 +175,14 @@ impl Masm for MacroAssembler {
         Ok(())
     }
 
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize) -> Result<()> {
-        self.asm.str(src, dst, size);
-        Ok(())
+    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize, op_kind: MemOpKind) -> Result<()> {
+        match op_kind {
+            MemOpKind::Atomic => Err(anyhow!(CodeGenError::unimplemented_masm_instruction())),
+            MemOpKind::Normal => {
+                self.asm.str(src, dst, size);
+                Ok(())
+            },
+        }
     }
 
     fn call(

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -175,13 +175,19 @@ impl Masm for MacroAssembler {
         Ok(())
     }
 
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize, op_kind: MemOpKind) -> Result<()> {
+    fn wasm_store(
+        &mut self,
+        src: Reg,
+        dst: Self::Address,
+        size: OperandSize,
+        op_kind: MemOpKind,
+    ) -> Result<()> {
         match op_kind {
             MemOpKind::Atomic => Err(anyhow!(CodeGenError::unimplemented_masm_instruction())),
             MemOpKind::Normal => {
                 self.asm.str(src, dst, size);
                 Ok(())
-            },
+            }
         }
     }
 

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -16,7 +16,10 @@ use cranelift_codegen::{
         unwind::UnwindInst,
         x64::{
             args::{
-                self, AluRmiROpcode, Amode, AvxOpcode, CmpOpcode, DivSignedness, ExtMode, FenceKind, FromWritableReg, Gpr, GprMem, GprMemImm, Imm8Gpr, Imm8Reg, RegMem, RegMemImm, ShiftKind as CraneliftShiftKind, SseOpcode, SyntheticAmode, WritableGpr, WritableXmm, Xmm, XmmMem, XmmMemAligned, CC
+                self, AluRmiROpcode, Amode, AvxOpcode, CmpOpcode, DivSignedness, ExtMode,
+                FenceKind, FromWritableReg, Gpr, GprMem, GprMemImm, Imm8Gpr, Imm8Reg, RegMem,
+                RegMemImm, ShiftKind as CraneliftShiftKind, SseOpcode, SyntheticAmode, WritableGpr,
+                WritableXmm, Xmm, XmmMem, XmmMemAligned, CC,
             },
             encoding::rex::{encode_modrm, RexFlags},
             settings as x64_settings, EmitInfo, EmitState, Inst,

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -16,10 +16,7 @@ use cranelift_codegen::{
         unwind::UnwindInst,
         x64::{
             args::{
-                self, AluRmiROpcode, Amode, AvxOpcode, CmpOpcode, DivSignedness, ExtMode,
-                FromWritableReg, Gpr, GprMem, GprMemImm, Imm8Gpr, Imm8Reg, RegMem, RegMemImm,
-                ShiftKind as CraneliftShiftKind, SseOpcode, SyntheticAmode, WritableGpr,
-                WritableXmm, Xmm, XmmMem, XmmMemAligned, CC,
+                self, AluRmiROpcode, Amode, AvxOpcode, CmpOpcode, DivSignedness, ExtMode, FenceKind, FromWritableReg, Gpr, GprMem, GprMemImm, Imm8Gpr, Imm8Reg, RegMem, RegMemImm, ShiftKind as CraneliftShiftKind, SseOpcode, SyntheticAmode, WritableGpr, WritableXmm, Xmm, XmmMem, XmmMemAligned, CC
             },
             encoding::rex::{encode_modrm, RexFlags},
             settings as x64_settings, EmitInfo, EmitState, Inst,
@@ -1482,6 +1479,10 @@ impl Assembler {
             dst_lo: dst_lo.to_reg().into(),
             dst_hi: dst_hi.to_reg().into(),
         });
+    }
+
+    pub fn fence(&mut self, kind: FenceKind) {
+        self.emit(Inst::Fence { kind });
     }
 }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -220,6 +220,10 @@ impl Masm for MacroAssembler {
     fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize, op_kind: MemOpKind) -> Result<()> {
         match op_kind {
             MemOpKind::Atomic => {
+                if size == OperandSize::S128 {
+                    // TODO: we don't support 128-bit atomic store yet.
+                    bail!(CodeGenError::unexpected_operand_size());
+                }
                 // To stay consistent with cranelift, we emit a normal load followed by a mfence,
                 // although, we could probably just emit a xchg.
                 self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)?;

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -217,8 +217,13 @@ impl Masm for MacroAssembler {
         self.store_impl(src, dst, size, TRUSTED_FLAGS)
     }
 
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize) -> Result<()> {
-        self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)
+    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize, op_kind: MemOpKind) -> Result<()> {
+        match op_kind {
+            MemOpKind::Atomic => Err(anyhow!(CodeGenError::unimplemented_masm_instruction())),
+            MemOpKind::Normal => {
+                self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)
+            },
+        }
     }
 
     fn pop(&mut self, dst: WritableReg, size: OperandSize) -> Result<()> {

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -217,7 +217,13 @@ impl Masm for MacroAssembler {
         self.store_impl(src, dst, size, TRUSTED_FLAGS)
     }
 
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize, op_kind: MemOpKind) -> Result<()> {
+    fn wasm_store(
+        &mut self,
+        src: Reg,
+        dst: Self::Address,
+        size: OperandSize,
+        op_kind: MemOpKind,
+    ) -> Result<()> {
         match op_kind {
             MemOpKind::Atomic => {
                 if size == OperandSize::S128 {
@@ -229,10 +235,8 @@ impl Masm for MacroAssembler {
                 self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)?;
                 self.asm.fence(FenceKind::MFence);
                 Ok(())
-            },
-            MemOpKind::Normal => {
-                self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)
-            },
+            }
+            MemOpKind::Normal => self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS),
         }
     }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -230,7 +230,7 @@ impl Masm for MacroAssembler {
                     // TODO: we don't support 128-bit atomic store yet.
                     bail!(CodeGenError::unexpected_operand_size());
                 }
-                // To stay consistent with cranelift, we emit a normal load followed by a mfence,
+                // To stay consistent with cranelift, we emit a normal store followed by a mfence,
                 // although, we could probably just emit a xchg.
                 self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)?;
                 self.asm.fence(FenceKind::MFence);

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -739,7 +739,7 @@ pub(crate) trait MacroAssembler {
     /// regards to the endianness depending on the target ISA. For this reason,
     /// [Self::wasm_store], should be explicitly used when emitting WebAssembly
     /// stores.
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize) -> Result<()>;
+    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize, op_kind: MemOpKind) -> Result<()>;
 
     /// Perform a zero-extended stack load.
     fn load(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize) -> Result<()>;

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -739,7 +739,13 @@ pub(crate) trait MacroAssembler {
     /// regards to the endianness depending on the target ISA. For this reason,
     /// [Self::wasm_store], should be explicitly used when emitting WebAssembly
     /// stores.
-    fn wasm_store(&mut self, src: Reg, dst: Self::Address, size: OperandSize, op_kind: MemOpKind) -> Result<()>;
+    fn wasm_store(
+        &mut self,
+        src: Reg,
+        dst: Self::Address,
+        size: OperandSize,
+        op_kind: MemOpKind,
+    ) -> Result<()>;
 
     /// Perform a zero-extended stack load.
     fn load(&mut self, src: Self::Address, dst: WritableReg, size: OperandSize) -> Result<()>;

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -46,6 +46,12 @@ pub(crate) enum MemOpKind {
     Normal,
 }
 
+impl MemOpKind {
+    pub(crate) fn is_atomic(&self) -> bool {
+        matches!(self, Self::Atomic)
+    }
+}
+
 #[derive(Eq, PartialEq)]
 pub(crate) enum MulWideKind {
     Signed,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -46,12 +46,6 @@ pub(crate) enum MemOpKind {
     Normal,
 }
 
-impl MemOpKind {
-    pub(crate) fn is_atomic(&self) -> bool {
-        matches!(self, Self::Atomic)
-    }
-}
-
 #[derive(Eq, PartialEq)]
 pub(crate) enum MulWideKind {
     Signed,

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1983,15 +1983,15 @@ where
     }
 
     fn visit_i32_store(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S32)
+        self.emit_wasm_store(&memarg, OperandSize::S32, MemOpKind::Normal)
     }
 
     fn visit_i32_store8(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S8)
+        self.emit_wasm_store(&memarg, OperandSize::S8, MemOpKind::Normal)
     }
 
     fn visit_i32_store16(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S16)
+        self.emit_wasm_store(&memarg, OperandSize::S16, MemOpKind::Normal)
     }
 
     fn visit_i64_load8_s(&mut self, memarg: MemArg) -> Self::Output {
@@ -2058,19 +2058,19 @@ where
     }
 
     fn visit_i64_store(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S64)
+        self.emit_wasm_store(&memarg, OperandSize::S64, MemOpKind::Normal)
     }
 
     fn visit_i64_store8(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S8)
+        self.emit_wasm_store(&memarg, OperandSize::S8, MemOpKind::Normal)
     }
 
     fn visit_i64_store16(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S16)
+        self.emit_wasm_store(&memarg, OperandSize::S16, MemOpKind::Normal)
     }
 
     fn visit_i64_store32(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S32)
+        self.emit_wasm_store(&memarg, OperandSize::S32, MemOpKind::Normal)
     }
 
     fn visit_f32_load(&mut self, memarg: MemArg) -> Self::Output {
@@ -2083,7 +2083,7 @@ where
     }
 
     fn visit_f32_store(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S32)
+        self.emit_wasm_store(&memarg, OperandSize::S32, MemOpKind::Normal)
     }
 
     fn visit_f64_load(&mut self, memarg: MemArg) -> Self::Output {
@@ -2096,7 +2096,7 @@ where
     }
 
     fn visit_f64_store(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S64)
+        self.emit_wasm_store(&memarg, OperandSize::S64, MemOpKind::Normal)
     }
 
     fn visit_i32_trunc_sat_f32_s(&mut self) -> Self::Output {
@@ -2287,7 +2287,7 @@ where
     }
 
     fn visit_v128_store(&mut self, memarg: MemArg) -> Self::Output {
-        self.emit_wasm_store(&memarg, OperandSize::S128)
+        self.emit_wasm_store(&memarg, OperandSize::S128, MemOpKind::Normal)
     }
 
     fn visit_v128_load8x8_s(&mut self, memarg: MemArg) -> Self::Output {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -271,6 +271,14 @@ macro_rules! def_unsupported {
     (emit V128Load16Splat $($rest:tt)*) => {};
     (emit V128Load32Splat $($rest:tt)*) => {};
     (emit V128Load64Splat $($rest:tt)*) => {};
+    (emit I32AtomicStore8 $($rest:tt)*) => {};
+    (emit I32AtomicStore16 $($rest:tt)*) => {};
+    (emit I32AtomicStore $($rest:tt)*) => {};
+    (emit I64AtomicStore8 $($rest:tt)*) => {};
+    (emit I64AtomicStore16 $($rest:tt)*) => {};
+    (emit I64AtomicStore32 $($rest:tt)*) => {};
+    (emit I64AtomicStore $($rest:tt)*) => {};
+
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
 
@@ -2201,7 +2209,7 @@ where
         self.masm.mul_wide(&mut self.context, MulWideKind::Unsigned)
     }
 
-    fn visit_i32_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+    fn visit_i32_atomic_load8_u(&mut self, memarg: MemArg) -> Self::Output {
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
@@ -2210,7 +2218,7 @@ where
         )
     }
 
-    fn visit_i32_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+    fn visit_i32_atomic_load16_u(&mut self, memarg: MemArg) -> Self::Output {
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
@@ -2219,7 +2227,7 @@ where
         )
     }
 
-    fn visit_i32_atomic_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+    fn visit_i32_atomic_load(&mut self, memarg: MemArg) -> Self::Output {
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
@@ -2228,7 +2236,7 @@ where
         )
     }
 
-    fn visit_i64_atomic_load8_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+    fn visit_i64_atomic_load8_u(&mut self, memarg: MemArg) -> Self::Output {
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
@@ -2237,7 +2245,7 @@ where
         )
     }
 
-    fn visit_i64_atomic_load16_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+    fn visit_i64_atomic_load16_u(&mut self, memarg: MemArg) -> Self::Output {
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
@@ -2246,7 +2254,7 @@ where
         )
     }
 
-    fn visit_i64_atomic_load32_u(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+    fn visit_i64_atomic_load32_u(&mut self, memarg: MemArg) -> Self::Output {
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
@@ -2255,13 +2263,41 @@ where
         )
     }
 
-    fn visit_i64_atomic_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
+    fn visit_i64_atomic_load(&mut self, memarg: MemArg) -> Self::Output {
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
             LoadKind::Operand(OperandSize::S64),
             MemOpKind::Atomic,
         )
+    }
+
+    fn visit_i32_atomic_store(&mut self, memarg: MemArg) -> Self::Output {
+        self.emit_wasm_store(&memarg, OperandSize::S32, MemOpKind::Atomic)
+    }
+
+    fn visit_i64_atomic_store(&mut self, memarg: MemArg) -> Self::Output {
+        self.emit_wasm_store(&memarg, OperandSize::S64, MemOpKind::Atomic)
+    }
+
+    fn visit_i32_atomic_store8(&mut self, memarg: MemArg) -> Self::Output {
+        self.emit_wasm_store(&memarg, OperandSize::S8, MemOpKind::Atomic)
+    }
+
+    fn visit_i32_atomic_store16(&mut self, memarg: MemArg) -> Self::Output {
+        self.emit_wasm_store(&memarg, OperandSize::S16, MemOpKind::Atomic)
+    }
+
+    fn visit_i64_atomic_store8(&mut self, memarg: MemArg) -> Self::Output {
+        self.emit_wasm_store(&memarg, OperandSize::S8, MemOpKind::Atomic)
+    }
+
+    fn visit_i64_atomic_store16(&mut self, memarg: MemArg) -> Self::Output {
+        self.emit_wasm_store(&memarg, OperandSize::S16, MemOpKind::Atomic)
+    }
+
+    fn visit_i64_atomic_store32(&mut self, memarg: MemArg) -> Self::Output {
+        self.emit_wasm_store(&memarg, OperandSize::S32, MemOpKind::Atomic)
     }
 
     wasmparser::for_each_visit_operator!(def_unsupported);


### PR DESCRIPTION
This PR implements x64 store operations:
- `i32.atomic.store8`
- `i32.atomic.store16`
- `i32.atomic.store`
- `i64.atomic.store8`
- `i64.atomic.store16`
- `i64.atomic.store32`
- `i64.atomic.store`

https://github.com/bytecodealliance/wasmtime/issues/9734
