### PR TITLE
Winch: return error on 128bit atomic loads

### DIFF
--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -280,8 +280,13 @@ impl Masm for MacroAssembler {
         dst: WritableReg,
         size: OperandSize,
         kind: Option<ExtendKind>,
-        _op_kind: MemOpKind,
+        op_kind: MemOpKind,
     ) -> Result<()> {
+        if op_kind == MemOpKind::Atomic && size == OperandSize::S128 {
+            // TODO: handle 128bits atomic loads
+            bail!(CodeGenError::unexpected_operand_size())
+        }
+
         // The guarantees of the x86-64 memory model ensure that `SeqCst`
         // loads are equivalent to normal loads.
         if let Some(ext) = kind {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -38,7 +38,7 @@ impl RemKind {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) enum MemOpKind {
     /// An atomic memory operation with SeqCst memory ordering.
     Atomic,


### PR DESCRIPTION
return an error on 128bits atomic loads.

followup to https://github.com/bytecodealliance/wasmtime/pull/9970
