### PR TITLE
refactor: remove `OnceLock`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -564,3 +564,6 @@ opt-level = 's'
 inherits = "release"
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+regalloc2 = { git = "https://github.com/bytecodealliance/regalloc2", branch = "jonas/refactor/static-machine-env" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -566,4 +566,4 @@ codegen-units = 1
 lto = true
 
 [patch.crates-io]
-regalloc2 = { git = "https://github.com/bytecodealliance/regalloc2", branch = "jonas/refactor/static-machine-env" }
+regalloc2 = { git = "https://github.com/JonasKruckenberg/regalloc2", branch = "jonas/refactor/static-machine-env" }

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -16,8 +16,6 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use regalloc2::{MachineEnv, PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::borrow::ToOwned;
-use std::sync::OnceLock;
 
 // We use a generic implementation that factors out AArch64 and x64 ABI commonalities, because
 // these ABIs are very similar.
@@ -1115,11 +1113,9 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
     fn get_machine_env(flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
         if flags.enable_pinned_reg() {
-            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
-            MACHINE_ENV.get_or_init(|| create_reg_env(true))
+            &PINNED_MACHINE_ENV
         } else {
-            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
-            MACHINE_ENV.get_or_init(|| create_reg_env(false))
+            &DEFAULT_MACHINE_ENV
         }
     }
 
@@ -1440,14 +1436,14 @@ const fn default_aapcs_clobbers() -> PRegSet {
 
 const DEFAULT_AAPCS_CLOBBERS: PRegSet = default_aapcs_clobbers();
 
-fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
-    fn preg(r: Reg) -> PReg {
-        r.to_real_reg().unwrap().into()
-    }
+const fn preg(r: Reg) -> PReg {
+    r.to_physical_reg().unwrap()
+}
 
-    let mut env = MachineEnv {
+static PINNED_MACHINE_ENV: MachineEnv = {
+    MachineEnv {
         preferred_regs_by_class: [
-            vec![
+            &[
                 preg(xreg(0)),
                 preg(xreg(1)),
                 preg(xreg(2)),
@@ -1471,7 +1467,7 @@ fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
                 // x21 is the pinned register (if enabled) and not allocatable if so.
                 // x29 is FP, x30 is LR, x31 is SP/ZR.
             ],
-            vec![
+            &[
                 preg(vreg(0)),
                 preg(vreg(1)),
                 preg(vreg(2)),
@@ -1499,13 +1495,12 @@ fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
                 preg(vreg(31)),
             ],
             // Vector Regclass is unused
-            vec![],
+            &[],
         ],
         non_preferred_regs_by_class: [
-            vec![
+            &[
                 preg(xreg(19)),
                 preg(xreg(20)),
-                // x21 is pinned reg if enabled; we add to this list below if not.
                 preg(xreg(22)),
                 preg(xreg(23)),
                 preg(xreg(24)),
@@ -1514,7 +1509,7 @@ fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
                 preg(xreg(27)),
                 preg(xreg(28)),
             ],
-            vec![
+            &[
                 preg(vreg(8)),
                 preg(vreg(9)),
                 preg(vreg(10)),
@@ -1525,16 +1520,99 @@ fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
                 preg(vreg(15)),
             ],
             // Vector Regclass is unused
-            vec![],
+            &[],
         ],
-        fixed_stack_slots: vec![],
+        fixed_stack_slots: &[],
         scratch_by_class: [None, None, None],
-    };
-
-    if !enable_pinned_reg {
-        debug_assert_eq!(PINNED_REG, 21); // We assumed this above in hardcoded reg list.
-        env.non_preferred_regs_by_class[0].push(preg(xreg(PINNED_REG)));
     }
+};
 
-    env
-}
+static DEFAULT_MACHINE_ENV: MachineEnv = {
+    debug_assert!(PINNED_REG == 21); // We assumed this below in hardcoded reg list.
+
+    MachineEnv {
+        preferred_regs_by_class: [
+            &[
+                preg(xreg(0)),
+                preg(xreg(1)),
+                preg(xreg(2)),
+                preg(xreg(3)),
+                preg(xreg(4)),
+                preg(xreg(5)),
+                preg(xreg(6)),
+                preg(xreg(7)),
+                preg(xreg(8)),
+                preg(xreg(9)),
+                preg(xreg(10)),
+                preg(xreg(11)),
+                preg(xreg(12)),
+                preg(xreg(13)),
+                preg(xreg(14)),
+                preg(xreg(15)),
+                // x16 and x17 are spilltmp and tmp2 (see above).
+                // x18 could be used by the platform to carry inter-procedural state;
+                // conservatively assume so and make it not allocatable.
+                // x19-28 are callee-saved and so not preferred.
+                // x21 is the pinned register (if enabled) and not allocatable if so.
+                // x29 is FP, x30 is LR, x31 is SP/ZR.
+            ],
+            &[
+                preg(vreg(0)),
+                preg(vreg(1)),
+                preg(vreg(2)),
+                preg(vreg(3)),
+                preg(vreg(4)),
+                preg(vreg(5)),
+                preg(vreg(6)),
+                preg(vreg(7)),
+                // v8-15 are callee-saved and so not preferred.
+                preg(vreg(16)),
+                preg(vreg(17)),
+                preg(vreg(18)),
+                preg(vreg(19)),
+                preg(vreg(20)),
+                preg(vreg(21)),
+                preg(vreg(22)),
+                preg(vreg(23)),
+                preg(vreg(24)),
+                preg(vreg(25)),
+                preg(vreg(26)),
+                preg(vreg(27)),
+                preg(vreg(28)),
+                preg(vreg(29)),
+                preg(vreg(30)),
+                preg(vreg(31)),
+            ],
+            // Vector Regclass is unused
+            &[],
+        ],
+        non_preferred_regs_by_class: [
+            &[
+                preg(xreg(19)),
+                preg(xreg(20)),
+                preg(xreg(22)),
+                preg(xreg(23)),
+                preg(xreg(24)),
+                preg(xreg(25)),
+                preg(xreg(26)),
+                preg(xreg(27)),
+                preg(xreg(28)),
+                preg(xreg(PINNED_REG)),
+            ],
+            &[
+                preg(vreg(8)),
+                preg(vreg(9)),
+                preg(vreg(10)),
+                preg(vreg(11)),
+                preg(vreg(12)),
+                preg(vreg(13)),
+                preg(vreg(14)),
+                preg(vreg(15)),
+            ],
+            // Vector Regclass is unused
+            &[],
+        ],
+        fixed_stack_slots: &[],
+        scratch_by_class: [None, None, None],
+    }
+};

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -20,8 +20,8 @@ pub const PINNED_REG: u8 = 21;
 
 /// Get a reference to an X-register (integer register). Do not use
 /// this for xsp / xzr; we have two special registers for those.
-pub fn xreg(num: u8) -> Reg {
-    Reg::from(xreg_preg(num))
+pub const fn xreg(num: u8) -> Reg {
+    Reg::from_preg(xreg_preg(num))
 }
 
 /// Get the given X-register as a PReg.
@@ -36,8 +36,8 @@ pub fn writable_xreg(num: u8) -> Writable<Reg> {
 }
 
 /// Get a reference to a V-register (vector/FP register).
-pub fn vreg(num: u8) -> Reg {
-    Reg::from(vreg_preg(num))
+pub const fn vreg(num: u8) -> Reg {
+    Reg::from_preg(vreg_preg(num))
 }
 
 /// Get the given V-register as a PReg.
@@ -101,7 +101,7 @@ pub fn writable_link_reg() -> Writable<Reg> {
 }
 
 /// Get a reference to the frame pointer (x29).
-pub fn fp_reg() -> Reg {
+pub const fn fp_reg() -> Reg {
     xreg(29)
 }
 

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -912,33 +912,123 @@ const DEFAULT_CLOBBERS: PRegSet = PRegSet::empty()
     .with(pv_reg(30))
     .with(pv_reg(31));
 
-static DEFAULT_MACHINE_ENV: MachineEnv = { todo!() };
+static DEFAULT_MACHINE_ENV: MachineEnv = {
+    debug_assert!(XReg::SPECIAL_START == 30);
+    // Prefer caller-saved registers over callee-saved registers, because that
+    // way we don't need to emit code to save and restore them if we don't
+    // mutate them.
 
-// fn create_reg_environment() -> MachineEnv {
-//     // Prefer caller-saved registers over callee-saved registers, because that
-//     // way we don't need to emit code to save and restore them if we don't
-//     // mutate them.
-//
-//     let preferred_regs_by_class: [Vec<PReg>; 3] = {
-//         let x_registers: Vec<PReg> = (0..16).map(|x| px_reg(x)).collect();
-//         let f_registers: Vec<PReg> = (0..16).map(|x| pf_reg(x)).collect();
-//         let v_registers: Vec<PReg> = (0..32).map(|x| pv_reg(x)).collect();
-//         [x_registers, f_registers, v_registers]
-//     };
-//
-//     let non_preferred_regs_by_class: [Vec<PReg>; 3] = {
-//         let x_registers: Vec<PReg> = (16..XReg::SPECIAL_START)
-//             .map(|x| px_reg(x.into()))
-//             .collect();
-//         let f_registers: Vec<PReg> = (16..32).map(|x| pf_reg(x)).collect();
-//         let v_registers: Vec<PReg> = vec![];
-//         [x_registers, f_registers, v_registers]
-//     };
-//
-//     MachineEnv {
-//         preferred_regs_by_class,
-//         non_preferred_regs_by_class,
-//         fixed_stack_slots: vec![],
-//         scratch_by_class: [None, None, None],
-//     }
-// }
+    MachineEnv {
+        preferred_regs_by_class: [
+            &[
+                px_reg(0),
+                px_reg(1),
+                px_reg(2),
+                px_reg(3),
+                px_reg(4),
+                px_reg(5),
+                px_reg(6),
+                px_reg(7),
+                px_reg(8),
+                px_reg(9),
+                px_reg(10),
+                px_reg(11),
+                px_reg(12),
+                px_reg(13),
+                px_reg(14),
+                px_reg(15),
+            ],
+            &[
+                pf_reg(0),
+                pf_reg(1),
+                pf_reg(2),
+                pf_reg(3),
+                pf_reg(4),
+                pf_reg(5),
+                pf_reg(6),
+                pf_reg(7),
+                pf_reg(8),
+                pf_reg(9),
+                pf_reg(10),
+                pf_reg(11),
+                pf_reg(12),
+                pf_reg(13),
+                pf_reg(14),
+                pf_reg(15),
+            ],
+            &[
+                pv_reg(0),
+                pv_reg(1),
+                pv_reg(2),
+                pv_reg(3),
+                pv_reg(4),
+                pv_reg(5),
+                pv_reg(6),
+                pv_reg(7),
+                pv_reg(8),
+                pv_reg(9),
+                pv_reg(10),
+                pv_reg(11),
+                pv_reg(12),
+                pv_reg(13),
+                pv_reg(14),
+                pv_reg(15),
+                pv_reg(16),
+                pv_reg(17),
+                pv_reg(18),
+                pv_reg(19),
+                pv_reg(20),
+                pv_reg(21),
+                pv_reg(22),
+                pv_reg(23),
+                pv_reg(24),
+                pv_reg(25),
+                pv_reg(26),
+                pv_reg(27),
+                pv_reg(28),
+                pv_reg(29),
+                pv_reg(30),
+                pv_reg(31),
+            ]
+        ],
+        non_preferred_regs_by_class: [
+            &[
+                px_reg(16),
+                px_reg(17),
+                px_reg(18),
+                px_reg(19),
+                px_reg(20),
+                px_reg(21),
+                px_reg(22),
+                px_reg(23),
+                px_reg(24),
+                px_reg(25),
+                px_reg(26),
+                px_reg(27),
+                px_reg(28),
+                px_reg(29),
+            ],
+            &[
+                pf_reg(16),
+                pf_reg(17),
+                pf_reg(18),
+                pf_reg(19),
+                pf_reg(20),
+                pf_reg(21),
+                pf_reg(22),
+                pf_reg(23),
+                pf_reg(24),
+                pf_reg(25),
+                pf_reg(26),
+                pf_reg(27),
+                pf_reg(28),
+                pf_reg(29),
+                pf_reg(30),
+                pf_reg(31),
+            ],
+            &[]
+        ],
+        scratch_by_class: [None, None, None],
+        fixed_stack_slots: &[],
+    }
+};

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -525,8 +525,7 @@ where
     }
 
     fn get_machine_env(_flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
-        static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
-        MACHINE_ENV.get_or_init(create_reg_environment)
+        &DEFAULT_MACHINE_ENV
     }
 
     fn get_regs_clobbered_by_call(_call_conv_of_callee: isa::CallConv) -> PRegSet {
@@ -913,31 +912,33 @@ const DEFAULT_CLOBBERS: PRegSet = PRegSet::empty()
     .with(pv_reg(30))
     .with(pv_reg(31));
 
-fn create_reg_environment() -> MachineEnv {
-    // Prefer caller-saved registers over callee-saved registers, because that
-    // way we don't need to emit code to save and restore them if we don't
-    // mutate them.
+static DEFAULT_MACHINE_ENV: MachineEnv = { todo!() };
 
-    let preferred_regs_by_class: [Vec<PReg>; 3] = {
-        let x_registers: Vec<PReg> = (0..16).map(|x| px_reg(x)).collect();
-        let f_registers: Vec<PReg> = (0..16).map(|x| pf_reg(x)).collect();
-        let v_registers: Vec<PReg> = (0..32).map(|x| pv_reg(x)).collect();
-        [x_registers, f_registers, v_registers]
-    };
-
-    let non_preferred_regs_by_class: [Vec<PReg>; 3] = {
-        let x_registers: Vec<PReg> = (16..XReg::SPECIAL_START)
-            .map(|x| px_reg(x.into()))
-            .collect();
-        let f_registers: Vec<PReg> = (16..32).map(|x| pf_reg(x)).collect();
-        let v_registers: Vec<PReg> = vec![];
-        [x_registers, f_registers, v_registers]
-    };
-
-    MachineEnv {
-        preferred_regs_by_class,
-        non_preferred_regs_by_class,
-        fixed_stack_slots: vec![],
-        scratch_by_class: [None, None, None],
-    }
-}
+// fn create_reg_environment() -> MachineEnv {
+//     // Prefer caller-saved registers over callee-saved registers, because that
+//     // way we don't need to emit code to save and restore them if we don't
+//     // mutate them.
+//
+//     let preferred_regs_by_class: [Vec<PReg>; 3] = {
+//         let x_registers: Vec<PReg> = (0..16).map(|x| px_reg(x)).collect();
+//         let f_registers: Vec<PReg> = (0..16).map(|x| pf_reg(x)).collect();
+//         let v_registers: Vec<PReg> = (0..32).map(|x| pv_reg(x)).collect();
+//         [x_registers, f_registers, v_registers]
+//     };
+//
+//     let non_preferred_regs_by_class: [Vec<PReg>; 3] = {
+//         let x_registers: Vec<PReg> = (16..XReg::SPECIAL_START)
+//             .map(|x| px_reg(x.into()))
+//             .collect();
+//         let f_registers: Vec<PReg> = (16..32).map(|x| pf_reg(x)).collect();
+//         let v_registers: Vec<PReg> = vec![];
+//         [x_registers, f_registers, v_registers]
+//     };
+//
+//     MachineEnv {
+//         preferred_regs_by_class,
+//         non_preferred_regs_by_class,
+//         fixed_stack_slots: vec![],
+//         scratch_by_class: [None, None, None],
+//     }
+// }

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -11,10 +11,9 @@ use crate::{
 use alloc::{boxed::Box, vec::Vec};
 use core::marker::PhantomData;
 use cranelift_bitset::ScalarBitSet;
-use regalloc2::{MachineEnv, PReg, PRegSet};
+use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
 use std::borrow::ToOwned;
-use std::sync::OnceLock;
 
 /// Support for the Pulley ABI from the callee side (within a function body).
 pub(crate) type PulleyCallee<P> = Callee<PulleyMachineDeps<P>>;

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -19,6 +19,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
+use alloc::borrow::ToOwned;
 
 /// Support for the Riscv64 ABI from the callee side (within a function body).
 pub(crate) type Riscv64Callee = Callee<Riscv64MachineDeps>;

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -1375,8 +1375,6 @@ static DEFAULT_MACHINE_ENV: MachineEnv = {
 };
 
 static PINNED_MACHINE_ENV: MachineEnv = {
-    debug_assert!(regs::r15() == regs::pinned_reg());
-
     MachineEnv {
         preferred_regs_by_class: [
             // Preferred GPRs: caller-saved in the SysV ABI.

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -1312,7 +1312,7 @@ const fn all_clobbers() -> PRegSet {
         .with(regs::fpr_preg(15))
 }
 
-fn preg(r: Reg) -> PReg {
+const fn preg(r: Reg) -> PReg {
     r.to_physical_reg().unwrap()
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -31,7 +31,7 @@ pub const ENC_R15: u8 = 15;
 
 // Constructors for Regs.
 
-fn gpr(enc: u8) -> Reg {
+const fn gpr(enc: u8) -> Reg {
     let preg = gpr_preg(enc);
     Reg::from(VReg::new(preg.index(), RegClass::Int))
 }
@@ -39,65 +39,65 @@ pub(crate) const fn gpr_preg(enc: u8) -> PReg {
     PReg::new(enc as usize, RegClass::Int)
 }
 
-pub(crate) fn rsi() -> Reg {
+pub(crate) const fn rsi() -> Reg {
     gpr(ENC_RSI)
 }
-pub(crate) fn rdi() -> Reg {
+pub(crate) const fn rdi() -> Reg {
     gpr(ENC_RDI)
 }
-pub(crate) fn rax() -> Reg {
+pub(crate) const fn rax() -> Reg {
     gpr(ENC_RAX)
 }
-pub(crate) fn rcx() -> Reg {
+pub(crate) const fn rcx() -> Reg {
     gpr(ENC_RCX)
 }
-pub(crate) fn rdx() -> Reg {
+pub(crate) const fn rdx() -> Reg {
     gpr(ENC_RDX)
 }
-pub(crate) fn r8() -> Reg {
+pub(crate) const fn r8() -> Reg {
     gpr(ENC_R8)
 }
-pub(crate) fn r9() -> Reg {
+pub(crate) const fn r9() -> Reg {
     gpr(ENC_R9)
 }
-pub(crate) fn r10() -> Reg {
+pub(crate) const fn r10() -> Reg {
     gpr(ENC_R10)
 }
-pub(crate) fn r11() -> Reg {
+pub(crate) const fn r11() -> Reg {
     gpr(ENC_R11)
 }
-pub(crate) fn r12() -> Reg {
+pub(crate) const fn r12() -> Reg {
     gpr(ENC_R12)
 }
-pub(crate) fn r13() -> Reg {
+pub(crate) const fn r13() -> Reg {
     gpr(ENC_R13)
 }
-pub(crate) fn r14() -> Reg {
+pub(crate) const fn r14() -> Reg {
     gpr(ENC_R14)
 }
-pub(crate) fn rbx() -> Reg {
+pub(crate) const fn rbx() -> Reg {
     gpr(ENC_RBX)
 }
 
-pub(crate) fn r15() -> Reg {
+pub(crate) const fn r15() -> Reg {
     gpr(ENC_R15)
 }
 
-pub(crate) fn rsp() -> Reg {
+pub(crate) const fn rsp() -> Reg {
     gpr(ENC_RSP)
 }
-pub(crate) fn rbp() -> Reg {
+pub(crate) const fn rbp() -> Reg {
     gpr(ENC_RBP)
 }
 
 /// The pinned register on this architecture.
 /// It must be the same as Spidermonkey's HeapReg, as found in this file.
 /// https://searchfox.org/mozilla-central/source/js/src/jit/x64/Assembler-x64.h#99
-pub(crate) fn pinned_reg() -> Reg {
+pub(crate) const fn pinned_reg() -> Reg {
     r15()
 }
 
-fn fpr(enc: u8) -> Reg {
+const fn fpr(enc: u8) -> Reg {
     let preg = fpr_preg(enc);
     Reg::from(VReg::new(preg.index(), RegClass::Float))
 }
@@ -106,52 +106,52 @@ pub(crate) const fn fpr_preg(enc: u8) -> PReg {
     PReg::new(enc as usize, RegClass::Float)
 }
 
-pub(crate) fn xmm0() -> Reg {
+pub(crate) const fn xmm0() -> Reg {
     fpr(0)
 }
-pub(crate) fn xmm1() -> Reg {
+pub(crate) const fn xmm1() -> Reg {
     fpr(1)
 }
-pub(crate) fn xmm2() -> Reg {
+pub(crate) const fn xmm2() -> Reg {
     fpr(2)
 }
-pub(crate) fn xmm3() -> Reg {
+pub(crate) const fn xmm3() -> Reg {
     fpr(3)
 }
-pub(crate) fn xmm4() -> Reg {
+pub(crate) const fn xmm4() -> Reg {
     fpr(4)
 }
-pub(crate) fn xmm5() -> Reg {
+pub(crate) const fn xmm5() -> Reg {
     fpr(5)
 }
-pub(crate) fn xmm6() -> Reg {
+pub(crate) const fn xmm6() -> Reg {
     fpr(6)
 }
-pub(crate) fn xmm7() -> Reg {
+pub(crate) const fn xmm7() -> Reg {
     fpr(7)
 }
-pub(crate) fn xmm8() -> Reg {
+pub(crate) const fn xmm8() -> Reg {
     fpr(8)
 }
-pub(crate) fn xmm9() -> Reg {
+pub(crate) const fn xmm9() -> Reg {
     fpr(9)
 }
-pub(crate) fn xmm10() -> Reg {
+pub(crate) const fn xmm10() -> Reg {
     fpr(10)
 }
-pub(crate) fn xmm11() -> Reg {
+pub(crate) const fn xmm11() -> Reg {
     fpr(11)
 }
-pub(crate) fn xmm12() -> Reg {
+pub(crate) const fn xmm12() -> Reg {
     fpr(12)
 }
-pub(crate) fn xmm13() -> Reg {
+pub(crate) const fn xmm13() -> Reg {
     fpr(13)
 }
-pub(crate) fn xmm14() -> Reg {
+pub(crate) const fn xmm14() -> Reg {
     fpr(14)
 }
-pub(crate) fn xmm15() -> Reg {
+pub(crate) const fn xmm15() -> Reg {
     fpr(15)
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -33,7 +33,7 @@ pub const ENC_R15: u8 = 15;
 
 const fn gpr(enc: u8) -> Reg {
     let preg = gpr_preg(enc);
-    Reg::from(VReg::new(preg.index(), RegClass::Int))
+    Reg::from_vreg(VReg::new(preg.index(), RegClass::Int))
 }
 pub(crate) const fn gpr_preg(enc: u8) -> PReg {
     PReg::new(enc as usize, RegClass::Int)
@@ -99,7 +99,7 @@ pub(crate) const fn pinned_reg() -> Reg {
 
 const fn fpr(enc: u8) -> Reg {
     let preg = fpr_preg(enc);
-    Reg::from(VReg::new(preg.index(), RegClass::Float))
+    Reg::from_vreg(VReg::new(preg.index(), RegClass::Float))
 }
 
 pub(crate) const fn fpr_preg(enc: u8) -> PReg {

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -49,8 +49,12 @@ pub struct Reg(VReg);
 
 impl Reg {
     // FIXME(const-hack) remove in favor of `From` impl
-    pub(crate) const fn from_preg(preg: PReg) -> Reg {
+    pub const fn from_preg(preg: PReg) -> Reg {
         Reg(RealReg(preg).to_vreg())
+    }
+
+    pub const fn from_vreg(vreg: VReg) -> Reg {
+        Reg(vreg)
     }
 
     /// Get the physical register (`RealReg`), if this register is

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -48,11 +48,13 @@ pub fn first_user_vreg_index() -> usize {
 pub struct Reg(VReg);
 
 impl Reg {
+    /// Create a register from a physical register
     // FIXME(const-hack) remove in favor of `From` impl
     pub const fn from_preg(preg: PReg) -> Reg {
         Reg(RealReg(preg).to_vreg())
     }
 
+    /// Create a register from a virtual register
     pub const fn from_vreg(vreg: VReg) -> Reg {
         Reg(vreg)
     }


### PR DESCRIPTION
This PR is another attempt at #8489 (superseding it) this time by making the necessary changes in `regalloc2` (see [here](https://github.com/bytecodealliance/regalloc2/pull/208)) to allow `MachineEnv` to be created in const expressions and therefore placed into statics without the need for lazy initialization (as mentioned in [this comment](https://bytecodealliance.zulipchat.com/#narrow/channel/217117-cranelift/topic/Use.20in.20no_std/near/493078060))
This PR also makes the necessary changes in register creation functions to make them `const`.

While I agree with @cfallin that this is the "correct" move, it is slightly annoying that Rusts const limitation makes the static initializers so verbose where a `1..=16` range iterator was used previously, any ideas here are welcome :/

Edit: marked the PR as draft until the regalloc2 upstream PR is merged