### PR TITLE
winch(x64): Fix `MemOpKind` for `i64_atomic_load8`

### DIFF
--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -2221,7 +2221,7 @@ where
             WasmValType::I32,
             OperandSize::S8,
             LoadKind::Simple,
-            MemOpKind::Normal,
+            MemOpKind::Atomic,
         )
     }
 


### PR DESCRIPTION
Change from `MemOpKind::Normal` to `MemOpKind::Atomic`. In the case of x64 this change doesn't meaningfully change the output of the instruction. However, for correctness and for the purposes of other backends, we need to pass the right `MemOpKind`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
