### PR TITLE
Enable pulley simd fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -587,7 +587,6 @@ impl WasmtimeConfig {
             }
 
             CompilerStrategy::CraneliftPulley => {
-                config.simd_enabled = false;
                 config.threads_enabled = false;
             }
         }


### PR DESCRIPTION
Pulley finished its simd implementation in #9935 so now that fuzzing was enabled in #9966 as well be sure to fuzz the simd proposal too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
