### PR TITLE
Fix comment about `xbc32_bound32_trap` pulley macro-op

### DIFF
--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -588,7 +588,7 @@ macro_rules! for_each_op {
             /// `trapif(zext(low32(addr)) > bound - off)` (unsigned)
             xbc32_bound64_trap = XBc32Bound64Trap { addr: XReg, bound: XReg, off: u8 };
 
-            /// `trapif(zext(low32(addr)) > low32(bound) - off)` (unsigned)
+            /// `trapif(low32(addr) > low32(bound) - off)` (unsigned)
             xbc32_bound32_trap = XBc32Bound32Trap { addr: XReg, bound: XReg, off: u8 };
         }
     };


### PR DESCRIPTION
Unlike the `bound64` version, this instruction does not zero-extend the address.

Follow up from https://github.com/bytecodealliance/wasmtime/pull/9943

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
