### PR TITLE
pulley: Shrink frame save/restore instructions

### DIFF
--- a/cranelift/codegen/meta/src/pulley.rs
+++ b/cranelift/codegen/meta/src/pulley.rs
@@ -69,9 +69,9 @@ impl Inst<'_> {
                     Operand::Binop { dst, src1, src2 }
                 }
                 (name, ty) if name.starts_with("dst") => Operand::Writable { name, ty },
-                (name, "RegSet < XReg >") => Operand::Normal {
+                (name, "UpperRegSet < XReg >") => Operand::Normal {
                     name,
-                    ty: "XRegSet",
+                    ty: "UpperXRegSet",
                 },
                 (name, ty) => Operand::Normal { name, ty },
             })
@@ -126,7 +126,7 @@ pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
                         format_string.push_str(",");
                     }
 
-                    if ty == "XRegSet" {
+                    if ty == "UpperXRegSet" {
                         format_string.push_str(" {");
                         format_string.push_str(name);
                         format_string.push_str(":?}");
@@ -192,7 +192,7 @@ pub fn generate_rust(filename: &str, out_dir: &Path) -> Result<(), Error> {
                 // register allocation.
                 Operand::Normal {
                     name: _,
-                    ty: "XRegSet",
+                    ty: "UpperXRegSet",
                 } if *name == "PushFrameSave" || *name == "PopFrameRestore" => {}
 
                 Operand::Normal { name, ty } => {

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -153,7 +153,7 @@
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
 (type BoxReturnCallIndInfo (primitive BoxReturnCallIndInfo))
-(type XRegSet (primitive XRegSet))
+(type UpperXRegSet (primitive UpperXRegSet))
 (type BoxCallIndirectHostInfo (primitive BoxCallIndirectHostInfo))
 
 ;;;; Address Modes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -33,7 +33,7 @@ type BoxCallIndirectHostInfo = Box<CallInfo<ExternalName>>;
 type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
 type BoxReturnCallIndInfo = Box<ReturnCallInfo<XReg>>;
 type BoxExternalName = Box<ExternalName>;
-type XRegSet = pulley_interpreter::RegSet<pulley_interpreter::XReg>;
+type UpperXRegSet = pulley_interpreter::UpperRegSet<pulley_interpreter::XReg>;
 
 #[expect(
     unused_imports,

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -173,7 +173,7 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call4 x15, x15, x15, x15, 0x0    // target = 0x44
+; call4 x15, x15, x15, x15, 0x0    // target = 0x40
 ; pop_frame_restore 48, 
 ; ret
 
@@ -256,7 +256,7 @@ block0:
 ; Disassembled:
 ; push_frame_save 112, x17, x18, x20, x21, x22, x23, x29
 ; xmov x12, sp
-; call1 x12, 0x0    // target = 0xc
+; call1 x12, 0x0    // target = 0x8
 ; xmov x20, x13
 ; xmov x22, x11
 ; xload64le_offset8 x29, sp, 0

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -173,7 +173,7 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call4 x15, x15, x15, x15, 0x0    // target = 0x44
+; call4 x15, x15, x15, x15, 0x0    // target = 0x40
 ; pop_frame_restore 48, 
 ; ret
 
@@ -256,7 +256,7 @@ block0:
 ; Disassembled:
 ; push_frame_save 112, x17, x18, x20, x21, x22, x23, x29
 ; xmov x12, sp
-; call1 x12, 0x0    // target = 0xc
+; call1 x12, 0x0    // target = 0x8
 ; xmov x20, x13
 ; xmov x22, x11
 ; xload64le_offset8 x29, sp, 0
@@ -379,7 +379,7 @@ block0:
 ; xmov x12, x15
 ; xmov x13, x15
 ; xmov x14, x15
-; call4 x15, x15, x15, x15, 0x0    // target = 0x4c
+; call4 x15, x15, x15, x15, 0x0    // target = 0x48
 ; pop_frame_restore 64, 
 ; ret
 

--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -449,7 +449,7 @@ impl<S: Decode + ScalarBitSetStorage> Decode for ScalarBitSet<S> {
     }
 }
 
-impl<R: Reg + Decode> Decode for RegSet<R> {
+impl<R: Reg + Decode> Decode for UpperRegSet<R> {
     fn decode<T>(bytecode: &mut T) -> Result<Self, T::Error>
     where
         T: BytecodeStream,

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -239,7 +239,7 @@ where
     }
 }
 
-impl<R: Reg + Disas> Disas for RegSet<R> {
+impl<R: Reg + Disas> Disas for UpperRegSet<R> {
     fn disas(&self, position: usize, disas: &mut String) {
         disas_list(position, disas, *self)
     }

--- a/pulley/src/encode.rs
+++ b/pulley/src/encode.rs
@@ -191,8 +191,8 @@ impl<D: Reg, S1: Reg> Encode for BinaryOperands<D, S1, U6> {
     }
 }
 
-impl<R: Reg + Encode> Encode for RegSet<R> {
-    const WIDTH: u8 = 4;
+impl<R: Reg + Encode> Encode for UpperRegSet<R> {
+    const WIDTH: u8 = 2;
 
     fn encode<E>(&self, sink: &mut E)
     where

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1881,7 +1881,7 @@ impl OpVisitor for Interpreter<'_> {
     }
 
     #[inline]
-    fn push_frame_save(&mut self, amt: u32, regs: RegSet<XReg>) -> ControlFlow<Done> {
+    fn push_frame_save(&mut self, amt: u16, regs: UpperRegSet<XReg>) -> ControlFlow<Done> {
         // Decrement the stack pointer `amt` bytes plus 2 pointers more for
         // fp/lr.
         let ptr_size = size_of::<usize>();
@@ -1910,11 +1910,11 @@ impl OpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
-    fn pop_frame_restore(&mut self, amt: u32, regs: RegSet<XReg>) -> ControlFlow<Done> {
+    fn pop_frame_restore(&mut self, amt: u16, regs: UpperRegSet<XReg>) -> ControlFlow<Done> {
         // Restore all registers in `regs`, followed by the normal `pop_frame`
         // opcode below to restore fp/lr.
         unsafe {
-            let mut offset = amt as i32;
+            let mut offset = i32::from(amt);
             for reg in regs {
                 offset -= 8;
                 let val = self.load(XReg::sp, offset);
@@ -2499,58 +2499,6 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         let b = self.state[operands.src2].get_u64();
         let result = ((u128::from(a) * u128::from(b)) >> 64) as u64;
         self.state[operands.dst].set_u64(result);
-        ControlFlow::Continue(())
-    }
-
-    fn xpush32(&mut self, src: XReg) -> ControlFlow<Done> {
-        self.push::<crate::XPush32, _>(self.state[src].get_u32())?;
-        ControlFlow::Continue(())
-    }
-
-    fn xpush32_many(&mut self, srcs: RegSet<XReg>) -> ControlFlow<Done> {
-        for src in srcs {
-            self.push::<crate::XPush32Many, _>(self.state[src].get_u32())?;
-        }
-        ControlFlow::Continue(())
-    }
-
-    fn xpush64(&mut self, src: XReg) -> ControlFlow<Done> {
-        self.push::<crate::XPush64, _>(self.state[src].get_u64())?;
-        ControlFlow::Continue(())
-    }
-
-    fn xpush64_many(&mut self, srcs: RegSet<XReg>) -> ControlFlow<Done> {
-        for src in srcs {
-            self.push::<crate::XPush64Many, _>(self.state[src].get_u64())?;
-        }
-        ControlFlow::Continue(())
-    }
-
-    fn xpop32(&mut self, dst: XReg) -> ControlFlow<Done> {
-        let val = self.pop();
-        self.state[dst].set_u32(val);
-        ControlFlow::Continue(())
-    }
-
-    fn xpop32_many(&mut self, dsts: RegSet<XReg>) -> ControlFlow<Done> {
-        for dst in dsts.into_iter().rev() {
-            let val = self.pop();
-            self.state[dst].set_u32(val);
-        }
-        ControlFlow::Continue(())
-    }
-
-    fn xpop64(&mut self, dst: XReg) -> ControlFlow<Done> {
-        let val = self.pop();
-        self.state[dst].set_u64(val);
-        ControlFlow::Continue(())
-    }
-
-    fn xpop64_many(&mut self, dsts: RegSet<XReg>) -> ControlFlow<Done> {
-        for dst in dsts.into_iter().rev() {
-            let val = self.pop();
-            self.state[dst].set_u64(val);
-        }
         ControlFlow::Continue(())
     }
 

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1885,7 +1885,7 @@ impl OpVisitor for Interpreter<'_> {
         // Decrement the stack pointer `amt` bytes plus 2 pointers more for
         // fp/lr.
         let ptr_size = size_of::<usize>();
-        let full_amt = usize::try_from(amt).unwrap() + 2 * ptr_size;
+        let full_amt = usize::from(amt) + 2 * ptr_size;
         let new_sp = self.state[XReg::sp].get_ptr::<u8>().wrapping_sub(full_amt);
         self.set_sp::<crate::PushFrameSave>(new_sp)?;
 

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -467,10 +467,10 @@ macro_rules! for_each_op {
             ///
             /// This is equivalent to `push_frame`, `stack_alloc32 amt`, then
             /// saving all of `regs` to the top of the stack just allocated.
-            push_frame_save = PushFrameSave { amt: u32, regs: RegSet<XReg> };
+            push_frame_save = PushFrameSave { amt: u16, regs: UpperRegSet<XReg> };
             /// Inverse of `push_frame_save`. Restores `regs` from the top of
             /// the stack, then runs `stack_free32 amt`, then runs `pop_frame`.
-            pop_frame_restore = PopFrameRestore { amt: u32, regs: RegSet<XReg> };
+            pop_frame_restore = PopFrameRestore { amt: u16, regs: UpperRegSet<XReg> };
 
             /// `sp = sp.checked_sub(amt)`
             stack_alloc32 = StackAlloc32 { amt: u32 };
@@ -655,24 +655,6 @@ macro_rules! for_each_extended_op {
             xbmask32 = Xbmask32 { dst: XReg, src: XReg };
             /// dst = if src == 0 { 0 } else { -1 }
             xbmask64 = Xbmask64 { dst: XReg, src: XReg };
-
-            /// `*sp = low32(src); sp = sp.checked_add(4)`
-            xpush32 = XPush32 { src: XReg };
-            /// `for src in srcs { xpush32 src }`
-            xpush32_many = XPush32Many { srcs: RegSet<XReg> };
-            /// `*sp = src; sp = sp.checked_add(8)`
-            xpush64 = XPush64 { src: XReg };
-            /// `for src in srcs { xpush64 src }`
-            xpush64_many = XPush64Many { srcs: RegSet<XReg> };
-
-            /// `*dst = *sp; sp -= 4`
-            xpop32 = XPop32 { dst: XReg };
-            /// `for dst in dsts.rev() { xpop32 dst }`
-            xpop32_many = XPop32Many { dsts: RegSet<XReg> };
-            /// `*dst = *sp; sp -= 8`
-            xpop64 = XPop64 { dst: XReg };
-            /// `for dst in dsts.rev() { xpop64 dst }`
-            xpop64_many = XPop64Many { dsts: RegSet<XReg> };
 
             /// `dst = zext(*(ptr + offset))`
             xload16be_u64_offset32 = XLoad16BeU64Offset32 { dst: XReg, ptr: XReg, offset: i32 };

--- a/pulley/tests/all/disas.rs
+++ b/pulley/tests/all/disas.rs
@@ -61,41 +61,6 @@ fn simple() {
 }
 
 #[test]
-fn push_pop_many() {
-    assert_disas(
-        &[
-            // Prologue.
-            Op::PushFrame(PushFrame {}),
-            Op::ExtendedOp(ExtendedOp::XPush32Many(XPush32Many {
-                srcs: RegSet::from_iter([XReg::x0, XReg::x1, XReg::x2, XReg::x3, XReg::x4]),
-            })),
-            // Function body.
-            Op::Xadd32(Xadd32 {
-                operands: BinaryOperands {
-                    dst: XReg::x0,
-                    src1: XReg::x0,
-                    src2: XReg::x1,
-                },
-            }),
-            // Epilogue.
-            Op::ExtendedOp(ExtendedOp::XPop32Many(XPop32Many {
-                dsts: RegSet::from_iter([XReg::x0, XReg::x1, XReg::x2, XReg::x3, XReg::x4]),
-            })),
-            Op::PopFrame(PopFrame {}),
-            Op::Ret(Ret {}),
-        ],
-        r#"
-       0: push_frame
-       1: xpush32_many x0, x1, x2, x3, x4
-       8: xadd32 x0, x0, x1
-       b: xpop32_many x0, x1, x2, x3, x4
-      12: pop_frame
-      13: ret
-        "#,
-    );
-}
-
-#[test]
 fn no_offsets() {
     let bytecode = encoded(&[
         // Prologue.

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -14,5 +14,5 @@
 ;;       br_if_xulteq64 x6, x7, 0x9    // target = 0x1a
 ;;   18: pop_frame
 ;;       ret
-;;   1a: call 0x9c    // target = 0xb6
+;;   1a: call 0x94    // target = 0xae
 ;;   1f: jump 0xfffffffffffffff9    // target = 0x18


### PR DESCRIPTION
This commit shrinks the size of the `PushFrameSave` and `PopFrameRestore` functions which are used in almost all wasm functions. Previously these instructions allowed for 32-bits of stack space in addition to saving/restoring all 32 X-registers. In reality though it's quite uncommon to need more than 16-bits of stack space and ABI-wise the most commonly saved registers are the upper 16 registers of the X register set.

This commit therefore shrinks the frame size to 16 bits and only has the ability to save/restore the upper 16 X-registers. Note that any clobbered registers and frame sizes are still supported, they'll just use more pessimal encodings which aren't a single opcode. If a function uses >64KiB of stack space though it's probably not too important what the dispatch cost is at the beginning.

The overall result of this change is that each instruction shaves of 4 bytes (2 from the frame size and 2 from the registers being saved/restored). This results in a 4% faster execution time on the bz2 Sightglass benchmark, ~1% on pulldown-cmark, and while it shrinks `spidermonkey.cwasm` slightly it's not significant.

While here this commit also removes the Cranelift-unused instructions of `x{push,pop}{,_many}` since the `RegSet` type was repurposed as an `UpperRegSet` instead. It's possible to bring back these instructions but they're otherwise not used right now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
