### PR TITLE
winch: Include positional argument on internal error

### DIFF
--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -30,7 +30,7 @@ pub(crate) enum CodeGenError {
     ///
     /// This error means that an internal invariant was not met and usually
     /// implies a compiler bug.
-    #[error("Winch internal error")]
+    #[error("Winch internal error: {0}")]
     Internal(InternalError),
 }
 


### PR DESCRIPTION
This change includes a positional argument when formatting `CodeGenError::Internal`, to ensure that the details of the internal error are properly included.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
