### PR TITLE
Use `ir::types::I8X16` for `v128`s in GC objects

### DIFF
--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -115,7 +115,7 @@ fn read_field_at_addr(
             WasmValType::I64 => builder.ins().load(ir::types::I64, flags, addr, 0),
             WasmValType::F32 => builder.ins().load(ir::types::F32, flags, addr, 0),
             WasmValType::F64 => builder.ins().load(ir::types::F64, flags, addr, 0),
-            WasmValType::V128 => builder.ins().load(ir::types::I128, flags, addr, 0),
+            WasmValType::V128 => builder.ins().load(ir::types::I8X16, flags, addr, 0),
             WasmValType::Ref(r) => match r.heap_type.top() {
                 WasmHeapTopType::Any | WasmHeapTopType::Extern => gc_compiler(func_env)?
                     .translate_read_gc_reference(func_env, builder, r, addr, flags)?,
@@ -266,7 +266,10 @@ fn default_value(
             WasmValType::I64 => cursor.ins().iconst(ir::types::I64, 0),
             WasmValType::F32 => cursor.ins().f32const(0.0),
             WasmValType::F64 => cursor.ins().f64const(0.0),
-            WasmValType::V128 => cursor.ins().iconst(ir::types::I128, 0),
+            WasmValType::V128 => {
+                let c = cursor.func.dfg.constants.insert(vec![0; 16].into());
+                cursor.ins().vconst(ir::types::I8X16, c)
+            }
             WasmValType::Ref(r) => {
                 assert!(r.nullable);
                 let (ty, needs_stack_map) = func_env.reference_type(r.heap_type);

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -1,0 +1,42 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=null"
+;;! test = "optimize"
+
+(module
+  (type $ty (struct (field (mut v128))
+                    (field (mut v128))))
+
+  (func (param (ref $ty)) (result v128)
+    (v128.xor (struct.get $ty 0 (local.get 0))
+              (struct.get $ty 0 (local.get 0)))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0022                               trapz v2, user16
+;; @0022                               v9 = uextend.i64 v2
+;; @0022                               v10 = iconst.i64 16
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;;                                     v31 = iconst.i64 48
+;; @0022                               v13 = uadd_overflow_trap v9, v31, user1  ; v31 = 48
+;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v14 = icmp ule v13, v8
+;; @0022                               trapz v14, user1
+;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v15 = iadd v6, v11
+;; @0022                               v16 = load.i8x16 notrap aligned little v15
+;; @0028                               trapz v2, user16
+;; @0028                               trapz v14, user1
+;; @0028                               v29 = load.i8x16 notrap aligned little v15
+;; @002e                               jump block1
+;;
+;;                                 block1:
+;; @002c                               v30 = bxor.i8x16 v16, v29
+;; @002e                               return v30
+;; }

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -5,7 +5,8 @@
 (module
   (type $ty (struct (field (mut f32))
                     (field (mut i8))
-                    (field (mut anyref))))
+                    (field (mut anyref))
+                    (field (mut v128))))
 
   (func (result (ref $ty))
     (struct.new_default $ty)
@@ -18,51 +19,56 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32 uext, i32 uext, i32 uext, i32 uext) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
+;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v8 = iconst.i32 -1342177280
-;; @0021                               v4 = iconst.i32 0
-;; @0021                               v6 = iconst.i32 32
-;; @0021                               v10 = iconst.i32 8
-;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
-;; @0021                               v3 = f32const 0.0
-;; @0021                               v14 = load.i64 notrap aligned readonly v0+40
-;; @0021                               v12 = ireduce.i32 v11
-;; @0021                               v15 = uextend.i64 v12
-;; @0021                               v16 = iadd v14, v15
-;;                                     v47 = iconst.i64 16
-;; @0021                               v17 = iadd v16, v47  ; v47 = 16
-;; @0021                               store notrap aligned little v3, v17  ; v3 = 0.0
-;;                                     v48 = iconst.i64 20
-;; @0021                               v18 = iadd v16, v48  ; v48 = 20
-;; @0021                               istore8 notrap aligned little v4, v18  ; v4 = 0
-;;                                     v58 = iconst.i8 1
-;; @0021                               brif v58, block3, block2  ; v58 = 1
+;; @0023                               v9 = iconst.i32 -1342177280
+;; @0023                               v4 = iconst.i32 0
+;; @0023                               v7 = iconst.i32 48
+;; @0023                               v11 = iconst.i32 16
+;; @0023                               v12 = call fn0(v0, v9, v4, v7, v11)  ; v9 = -1342177280, v4 = 0, v7 = 48, v11 = 16
+;; @0023                               v3 = f32const 0.0
+;; @0023                               v15 = load.i64 notrap aligned readonly v0+40
+;; @0023                               v13 = ireduce.i32 v12
+;; @0023                               v16 = uextend.i64 v13
+;; @0023                               v17 = iadd v15, v16
+;;                                     v49 = iconst.i64 16
+;; @0023                               v18 = iadd v17, v49  ; v49 = 16
+;; @0023                               store notrap aligned little v3, v18  ; v3 = 0.0
+;;                                     v50 = iconst.i64 20
+;; @0023                               v19 = iadd v17, v50  ; v50 = 20
+;; @0023                               istore8 notrap aligned little v4, v19  ; v4 = 0
+;;                                     v61 = iconst.i8 1
+;; @0023                               brif v61, block3, block2  ; v61 = 1
 ;;
 ;;                                 block2:
-;;                                     v65 = iconst.i64 0
-;; @0021                               v28 = iconst.i64 8
-;; @0021                               v29 = uadd_overflow_trap v65, v28, user1  ; v65 = 0, v28 = 8
-;; @0021                               v31 = uadd_overflow_trap v29, v28, user1  ; v28 = 8
-;; @0021                               v26 = load.i64 notrap aligned readonly v0+48
-;; @0021                               v32 = icmp ule v31, v26
-;; @0021                               trapz v32, user1
-;; @0021                               v33 = iadd.i64 v14, v29
-;; @0021                               v34 = load.i64 notrap aligned v33
-;; @0021                               trapz v32, user1
-;;                                     v51 = iconst.i64 1
-;; @0021                               v35 = iadd v34, v51  ; v51 = 1
-;; @0021                               store notrap aligned v35, v33
-;; @0021                               jump block3
+;;                                     v68 = iconst.i64 0
+;; @0023                               v29 = iconst.i64 8
+;; @0023                               v30 = uadd_overflow_trap v68, v29, user1  ; v68 = 0, v29 = 8
+;; @0023                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
+;; @0023                               v27 = load.i64 notrap aligned readonly v0+48
+;; @0023                               v33 = icmp ule v32, v27
+;; @0023                               trapz v33, user1
+;; @0023                               v34 = iadd.i64 v15, v30
+;; @0023                               v35 = load.i64 notrap aligned v34
+;; @0023                               trapz v33, user1
+;;                                     v53 = iconst.i64 1
+;; @0023                               v36 = iadd v35, v53  ; v53 = 1
+;; @0023                               store notrap aligned v36, v34
+;; @0023                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v66 = iconst.i32 0
-;;                                     v49 = iconst.i64 24
-;; @0021                               v19 = iadd.i64 v16, v49  ; v49 = 24
-;; @0021                               store notrap aligned little v66, v19  ; v66 = 0
-;; @0024                               jump block1
+;;                                     v69 = iconst.i32 0
+;;                                     v51 = iconst.i64 24
+;; @0023                               v20 = iadd.i64 v17, v51  ; v51 = 24
+;; @0023                               store notrap aligned little v69, v20  ; v69 = 0
+;; @0023                               v6 = vconst.i8x16 const0
+;;                                     v54 = iconst.i64 32
+;; @0023                               v48 = iadd.i64 v17, v54  ; v54 = 32
+;; @0023                               store notrap aligned little v6, v48  ; v6 = const0
+;; @0026                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0026                               return v13
 ;; }


### PR DESCRIPTION
We were incorrectly using `i128` previously, which would lead to invalid CLIF like `iconst.i128` when default-initializing structs and type errors when we tried to use `v128` fields that we read from a struct in a SIMD instruction.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
