### PR TITLE
Cranelift: dedupe `trap[n]z` instructions

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -142,6 +142,11 @@ fn define_control_flow(
             Operand::new("code", &imm.trapcode),
         ])
         .can_trap()
+        // When one `trapz` dominates another `trapz` and they have identical
+        // conditions and trap codes, it is safe to deduplicate them (like GVN,
+        // although there is not actually any value being numbered). Either the
+        // first `trapz` raised a trap and execution halted, or it didn't and
+        // therefore the dominated `trapz` will not raise a trap either.
         .side_effects_idempotent(),
     );
 
@@ -160,6 +165,7 @@ fn define_control_flow(
             Operand::new("code", &imm.trapcode),
         ])
         .can_trap()
+        // See the above comment for `trapz` and idempotent side effects.
         .side_effects_idempotent(),
     );
 

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -141,7 +141,8 @@ fn define_control_flow(
             Operand::new("c", ScalarTruthy).with_doc("Controlling value to test"),
             Operand::new("code", &imm.trapcode),
         ])
-        .can_trap(),
+        .can_trap()
+        .side_effects_idempotent(),
     );
 
     ig.push(
@@ -158,7 +159,8 @@ fn define_control_flow(
             Operand::new("c", ScalarTruthy).with_doc("Controlling value to test"),
             Operand::new("code", &imm.trapcode),
         ])
-        .can_trap(),
+        .can_trap()
+        .side_effects_idempotent(),
     );
 
     ig.push(

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -443,8 +443,10 @@ where
                             trace!(" -> merges result {} to {}", result, orig_result);
                         }
                         (None, None) => {
+                            // Hit in the GVN map, but the instruction doesn't
+                            // produce results, only side effects. Nothing else
+                            // to do here.
                             trace!(" -> merges with dominating instruction");
-                            // Nothing else to do here.
                         }
                         (_, _) => unreachable!(),
                     }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -75,10 +75,9 @@ pub fn is_pure_for_egraph(func: &Function, inst: Inst) -> bool {
 /// result.
 pub fn is_mergeable_for_egraph(func: &Function, inst: Inst) -> bool {
     let op = func.dfg.insts[inst].opcode();
-    // We can only merge one-result operators due to the way that GVN
+    // We can only merge zero- and one-result operators due to the way that GVN
     // is structured in the egraph implementation.
-    let has_one_result = func.dfg.inst_results(inst).len() == 1;
-    has_one_result
+    func.dfg.inst_results(inst).len() <= 1
         // Loads/stores are handled by alias analysis and not
         // otherwise mergeable.
         && !op.can_load()

--- a/cranelift/filetests/filetests/egraph/idempotent-traps.clif
+++ b/cranelift/filetests/filetests/egraph/idempotent-traps.clif
@@ -1,0 +1,92 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %trapz(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    trapz v0, user1
+
+    ;; Duplicate `trapz` in the same block. Should be removed.
+    trapz v0, user1
+
+    brif v1, block1, block2
+
+block1:
+    ;; Duplicate `trapz` in a dominated block. Should be removed.
+    trapz v0, user1
+
+    return v2
+
+block2:
+    return v3
+}
+
+; check:  function %trapz(i32, i32, i32, i32) -> i32 fast {
+; nextln: block0(v0: i32, v1: i32, v2: i32, v3: i32):
+; nextln:     trapz v0, user1
+; nextln:     brif v1, block1, block2
+; check:  block1:
+; nextln:     return v2
+; check:  block2:
+; nextln:     return v3
+; nextln: }
+
+function %trapnz(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    trapnz v0, user1
+
+    ;; Duplicate `trapnz` in the same block. Should be removed.
+    trapnz v0, user1
+
+    brif v1, block1, block2
+
+block1:
+    ;; Duplicate `trapnz` in a dominated block. Should be removed.
+    trapnz v0, user1
+
+    return v2
+
+block2:
+    return v3
+}
+
+; check:  function %trapnz(i32, i32, i32, i32) -> i32 fast {
+; nextln: block0(v0: i32, v1: i32, v2: i32, v3: i32):
+; nextln:     trapnz v0, user1
+; nextln:     brif v1, block1, block2
+; check:  block1:
+; nextln:     return v2
+; check:  block2:
+; nextln:     return v3
+; nextln: }
+
+;; In this function, although both `trapz`s are identical, they should not get
+;; deduplicated because neither dominates the other.
+function %f(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    br_table v1, block1, [block2, block3]
+
+block1:
+    return v1
+
+block2:
+    trapz v0, user1
+    return v2
+
+block3:
+    trapz v0, user1
+    return v3
+}
+
+; check:  function %f(i32, i32, i32, i32) -> i32 fast {
+; nextln: block0(v0: i32, v1: i32, v2: i32, v3: i32):
+; nextln:     br_table v1, block1, [block2, block3]
+; check:  block1:
+; nextln:     return v1
+; check:  block2:
+; nextln:     trapz.i32 v0, user1
+; nextln:     return v2
+; check:  block3:
+; nextln:     trapz.i32 v0, user1
+; nextln:     return v3
+; nextln: }

--- a/cranelift/filetests/filetests/egraph/idempotent-traps.clif
+++ b/cranelift/filetests/filetests/egraph/idempotent-traps.clif
@@ -90,3 +90,54 @@ block3:
 ; nextln:     trapz.i32 v0, user1
 ; nextln:     return v3
 ; nextln: }
+
+function %g(i32) {
+block0(v0: i32):
+    ;; These should not dedupe because they are different instructions that trap
+    ;; on different conditions. This test exists to basically make sure that if
+    ;; we ever legalize `trapz` into `trapnz` or vice-versa that we remember to
+    ;; negate the condition of the instruction being legalized before passing
+    ;; that as the condition to the post-legalization instruction.
+    trapz v0, user1
+    trapnz v0, user1
+    return
+}
+
+; check:  function %g(i32) fast {
+; nextln: block0(v0: i32):
+; nextln:     trapz v0, user1
+; nextln:     trapnz v0, user1
+; nextln:     return
+; nextln: }
+
+function %h(i32, i32) {
+block0(v0: i32, v1: i32):
+    ;; These should not dedupe because they have different conditions.
+    trapz v0, user1
+    trapz v1, user1
+    return
+}
+
+; check:  function %h(i32, i32) fast {
+; nextln: block0(v0: i32, v1: i32):
+; nextln:     trapz v0, user1
+; nextln:     trapz v1, user1
+; nextln:     return
+; nextln: }
+
+function %i(i32) {
+block0(v0: i32):
+    ;; These should not dedupe because they have different trap codes. Arguably,
+    ;; they could be deduped so long as we preserve the first's trap code, since
+    ;; either we will get that trap, or else no trap.
+    trapz v0, user1
+    trapz v0, user2
+    return
+}
+
+; check:  function %i(i32) fast {
+; nextln: block0(v0: i32):
+; nextln:     trapz v0, user1
+; nextln:     trapz v0, user2
+; nextln:     return
+; nextln: }

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -52,23 +52,15 @@
 ;; @0047                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v11 = load.i32 little heap v10
-;; @004c                               v13 = load.i64 notrap aligned v0+104
-;; @004c                               v14 = icmp ugt v6, v13
-;; @004c                               trapnz v14, heap_oob
-;; @004c                               v15 = load.i64 notrap aligned checked v0+96
-;; @004c                               v16 = iadd v15, v6
 ;; @004c                               v17 = iconst.i64 4
-;; @004c                               v18 = iadd v16, v17  ; v17 = 4
+;; @004c                               v18 = iadd v10, v17  ; v17 = 4
 ;; @004c                               v19 = load.i32 little heap v18
 ;; @0051                               v21 = iconst.i64 0x0010_0003
 ;; @0051                               v22 = uadd_overflow_trap v6, v21, heap_oob  ; v21 = 0x0010_0003
-;; @0051                               v23 = load.i64 notrap aligned v0+104
-;; @0051                               v24 = icmp ugt v22, v23
+;; @0051                               v24 = icmp ugt v22, v7
 ;; @0051                               trapnz v24, heap_oob
-;; @0051                               v25 = load.i64 notrap aligned checked v0+96
-;; @0051                               v26 = iadd v25, v6
 ;; @0051                               v27 = iconst.i64 0x000f_ffff
-;; @0051                               v28 = iadd v26, v27  ; v27 = 0x000f_ffff
+;; @0051                               v28 = iadd v10, v27  ; v27 = 0x000f_ffff
 ;; @0051                               v29 = load.i32 little heap v28
 ;; @0056                               jump block1
 ;;
@@ -93,23 +85,15 @@
 ;; @005d                               v9 = load.i64 notrap aligned checked v0+96
 ;; @005d                               v10 = iadd v9, v6
 ;; @005d                               store little heap v3, v10
-;; @0064                               v12 = load.i64 notrap aligned v0+104
-;; @0064                               v13 = icmp ugt v6, v12
-;; @0064                               trapnz v13, heap_oob
-;; @0064                               v14 = load.i64 notrap aligned checked v0+96
-;; @0064                               v15 = iadd v14, v6
 ;; @0064                               v16 = iconst.i64 4
-;; @0064                               v17 = iadd v15, v16  ; v16 = 4
+;; @0064                               v17 = iadd v10, v16  ; v16 = 4
 ;; @0064                               store little heap v4, v17
 ;; @006b                               v19 = iconst.i64 0x0010_0003
 ;; @006b                               v20 = uadd_overflow_trap v6, v19, heap_oob  ; v19 = 0x0010_0003
-;; @006b                               v21 = load.i64 notrap aligned v0+104
-;; @006b                               v22 = icmp ugt v20, v21
+;; @006b                               v22 = icmp ugt v20, v7
 ;; @006b                               trapnz v22, heap_oob
-;; @006b                               v23 = load.i64 notrap aligned checked v0+96
-;; @006b                               v24 = iadd v23, v6
 ;; @006b                               v25 = iconst.i64 0x000f_ffff
-;; @006b                               v26 = iadd v24, v25  ; v25 = 0x000f_ffff
+;; @006b                               v26 = iadd v10, v25  ; v25 = 0x000f_ffff
 ;; @006b                               store little heap v5, v26
 ;; @0070                               jump block1
 ;;

--- a/tests/disas/epoch-interruption-x86.wat
+++ b/tests/disas/epoch-interruption-x86.wat
@@ -28,12 +28,12 @@
 ;;       jae     0x65
 ;;       jmp     0x47
 ;;   58: movq    %r13, %rdi
-;;       callq   0x118
+;;       callq   0x107
 ;;       jmp     0x47
 ;;   65: movq    8(%r12), %rax
 ;;       cmpq    %rax, %rdi
 ;;       jb      0x47
 ;;   73: movq    %r13, %rdi
-;;       callq   0x118
+;;       callq   0x107
 ;;       jmp     0x47
 ;;   80: ud2

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -50,16 +50,9 @@
 ;; @0034                               v13 = load.i64 notrap aligned readonly v0+40
 ;; @0034                               v22 = iadd v13, v18
 ;; @0034                               v23 = load.i64 notrap aligned v22
-;;                                     v42 = load.i32 notrap v46
-;; @0034                               v29 = uextend.i64 v42
-;; @0034                               v31 = uadd_overflow_trap v29, v17, user1  ; v17 = 8
-;; @0034                               v33 = uadd_overflow_trap v31, v17, user1  ; v17 = 8
-;; @0034                               v34 = icmp ule v33, v15
-;; @0034                               trapz v34, user1
 ;;                                     v50 = iconst.i64 1
 ;; @0034                               v24 = iadd v23, v50  ; v50 = 1
-;; @0034                               v35 = iadd v13, v31
-;; @0034                               store notrap aligned v24, v35
+;; @0034                               store notrap aligned v24, v22
 ;;                                     v41 = load.i32 notrap v46
 ;; @0034                               store notrap aligned v41, v9
 ;;                                     v53 = iconst.i64 4
@@ -107,7 +100,6 @@
 ;; @003b                               v33 = load.i64 notrap aligned readonly v0+40
 ;; @003b                               v17 = iadd v33, v13
 ;; @003b                               v18 = load.i64 notrap aligned v17
-;; @003b                               trapz v16, user1
 ;;                                     v60 = iconst.i64 1
 ;; @003b                               v19 = iadd v18, v60  ; v60 = 1
 ;; @003b                               store notrap aligned v19, v17
@@ -142,7 +134,6 @@
 ;; @003b                               jump block7
 ;;
 ;;                                 block6:
-;; @003b                               trapz.i8 v41, user1
 ;;                                     v70 = iadd.i64 v43, v62  ; v62 = -1
 ;; @003b                               store notrap aligned v70, v42
 ;; @003b                               jump block7

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -52,25 +52,12 @@
 ;; @0024                               trapz v39, user1
 ;; @0024                               v40 = iadd v8, v36
 ;; @0024                               v41 = load.i64 notrap aligned little v40
-;; @002b                               trapz v2, user16
-;; @002b                               trapz v16, user1
-;; @002b                               v53 = load.i32 notrap aligned v17
-;; @002b                               v54 = icmp ult v4, v53
+;; @002b                               v54 = icmp ult v4, v18
 ;; @002b                               trapz v54, user17
-;; @002b                               v56 = uextend.i64 v53
-;;                                     v99 = ishl v56, v79  ; v79 = 3
-;; @002b                               v58 = ushr v99, v77  ; v77 = 32
-;; @002b                               trapnz v58, user1
-;;                                     v106 = ishl v53, v89  ; v89 = 3
-;; @002b                               v61 = uadd_overflow_trap v106, v25, user1  ; v25 = 24
-;;                                     v113 = ishl v4, v89  ; v89 = 3
-;; @002b                               v64 = iadd v113, v25  ; v25 = 24
+;;                                     v99 = ishl v4, v89  ; v89 = 3
+;; @002b                               v64 = iadd v99, v25  ; v25 = 24
 ;; @002b                               v70 = uextend.i64 v64
 ;; @002b                               v71 = uadd_overflow_trap v11, v70, user1
-;; @002b                               v72 = uextend.i64 v61
-;; @002b                               v73 = uadd_overflow_trap v11, v72, user1
-;; @002b                               v74 = icmp ule v73, v10
-;; @002b                               trapz v74, user1
 ;; @002b                               v75 = iadd v8, v71
 ;; @002b                               v76 = load.i64 notrap aligned little v75
 ;; @002e                               jump block1

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -31,10 +31,8 @@
 ;; @0023                               v7 = load.i64 notrap aligned readonly v0+40
 ;; @0023                               v16 = iadd v7, v12
 ;; @0023                               v17 = load.f32 notrap aligned little v16
-;; @0029                               trapz v2, user16
 ;; @0029                               v24 = iconst.i64 20
 ;; @0029                               v25 = uadd_overflow_trap v10, v24, user1  ; v24 = 20
-;; @0029                               trapz v15, user1
 ;; @0029                               v29 = iadd v7, v25
 ;; @0029                               v30 = load.i8 notrap aligned little v29
 ;; @002d                               jump block1

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -150,16 +150,9 @@
 ;; @004e                               trapz v34, user1
 ;; @004e                               v35 = iadd.i64 v6, v31
 ;; @004e                               v36 = load.i64 notrap aligned v35
-;;                                     v55 = load.i32 notrap v58
-;; @004e                               v42 = uextend.i64 v55
-;; @004e                               v44 = uadd_overflow_trap v42, v30, user1  ; v30 = 8
-;; @004e                               v46 = uadd_overflow_trap v44, v30, user1  ; v30 = 8
-;; @004e                               v47 = icmp ule v46, v8
-;; @004e                               trapz v47, user1
 ;;                                     v62 = iconst.i64 1
 ;; @004e                               v37 = iadd v36, v62  ; v62 = 1
-;; @004e                               v48 = iadd.i64 v6, v44
-;; @004e                               store notrap aligned v37, v48
+;; @004e                               store notrap aligned v37, v35
 ;;                                     v54 = load.i32 notrap v58
 ;; @004e                               store notrap aligned v54, v22
 ;;                                     v65 = iconst.i64 4

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -50,7 +50,6 @@
 ;; @0021                               trapz v32, user1
 ;; @0021                               v33 = iadd.i64 v14, v29
 ;; @0021                               v34 = load.i64 notrap aligned v33
-;; @0021                               trapz v32, user1
 ;;                                     v51 = iconst.i64 1
 ;; @0021                               v35 = iadd v34, v51  ; v51 = 1
 ;; @0021                               store notrap aligned v35, v33

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -55,16 +55,9 @@
 ;; @002a                               trapz v32, user1
 ;; @002a                               v33 = iadd.i64 v14, v29
 ;; @002a                               v34 = load.i64 notrap aligned v33
-;;                                     v48 = load.i32 notrap v51
-;; @002a                               v40 = uextend.i64 v48
-;; @002a                               v42 = uadd_overflow_trap v40, v28, user1  ; v28 = 8
-;; @002a                               v44 = uadd_overflow_trap v42, v28, user1  ; v28 = 8
-;; @002a                               v45 = icmp ule v44, v26
-;; @002a                               trapz v45, user1
 ;;                                     v58 = iconst.i64 1
 ;; @002a                               v35 = iadd v34, v58  ; v58 = 1
-;; @002a                               v46 = iadd.i64 v14, v42
-;; @002a                               store notrap aligned v35, v46
+;; @002a                               store notrap aligned v35, v33
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -108,7 +108,6 @@
 ;; @004a                               trapz v29, user1
 ;; @004a                               v30 = iadd.i64 v6, v26
 ;; @004a                               v31 = load.i64 notrap aligned v30
-;; @004a                               trapz v29, user1
 ;;                                     v74 = iconst.i64 1
 ;; @004a                               v32 = iadd v31, v74  ; v74 = 1
 ;; @004a                               store notrap aligned v32, v30
@@ -142,7 +141,6 @@
 ;; @004a                               jump block7
 ;;
 ;;                                 block6:
-;; @004a                               trapz.i8 v56, user1
 ;;                                     v84 = iadd.i64 v58, v76  ; v76 = -1
 ;; @004a                               store notrap aligned v84, v57
 ;; @004a                               jump block7

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -52,25 +52,12 @@
 ;; @0024                               trapz v39, user1
 ;; @0024                               v40 = iadd v8, v36
 ;; @0024                               v41 = load.i64 notrap aligned little v40
-;; @002b                               trapz v2, user16
-;; @002b                               trapz v16, user1
-;; @002b                               v53 = load.i32 notrap aligned v17
-;; @002b                               v54 = icmp ult v4, v53
+;; @002b                               v54 = icmp ult v4, v18
 ;; @002b                               trapz v54, user17
-;; @002b                               v56 = uextend.i64 v53
-;;                                     v99 = ishl v56, v79  ; v79 = 3
-;; @002b                               v58 = ushr v99, v77  ; v77 = 32
-;; @002b                               trapnz v58, user1
-;;                                     v106 = ishl v53, v89  ; v89 = 3
-;; @002b                               v61 = uadd_overflow_trap v106, v25, user1  ; v25 = 16
-;;                                     v113 = ishl v4, v89  ; v89 = 3
-;; @002b                               v64 = iadd v113, v25  ; v25 = 16
+;;                                     v99 = ishl v4, v89  ; v89 = 3
+;; @002b                               v64 = iadd v99, v25  ; v25 = 16
 ;; @002b                               v70 = uextend.i64 v64
 ;; @002b                               v71 = uadd_overflow_trap v11, v70, user1
-;; @002b                               v72 = uextend.i64 v61
-;; @002b                               v73 = uadd_overflow_trap v11, v72, user1
-;; @002b                               v74 = icmp ule v73, v10
-;; @002b                               trapz v74, user1
 ;; @002b                               v75 = iadd v8, v71
 ;; @002b                               v76 = load.i64 notrap aligned little v75
 ;; @002e                               jump block1

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -31,10 +31,8 @@
 ;; @0023                               v7 = load.i64 notrap aligned readonly v0+40
 ;; @0023                               v16 = iadd v7, v12
 ;; @0023                               v17 = load.f32 notrap aligned little v16
-;; @0029                               trapz v2, user16
 ;; @0029                               v24 = iconst.i64 12
 ;; @0029                               v25 = uadd_overflow_trap v10, v24, user1  ; v24 = 12
-;; @0029                               trapz v15, user1
 ;; @0029                               v29 = iadd v7, v25
 ;; @0029                               v30 = load.i8 notrap aligned little v29
 ;; @002d                               jump block1

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -31,12 +31,9 @@
 ;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i8x16 notrap aligned little v15
-;; @0028                               trapz v2, user16
-;; @0028                               trapz v14, user1
-;; @0028                               v29 = load.i8x16 notrap aligned little v15
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               v30 = bxor.i8x16 v16, v29
+;; @002c                               v30 = bxor.i8x16 v16, v16
 ;; @002e                               return v30
 ;; }

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -52,7 +52,6 @@
 ;; @0023                               trapz v33, user1
 ;; @0023                               v34 = iadd.i64 v15, v30
 ;; @0023                               v35 = load.i64 notrap aligned v34
-;; @0023                               trapz v33, user1
 ;;                                     v53 = iconst.i64 1
 ;; @0023                               v36 = iadd v35, v53  ; v53 = 1
 ;; @0023                               store notrap aligned v36, v34

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -55,16 +55,9 @@
 ;; @002a                               trapz v32, user1
 ;; @002a                               v33 = iadd.i64 v14, v29
 ;; @002a                               v34 = load.i64 notrap aligned v33
-;;                                     v48 = load.i32 notrap v51
-;; @002a                               v40 = uextend.i64 v48
-;; @002a                               v42 = uadd_overflow_trap v40, v28, user1  ; v28 = 8
-;; @002a                               v44 = uadd_overflow_trap v42, v28, user1  ; v28 = 8
-;; @002a                               v45 = icmp ule v44, v26
-;; @002a                               trapz v45, user1
 ;;                                     v58 = iconst.i64 1
 ;; @002a                               v35 = iadd v34, v58  ; v58 = 1
-;; @002a                               v46 = iadd.i64 v14, v42
-;; @002a                               store notrap aligned v35, v46
+;; @002a                               store notrap aligned v35, v33
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -14,5 +14,5 @@
 ;;       br_if_xulteq64 x6, x7, 0x9    // target = 0x1a
 ;;   18: pop_frame
 ;;       ret
-;;   1a: call 0x94    // target = 0xae
+;;   1a: call 0x89    // target = 0xa3
 ;;   1f: jump 0xfffffffffffffff9    // target = 0x18

--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -78,7 +78,7 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x3b4
+;;       bl      #0x398
 ;;   c4: add     sp, sp, #4
 ;;       mov     x28, sp
 ;;       ldur    x9, [x28, #0x14]
@@ -144,7 +144,7 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28, #0xc]
-;;       bl      #0x3b4
+;;       bl      #0x398
 ;;  1cc: add     sp, sp, #0xc
 ;;       mov     x28, sp
 ;;       add     sp, sp, #4

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -31,7 +31,7 @@
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;; 
+;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
@@ -72,7 +72,7 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x3a4
+;;       bl      #0x378
 ;;   e0: add     sp, sp, #4
 ;;       mov     x28, sp
 ;;       ldur    x9, [x28, #0x14]

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -76,7 +76,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x31a
+;;       callq   0x2f8
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
@@ -128,7 +128,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x31a
+;;       callq   0x2f8
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x20(%rsp), %r14

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -72,7 +72,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x35d
+;;       callq   0x331
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14

--- a/tests/disas/winch/x64/epoch/func.wat
+++ b/tests/disas/winch/x64/epoch/func.wat
@@ -23,7 +23,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x51
 ;;   44: movq    %r14, %rdi
-;;       callq   0x165
+;;       callq   0x14a
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/winch/x64/epoch/loop.wat
+++ b/tests/disas/winch/x64/epoch/loop.wat
@@ -25,7 +25,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x51
 ;;   44: movq    %r14, %rdi
-;;       callq   0x18f
+;;       callq   0x174
 ;;       movq    8(%rsp), %r14
 ;;       movq    0x20(%r14), %rdx
 ;;       movq    (%rdx), %rdx
@@ -34,7 +34,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x76
 ;;   69: movq    %r14, %rdi
-;;       callq   0x18f
+;;       callq   0x174
 ;;       movq    8(%rsp), %r14
 ;;       jmp     0x51
 ;;   7b: addq    $0x10, %rsp

--- a/tests/disas/winch/x64/fuel/call.wat
+++ b/tests/disas/winch/x64/fuel/call.wat
@@ -24,7 +24,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x4a
 ;;   3d: movq    %r14, %rdi
-;;       callq   0x20c
+;;       callq   0x1f1
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
@@ -66,7 +66,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0xea
 ;;   dd: movq    %r14, %rdi
-;;       callq   0x20c
+;;       callq   0x1f1
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11

--- a/tests/disas/winch/x64/fuel/func.wat
+++ b/tests/disas/winch/x64/fuel/func.wat
@@ -20,7 +20,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x4a
 ;;   3d: movq    %r14, %rdi
-;;       callq   0x16c
+;;       callq   0x151
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11

--- a/tests/disas/winch/x64/fuel/loop.wat
+++ b/tests/disas/winch/x64/fuel/loop.wat
@@ -22,7 +22,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x4a
 ;;   3d: movq    %r14, %rdi
-;;       callq   0x19d
+;;       callq   0x182
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
@@ -33,7 +33,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x76
 ;;   69: movq    %r14, %rdi
-;;       callq   0x19d
+;;       callq   0x182
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11

--- a/tests/disas/winch/x64/load/grow_load.wat
+++ b/tests/disas/winch/x64/load/grow_load.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
 ;;       movl    $0, %edx
-;;       callq   0x2eb
+;;       callq   0x2de
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x58(%rsp), %r14

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -113,7 +113,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x516
+;;       callq   0x4d4
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
@@ -133,7 +133,7 @@
 ;;       movl    0xc(%rsp), %edx
 ;;       movq    4(%rsp), %rcx
 ;;       movl    (%rsp), %r8d
-;;       callq   0x557
+;;       callq   0x515
 ;;       addq    $0x10, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       addq    $0x30, %rsp

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x32e
+;;       callq   0x2f1
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/grow.wat
+++ b/tests/disas/winch/x64/table/grow.wat
@@ -30,7 +30,7 @@
 ;;       movl    $0, %esi
 ;;       movl    $0xa, %edx
 ;;       movq    8(%rsp), %rcx
-;;       callq   0x197
+;;       callq   0x175
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x975
+;;       callq   0x929
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x9d0
+;;       callq   0x984
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x975
+;;       callq   0x929
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x9d0
+;;       callq   0x984
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0xa0f
+;;       callq   0x9c3
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0xa0f
+;;       callq   0x9c3
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0xa0f
+;;       callq   0x9c3
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0xa0f
+;;       callq   0x9c3
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0xa0f
+;;       callq   0x9c3
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -243,7 +243,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0xa6a
+;;       callq   0xa1e
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -109,7 +109,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x500
+;;       callq   0x4cd
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14


### PR DESCRIPTION
This commit extends our existing support for merging idempotently side-effectful instructions that produce exactly one value to those that produce zero or one value, and marks the `trap[n]z` instructions as having idempotent side effects. This cleans up a lot test cases in our `disas` test suite, particularly those related to explicit bounds checks and GC.

As an aside, it seems like it should be easy to extend this to idempotently side-effectful instructions that produce multiple values as well, but I don't believe we have any such instructions, so I didn't bother.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
