### PR TITLE
Fix dropping cached stack with `Store::into_data`

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -655,6 +655,8 @@ impl<T> Store<T> {
 
     /// Consumes this [`Store`], destroying it, and returns the underlying data.
     pub fn into_data(mut self) -> T {
+        self.inner.flush_fiber_stack();
+
         // This is an unsafe operation because we want to avoid having a runtime
         // check or boolean for whether the data is actually contained within a
         // `Store`. The data itself is stored as `ManuallyDrop` since we're


### PR DESCRIPTION
This commit fixes a regression from #9604 where using `Store::into_data` wouldn't properly drop a cached stack in a store like a `Drop` destructor. The fix here is to add the `flush_fiber_stack` method into the `into_data` here as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
