### PR TITLE
Emit post-optimization CLIF with `--emit-clif`

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -23,7 +23,7 @@ struct TrampolineCompiler<'a> {
     tunables: &'a Tunables,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 enum Abi {
     Wasm,
     Array,
@@ -746,7 +746,10 @@ impl ComponentCompiler for Compiler {
             c.translate(&component.trampolines[index]);
             c.builder.finalize();
 
-            Ok(Box::new(compiler.finish()?))
+            Ok(Box::new(compiler.finish(&format!(
+                "component_trampoline_{}_{abi:?}",
+                index.as_u32(),
+            ))?))
         };
         Ok(AllCallFunc {
             wasm_call: compile(Abi::Wasm)?,

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -20,16 +20,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0021                               v5 = uextend.i64 v2
-;; @0021                               v6 = global_value.i64 gv5
+;; @0021                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0021                               v7 = iadd v6, v5
 ;; @0021                               v8 = load.i32 little heap v7
 ;; @0026                               v9 = uextend.i64 v3
-;; @0026                               v10 = global_value.i64 gv5
+;; @0026                               v10 = load.i64 notrap aligned readonly checked v0+96
 ;; @0026                               v11 = iadd v10, v9
 ;; @0026                               v12 = load.i32 little heap v11
 ;; @0029                               v13 = iadd v8, v12
-;; @002a                               jump block1(v13)
+;; @002a                               jump block1
 ;;
-;;                                 block1(v4: i32):
-;; @002a                               return v4
+;;                                 block1:
+;; @002a                               return v13
 ;; }

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -43,28 +43,28 @@
 ;; @0025                               br_table v7, block8, [block5, block6, block7]  ; v7 = 0
 ;;
 ;;                                 block5:
-;; @0025                               jump block4(v6)  ; v6 = 42
+;; @0025                               jump block4
 ;;
 ;;                                 block6:
-;; @0025                               jump block3(v6)  ; v6 = 42
+;; @0025                               jump block3
 ;;
 ;;                                 block7:
-;; @0025                               jump block2(v6)  ; v6 = 42
+;; @0025                               jump block2
 ;;
 ;;                                 block8:
-;; @0025                               jump block1(v6)  ; v6 = 42
+;; @0025                               jump block1
 ;;
-;;                                 block4(v5: i32):
-;; @002c                               jump block3(v5)
+;;                                 block4:
+;; @002c                               jump block3
 ;;
-;;                                 block3(v4: i32):
-;; @002d                               jump block2(v4)
+;;                                 block3:
+;; @002d                               jump block2
 ;;
-;;                                 block2(v3: i32):
-;; @002e                               jump block1(v3)
+;;                                 block2:
+;; @002e                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @002e                               return v2
+;;                                 block1:
+;; @002e                               return v6  ; v6 = 42
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -79,28 +79,28 @@
 ;; @003b                               br_table v7, block8, [block5, block6, block7]  ; v7 = 0
 ;;
 ;;                                 block5:
-;; @003b                               jump block1(v6)  ; v6 = 42
+;; @003b                               jump block1
 ;;
 ;;                                 block6:
-;; @003b                               jump block2(v6)  ; v6 = 42
+;; @003b                               jump block2
 ;;
 ;;                                 block7:
-;; @003b                               jump block3(v6)  ; v6 = 42
+;; @003b                               jump block3
 ;;
 ;;                                 block8:
-;; @003b                               jump block4(v6)  ; v6 = 42
+;; @003b                               jump block4
 ;;
-;;                                 block4(v5: i32):
-;; @0042                               jump block3(v5)
+;;                                 block4:
+;; @0042                               jump block3
 ;;
-;;                                 block3(v4: i32):
-;; @0043                               jump block2(v4)
+;;                                 block3:
+;; @0043                               jump block2
 ;;
-;;                                 block2(v3: i32):
-;; @0044                               jump block1(v3)
+;;                                 block2:
+;; @0044                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0044                               return v2
+;;                                 block1:
+;; @0044                               return v6  ; v6 = 42
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -115,16 +115,16 @@
 ;; @004d                               br_table v5, block4, [block3, block3, block4]  ; v5 = 0
 ;;
 ;;                                 block3:
-;; @004d                               jump block2(v4)  ; v4 = 42
+;; @004d                               jump block2
 ;;
 ;;                                 block4:
-;; @004d                               jump block1(v4)  ; v4 = 42
+;; @004d                               jump block1
 ;;
-;;                                 block2(v3: i32):
-;; @0054                               jump block1(v3)
+;;                                 block2:
+;; @0054                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0054                               return v2
+;;                                 block1:
+;; @0054                               return v4  ; v4 = 42
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
@@ -139,14 +139,14 @@
 ;; @005d                               br_table v5, block4, [block3, block3, block4]  ; v5 = 0
 ;;
 ;;                                 block3:
-;; @005d                               jump block1(v4)  ; v4 = 42
+;; @005d                               jump block1
 ;;
 ;;                                 block4:
-;; @005d                               jump block2(v4)  ; v4 = 42
+;; @005d                               jump block2
 ;;
-;;                                 block2(v3: i32):
-;; @0064                               jump block1(v3)
+;;                                 block2:
+;; @0064                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0064                               return v2
+;;                                 block1:
+;; @0064                               return v4  ; v4 = 42
 ;; }

--- a/tests/disas/call-simd.wat
+++ b/tests/disas/call-simd.wat
@@ -45,8 +45,8 @@
 ;; @004f                               v6 = bitcast.i32x4 little v3
 ;; @004f                               v7 = iadd v5, v6
 ;; @0052                               v8 = bitcast.i8x16 little v7
-;; @0052                               jump block1(v8)
+;; @0052                               jump block1
 ;;
-;;                                 block1(v4: i8x16):
-;; @0052                               return v4
+;;                                 block1:
+;; @0052                               return v8
 ;; }

--- a/tests/disas/call.wat
+++ b/tests/disas/call.wat
@@ -37,8 +37,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @002b                               v3 = iconst.i32 1
-;; @002d                               jump block1(v3)  ; v3 = 1
+;; @002d                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @002d                               return v2
+;;                                 block1:
+;; @002d                               return v3  ; v3 = 1
 ;; }

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -17,11 +17,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv5
+;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f32 little heap v6
-;; @0031                               jump block1(v7)
+;; @0031                               jump block1
 ;;
-;;                                 block1(v3: f32):
-;; @0031                               return v3
+;;                                 block1:
+;; @0031                               return v7
 ;; }

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv5
+;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f64 little heap v6
-;; @0031                               jump block1(v7)
+;; @0031                               jump block1
 ;;
-;;                                 block1(v3: f64):
-;; @0031                               return v3
+;;                                 block1:
+;; @0031                               return v7
 ;; }

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -27,10 +27,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0040                               jump block1(v2, v2)
+;; @0040                               jump block1
 ;;
-;;                                 block1(v3: i64, v4: i64):
-;; @0040                               return v3, v4
+;;                                 block1:
+;; @0040                               return v2, v2
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail {
@@ -40,10 +40,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0049                               jump block1(v2, v3, v2)
+;; @0049                               jump block1
 ;;
-;;                                 block1(v4: i64, v5: i64, v6: i64):
-;; @0049                               return v4, v5, v6
+;;                                 block1:
+;; @0049                               return v2, v3, v2
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i64) -> i64 tail {

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -55,7 +55,7 @@
 ;;                                 block2:
 ;; @0056                               v16 = iconst.i32 0
 ;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
-;; @005a                               v18 = global_value.i64 gv5
+;; @005a                               v18 = load.i64 notrap aligned readonly checked v0+96
 ;; @005a                               v19 = iadd v18, v17
 ;; @005a                               store.i32 little heap v11, v19
 ;; @005d                               jump block1

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -34,7 +34,7 @@
 ;; @0041                               v5 = iconst.i64 0x0001_0000
 ;; @0041                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = global_value.i64 gv5
+;; @0041                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0041                               v8 = iadd v7, v4
 ;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
@@ -57,11 +57,11 @@
 ;; @0049                               v5 = iconst.i64 0x0001_0000
 ;; @0049                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = uload8.i32 little heap v8
-;; @004c                               jump block1(v9)
+;; @004c                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004c                               return v3
+;;                                 block1:
+;; @004c                               return v9
 ;; }

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -21,10 +21,9 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0027                               v2 = iconst.i32 0
 ;; @0029                               v3 = iconst.i32 0
-;; @002b                               v4 = global_value.i64 gv3
-;; @002b                               v5 = load.i32 notrap aligned table v4+112
+;; @002b                               v5 = load.i32 notrap aligned table v0+112
 ;; @002d                               v6 = uextend.i64 v3  ; v3 = 0
-;; @002d                               v7 = global_value.i64 gv5
+;; @002d                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @002d                               v8 = iadd v7, v6
 ;; @002d                               store little heap v5, v8
 ;; @0030                               jump block1

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv5
+;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i32 little heap v6
-;; @0031                               jump block1(v7)
+;; @0031                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0031                               return v3
+;;                                 block1:
+;; @0031                               return v7
 ;; }

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv5
+;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i32 little heap v6
-;; @0035                               jump block1(v7)
+;; @0035                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0035                               return v3
+;;                                 block1:
+;; @0035                               return v7
 ;; }

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv5
+;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i32 little heap v6
-;; @0035                               jump block1(v7)
+;; @0035                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0035                               return v3
+;;                                 block1:
+;; @0035                               return v7
 ;; }

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i32 little heap v6
-;; @0034                               jump block1(v7)
+;; @0034                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0034                               return v3
+;;                                 block1:
+;; @0034                               return v7
 ;; }

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i32 little heap v6
-;; @0034                               jump block1(v7)
+;; @0034                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0034                               return v3
+;;                                 block1:
+;; @0034                               return v7
 ;; }

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = global_value.i64 gv5
+;; @0033                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv5
+;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = global_value.i64 gv5
+;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i64 little heap v6
-;; @0031                               jump block1(v7)
+;; @0031                               jump block1
 ;;
-;;                                 block1(v3: i64):
-;; @0031                               return v3
+;;                                 block1:
+;; @0031                               return v7
 ;; }

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv5
+;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i64 little heap v6
-;; @0035                               jump block1(v7)
+;; @0035                               jump block1
 ;;
-;;                                 block1(v3: i64):
-;; @0035                               return v3
+;;                                 block1:
+;; @0035                               return v7
 ;; }

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv5
+;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i64 little heap v6
-;; @0035                               jump block1(v7)
+;; @0035                               jump block1
 ;;
-;;                                 block1(v3: i64):
-;; @0035                               return v3
+;;                                 block1:
+;; @0035                               return v7
 ;; }

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i64 little heap v6
-;; @0034                               jump block1(v7)
+;; @0034                               jump block1
 ;;
-;;                                 block1(v3: i64):
-;; @0034                               return v3
+;;                                 block1:
+;; @0034                               return v7
 ;; }

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -19,11 +19,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i64 little heap v6
-;; @0034                               jump block1(v7)
+;; @0034                               jump block1
 ;;
-;;                                 block1(v3: i64):
-;; @0034                               return v3
+;;                                 block1:
+;; @0034                               return v7
 ;; }

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = global_value.i64 gv5
+;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = global_value.i64 gv5
+;; @0033                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = global_value.i64 gv5
+;; @0033                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore32 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -20,7 +20,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = global_value.i64 gv5
+;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -23,25 +23,25 @@
 ;; @0033                               v5 = iconst.i32 23
 ;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
 ;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = global_value.i64 gv4
-;; @0033                               v9 = ishl_imm v7, 3
+;; @0033                               v8 = load.i64 notrap aligned readonly v0+88
+;;                                     v29 = iconst.i64 3
+;; @0033                               v9 = ishl v7, v29  ; v29 = 3
 ;; @0033                               v10 = iadd v8, v9
 ;; @0033                               v11 = iconst.i64 0
 ;; @0033                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0033                               v13 = load.i64 user5 aligned table v12
-;; @0033                               v14 = band_imm v13, -2
+;;                                     v30 = iconst.i64 -2
+;; @0033                               v14 = band v13, v30  ; v30 = -2
 ;; @0033                               brif v13, block3(v14), block2
 ;;
 ;;                                 block2 cold:
 ;; @0033                               v16 = iconst.i32 0
-;; @0033                               v17 = global_value.i64 gv3
 ;; @0033                               v18 = uextend.i64 v2
-;; @0033                               v19 = call fn0(v17, v16, v18)  ; v16 = 0
+;; @0033                               v19 = call fn0(v0, v16, v18)  ; v16 = 0
 ;; @0033                               jump block3(v19)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               v20 = global_value.i64 gv3
-;; @0033                               v21 = load.i64 notrap aligned readonly v20+80
+;; @0033                               v21 = load.i64 notrap aligned readonly v0+80
 ;; @0033                               v22 = load.i32 notrap aligned readonly v21
 ;; @0033                               v23 = load.i32 user6 aligned readonly v15+16
 ;; @0033                               v24 = icmp eq v23, v22
@@ -49,8 +49,8 @@
 ;; @0033                               v25 = load.i64 notrap aligned readonly v15+8
 ;; @0033                               v26 = load.i64 notrap aligned readonly v15+24
 ;; @0033                               v27 = call_indirect sig0, v25(v26, v0, v3)
-;; @0036                               jump block1(v27)
+;; @0036                               jump block1
 ;;
-;;                                 block1(v4: i8x16):
-;; @0036                               return v4
+;;                                 block1:
+;; @0036                               return v27
 ;; }

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -23,25 +23,25 @@
 ;; @0033                               v5 = iconst.i32 23
 ;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
 ;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = global_value.i64 gv4
-;; @0033                               v9 = ishl_imm v7, 3
+;; @0033                               v8 = load.i64 notrap aligned readonly v0+88
+;;                                     v29 = iconst.i64 3
+;; @0033                               v9 = ishl v7, v29  ; v29 = 3
 ;; @0033                               v10 = iadd v8, v9
 ;; @0033                               v11 = iconst.i64 0
 ;; @0033                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0033                               v13 = load.i64 user5 aligned table v12
-;; @0033                               v14 = band_imm v13, -2
+;;                                     v30 = iconst.i64 -2
+;; @0033                               v14 = band v13, v30  ; v30 = -2
 ;; @0033                               brif v13, block3(v14), block2
 ;;
 ;;                                 block2 cold:
 ;; @0033                               v16 = iconst.i32 0
-;; @0033                               v17 = global_value.i64 gv3
 ;; @0033                               v18 = uextend.i64 v2
-;; @0033                               v19 = call fn0(v17, v16, v18)  ; v16 = 0
+;; @0033                               v19 = call fn0(v0, v16, v18)  ; v16 = 0
 ;; @0033                               jump block3(v19)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               v20 = global_value.i64 gv3
-;; @0033                               v21 = load.i64 notrap aligned readonly v20+80
+;; @0033                               v21 = load.i64 notrap aligned readonly v0+80
 ;; @0033                               v22 = load.i32 notrap aligned readonly v21
 ;; @0033                               v23 = load.i32 user6 aligned readonly v15+16
 ;; @0033                               v24 = icmp eq v23, v22
@@ -49,8 +49,8 @@
 ;; @0033                               v25 = load.i64 notrap aligned readonly v15+8
 ;; @0033                               v26 = load.i64 notrap aligned readonly v15+24
 ;; @0033                               v27 = call_indirect sig0, v25(v26, v0, v3)
-;; @0036                               jump block1(v27)
+;; @0036                               jump block1
 ;;
-;;                                 block1(v4: i32):
-;; @0036                               return v4
+;;                                 block1:
+;; @0036                               return v27
 ;; }

--- a/tests/disas/if-reachability-translation-1.wat
+++ b/tests/disas/if-reachability-translation-1.wat
@@ -30,8 +30,8 @@
 ;;
 ;;                                 block3:
 ;; @0021                               v4 = iconst.i32 0
-;; @0023                               jump block1(v4)  ; v4 = 0
+;; @0023                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0023                               return v3
+;;                                 block1:
+;; @0023                               return v4  ; v4 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -30,8 +30,8 @@
 ;;
 ;;                                 block3:
 ;; @0021                               v4 = iconst.i32 0
-;; @0023                               jump block1(v4)  ; v4 = 0
+;; @0023                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0023                               return v3
+;;                                 block1:
+;; @0023                               return v4  ; v4 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -30,8 +30,8 @@
 ;;
 ;;                                 block3:
 ;; @0021                               v4 = iconst.i32 0
-;; @0023                               jump block1(v4)  ; v4 = 0
+;; @0023                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0023                               return v3
+;;                                 block1:
+;; @0023                               return v4  ; v4 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -35,8 +35,8 @@
 ;;
 ;;                                 block3:
 ;; @0026                               v5 = iconst.i32 0
-;; @0028                               jump block1(v5)  ; v5 = 0
+;; @0028                               jump block1
 ;;
-;;                                 block1(v4: i32):
-;; @0028                               return v4
+;;                                 block1:
+;; @0028                               return v5  ; v5 = 0
 ;; }

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -35,8 +35,8 @@
 ;;
 ;;                                 block3:
 ;; @0026                               v5 = iconst.i32 0
-;; @0028                               jump block1(v5)  ; v5 = 0
+;; @0028                               jump block1
 ;;
-;;                                 block1(v4: i32):
-;; @0028                               return v4
+;;                                 block1:
+;; @0028                               return v5  ; v5 = 0
 ;; }

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -30,21 +30,21 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0049                               v5 = f64const 0x1.0000000000000p0
-;; @0056                               brif v3, block2, block4(v2)
+;; @0056                               brif v3, block2, block4
 ;;
 ;;                                 block2:
 ;; @0058                               v7 = uextend.i64 v2
-;; @0058                               v8 = global_value.i64 gv5
+;; @0058                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0058                               v9 = iadd v8, v7
 ;; @0058                               v10 = sload16.i64 little heap v9
 ;; @005c                               jump block3
 ;;
-;;                                 block4(v6: i32):
+;;                                 block4:
 ;; @005d                               trap user11
 ;;
 ;;                                 block3:
-;; @005f                               jump block1(v5)  ; v5 = 0x1.0000000000000p0
+;; @005f                               jump block1
 ;;
-;;                                 block1(v4: f64):
-;; @005f                               return v4
+;;                                 block1:
+;; @005f                               return v5  ; v5 = 0x1.0000000000000p0
 ;; }

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -53,19 +53,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0043                               v3 = iconst.i32 35
-;; @0045                               jump block2(v3)  ; v3 = 35
+;; @0045                               jump block2
 ;;
-;;                                 block2(v4: i32):
-;; @0049                               brif.i32 v2, block4, block6(v4)
+;;                                 block2:
+;; @0049                               brif.i32 v2, block4, block6
 ;;
 ;;                                 block4:
-;; @004b                               v7 = uextend.i64 v4
-;; @004b                               v8 = global_value.i64 gv5
+;; @004b                               v7 = uextend.i64 v3  ; v3 = 35
+;; @004b                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @004b                               v9 = iadd v8, v7
 ;; @004b                               v10 = sload16.i64 little heap v9
 ;; @004e                               trap user11
 ;;
-;;                                 block6(v6: i32):
-;; @005d                               v11 = popcnt.i32 v4
+;;                                 block6:
+;; @005d                               v11 = popcnt.i32 v3  ; v3 = 35
 ;; @0060                               return
 ;; }

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -28,10 +28,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @003f                               v3 = iconst.i32 1
-;; @0041                               jump block1(v3)  ; v3 = 1
+;; @0041                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0041                               return v2
+;;                                 block1:
+;; @0041                               return v3  ; v3 = 1
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -42,10 +42,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0044                               v3 = iconst.i32 2
-;; @0046                               jump block1(v3)  ; v3 = 2
+;; @0046                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0046                               return v2
+;;                                 block1:
+;; @0046                               return v3  ; v3 = 2
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -56,10 +56,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = iconst.i32 3
-;; @004b                               jump block1(v3)  ; v3 = 3
+;; @004b                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @004b                               return v2
+;;                                 block1:
+;; @004b                               return v3  ; v3 = 3
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
@@ -77,25 +77,25 @@
 ;; @0050                               v4 = iconst.i32 10
 ;; @0050                               v5 = icmp uge v2, v4  ; v4 = 10
 ;; @0050                               v6 = uextend.i64 v2
-;; @0050                               v7 = global_value.i64 gv4
-;; @0050                               v8 = ishl_imm v6, 3
+;; @0050                               v7 = load.i64 notrap aligned readonly v0+88
+;;                                     v28 = iconst.i64 3
+;; @0050                               v8 = ishl v6, v28  ; v28 = 3
 ;; @0050                               v9 = iadd v7, v8
 ;; @0050                               v10 = iconst.i64 0
 ;; @0050                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0050                               v12 = load.i64 user5 aligned table v11
-;; @0050                               v13 = band_imm v12, -2
+;;                                     v29 = iconst.i64 -2
+;; @0050                               v13 = band v12, v29  ; v29 = -2
 ;; @0050                               brif v12, block3(v13), block2
 ;;
 ;;                                 block2 cold:
 ;; @0050                               v15 = iconst.i32 0
-;; @0050                               v16 = global_value.i64 gv3
 ;; @0050                               v17 = uextend.i64 v2
-;; @0050                               v18 = call fn0(v16, v15, v17)  ; v15 = 0
+;; @0050                               v18 = call fn0(v0, v15, v17)  ; v15 = 0
 ;; @0050                               jump block3(v18)
 ;;
 ;;                                 block3(v14: i64):
-;; @0050                               v19 = global_value.i64 gv3
-;; @0050                               v20 = load.i64 notrap aligned readonly v19+80
+;; @0050                               v20 = load.i64 notrap aligned readonly v0+80
 ;; @0050                               v21 = load.i32 notrap aligned readonly v20
 ;; @0050                               v22 = load.i32 user6 aligned readonly v14+16
 ;; @0050                               v23 = icmp eq v22, v21
@@ -103,8 +103,8 @@
 ;; @0050                               v24 = load.i64 notrap aligned readonly v14+8
 ;; @0050                               v25 = load.i64 notrap aligned readonly v14+24
 ;; @0050                               v26 = call_indirect sig0, v24(v25, v0)
-;; @0053                               jump block1(v26)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v26
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -29,12 +29,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = iconst.i64 4
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               store little heap v3, v10
 ;; @0043                               jump block1
@@ -54,16 +54,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = iconst.i64 4
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
 ;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = global_value.i64 gv5
+;; @0048                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = load.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -29,12 +29,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = iconst.i64 4100
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -56,18 +56,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = iconst.i64 4100
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = load.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -31,10 +31,10 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0004
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = load.i64 notrap aligned v0+104
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -58,16 +58,16 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0004
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = load.i64 notrap aligned v0+104
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v9 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = load.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -29,10 +29,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
@@ -52,14 +52,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = uload8.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -29,12 +29,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = iconst.i64 4097
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -56,18 +56,18 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = iconst.i64 4097
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = uload8.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -31,10 +31,10 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0001
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = load.i64 notrap aligned v0+104
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -58,16 +58,16 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0001
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = load.i64 notrap aligned v0+104
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v9 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = uload8.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -29,11 +29,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = iconst.i64 4
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
@@ -55,17 +55,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = iconst.i64 4
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
-;; @0048                               v9 = global_value.i64 gv5
+;; @0048                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = iconst.i64 0
 ;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @0048                               v13 = load.i32 little heap v12
-;; @004b                               jump block1(v13)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -29,11 +29,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = iconst.i64 4100
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -57,19 +57,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = iconst.i64 4100
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
 ;; @0049                               v15 = load.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v15
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -31,9 +31,9 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0004
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = load.i64 notrap aligned v0+104
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -59,17 +59,17 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0004
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = load.i64 notrap aligned v0+104
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v9 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
 ;; @004c                               v15 = load.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v15
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -29,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -53,15 +53,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0048                               v11 = uload8.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -29,11 +29,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = iconst.i64 4097
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -57,19 +57,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = iconst.i64 4097
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = global_value.i64 gv5
+;; @0049                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096
 ;; @0049                               v13 = iconst.i64 0
 ;; @0049                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
 ;; @0049                               v15 = uload8.i32 little heap v14
-;; @004d                               jump block1(v15)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v15
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -31,9 +31,9 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_0001
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @0040                               v7 = global_value.i64 gv4
+;; @0040                               v7 = load.i64 notrap aligned v0+104
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = global_value.i64 gv5
+;; @0040                               v9 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -59,17 +59,17 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff_0001
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
-;; @004c                               v7 = global_value.i64 gv4
+;; @004c                               v7 = load.i64 notrap aligned v0+104
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = global_value.i64 gv5
+;; @004c                               v9 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
 ;; @004c                               v13 = iconst.i64 0
 ;; @004c                               v14 = select_spectre_guard v8, v13, v12  ; v13 = 0
 ;; @004c                               v15 = uload8.i32 little heap v14
-;; @0053                               jump block1(v15)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v15
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -29,10 +29,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
@@ -52,14 +52,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = icmp ugt v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = load.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -29,10 +29,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -54,16 +54,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = load.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -29,10 +29,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -54,16 +54,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = load.i64 notrap aligned v0+104
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = load.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -29,10 +29,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
@@ -52,14 +52,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = uload8.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -29,10 +29,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -54,16 +54,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = uload8.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -29,10 +29,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -54,16 +54,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = load.i64 notrap aligned v0+104
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = uload8.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -29,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -53,15 +53,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = icmp ugt v4, v5
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0048                               v11 = load.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -29,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -55,17 +55,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0049                               v13 = load.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -29,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -55,17 +55,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = load.i64 notrap aligned v0+104
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @004c                               v13 = load.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -29,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -53,15 +53,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv4
+;; @0048                               v5 = load.i64 notrap aligned v0+104
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0048                               v11 = uload8.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -29,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -55,17 +55,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0049                               v13 = uload8.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -29,9 +29,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv4
+;; @0040                               v5 = load.i64 notrap aligned v0+104
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -55,17 +55,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv4
+;; @004c                               v5 = load.i64 notrap aligned v0+104
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @004c                               v13 = uload8.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -28,12 +28,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = iconst.i64 4
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               store little heap v3, v9
 ;; @0043                               jump block1
@@ -52,16 +52,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = iconst.i64 4
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
 ;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = global_value.i64 gv5
+;; @0048                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -28,12 +28,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = iconst.i64 4100
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -54,18 +54,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = iconst.i64 4100
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -30,10 +30,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0004
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = load.i64 notrap aligned v0+104
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -56,16 +56,16 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0004
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = load.i64 notrap aligned v0+104
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v8 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -50,14 +50,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -28,12 +28,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = iconst.i64 4097
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -54,18 +54,18 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = iconst.i64 4097
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -30,10 +30,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0001
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = load.i64 notrap aligned v0+104
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -56,16 +56,16 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0001
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = load.i64 notrap aligned v0+104
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v8 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -28,11 +28,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = iconst.i64 4
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
@@ -53,17 +53,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = iconst.i64 4
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               v8 = global_value.i64 gv5
+;; @0048                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = iconst.i64 0
 ;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
 ;; @0048                               v12 = load.i32 little heap v11
-;; @004b                               jump block1(v12)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -28,11 +28,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = iconst.i64 4100
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -55,19 +55,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = iconst.i64 4100
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
 ;; @0049                               v14 = load.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,9 +30,9 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0004
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = load.i64 notrap aligned v0+104
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -57,17 +57,17 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0004
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = load.i64 notrap aligned v0+104
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v8 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
 ;; @004c                               v14 = load.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -28,9 +28,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -51,15 +51,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -28,11 +28,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = iconst.i64 4097
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -55,19 +55,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = iconst.i64 4097
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = global_value.i64 gv5
+;; @0049                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
 ;; @0049                               v12 = iconst.i64 0
 ;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
 ;; @0049                               v14 = uload8.i32 little heap v13
-;; @004d                               jump block1(v14)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -30,9 +30,9 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_0001
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @0040                               v6 = global_value.i64 gv4
+;; @0040                               v6 = load.i64 notrap aligned v0+104
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = global_value.i64 gv5
+;; @0040                               v8 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -57,17 +57,17 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff_0001
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = global_value.i64 gv4
+;; @004c                               v6 = load.i64 notrap aligned v0+104
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = global_value.i64 gv5
+;; @004c                               v8 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
 ;; @004c                               v12 = iconst.i64 0
 ;; @004c                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
 ;; @004c                               v14 = uload8.i32 little heap v13
-;; @0053                               jump block1(v14)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v14
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -50,14 +50,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = icmp ugt v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -52,16 +52,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = load.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -52,16 +52,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v4 = load.i64 notrap aligned v0+104
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = load.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -50,14 +50,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -52,16 +52,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = uload8.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -52,16 +52,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v4 = load.i64 notrap aligned v0+104
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = uload8.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -28,9 +28,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -51,15 +51,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = icmp ugt v2, v4
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -28,9 +28,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -53,17 +53,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -28,9 +28,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -53,17 +53,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v4 = load.i64 notrap aligned v0+104
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -28,9 +28,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -51,15 +51,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0048                               v4 = global_value.i64 gv4
+;; @0048                               v4 = load.i64 notrap aligned v0+104
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -28,9 +28,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -53,17 +53,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0049                               v4 = global_value.i64 gv4
+;; @0049                               v4 = load.i64 notrap aligned v0+104
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -28,9 +28,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0040                               v4 = global_value.i64 gv4
+;; @0040                               v4 = load.i64 notrap aligned v0+104
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -53,17 +53,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @004c                               v4 = global_value.i64 gv4
+;; @004c                               v4 = load.i64 notrap aligned v0+104
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
@@ -55,11 +55,11 @@
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = load.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -57,13 +57,13 @@
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = load.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -57,13 +57,13 @@
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = load.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -49,11 +49,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv5
+;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -57,13 +57,13 @@
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = uload8.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -57,13 +57,13 @@
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = uload8.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -55,13 +55,13 @@
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0048                               v7 = global_value.i64 gv5
+;; @0048                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0048                               v11 = load.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v11
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -57,15 +57,15 @@
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0049                               v13 = load.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -57,15 +57,15 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @004c                               v13 = load.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -49,11 +49,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv5
+;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -57,15 +57,15 @@
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
 ;; @0049                               v11 = iconst.i64 0
 ;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0049                               v13 = uload8.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @0040                               v7 = global_value.i64 gv5
+;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -57,15 +57,15 @@
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @004c                               v7 = global_value.i64 gv5
+;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
 ;; @004c                               v11 = iconst.i64 0
 ;; @004c                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @004c                               v13 = uload8.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v13
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -49,11 +49,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv5
+;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv5
+;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
 ;; @0049                               v9 = load.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv5
+;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
 ;; @004c                               v9 = load.i32 little heap v8
-;; @0053                               jump block1(v9)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -49,11 +49,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv5
+;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv5
+;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
 ;; @0049                               v9 = uload8.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv5
+;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
 ;; @004c                               v9 = uload8.i32 little heap v8
-;; @0053                               jump block1(v9)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -49,11 +49,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv5
+;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv5
+;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
 ;; @0049                               v9 = load.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv5
+;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
 ;; @004c                               v9 = load.i32 little heap v8
-;; @0053                               jump block1(v9)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -49,11 +49,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = global_value.i64 gv5
+;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v7
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv5
+;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
 ;; @0049                               v9 = uload8.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -29,7 +29,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = global_value.i64 gv5
+;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -51,13 +51,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = global_value.i64 gv5
+;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
 ;; @004c                               v9 = uload8.i32 little heap v8
-;; @0053                               jump block1(v9)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v9
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -53,11 +53,11 @@
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,13 +55,13 @@
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = load.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,13 +55,13 @@
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = load.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -53,11 +53,11 @@
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,13 +55,13 @@
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = uload8.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,13 +55,13 @@
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = uload8.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -53,13 +53,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -53,13 +53,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -53,11 +53,11 @@
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,13 +55,13 @@
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = load.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,13 +55,13 @@
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = load.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -53,11 +53,11 @@
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v8
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,13 +55,13 @@
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = uload8.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -31,7 +31,7 @@
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,13 +55,13 @@
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = uload8.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -53,13 +53,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -53,13 +53,13 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = global_value.i64 gv5
+;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0048                               v10 = uload8.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @004b                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004b                               return v3
+;;                                 block1:
+;; @004b                               return v10
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = global_value.i64 gv5
+;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
 ;; @0049                               v10 = iconst.i64 0
 ;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @004d                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004d                               return v3
+;;                                 block1:
+;; @004d                               return v12
 ;; }

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -30,7 +30,7 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = global_value.i64 gv5
+;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -55,15 +55,15 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = global_value.i64 gv5
+;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
 ;; @004c                               v10 = iconst.i64 0
 ;; @004c                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @0053                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0053                               return v3
+;;                                 block1:
+;; @0053                               return v12
 ;; }

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -26,12 +26,12 @@
 ;; @0021                               v3 = iconst.i32 0
 ;; @0023                               v4 = iconst.i32 0
 ;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0025                               v6 = global_value.i64 gv5
+;; @0025                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0025                               v7 = iadd v6, v5
 ;; @0025                               store little heap v4, v7  ; v4 = 0
 ;; @0028                               v8 = iconst.i32 0
 ;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
-;; @002a                               v10 = global_value.i64 gv5
+;; @002a                               v10 = load.i64 notrap aligned readonly checked v0+96
 ;; @002a                               v11 = iadd v10, v9
 ;; @002a                               v12 = load.i32 little heap v11
 ;; @002d                               brif v12, block2, block4
@@ -40,7 +40,7 @@
 ;; @002f                               v13 = iconst.i32 0
 ;; @0031                               v14 = iconst.i32 10
 ;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
-;; @0033                               v16 = global_value.i64 gv5
+;; @0033                               v16 = load.i64 notrap aligned readonly checked v0+96
 ;; @0033                               v17 = iadd v16, v15
 ;; @0033                               store little heap v14, v17  ; v14 = 10
 ;; @0036                               jump block3
@@ -49,7 +49,7 @@
 ;; @0037                               v18 = iconst.i32 0
 ;; @0039                               v19 = iconst.i32 11
 ;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
-;; @003b                               v21 = global_value.i64 gv5
+;; @003b                               v21 = load.i64 notrap aligned readonly checked v0+96
 ;; @003b                               v22 = iadd v21, v20
 ;; @003b                               store little heap v19, v22  ; v19 = 11
 ;; @003e                               jump block3

--- a/tests/disas/multi-0.wat
+++ b/tests/disas/multi-0.wat
@@ -11,8 +11,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @002b                               jump block1(v2, v2)
+;; @002b                               jump block1
 ;;
-;;                                 block1(v3: i64, v4: i64):
-;; @002b                               return v3, v4
+;;                                 block1:
+;; @002b                               return v2, v2
 ;; }

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -15,11 +15,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @003a                               v10 = f64const 0x1.34a0000000000p10
-;; @0043                               jump block2(v3, v2, v10)  ; v10 = 0x1.34a0000000000p10
+;; @0043                               jump block2
 ;;
-;;                                 block2(v7: i32, v8: i64, v9: f64):
-;; @0044                               jump block1(v7, v8, v9)
+;;                                 block2:
+;; @0044                               jump block1
 ;;
-;;                                 block1(v4: i32, v5: i64, v6: f64):
-;; @0044                               return v4, v5, v6
+;;                                 block1:
+;; @0044                               return v3, v2, v10  ; v10 = 0x1.34a0000000000p10
 ;; }

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -18,19 +18,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @002c                               brif v3, block2, block4(v2)
+;; @002c                               brif v3, block2, block4
 ;;
 ;;                                 block2:
 ;; @002e                               v9 = iconst.i64 -1
-;; @0030                               jump block3(v2, v9)  ; v9 = -1
+;; @0030                               jump block3(v9)  ; v9 = -1
 ;;
-;;                                 block4(v8: i64):
+;;                                 block4:
 ;; @0031                               v10 = iconst.i64 -2
-;; @0033                               jump block3(v2, v10)  ; v10 = -2
+;; @0033                               jump block3(v10)  ; v10 = -2
 ;;
-;;                                 block3(v6: i64, v7: i64):
-;; @0034                               jump block1(v6, v7)
+;;                                 block3(v7: i64):
+;; @0034                               jump block1(v7)
 ;;
-;;                                 block1(v4: i64, v5: i64):
-;; @0034                               return v4, v5
+;;                                 block1(v5: i64):
+;; @0034                               return v2, v5
 ;; }

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -15,9 +15,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @002b                               jump block2(v2)
+;; @002b                               jump block2
 ;;
-;;                                 block2(v5: i64):
+;;                                 block2:
 ;; @002d                               v8 = iconst.i64 42
-;; @002f                               return v5, v8  ; v8 = 42
+;; @002f                               return v2, v8  ; v8 = 42
 ;; }

--- a/tests/disas/multi-12.wat
+++ b/tests/disas/multi-12.wat
@@ -17,8 +17,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0031                               jump block2(v4, v3, v2)
+;; @0031                               jump block2
 ;;
-;;                                 block2(v7: i64, v8: i64, v9: i64):
-;; @0034                               return v7, v8
+;;                                 block2:
+;; @0034                               return v4, v3
 ;; }

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -25,10 +25,10 @@
 ;; @0032                               jump block2(v7)  ; v7 = 3
 ;;
 ;;                                 block5:
-;; @0037                               jump block4(v3)
+;; @0037                               jump block4
 ;;
-;;                                 block4(v6: i32):
-;; @0038                               jump block2(v6)
+;;                                 block4:
+;; @0038                               jump block2(v3)
 ;;
 ;;                                 block2(v5: i32):
 ;; @0039                               jump block1(v5)

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -21,14 +21,14 @@
 ;; @002e                               brif v2, block3, block5
 ;;
 ;;                                 block3:
-;; @0032                               jump block4(v3)
+;; @0032                               jump block4
 ;;
 ;;                                 block5:
 ;; @0033                               v7 = iconst.i32 4
 ;; @0035                               jump block2(v7)  ; v7 = 4
 ;;
-;;                                 block4(v6: i32):
-;; @0038                               jump block2(v6)
+;;                                 block4:
+;; @0038                               jump block2(v3)
 ;;
 ;;                                 block2(v5: i32):
 ;; @0039                               jump block1(v5)

--- a/tests/disas/multi-15.wat
+++ b/tests/disas/multi-15.wat
@@ -30,8 +30,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: f32, v5: f32, v6: i32, v7: f64, v8: f32, v9: i32, v10: i32, v11: i32, v12: f32, v13: f64, v14: f64, v15: f64, v16: i32, v17: i32, v18: f32):
-;; @0067                               jump block1(v7, v4, v2, v10, v9, v3, v5, v11, v6, v8, v15, v13, v17, v18, v16, v14)
+;; @0067                               jump block1
 ;;
-;;                                 block1(v19: f64, v20: f32, v21: i32, v22: i32, v23: i32, v24: i64, v25: f32, v26: i32, v27: i32, v28: f32, v29: f64, v30: f64, v31: i32, v32: f32, v33: i32, v34: f64):
-;; @0067                               return v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34
+;;                                 block1:
+;; @0067                               return v7, v4, v2, v10, v9, v3, v5, v11, v6, v8, v15, v13, v17, v18, v16, v14
 ;; }

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -18,14 +18,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0024                               v4 = iconst.i32 1
-;; @0028                               brif v2, block2, block4(v4)  ; v4 = 1
+;; @0028                               brif v2, block2, block4
 ;;
 ;;                                 block2:
 ;; @002a                               v6 = iconst.i32 2
 ;; @002c                               v7 = iadd.i32 v4, v6  ; v4 = 1, v6 = 2
 ;; @002d                               jump block3(v7)
 ;;
-;;                                 block4(v8: i32):
+;;                                 block4:
 ;; @002e                               v9 = iconst.i32 -2
 ;; @0030                               v10 = iadd.i32 v4, v9  ; v4 = 1, v9 = -2
 ;; @0031                               jump block3(v10)

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -41,29 +41,29 @@
 ;; @0029                               v8 = iconst.i32 0
 ;; @002b                               v9 = iconst.i32 0
 ;; @002d                               v10 = iconst.i32 0
-;; @002f                               brif v10, block2, block4(v7, v8, v9)  ; v10 = 0, v7 = 0, v8 = 0, v9 = 0
+;; @002f                               brif v10, block2, block4  ; v10 = 0
 ;;
 ;;                                 block2:
 ;; @0031                               jump block3(v9)  ; v9 = 0
 ;;
-;;                                 block4(v12: i32, v13: i32, v14: i32):
+;;                                 block4:
 ;; @0034                               v15 = call fn0(v0, v0, v7, v8, v9)  ; v7 = 0, v8 = 0, v9 = 0
 ;; @0036                               jump block3(v15)
 ;;
 ;;                                 block3(v11: i32):
 ;; @0037                               v16 = iconst.i32 0
 ;; @0039                               v17 = iconst.i32 0
-;; @003b                               brif v17, block5, block7(v6, v11, v16)  ; v17 = 0, v6 = 0, v16 = 0
+;; @003b                               brif v17, block5, block7(v11)  ; v17 = 0
 ;;
 ;;                                 block5:
-;; @003f                               jump block6(v6)  ; v6 = 0
+;; @003f                               jump block6
 ;;
-;;                                 block7(v19: i32, v20: i32, v21: i32):
-;; @0042                               jump block6(v6)  ; v6 = 0
+;;                                 block7(v20: i32):
+;; @0042                               jump block6
 ;;
-;;                                 block6(v18: i32):
-;; @0043                               jump block1(v18)
+;;                                 block6:
+;; @0043                               jump block1
 ;;
-;;                                 block1(v5: i32):
-;; @0043                               return v5
+;;                                 block1:
+;; @0043                               return v6  ; v6 = 0
 ;; }

--- a/tests/disas/multi-2.wat
+++ b/tests/disas/multi-2.wat
@@ -14,8 +14,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @002e                               jump block2(v3, v2)
+;; @002e                               jump block2
 ;;
-;;                                 block2(v6: i64, v7: i64):
-;; @0030                               return v6, v7
+;;                                 block2:
+;; @0030                               return v3, v2
 ;; }

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -21,19 +21,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i64):
-;; @0036                               brif v2, block2, block4(v4, v3)
+;; @0036                               brif v2, block2, block4
 ;;
 ;;                                 block2:
 ;; @0038                               return v4, v3
 ;;
-;;                                 block4(v9: i64, v10: i64):
+;;                                 block4:
 ;; @003c                               v11 = iconst.i64 0
 ;; @003e                               v12 = iconst.i64 0
-;; @0040                               jump block3(v11, v12)  ; v11 = 0, v12 = 0
+;; @0040                               jump block3
 ;;
-;;                                 block3(v7: i64, v8: i64):
-;; @0041                               jump block1(v7, v8)
+;;                                 block3:
+;; @0041                               jump block1
 ;;
-;;                                 block1(v5: i64, v6: i64):
-;; @0041                               return v5, v6
+;;                                 block1:
+;; @0041                               return v11, v12  ; v11 = 0, v12 = 0
 ;; }

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -21,14 +21,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i64):
-;; @0037                               brif v2, block2, block4(v4, v3)
+;; @0037                               brif v2, block2, block4
 ;;
 ;;                                 block2:
 ;; @0039                               v9 = iadd.i64 v4, v3
 ;; @003a                               v10 = iconst.i64 1
 ;; @003c                               jump block3(v9, v10)  ; v10 = 1
 ;;
-;;                                 block4(v11: i64, v12: i64):
+;;                                 block4:
 ;; @003d                               v13 = isub.i64 v4, v3
 ;; @003e                               v14 = iconst.i64 2
 ;; @0040                               jump block3(v13, v14)  ; v14 = 2

--- a/tests/disas/multi-5.wat
+++ b/tests/disas/multi-5.wat
@@ -21,9 +21,9 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0026                               v2 = iconst.i32 1
 ;; @0028                               v3 = iconst.i64 2
-;; @002d                               jump block2(v2)  ; v2 = 1
+;; @002d                               jump block2
 ;;
-;;                                 block2(v4: i32):
+;;                                 block2:
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/multi-6.wat
+++ b/tests/disas/multi-6.wat
@@ -21,9 +21,9 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0026                               v2 = iconst.i32 1
 ;; @002a                               v5 = iconst.i64 2
-;; @002c                               jump block2(v2, v5)  ; v2 = 1, v5 = 2
+;; @002c                               jump block2
 ;;
-;;                                 block2(v3: i32, v4: i64):
+;;                                 block2:
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -20,13 +20,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @002a                               brif v3, block2, block4(v2)
+;; @002a                               brif v3, block2, block4
 ;;
 ;;                                 block2:
 ;; @002d                               v6 = iconst.i64 -1
 ;; @002f                               jump block3(v6)  ; v6 = -1
 ;;
-;;                                 block4(v7: i64):
+;;                                 block4:
 ;; @0031                               v8 = iconst.i64 -2
 ;; @0033                               jump block3(v8)  ; v8 = -2
 ;;

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -23,13 +23,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
-;; @0027                               brif v3, block2, block4(v2, v3)
+;; @0027                               brif v3, block2, block4
 ;;
 ;;                                 block2:
 ;; @002b                               v8 = iconst.i64 -1
 ;; @002d                               jump block3(v8)  ; v8 = -1
 ;;
-;;                                 block4(v6: i64, v7: i32):
+;;                                 block4:
 ;; @0030                               v9 = iconst.i64 -2
 ;; @0032                               jump block3(v9)  ; v9 = -2
 ;;

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -31,10 +31,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0041                               v4 = uextend.i64 v2
-;; @0041                               v5 = global_value.i64 gv4
+;; @0041                               v5 = load.i64 notrap aligned v0+104
 ;; @0041                               v6 = icmp uge v4, v5
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = global_value.i64 gv5
+;; @0041                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0041                               v8 = iadd v7, v4
 ;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
@@ -54,14 +54,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = global_value.i64 gv4
+;; @0049                               v5 = load.i64 notrap aligned v0+104
 ;; @0049                               v6 = icmp uge v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv5
+;; @0049                               v7 = load.i64 notrap aligned checked v0+96
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = uload8.i32 little heap v8
-;; @004c                               jump block1(v9)
+;; @004c                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @004c                               return v3
+;;                                 block1:
+;; @004c                               return v9
 ;; }

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -20,10 +20,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0019                               v3 = iconst.i32 0
-;; @001b                               jump block1(v3)  ; v3 = 0
+;; @001b                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @001b                               return v2
+;;                                 block1:
+;; @001b                               return v3  ; v3 = 0
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -34,11 +34,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0020                               v4 = iconst.i32 0
-;; @0022                               jump block2(v4)  ; v4 = 0
+;; @0022                               jump block2
 ;;
-;;                                 block2(v3: i32):
-;; @0023                               jump block1(v3)
+;;                                 block2:
+;; @0023                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0023                               return v2
+;;                                 block1:
+;; @0023                               return v4  ; v4 = 0
 ;; }

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -27,9 +27,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003d                               v5 = iconst.i32 0
 ;; @003d                               v6 = iconst.i32 0
-;; @003d                               v7 = global_value.i64 gv3
 ;; @003d                               v8 = uextend.i64 v2
-;; @003d                               v9 = call fn0(v7, v5, v6, v8, v3, v4)  ; v5 = 0, v6 = 0
+;; @003d                               v9 = call fn0(v0, v5, v6, v8, v3, v4)  ; v5 = 0, v6 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -47,8 +46,7 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0044                               v2 = iconst.i32 0
-;; @0044                               v3 = global_value.i64 gv3
-;; @0044                               call fn0(v3, v2)  ; v2 = 0
+;; @0044                               call fn0(v0, v2)  ; v2 = 0
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -29,15 +29,15 @@
 ;; @0036                               v3 = iconst.i32 48
 ;; @0038                               v4 = iconst.i32 0
 ;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
-;; @003a                               v6 = global_value.i64 gv5
+;; @003a                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @003a                               v7 = iadd v6, v5
 ;; @003a                               v8 = load.i8x16 little heap v7
 ;; @003e                               v9 = iconst.i32 16
 ;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
-;; @0040                               v11 = global_value.i64 gv5
+;; @0040                               v11 = load.i64 notrap aligned readonly checked v0+96
 ;; @0040                               v12 = iadd v11, v10
 ;; @0040                               v13 = load.i8x16 little heap v12
-;; @0046                               brif v2, block2, block4(v8, v13)
+;; @0046                               brif v2, block2, block4
 ;;
 ;;                                 block2:
 ;; @0048                               v16 = bitcast.i64x2 little v8
@@ -45,19 +45,19 @@
 ;; @0048                               v18 = iadd v16, v17
 ;; @004b                               v19 = iconst.i32 32
 ;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
-;; @004d                               v21 = global_value.i64 gv5
+;; @004d                               v21 = load.i64 notrap aligned readonly checked v0+96
 ;; @004d                               v22 = iadd v21, v20
 ;; @004d                               v23 = load.i8x16 little heap v22
 ;; @0051                               v26 = bitcast.i8x16 little v18
 ;; @0051                               jump block3(v26, v23)
 ;;
-;;                                 block4(v24: i8x16, v25: i8x16):
+;;                                 block4:
 ;; @0052                               v27 = bitcast.i32x4 little v8
 ;; @0052                               v28 = bitcast.i32x4 little v13
 ;; @0052                               v29 = isub v27, v28
 ;; @0055                               v30 = iconst.i32 0
 ;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
-;; @0057                               v32 = global_value.i64 gv5
+;; @0057                               v32 = load.i64 notrap aligned readonly checked v0+96
 ;; @0057                               v33 = iadd v32, v31
 ;; @0057                               v34 = load.i8x16 little heap v33
 ;; @005b                               v35 = bitcast.i8x16 little v29
@@ -68,7 +68,7 @@
 ;; @005c                               v37 = bitcast.i16x8 little v15
 ;; @005c                               v38 = imul v36, v37
 ;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
-;; @005f                               v40 = global_value.i64 gv5
+;; @005f                               v40 = load.i64 notrap aligned readonly checked v0+96
 ;; @005f                               v41 = iadd v40, v39
 ;; @005f                               store little heap v38, v41
 ;; @0063                               jump block1

--- a/tests/disas/pr2559.wat
+++ b/tests/disas/pr2559.wat
@@ -70,17 +70,17 @@
 ;; @0036                               v15 = icmp ne v13, v14
 ;; @0038                               v16 = iconst.i32 13
 ;; @003a                               v17 = bitcast.i8x16 little v15
-;; @003a                               brif v16, block1(v5, v8, v17), block2  ; v16 = 13
+;; @003a                               brif v16, block1(v17), block2  ; v16 = 13
 ;;
 ;;                                 block2:
 ;; @003c                               v18 = iconst.i32 43
 ;; @003e                               v19 = bitcast.i8x16 little v15
-;; @003e                               brif v18, block1(v5, v8, v19), block3  ; v18 = 43
+;; @003e                               brif v18, block1(v19), block3  ; v18 = 43
 ;;
 ;;                                 block3:
 ;; @0040                               v20 = iconst.i32 13
 ;; @0042                               v21 = bitcast.i8x16 little v15
-;; @0042                               brif v20, block1(v5, v8, v21), block4  ; v20 = 13
+;; @0042                               brif v20, block1(v21), block4  ; v20 = 13
 ;;
 ;;                                 block4:
 ;; @0044                               v22 = iconst.i32 87
@@ -88,8 +88,8 @@
 ;; @0047                               v24 = select.i8x16 v22, v8, v23  ; v22 = 87
 ;; @0048                               trap user11
 ;;
-;;                                 block1(v2: i8x16, v3: i8x16, v4: i8x16):
-;; @0055                               return v2, v3, v4
+;;                                 block1(v4: i8x16):
+;; @0055                               return v5, v8, v4
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
@@ -110,17 +110,17 @@
 ;; @0060                               v15 = icmp ne v13, v14
 ;; @0062                               v16 = iconst.i32 13
 ;; @0064                               v17 = bitcast.i8x16 little v15
-;; @0064                               brif v16, block1(v5, v8, v17), block2  ; v16 = 13
+;; @0064                               brif v16, block1(v17), block2  ; v16 = 13
 ;;
 ;;                                 block2:
 ;; @0066                               v18 = iconst.i32 43
 ;; @0068                               v19 = bitcast.i8x16 little v15
-;; @0068                               brif v18, block1(v5, v8, v19), block3  ; v18 = 43
+;; @0068                               brif v18, block1(v19), block3  ; v18 = 43
 ;;
 ;;                                 block3:
 ;; @006a                               v20 = iconst.i32 13
 ;; @006c                               v21 = bitcast.i8x16 little v15
-;; @006c                               brif v20, block1(v5, v8, v21), block4  ; v20 = 13
+;; @006c                               brif v20, block1(v21), block4  ; v20 = 13
 ;;
 ;;                                 block4:
 ;; @006e                               v22 = iconst.i32 87
@@ -128,6 +128,6 @@
 ;; @0071                               v24 = select.i8x16 v22, v8, v23  ; v22 = 87
 ;; @0074                               trap user11
 ;;
-;;                                 block1(v2: i8x16, v3: i8x16, v4: i8x16):
-;; @0081                               return v2, v3, v4
+;;                                 block1(v4: i8x16):
+;; @0081                               return v5, v8, v4
 ;; }

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -25,28 +25,29 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @008f                               v6 = global_value.i64 gv3
-;; @008f                               v7 = iadd_imm v6, 112
+;;                                     v94 = iconst.i64 112
+;; @008f                               v7 = iadd v0, v94  ; v94 = 112
 ;; @008f                               v8 = load.i32 notrap aligned v7
-;;                                     stack_store v8, ss0
-;;                                     v93 = stack_load.i32 ss0
-;; @008f                               v9 = icmp_imm eq v93, 0
+;;                                     v95 = stack_addr.i64 ss0
+;;                                     store notrap v8, v95
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     v93 = load.i32 notrap v96
+;;                                     v97 = iconst.i32 0
+;; @008f                               v9 = icmp eq v93, v97  ; v97 = 0
 ;; @008f                               brif v9, block5, block2
 ;;
 ;;                                 block2:
-;; @008f                               v10 = global_value.i64 gv3
-;; @008f                               v11 = load.i64 notrap aligned readonly v10+56
+;; @008f                               v11 = load.i64 notrap aligned readonly v0+56
 ;; @008f                               v12 = load.i64 notrap aligned v11
 ;; @008f                               v13 = load.i64 notrap aligned v11+8
 ;; @008f                               v14 = icmp eq v12, v13
 ;; @008f                               brif v14, block3, block4
 ;;
 ;;                                 block4:
-;; @008f                               v15 = global_value.i64 gv3
-;; @008f                               v16 = load.i64 notrap aligned readonly v15+40
-;; @008f                               v17 = global_value.i64 gv3
-;; @008f                               v18 = load.i64 notrap aligned readonly v17+48
-;;                                     v92 = stack_load.i32 ss0
+;; @008f                               v16 = load.i64 notrap aligned readonly v0+40
+;; @008f                               v18 = load.i64 notrap aligned readonly v0+48
+;;                                     v98 = stack_addr.i64 ss0
+;;                                     v92 = load.i32 notrap v98
 ;; @008f                               v19 = uextend.i64 v92
 ;; @008f                               v20 = iconst.i64 8
 ;; @008f                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
@@ -56,12 +57,12 @@
 ;; @008f                               trapz v24, user1
 ;; @008f                               v25 = iadd v16, v21
 ;; @008f                               v26 = load.i64 notrap aligned v25
-;; @008f                               v27 = iadd_imm v26, 1
-;; @008f                               v28 = global_value.i64 gv3
-;; @008f                               v29 = load.i64 notrap aligned readonly v28+40
-;; @008f                               v30 = global_value.i64 gv3
-;; @008f                               v31 = load.i64 notrap aligned readonly v30+48
-;;                                     v91 = stack_load.i32 ss0
+;;                                     v99 = iconst.i64 1
+;; @008f                               v27 = iadd v26, v99  ; v99 = 1
+;; @008f                               v29 = load.i64 notrap aligned readonly v0+40
+;; @008f                               v31 = load.i64 notrap aligned readonly v0+48
+;;                                     v100 = stack_addr.i64 ss0
+;;                                     v91 = load.i32 notrap v100
 ;; @008f                               v32 = uextend.i64 v91
 ;; @008f                               v33 = iconst.i64 8
 ;; @008f                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
@@ -71,41 +72,44 @@
 ;; @008f                               trapz v37, user1
 ;; @008f                               v38 = iadd v29, v34
 ;; @008f                               store notrap aligned v27, v38
-;;                                     v90 = stack_load.i32 ss0
+;;                                     v101 = stack_addr.i64 ss0
+;;                                     v90 = load.i32 notrap v101
 ;; @008f                               store notrap aligned v90, v12
-;; @008f                               v39 = iadd_imm.i64 v12, 4
+;;                                     v102 = iconst.i64 4
+;; @008f                               v39 = iadd.i64 v12, v102  ; v102 = 4
 ;; @008f                               store notrap aligned v39, v11
 ;; @008f                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @008f                               v40 = global_value.i64 gv3
-;;                                     v89 = stack_load.i32 ss0
-;; @008f                               v41 = call fn0(v40, v89), stack_map=[i32 @ ss0+0]
+;;                                     v103 = stack_addr.i64 ss0
+;;                                     v89 = load.i32 notrap v103
+;; @008f                               v41 = call fn0(v0, v89), stack_map=[i32 @ ss0+0]
 ;; @008f                               jump block5
 ;;
 ;;                                 block5:
-;; @0091                               v42 = global_value.i64 gv3
-;; @0091                               v43 = iadd_imm v42, 128
+;;                                     v104 = iconst.i64 128
+;; @0091                               v43 = iadd.i64 v0, v104  ; v104 = 128
 ;; @0091                               v44 = load.i32 notrap aligned v43
-;;                                     stack_store v44, ss1
-;;                                     v88 = stack_load.i32 ss1
-;; @0091                               v45 = icmp_imm eq v88, 0
+;;                                     v105 = stack_addr.i64 ss1
+;;                                     store notrap v44, v105
+;;                                     v106 = stack_addr.i64 ss1
+;;                                     v88 = load.i32 notrap v106
+;;                                     v107 = iconst.i32 0
+;; @0091                               v45 = icmp eq v88, v107  ; v107 = 0
 ;; @0091                               brif v45, block9, block6
 ;;
 ;;                                 block6:
-;; @0091                               v46 = global_value.i64 gv3
-;; @0091                               v47 = load.i64 notrap aligned readonly v46+56
+;; @0091                               v47 = load.i64 notrap aligned readonly v0+56
 ;; @0091                               v48 = load.i64 notrap aligned v47
 ;; @0091                               v49 = load.i64 notrap aligned v47+8
 ;; @0091                               v50 = icmp eq v48, v49
 ;; @0091                               brif v50, block7, block8
 ;;
 ;;                                 block8:
-;; @0091                               v51 = global_value.i64 gv3
-;; @0091                               v52 = load.i64 notrap aligned readonly v51+40
-;; @0091                               v53 = global_value.i64 gv3
-;; @0091                               v54 = load.i64 notrap aligned readonly v53+48
-;;                                     v87 = stack_load.i32 ss1
+;; @0091                               v52 = load.i64 notrap aligned readonly v0+40
+;; @0091                               v54 = load.i64 notrap aligned readonly v0+48
+;;                                     v108 = stack_addr.i64 ss1
+;;                                     v87 = load.i32 notrap v108
 ;; @0091                               v55 = uextend.i64 v87
 ;; @0091                               v56 = iconst.i64 8
 ;; @0091                               v57 = uadd_overflow_trap v55, v56, user1  ; v56 = 8
@@ -115,12 +119,12 @@
 ;; @0091                               trapz v60, user1
 ;; @0091                               v61 = iadd v52, v57
 ;; @0091                               v62 = load.i64 notrap aligned v61
-;; @0091                               v63 = iadd_imm v62, 1
-;; @0091                               v64 = global_value.i64 gv3
-;; @0091                               v65 = load.i64 notrap aligned readonly v64+40
-;; @0091                               v66 = global_value.i64 gv3
-;; @0091                               v67 = load.i64 notrap aligned readonly v66+48
-;;                                     v86 = stack_load.i32 ss1
+;;                                     v109 = iconst.i64 1
+;; @0091                               v63 = iadd v62, v109  ; v109 = 1
+;; @0091                               v65 = load.i64 notrap aligned readonly v0+40
+;; @0091                               v67 = load.i64 notrap aligned readonly v0+48
+;;                                     v110 = stack_addr.i64 ss1
+;;                                     v86 = load.i32 notrap v110
 ;; @0091                               v68 = uextend.i64 v86
 ;; @0091                               v69 = iconst.i64 8
 ;; @0091                               v70 = uadd_overflow_trap v68, v69, user1  ; v69 = 8
@@ -130,27 +134,29 @@
 ;; @0091                               trapz v73, user1
 ;; @0091                               v74 = iadd v65, v70
 ;; @0091                               store notrap aligned v63, v74
-;;                                     v85 = stack_load.i32 ss1
+;;                                     v111 = stack_addr.i64 ss1
+;;                                     v85 = load.i32 notrap v111
 ;; @0091                               store notrap aligned v85, v48
-;; @0091                               v75 = iadd_imm.i64 v48, 4
+;;                                     v112 = iconst.i64 4
+;; @0091                               v75 = iadd.i64 v48, v112  ; v112 = 4
 ;; @0091                               store notrap aligned v75, v47
 ;; @0091                               jump block9
 ;;
 ;;                                 block7 cold:
-;; @0091                               v76 = global_value.i64 gv3
-;;                                     v84 = stack_load.i32 ss1
-;; @0091                               v77 = call fn0(v76, v84), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;;                                     v113 = stack_addr.i64 ss1
+;;                                     v84 = load.i32 notrap v113
+;; @0091                               v77 = call fn0(v0, v84), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0091                               jump block9
 ;;
 ;;                                 block9:
-;; @0093                               v78 = global_value.i64 gv3
-;; @0093                               v79 = load.i64 notrap aligned table v78+144
-;; @0095                               v80 = global_value.i64 gv3
-;; @0095                               v81 = load.i64 notrap aligned table v80+160
-;;                                     v82 = stack_load.i32 ss0
-;;                                     v83 = stack_load.i32 ss1
-;; @0097                               jump block1(v82, v83, v79, v81)
+;; @0093                               v79 = load.i64 notrap aligned table v0+144
+;; @0095                               v81 = load.i64 notrap aligned table v0+160
+;;                                     v114 = stack_addr.i64 ss0
+;;                                     v82 = load.i32 notrap v114
+;;                                     v115 = stack_addr.i64 ss1
+;;                                     v83 = load.i32 notrap v115
+;; @0097                               jump block1
 ;;
-;;                                 block1(v2: i32, v3: i32, v4: i64, v5: i64):
-;; @0097                               return v2, v3, v4, v5
+;;                                 block1:
+;; @0097                               return v82, v83, v79, v81
 ;; }

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -31,10 +31,10 @@
 ;; @0025                               v4 = iconst.i32 24
 ;; @0027                               v5 = iconst.i32 1
 ;; @0029                               v6 = select v5, v3, v4  ; v5 = 1, v3 = 42, v4 = 24
-;; @002a                               jump block1(v6)
+;; @002a                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @002a                               return v2
+;;                                 block1:
+;; @002a                               return v6
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -48,10 +48,10 @@
 ;; @002f                               v4 = iconst.i32 0
 ;; @0031                               v5 = iconst.i32 1
 ;; @0033                               v6 = select v5, v3, v4  ; v5 = 1, v3 = 0, v4 = 0
-;; @0036                               jump block1(v6)
+;; @0036                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0036                               return v2
+;;                                 block1:
+;; @0036                               return v6
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
@@ -64,8 +64,8 @@
 ;; @0039                               v4 = iconst.i32 0
 ;; @003d                               v5 = iconst.i32 1
 ;; @003f                               v6 = select v5, v4, v2  ; v5 = 1, v4 = 0
-;; @0042                               jump block1(v6)
+;; @0042                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0042                               return v3
+;;                                 block1:
+;; @0042                               return v6
 ;; }

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -97,7 +97,7 @@
 ;; @003f                               v3 = iconst.i32 0
 ;; @0045                               v4 = icmp eq v2, v2
 ;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0047                               v6 = global_value.i64 gv5
+;; @0047                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0047                               v7 = iadd v6, v5
 ;; @0047                               store little heap v4, v7
 ;; @004b                               jump block1
@@ -121,7 +121,7 @@
 ;; @0054                               v5 = bitcast.i16x8 little v2
 ;; @0054                               v6 = icmp eq v4, v5
 ;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v8 = global_value.i64 gv5
+;; @0056                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0056                               v9 = iadd v8, v7
 ;; @0056                               store little heap v6, v9
 ;; @005a                               jump block1
@@ -145,7 +145,7 @@
 ;; @0063                               v5 = bitcast.i32x4 little v2
 ;; @0063                               v6 = icmp eq v4, v5
 ;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0065                               v8 = global_value.i64 gv5
+;; @0065                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0065                               v9 = iadd v8, v7
 ;; @0065                               store little heap v6, v9
 ;; @0069                               jump block1
@@ -169,7 +169,7 @@
 ;; @0072                               v5 = bitcast.i64x2 little v2
 ;; @0072                               v6 = icmp eq v4, v5
 ;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0075                               v8 = global_value.i64 gv5
+;; @0075                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0075                               v9 = iadd v8, v7
 ;; @0075                               store little heap v6, v9
 ;; @0079                               jump block1
@@ -191,7 +191,7 @@
 ;; @007c                               v3 = iconst.i32 0
 ;; @0082                               v4 = icmp ne v2, v2
 ;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0084                               v6 = global_value.i64 gv5
+;; @0084                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0084                               v7 = iadd v6, v5
 ;; @0084                               store little heap v4, v7
 ;; @0088                               jump block1
@@ -215,7 +215,7 @@
 ;; @0091                               v5 = bitcast.i16x8 little v2
 ;; @0091                               v6 = icmp ne v4, v5
 ;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0093                               v8 = global_value.i64 gv5
+;; @0093                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0093                               v9 = iadd v8, v7
 ;; @0093                               store little heap v6, v9
 ;; @0097                               jump block1
@@ -239,7 +239,7 @@
 ;; @00a0                               v5 = bitcast.i32x4 little v2
 ;; @00a0                               v6 = icmp ne v4, v5
 ;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00a2                               v8 = global_value.i64 gv5
+;; @00a2                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @00a2                               v9 = iadd v8, v7
 ;; @00a2                               store little heap v6, v9
 ;; @00a6                               jump block1
@@ -263,7 +263,7 @@
 ;; @00af                               v5 = bitcast.i64x2 little v2
 ;; @00af                               v6 = icmp ne v4, v5
 ;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00b2                               v8 = global_value.i64 gv5
+;; @00b2                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @00b2                               v9 = iadd v8, v7
 ;; @00b2                               store little heap v6, v9
 ;; @00b6                               jump block1
@@ -285,7 +285,7 @@
 ;; @00b9                               v3 = iconst.i32 0
 ;; @00bf                               v4 = icmp slt v2, v2
 ;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00c1                               v6 = global_value.i64 gv5
+;; @00c1                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @00c1                               v7 = iadd v6, v5
 ;; @00c1                               store little heap v4, v7
 ;; @00c5                               jump block1
@@ -309,7 +309,7 @@
 ;; @00ce                               v5 = bitcast.i16x8 little v2
 ;; @00ce                               v6 = icmp slt v4, v5
 ;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00d0                               v8 = global_value.i64 gv5
+;; @00d0                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @00d0                               v9 = iadd v8, v7
 ;; @00d0                               store little heap v6, v9
 ;; @00d4                               jump block1
@@ -333,7 +333,7 @@
 ;; @00dd                               v5 = bitcast.i32x4 little v2
 ;; @00dd                               v6 = icmp slt v4, v5
 ;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00df                               v8 = global_value.i64 gv5
+;; @00df                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @00df                               v9 = iadd v8, v7
 ;; @00df                               store little heap v6, v9
 ;; @00e3                               jump block1
@@ -357,7 +357,7 @@
 ;; @00ec                               v5 = bitcast.i64x2 little v2
 ;; @00ec                               v6 = icmp slt v4, v5
 ;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00ef                               v8 = global_value.i64 gv5
+;; @00ef                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @00ef                               v9 = iadd v8, v7
 ;; @00ef                               store little heap v6, v9
 ;; @00f3                               jump block1
@@ -379,7 +379,7 @@
 ;; @00f6                               v3 = iconst.i32 0
 ;; @00fc                               v4 = icmp ult v2, v2
 ;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00fe                               v6 = global_value.i64 gv5
+;; @00fe                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @00fe                               v7 = iadd v6, v5
 ;; @00fe                               store little heap v4, v7
 ;; @0102                               jump block1
@@ -403,7 +403,7 @@
 ;; @010b                               v5 = bitcast.i16x8 little v2
 ;; @010b                               v6 = icmp ult v4, v5
 ;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @010d                               v8 = global_value.i64 gv5
+;; @010d                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @010d                               v9 = iadd v8, v7
 ;; @010d                               store little heap v6, v9
 ;; @0111                               jump block1
@@ -427,7 +427,7 @@
 ;; @011a                               v5 = bitcast.i32x4 little v2
 ;; @011a                               v6 = icmp ult v4, v5
 ;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @011c                               v8 = global_value.i64 gv5
+;; @011c                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @011c                               v9 = iadd v8, v7
 ;; @011c                               store little heap v6, v9
 ;; @0120                               jump block1
@@ -449,7 +449,7 @@
 ;; @0123                               v3 = iconst.i32 0
 ;; @0129                               v4 = icmp sgt v2, v2
 ;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
-;; @012b                               v6 = global_value.i64 gv5
+;; @012b                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @012b                               v7 = iadd v6, v5
 ;; @012b                               store little heap v4, v7
 ;; @012f                               jump block1
@@ -473,7 +473,7 @@
 ;; @0138                               v5 = bitcast.i16x8 little v2
 ;; @0138                               v6 = icmp sgt v4, v5
 ;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @013a                               v8 = global_value.i64 gv5
+;; @013a                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @013a                               v9 = iadd v8, v7
 ;; @013a                               store little heap v6, v9
 ;; @013e                               jump block1
@@ -497,7 +497,7 @@
 ;; @0147                               v5 = bitcast.i32x4 little v2
 ;; @0147                               v6 = icmp sgt v4, v5
 ;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0149                               v8 = global_value.i64 gv5
+;; @0149                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0149                               v9 = iadd v8, v7
 ;; @0149                               store little heap v6, v9
 ;; @014d                               jump block1
@@ -521,7 +521,7 @@
 ;; @0156                               v5 = bitcast.i64x2 little v2
 ;; @0156                               v6 = icmp sgt v4, v5
 ;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0159                               v8 = global_value.i64 gv5
+;; @0159                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0159                               v9 = iadd v8, v7
 ;; @0159                               store little heap v6, v9
 ;; @015d                               jump block1
@@ -543,7 +543,7 @@
 ;; @0160                               v3 = iconst.i32 0
 ;; @0166                               v4 = icmp ugt v2, v2
 ;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0168                               v6 = global_value.i64 gv5
+;; @0168                               v6 = load.i64 notrap aligned readonly checked v0+96
 ;; @0168                               v7 = iadd v6, v5
 ;; @0168                               store little heap v4, v7
 ;; @016c                               jump block1
@@ -567,7 +567,7 @@
 ;; @0175                               v5 = bitcast.i16x8 little v2
 ;; @0175                               v6 = icmp ugt v4, v5
 ;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0177                               v8 = global_value.i64 gv5
+;; @0177                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0177                               v9 = iadd v8, v7
 ;; @0177                               store little heap v6, v9
 ;; @017b                               jump block1
@@ -591,7 +591,7 @@
 ;; @0184                               v5 = bitcast.i32x4 little v2
 ;; @0184                               v6 = icmp ugt v4, v5
 ;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0186                               v8 = global_value.i64 gv5
+;; @0186                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0186                               v9 = iadd v8, v7
 ;; @0186                               store little heap v6, v9
 ;; @018a                               jump block1
@@ -615,7 +615,7 @@
 ;; @0193                               v5 = bitcast.f32x4 little v2
 ;; @0193                               v6 = fcmp eq v4, v5
 ;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0195                               v8 = global_value.i64 gv5
+;; @0195                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @0195                               v9 = iadd v8, v7
 ;; @0195                               store little heap v6, v9
 ;; @0199                               jump block1
@@ -639,7 +639,7 @@
 ;; @01a2                               v5 = bitcast.f64x2 little v2
 ;; @01a2                               v6 = fcmp eq v4, v5
 ;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01a4                               v8 = global_value.i64 gv5
+;; @01a4                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @01a4                               v9 = iadd v8, v7
 ;; @01a4                               store little heap v6, v9
 ;; @01a8                               jump block1
@@ -663,7 +663,7 @@
 ;; @01b1                               v5 = bitcast.f32x4 little v2
 ;; @01b1                               v6 = fcmp ne v4, v5
 ;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01b3                               v8 = global_value.i64 gv5
+;; @01b3                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @01b3                               v9 = iadd v8, v7
 ;; @01b3                               store little heap v6, v9
 ;; @01b7                               jump block1
@@ -687,7 +687,7 @@
 ;; @01c0                               v5 = bitcast.f64x2 little v2
 ;; @01c0                               v6 = fcmp ne v4, v5
 ;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01c2                               v8 = global_value.i64 gv5
+;; @01c2                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @01c2                               v9 = iadd v8, v7
 ;; @01c2                               store little heap v6, v9
 ;; @01c6                               jump block1
@@ -711,7 +711,7 @@
 ;; @01cf                               v5 = bitcast.f32x4 little v2
 ;; @01cf                               v6 = fcmp lt v4, v5
 ;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01d1                               v8 = global_value.i64 gv5
+;; @01d1                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @01d1                               v9 = iadd v8, v7
 ;; @01d1                               store little heap v6, v9
 ;; @01d5                               jump block1
@@ -735,7 +735,7 @@
 ;; @01de                               v5 = bitcast.f64x2 little v2
 ;; @01de                               v6 = fcmp lt v4, v5
 ;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01e0                               v8 = global_value.i64 gv5
+;; @01e0                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @01e0                               v9 = iadd v8, v7
 ;; @01e0                               store little heap v6, v9
 ;; @01e4                               jump block1
@@ -759,7 +759,7 @@
 ;; @01ed                               v5 = bitcast.f32x4 little v2
 ;; @01ed                               v6 = fcmp le v4, v5
 ;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01ef                               v8 = global_value.i64 gv5
+;; @01ef                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @01ef                               v9 = iadd v8, v7
 ;; @01ef                               store little heap v6, v9
 ;; @01f3                               jump block1
@@ -783,7 +783,7 @@
 ;; @01fc                               v5 = bitcast.f64x2 little v2
 ;; @01fc                               v6 = fcmp le v4, v5
 ;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01fe                               v8 = global_value.i64 gv5
+;; @01fe                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @01fe                               v9 = iadd v8, v7
 ;; @01fe                               store little heap v6, v9
 ;; @0202                               jump block1
@@ -807,7 +807,7 @@
 ;; @020b                               v5 = bitcast.f32x4 little v2
 ;; @020b                               v6 = fcmp gt v4, v5
 ;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @020d                               v8 = global_value.i64 gv5
+;; @020d                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @020d                               v9 = iadd v8, v7
 ;; @020d                               store little heap v6, v9
 ;; @0211                               jump block1
@@ -831,7 +831,7 @@
 ;; @021a                               v5 = bitcast.f64x2 little v2
 ;; @021a                               v6 = fcmp gt v4, v5
 ;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @021c                               v8 = global_value.i64 gv5
+;; @021c                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @021c                               v9 = iadd v8, v7
 ;; @021c                               store little heap v6, v9
 ;; @0220                               jump block1
@@ -855,7 +855,7 @@
 ;; @0229                               v5 = bitcast.f32x4 little v2
 ;; @0229                               v6 = fcmp ge v4, v5
 ;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
-;; @022b                               v8 = global_value.i64 gv5
+;; @022b                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @022b                               v9 = iadd v8, v7
 ;; @022b                               store little heap v6, v9
 ;; @022f                               jump block1
@@ -879,7 +879,7 @@
 ;; @0238                               v5 = bitcast.f64x2 little v2
 ;; @0238                               v6 = fcmp ge v4, v5
 ;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @023a                               v8 = global_value.i64 gv5
+;; @023a                               v8 = load.i64 notrap aligned readonly checked v0+96
 ;; @023a                               v9 = iadd v8, v7
 ;; @023a                               store little heap v6, v9
 ;; @023e                               jump block1

--- a/tests/disas/simd.wat
+++ b/tests/disas/simd.wat
@@ -40,10 +40,10 @@
 ;; @004e                               v3 = iconst.i32 42
 ;; @0050                               v4 = splat.i32x4 v3  ; v3 = 42
 ;; @0052                               v5 = extractlane v4, 0
-;; @0055                               jump block1(v5)
+;; @0055                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0055                               return v2
+;;                                 block1:
+;; @0055                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
@@ -59,10 +59,10 @@
 ;; @006d                               v5 = bitcast.i32x4 little v3  ; v3 = const0
 ;; @006d                               v6 = insertlane v5, v4, 1  ; v4 = 99
 ;; @0070                               v7 = extractlane v6, 1
-;; @0073                               jump block1(v7)
+;; @0073                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @0073                               return v2
+;;                                 block1:
+;; @0073                               return v7
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
@@ -76,10 +76,10 @@
 ;; @0076                               v3 = vconst.i8x16 const0
 ;; @0088                               v4 = bitcast.i32x4 little v3  ; v3 = const0
 ;; @0088                               v5 = extractlane v4, 3
-;; @008b                               jump block1(v5)
+;; @008b                               jump block1
 ;;
-;;                                 block1(v2: i32):
-;; @008b                               return v2
+;;                                 block1:
+;; @008b                               return v5
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -27,10 +27,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0021                               v4 = iconst.i32 1
 ;; @0023                               v5 = iadd v2, v4  ; v4 = 1
-;; @0024                               jump block1(v5)
+;; @0024                               jump block1
 ;;
-;;                                 block1(v3: i32):
-;; @0024                               return v3
+;;                                 block1:
+;; @0024                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -30,10 +30,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
-;; @007b                               jump block1(v5)
+;; @007b                               jump block1
 ;;
-;;                                 block1(v8: i32):
-;; @007b                               return v8
+;;                                 block1:
+;; @007b                               return v5
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
@@ -43,10 +43,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
-;; @0080                               jump block1(v6)
+;; @0080                               jump block1
 ;;
-;;                                 block1(v8: i32):
-;; @0080                               return v8
+;;                                 block1:
+;; @0080                               return v6
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
@@ -56,10 +56,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32):
-;; @0085                               jump block1(v7)
+;; @0085                               jump block1
 ;;
-;;                                 block1(v8: i32):
-;; @0085                               return v8
+;;                                 block1:
+;; @0085                               return v7
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
@@ -77,12 +77,11 @@
 ;; @0090                               v9 = uextend.i64 v5
 ;; @0090                               v10 = iconst.i32 0
 ;; @0090                               v11 = iconst.i32 1
-;; @0090                               v12 = global_value.i64 gv3
-;; @0090                               v13 = call fn0(v12, v10, v11, v7, v8, v9)  ; v10 = 0, v11 = 1
-;; @0094                               jump block1(v2)
+;; @0090                               v13 = call fn0(v0, v10, v11, v7, v8, v9)  ; v10 = 0, v11 = 1
+;; @0094                               jump block1
 ;;
-;;                                 block1(v6: i32):
-;; @0094                               return v6
+;;                                 block1:
+;; @0094                               return v2
 ;; }
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
@@ -100,10 +99,9 @@
 ;; @009f                               v9 = uextend.i64 v5
 ;; @009f                               v10 = iconst.i32 1
 ;; @009f                               v11 = iconst.i32 0
-;; @009f                               v12 = global_value.i64 gv3
-;; @009f                               v13 = call fn0(v12, v10, v11, v7, v8, v9)  ; v10 = 1, v11 = 0
-;; @00a3                               jump block1(v2)
+;; @009f                               v13 = call fn0(v0, v10, v11, v7, v8, v9)  ; v10 = 1, v11 = 0
+;; @00a3                               jump block1
 ;;
-;;                                 block1(v6: i32):
-;; @00a3                               return v6
+;;                                 block1:
+;; @00a3                               return v2
 ;; }

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -141,9 +141,9 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0095                               v4 = iconst.i32 1
-;; @0097                               jump block2(v4)  ; v4 = 1
+;; @0097                               jump block2
 ;;
-;;                                 block2(v2: i32):
+;;                                 block2:
 ;; @009c                               jump block1
 ;;
 ;;                                 block1:


### PR DESCRIPTION
This commit updates the implementation of the `wasmtime` CLI flag `--emit-clif` to emit the IR post-optimization rather than pre-optimization. This is now emitting the IR that's directly fed to the backend for lowering which reflects any mid-level transformation that's performed. It should still be possible to recover pre-optimized CLIF with `-O opt-level=0`.

This then additionally refactors functions to emit CLIF in a more "core" location so all trampolines get their CLIF emitted as well in case those are needed for debugging.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
