### PR TITLE
winch: Simplify the handling of `wasm_load`s

### DIFF
--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -214,14 +214,14 @@ impl Masm for MacroAssembler {
         &mut self,
         src: Self::Address,
         dst: WritableReg,
-        size: OperandSize,
         kind: LoadKind,
         op_kind: MemOpKind,
     ) -> Result<()> {
+        let size = kind.derive_operand_size();
         match op_kind {
             MemOpKind::Normal => match kind {
-                LoadKind::Simple => self.asm.uload(src, dst, size),
-                LoadKind::Splat => bail!(CodeGenError::UnimplementedWasmLoadKind),
+                LoadKind::Operand(_) => self.asm.uload(src, dst, size),
+                LoadKind::Splat(_) => bail!(CodeGenError::UnimplementedWasmLoadKind),
                 LoadKind::ScalarExtend(extend_kind) => {
                     if extend_kind.signed() {
                         self.asm.sload(src, dst, size)

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -145,13 +145,11 @@ impl From<ShiftKind> for CraneliftShiftKind {
 impl From<ExtendKind> for ExtMode {
     fn from(value: ExtendKind) -> Self {
         match value {
-            ExtendKind::I64ExtendI32S | ExtendKind::I64ExtendI32U | ExtendKind::I64Extend32S => {
-                ExtMode::LQ
-            }
-            ExtendKind::I32Extend8S => ExtMode::BL,
-            ExtendKind::I32Extend16S => ExtMode::WL,
-            ExtendKind::I64Extend8S => ExtMode::BQ,
-            ExtendKind::I64Extend16S => ExtMode::WQ,
+            ExtendKind::I64Extend32U | ExtendKind::I64Extend32S => ExtMode::LQ,
+            ExtendKind::I32Extend8S | ExtendKind::I32Extend8U => ExtMode::BL,
+            ExtendKind::I32Extend16S | ExtendKind::I32Extend16U => ExtMode::WL,
+            ExtendKind::I64Extend8S | ExtendKind::I64Extend8U => ExtMode::BQ,
+            ExtendKind::I64Extend16S | ExtendKind::I64Extend16U => ExtMode::WQ,
         }
     }
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -11,7 +11,7 @@ use crate::codegen::{
 use crate::masm::{
     DivKind, ExtendKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler, MemMoveDirection,
     MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RoundingMode, SPOffset, ShiftKind,
-    TruncKind, VectorExtendKind,
+    SplatKind, TruncKind, VectorExtendKind,
 };
 
 use crate::reg::{writable, Reg};
@@ -1196,7 +1196,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32S)?;
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32S)?;
             Ok(TypedReg::i64(reg))
         })
     }
@@ -1205,7 +1205,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, _size| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64ExtendI32U)?;
+            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32U)?;
             Ok(TypedReg::i64(reg))
         })
     }
@@ -1941,8 +1941,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S32,
-            LoadKind::Simple,
+            LoadKind::Operand(OperandSize::S32),
             MemOpKind::Normal,
         )
     }
@@ -1951,7 +1950,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S8,
             LoadKind::ScalarExtend(ExtendKind::I32Extend8S),
             MemOpKind::Normal,
         )
@@ -1961,8 +1959,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S8,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I32Extend8U),
             MemOpKind::Normal,
         )
     }
@@ -1971,7 +1968,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S16,
             LoadKind::ScalarExtend(ExtendKind::I32Extend16S),
             MemOpKind::Normal,
         )
@@ -1981,8 +1977,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S16,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I32Extend16U),
             MemOpKind::Normal,
         )
     }
@@ -2003,7 +1998,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S8,
             LoadKind::ScalarExtend(ExtendKind::I64Extend8S),
             MemOpKind::Normal,
         )
@@ -2013,8 +2007,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S8,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I64Extend8U),
             MemOpKind::Normal,
         )
     }
@@ -2023,8 +2016,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S16,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I64Extend16U),
             MemOpKind::Normal,
         )
     }
@@ -2033,7 +2025,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S16,
             LoadKind::ScalarExtend(ExtendKind::I64Extend16S),
             MemOpKind::Normal,
         )
@@ -2043,8 +2034,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S32,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I64Extend32U),
             MemOpKind::Normal,
         )
     }
@@ -2053,7 +2043,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S32,
             LoadKind::ScalarExtend(ExtendKind::I64Extend32S),
             MemOpKind::Normal,
         )
@@ -2063,8 +2052,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S64,
-            LoadKind::Simple,
+            LoadKind::Operand(OperandSize::S64),
             MemOpKind::Normal,
         )
     }
@@ -2089,8 +2077,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::F32,
-            OperandSize::S32,
-            LoadKind::Simple,
+            LoadKind::Operand(OperandSize::S32),
             MemOpKind::Normal,
         )
     }
@@ -2103,8 +2090,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::F64,
-            OperandSize::S64,
-            LoadKind::Simple,
+            LoadKind::Operand(OperandSize::S64),
             MemOpKind::Normal,
         )
     }
@@ -2219,8 +2205,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S8,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I32Extend8U),
             MemOpKind::Atomic,
         )
     }
@@ -2229,8 +2214,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S16,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I32Extend16U),
             MemOpKind::Atomic,
         )
     }
@@ -2239,8 +2223,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            OperandSize::S32,
-            LoadKind::Simple,
+            LoadKind::Operand(OperandSize::S32),
             MemOpKind::Atomic,
         )
     }
@@ -2249,8 +2232,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S8,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I64Extend8U),
             MemOpKind::Atomic,
         )
     }
@@ -2259,8 +2241,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S16,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I64Extend16U),
             MemOpKind::Atomic,
         )
     }
@@ -2269,8 +2250,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S32,
-            LoadKind::Simple,
+            LoadKind::ScalarExtend(ExtendKind::I64Extend32U),
             MemOpKind::Atomic,
         )
     }
@@ -2279,8 +2259,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            OperandSize::S64,
-            LoadKind::Simple,
+            LoadKind::Operand(OperandSize::S64),
             MemOpKind::Atomic,
         )
     }
@@ -2302,8 +2281,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S128,
-            LoadKind::Simple,
+            LoadKind::Operand(OperandSize::S128),
             MemOpKind::Normal,
         )
     }
@@ -2316,7 +2294,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S64,
             LoadKind::VectorExtend(VectorExtendKind::V128Extend8x8S),
             MemOpKind::Normal,
         )
@@ -2326,7 +2303,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S64,
             LoadKind::VectorExtend(VectorExtendKind::V128Extend8x8U),
             MemOpKind::Normal,
         )
@@ -2336,7 +2312,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S64,
             LoadKind::VectorExtend(VectorExtendKind::V128Extend16x4S),
             MemOpKind::Normal,
         )
@@ -2346,7 +2321,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S64,
             LoadKind::VectorExtend(VectorExtendKind::V128Extend16x4U),
             MemOpKind::Normal,
         )
@@ -2356,7 +2330,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S64,
             LoadKind::VectorExtend(VectorExtendKind::V128Extend32x2S),
             MemOpKind::Normal,
         )
@@ -2366,7 +2339,6 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S64,
             LoadKind::VectorExtend(VectorExtendKind::V128Extend32x2U),
             MemOpKind::Normal,
         )
@@ -2376,8 +2348,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S8,
-            LoadKind::Splat,
+            LoadKind::Splat(SplatKind::S8),
             MemOpKind::Normal,
         )
     }
@@ -2386,8 +2357,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S16,
-            LoadKind::Splat,
+            LoadKind::Splat(SplatKind::S16),
             MemOpKind::Normal,
         )
     }
@@ -2396,8 +2366,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S32,
-            LoadKind::Splat,
+            LoadKind::Splat(SplatKind::S32),
             MemOpKind::Normal,
         )
     }
@@ -2406,8 +2375,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            OperandSize::S64,
-            LoadKind::Splat,
+            LoadKind::Splat(SplatKind::S64),
             MemOpKind::Normal,
         )
     }


### PR DESCRIPTION
This commit aims to simplify how `wasm_load`s are currently handled in the compiler by reducing the number of invariants that need to be encoded at callsites which make their emission error prone.

Concretely this change:

* Augments `ExtendKind`, to account for unsigned extends; prior to this commit it wasn't explicit which loads required unsigned extends.
* Derive `OperandSize` from `ExtendKind`, removing from the caller the responsibility of encoding the operand size to use.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
