### PR TITLE
[29.0.0] Fix dropping cached stack with `Store::into_data` 

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -655,6 +655,8 @@ impl<T> Store<T> {
 
     /// Consumes this [`Store`], destroying it, and returns the underlying data.
     pub fn into_data(mut self) -> T {
+        self.inner.flush_fiber_stack();
+
         // This is an unsafe operation because we want to avoid having a runtime
         // check or boolean for whether the data is actually contained within a
         // `Store`. The data itself is stored as `ManuallyDrop` since we're


### PR DESCRIPTION
Backport of #10009 for this release branch before it's released this weekend.