### PR TITLE
Release Wasmtime 28.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "28.0.0"
+version = "28.0.1"
 
 [[package]]
 name = "byteorder"
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -707,14 +707,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "arbitrary",
  "serde",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -755,25 +755,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.115.0"
+version = "0.115.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.115.0"
+version = "0.115.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1185,7 +1185,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3598,7 +3598,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "wasmparser 0.221.2",
@@ -3648,7 +3648,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4005,14 +4005,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4028,14 +4028,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4185,11 +4185,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "28.0.0"
+version = "28.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "object",
  "rustix",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "28.0.0"
+version = "28.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast-util"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "28.0.0"
+version = "28.0.1"
 
 [[package]]
 name = "wast"
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4706,7 +4706,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "28.0.0"
+version = "28.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "28.0.0"
+version = "28.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -197,60 +197,60 @@ allow_attributes_without_reason = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=28.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "28.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=28.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=28.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=28.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=28.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=28.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=28.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=28.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=28.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=28.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=28.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "28.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=28.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "28.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "28.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "28.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "28.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=28.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=28.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=28.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=28.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=28.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=28.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "28.0.1", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=28.0.1" }
+wasmtime-cache = { path = "crates/cache", version = "=28.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=28.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=28.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=28.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=28.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=28.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=28.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=28.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=28.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "28.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=28.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "28.0.1" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "28.0.1" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "28.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "28.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=28.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=28.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=28.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=28.0.1" }
+wasmtime-slab = { path = "crates/slab", version = "=28.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=28.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=28.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=28.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=28.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=28.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=28.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=28.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=28.0.1", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=28.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=28.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=28.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=28.0.1" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=28.0.0" }
+pulley-interpreter = { path = 'pulley', version = "=28.0.1" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-codegen = { path = "cranelift/codegen", version = "0.115.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.115.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.115.0" }
-cranelift-native = { path = "cranelift/native", version = "0.115.0" }
-cranelift-module = { path = "cranelift/module", version = "0.115.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.115.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.115.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.115.1", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.115.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.115.1" }
+cranelift-native = { path = "cranelift/native", version = "0.115.1" }
+cranelift-module = { path = "cranelift/module", version = "0.115.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.115.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.115.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.115.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.115.0" }
+cranelift-object = { path = "cranelift/object", version = "0.115.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.115.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.115.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.115.0" }
-cranelift-control = { path = "cranelift/control", version = "0.115.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.115.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.115.1" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.115.1" }
+cranelift-control = { path = "cranelift/control", version = "0.115.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.115.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=28.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=28.0.1" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+## 28.0.1
+
+Released 2025-01-14.
+
+### Fixed
+
+* Fixed deallocating async stacks when using `Store::into_data`.
+  [#10009](https://github.com/bytecodealliance/wasmtime/pull/10009)
+
+--------------------------------------------------------------------------------
+
 ## 28.0.0
 
 Released 2024-12-20.

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.115.0"
+version = "0.115.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.115.0"
+version = "0.115.1"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.115.0"
+version = "0.115.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -24,7 +24,7 @@ features = ["all-arch"]
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.115.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.115.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -53,8 +53,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.115.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.115.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.115.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.115.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.115.0"
+version = "0.115.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,4 +16,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.115.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.115.1" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.115.0"
+version = "0.115.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.115.0"
+version = "0.115.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.115.0"
+version = "0.115.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.115.0"
+version = "0.115.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.115.0"
+version = "0.115.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.115.0"
+version = "0.115.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.115.0"
+version = "0.115.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.115.0"
+version = "0.115.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.115.0"
+version = "0.115.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.115.0"
+version = "0.115.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.115.0"
+version = "0.115.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.115.0"
+version = "0.115.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.115.0"
+version = "0.115.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "28.0.0"
+#define WASMTIME_VERSION "28.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,185 +5,369 @@
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-control]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-control]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-module]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-module]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-native]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-native]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-object]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-object]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.115.0"
 audited_as = "0.113.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.115.1"
+audited_as = "0.115.0"
 
 [[unpublished.cranelift-serde]]
 version = "0.115.0"
 audited_as = "0.113.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.115.1"
+audited_as = "0.115.0"
+
 [[unpublished.pulley-interpreter]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.pulley-interpreter]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasi-common]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasi-common]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-cache]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-cache]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-cli]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-cli]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-component-macro]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-component-macro]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-component-util]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-component-util]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-cranelift]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-cranelift]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-explorer]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-explorer]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-fiber]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-fiber]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-slab]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-slab]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wasi]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-wasi]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "28.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-winch]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-winch]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wiggle]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wiggle]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wiggle-generate]]
 version = "28.0.0"
 audited_as = "26.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "28.0.1"
+audited_as = "28.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -192,6 +376,10 @@ audited_as = "0.1.0"
 [[unpublished.winch-codegen]]
 version = "28.0.0"
 audited_as = "26.0.1"
+
+[[unpublished.winch-codegen]]
+version = "28.0.1"
+audited_as = "28.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -376,104 +564,104 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.113.1"
-when = "2024-11-05"
+version = "0.115.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -667,8 +855,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -896,8 +1084,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.wasi-common]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -985,146 +1173,146 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-slab]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "27.0.0"
-when = "2024-11-20"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1141,20 +1329,20 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1173,8 +1361,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "26.0.1"
-when = "2024-11-05"
+version = "28.0.0"
+when = "2024-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 28.0.1, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-28.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
