### PR TITLE
pulley: Support smaller int-to-float conversions

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -1258,28 +1258,28 @@
 
 ;;;; Rules for `fcvt_from_{u,s}int` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type $F32 (fcvt_from_uint val @ (value_type $I32))))
-  (pulley_f32_from_x32_u val))
+(rule 0 (lower (has_type $F32 (fcvt_from_uint val @ (value_type (fits_in_32 _)))))
+  (pulley_f32_from_x32_u (zext32 val)))
 
-(rule (lower (has_type $F32 (fcvt_from_uint val @ (value_type $I64))))
+(rule 1 (lower (has_type $F32 (fcvt_from_uint val @ (value_type $I64))))
   (pulley_f32_from_x64_u val))
 
-(rule (lower (has_type $F64 (fcvt_from_uint val @ (value_type $I32))))
-  (pulley_f64_from_x32_u val))
+(rule 0 (lower (has_type $F64 (fcvt_from_uint val @ (value_type (fits_in_32 _)))))
+  (pulley_f64_from_x32_u (zext32 val)))
 
-(rule (lower (has_type $F64 (fcvt_from_uint val @ (value_type $I64))))
+(rule 1 (lower (has_type $F64 (fcvt_from_uint val @ (value_type $I64))))
   (pulley_f64_from_x64_u val))
 
-(rule (lower (has_type $F32 (fcvt_from_sint val @ (value_type $I32))))
-  (pulley_f32_from_x32_s val))
+(rule 0 (lower (has_type $F32 (fcvt_from_sint val @ (value_type (fits_in_32 _)))))
+  (pulley_f32_from_x32_s (sext32 val)))
 
-(rule (lower (has_type $F32 (fcvt_from_sint val @ (value_type $I64))))
+(rule 1 (lower (has_type $F32 (fcvt_from_sint val @ (value_type $I64))))
   (pulley_f32_from_x64_s val))
 
-(rule (lower (has_type $F64 (fcvt_from_sint val @ (value_type $I32))))
-  (pulley_f64_from_x32_s val))
+(rule 0 (lower (has_type $F64 (fcvt_from_sint val @ (value_type (fits_in_32 _)))))
+  (pulley_f64_from_x32_s (sext32 val)))
 
-(rule (lower (has_type $F64 (fcvt_from_sint val @ (value_type $I64))))
+(rule 1 (lower (has_type $F64 (fcvt_from_sint val @ (value_type $I64))))
   (pulley_f64_from_x64_s val))
 
 (rule (lower (has_type $F32X4 (fcvt_from_sint val @ (value_type $I32X4))))

--- a/cranelift/filetests/filetests/runtests/fcvt-from-int.clif
+++ b/cranelift/filetests/filetests/runtests/fcvt-from-int.clif
@@ -1,0 +1,179 @@
+test interpret
+test run
+target aarch64
+target x86_64
+target s390x
+target riscv64
+target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
+
+function %i8_to_f32(i8) -> f32 {
+block0(v0: i8):
+    v1 = fcvt_from_sint.f32 v0
+    return v1
+}
+
+; run: %i8_to_f32(0) == 0.0
+; run: %i8_to_f32(1) == 0x1.0
+; run: %i8_to_f32(-1) == -0x1.0
+
+
+function %u8_to_f32(i8) -> f32 {
+block0(v0: i8):
+    v1 = fcvt_from_uint.f32 v0
+    return v1
+}
+
+; run: %u8_to_f32(0) == 0.0
+; run: %u8_to_f32(1) == 0x1.0
+; run: %u8_to_f32(-1) == 0x1.fep7
+
+function %i16_to_f32(i16) -> f32 {
+block0(v0: i16):
+    v1 = fcvt_from_sint.f32 v0
+    return v1
+}
+
+; run: %i16_to_f32(0) == 0.0
+; run: %i16_to_f32(1) == 0x1.0
+; run: %i16_to_f32(-1) == -0x1.0
+
+
+function %u16_to_f32(i16) -> f32 {
+block0(v0: i16):
+    v1 = fcvt_from_uint.f32 v0
+    return v1
+}
+
+; run: %u16_to_f32(0) == 0.0
+; run: %u16_to_f32(1) == 0x1.0
+; run: %u16_to_f32(-1) == 0x1.fffep15
+
+function %i32_to_f32(i32) -> f32 {
+block0(v0: i32):
+    v1 = fcvt_from_sint.f32 v0
+    return v1
+}
+
+; run: %i32_to_f32(0) == 0.0
+; run: %i32_to_f32(1) == 0x1.0
+; run: %i32_to_f32(-1) == -0x1.0
+
+
+function %u32_to_f32(i32) -> f32 {
+block0(v0: i32):
+    v1 = fcvt_from_uint.f32 v0
+    return v1
+}
+
+; run: %u32_to_f32(0) == 0.0
+; run: %u32_to_f32(1) == 0x1.0
+; run: %u32_to_f32(-1) == 0x1.0p32
+
+function %i64_to_f32(i64) -> f32 {
+block0(v0: i64):
+    v1 = fcvt_from_sint.f32 v0
+    return v1
+}
+
+; run: %i64_to_f32(0) == 0.0
+; run: %i64_to_f32(1) == 0x1.0
+; run: %i64_to_f32(-1) == -0x1.0
+
+
+function %u64_to_f32(i64) -> f32 {
+block0(v0: i64):
+    v1 = fcvt_from_uint.f32 v0
+    return v1
+}
+
+; run: %u64_to_f32(0) == 0.0
+; run: %u64_to_f32(1) == 0x1.0
+; run: %u64_to_f32(-1) == 0x1.0p64
+
+function %i8_to_f64(i8) -> f64 {
+block0(v0: i8):
+    v1 = fcvt_from_sint.f64 v0
+    return v1
+}
+
+; run: %i8_to_f64(0) == 0.0
+; run: %i8_to_f64(1) == 0x1.0
+; run: %i8_to_f64(-1) == -0x1.0
+
+
+function %u8_to_f64(i8) -> f64 {
+block0(v0: i8):
+    v1 = fcvt_from_uint.f64 v0
+    return v1
+}
+
+; run: %u8_to_f64(0) == 0.0
+; run: %u8_to_f64(1) == 0x1.0
+; run: %u8_to_f64(-1) == 0x1.fep7
+
+function %i16_to_f64(i16) -> f64 {
+block0(v0: i16):
+    v1 = fcvt_from_sint.f64 v0
+    return v1
+}
+
+; run: %i16_to_f64(0) == 0.0
+; run: %i16_to_f64(1) == 0x1.0
+; run: %i16_to_f64(-1) == -0x1.0
+
+
+function %u16_to_f64(i16) -> f64 {
+block0(v0: i16):
+    v1 = fcvt_from_uint.f64 v0
+    return v1
+}
+
+; run: %u16_to_f64(0) == 0.0
+; run: %u16_to_f64(1) == 0x1.0
+; run: %u16_to_f64(-1) == 0x1.fffep15
+
+function %i32_to_f64(i32) -> f64 {
+block0(v0: i32):
+    v1 = fcvt_from_sint.f64 v0
+    return v1
+}
+
+; run: %i32_to_f64(0) == 0.0
+; run: %i32_to_f64(1) == 0x1.0
+; run: %i32_to_f64(-1) == -0x1.0
+
+
+function %u32_to_f64(i32) -> f64 {
+block0(v0: i32):
+    v1 = fcvt_from_uint.f64 v0
+    return v1
+}
+
+; run: %u32_to_f64(0) == 0.0
+; run: %u32_to_f64(1) == 0x1.0
+; run: %u32_to_f64(-1) == 0x1.fffffffep31
+
+function %i64_to_f64(i64) -> f64 {
+block0(v0: i64):
+    v1 = fcvt_from_sint.f64 v0
+    return v1
+}
+
+; run: %i64_to_f64(0) == 0.0
+; run: %i64_to_f64(1) == 0x1.0
+; run: %i64_to_f64(-1) == -0x1.0
+
+
+function %u64_to_f64(i64) -> f64 {
+block0(v0: i64):
+    v1 = fcvt_from_uint.f64 v0
+    return v1
+}
+
+; run: %u64_to_f64(0) == 0.0
+; run: %u64_to_f64(1) == 0x1.0
+; run: %u64_to_f64(-1) == 0x1.0p64

--- a/cranelift/filetests/filetests/runtests/issue5952.clif
+++ b/cranelift/filetests/filetests/runtests/issue5952.clif
@@ -5,6 +5,10 @@ target x86_64
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %a(i16 uext) -> f32 {
 block0(v0: i16):


### PR DESCRIPTION
This adds support for converting 8/16-bit integers to floats to Pulley. This is not directly accessible from wasm instructions but is possible through various optimizations to create. A new `*.clif` runtest was added exercising many combinations of scalars-to-scalars for int-to-floats of varying widths.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
