### PR TITLE
wasmtime-wasi: remove dependency on trait-variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,7 +4427,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "trait-variant",
  "url",
  "wasmtime",
  "wiggle",

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -32,7 +32,6 @@ io-lifetimes = { workspace = true }
 fs-set-times = { workspace = true }
 bitflags = { workspace = true }
 async-trait = { workspace = true }
-trait-variant = {workspace = true}
 system-interface = { workspace = true}
 futures = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
This seems to have been added by mistake. There is a dep on this crate in wasmtime for use by the component macro, but all use sites use it through the wasmtime crate's re-export.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
