### PR TITLE
pulley: Refactor register restores on tail-calls

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -360,16 +360,6 @@ where
         _call_conv: isa::CallConv,
         _flags: &settings::Flags,
         _isa_flags: &PulleyFlags,
-        _frame_layout: &FrameLayout,
-    ) -> SmallInstVec<Self::I> {
-        // Note that this is intentionally empty as `gen_return` does
-        // everything.
-        SmallVec::new()
-    }
-
-    fn gen_return(
-        _call_conv: isa::CallConv,
-        _isa_flags: &PulleyFlags,
         frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
         let mut insts = SmallVec::new();
@@ -418,14 +408,15 @@ where
             ));
         }
 
-        // And finally, return.
-        //
-        // FIXME: if `frame_layout.tail_args_size` is zero this instruction
-        // should get folded into the macro-instructions above. No need to have
-        // all functions do `pop_frame; ret`, that could be `pop_frame_and_ret`.
-        // Should benchmark whether this is worth it though.
-        insts.push(RawInst::Ret {}.into());
         insts
+    }
+
+    fn gen_return(
+        _call_conv: isa::CallConv,
+        _isa_flags: &PulleyFlags,
+        _frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Self::I> {
+        smallvec![RawInst::Ret {}.into()]
     }
 
     fn gen_probestack(_insts: &mut SmallInstVec<Self::I>, _frame_size: u32) {

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -401,22 +401,25 @@ where
             }
         }
 
-        // Handle final stack adjustments for the tail-call ABI.
-        if frame_layout.tail_args_size > 0 {
-            insts.extend(Self::gen_sp_reg_adjust(
-                frame_layout.tail_args_size.try_into().unwrap(),
-            ));
-        }
-
         insts
     }
 
     fn gen_return(
         _call_conv: isa::CallConv,
         _isa_flags: &PulleyFlags,
-        _frame_layout: &FrameLayout,
+        frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
-        smallvec![RawInst::Ret {}.into()]
+        let mut insts = SmallVec::new();
+
+        // Handle final stack adjustments for the tail-call ABI.
+        if frame_layout.tail_args_size > 0 {
+            insts.extend(Self::gen_sp_reg_adjust(
+                frame_layout.tail_args_size.try_into().unwrap(),
+            ));
+        }
+        insts.push(RawInst::Ret {}.into());
+
+        insts
     }
 
     fn gen_probestack(_insts: &mut SmallInstVec<Self::I>, _frame_size: u32) {

--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -124,7 +124,11 @@ where
         domtree: &DominatorTree,
         ctrl_plane: &mut ControlPlane,
     ) -> CodegenResult<(VCode<inst::InstAndKind<P>>, regalloc2::Output)> {
-        let emit_info = EmitInfo::new(self.flags.clone(), self.isa_flags.clone());
+        let emit_info = EmitInfo::new(
+            func.signature.call_conv,
+            self.flags.clone(),
+            self.isa_flags.clone(),
+        );
         let sigs = SigSet::new::<abi::PulleyMachineDeps<P>>(func, &self.flags)?;
         let abi = abi::PulleyCallee::new(func, self, &self.isa_flags, &sigs)?;
         machinst::compile::<Self>(func, domtree, self, abi, emit_info, sigs, ctrl_plane)


### PR DESCRIPTION
Use helpers from `abi.rs` where possible to avoid duplicating logic.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
