### PR TITLE
Add release binaries for 32-bit platforms

### DIFF
--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -92,6 +92,24 @@ const array = [
     "target": "aarch64-pc-windows-msvc",
     "env": { "RUSTFLAGS": "-Ctarget-feature=+crt-static" },
   },
+  {
+    "build": "i686-linux",
+    "os": ubuntu,
+    "target": "i686-unknown-linux-gnu",
+    "env": { "DOCKER_IMAGE": "./ci/docker/i686-linux/Dockerfile" },
+  },
+  {
+    "build": "armv7-linux",
+    "os": ubuntu,
+    "target": "armv7-unknown-linux-gnueabihf",
+    "env": { "DOCKER_IMAGE": "./ci/docker/armv7-linux/Dockerfile" },
+  },
+  {
+    "build": "i686-windows",
+    "os": windows,
+    "target": "i686-pc-windows-msvc",
+    "env": { "RUSTFLAGS": "-Ctarget-feature=+crt-static" },
+  },
 ];
 
 const builds = [];

--- a/ci/docker/armv7-linux/Dockerfile
+++ b/ci/docker/armv7-linux/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install -y gcc gcc-arm-linux-gnueabihf ca-certificates curl make git ninja-build
+RUN git config --global --add safe.directory '*'
+
+# The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
+# CMake's own releases and use that instead.
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
+ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
+
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc

--- a/ci/docker/i686-linux/Dockerfile
+++ b/ci/docker/i686-linux/Dockerfile
@@ -1,0 +1,11 @@
+FROM almalinux:8
+
+RUN dnf install -y git gcc make cmake git unzip glibc-devel.i686
+RUN git config --global --add safe.directory '*'
+
+WORKDIR /usr/local/bin
+RUN curl -LO https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+RUN unzip ./ninja-linux
+WORKDIR /
+
+ENV CC_i686-unknown-linux-gnu=gcc

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -152,7 +152,7 @@ pub union wasmtime_val_union {
 
 const _: () = {
     assert!(std::mem::size_of::<wasmtime_val_union>() == 16);
-    assert!(std::mem::align_of::<wasmtime_val_union>() == 8);
+    assert!(std::mem::align_of::<wasmtime_val_union>() == std::mem::align_of::<u64>());
 };
 
 // The raw pointers are actually optional boxes.

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -87,16 +87,22 @@ For explanations of what each tier means see below.
 
 | Category             | Description                       | Missing Tier 2 Requirements |
 |----------------------|-----------------------------------|-----------------------------|
-| Target               | `aarch64-pc-windows-msvc`         | CI testing, unwinding, full-time maintainer |
+| Target               | `aarch64-apple-ios`               | CI testing, full-time maintainer |
+| Target               | `aarch64-linux-android`           | CI testing, full-time maintainer |
+| Target               | `aarch64-pc-windows-msvc`         | CI testing, full-time maintainer |
+| Target               | `aarch64-unknown-linux-musl` [^4] | CI testing, full-time maintainer |
+| Target               | `armv7-unknown-linux-gnueabihf`   | full-time maintainer |
+| Target               | `i686-pc-windows-msvc`            | CI testing, full-time maintainer |
+| Target               | `i686-unknown-linux-gnu`          | full-time maintainer |
 | Target               | `riscv64gc-unknown-linux-gnu`     | full-time maintainer        |
 | Target               | `wasm32-wasip1` [^3]              | Supported but not tested    |
-| Target               | `aarch64-linux-android`           | CI testing, full-time maintainer |
 | Target               | `x86_64-linux-android`            | CI testing, full-time maintainer |
-| Target               | `x86_64-unknown-linux-musl` [^4]  | CI testing, full-time maintainer |
-| Target               | `x86_64-unknown-illumos`          | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-freebsd`          | CI testing, full-time maintainer |
+| Target               | `x86_64-unknown-illumos`          | CI testing, full-time maintainer |
+| Target               | `x86_64-unknown-linux-musl` [^4]  | CI testing, full-time maintainer |
 | Compiler Backend     | Winch on x86\_64                  | WebAssembly proposals (`simd`, `relaxed-simd`, `tail-call`, `reference-types`, `threads`)     |
 | Compiler Backend     | Winch on aarch64                  | Complete implementation     |
+| Execution Backend    | Pulley                            | fuzzing                     |
 | WebAssembly Proposal | [`gc`]                            | Complete implementation     |
 | WASI Proposal        | [`wasi-nn`]                       | More expansive CI testing   |
 | WASI Proposal        | [`wasi-threads`]                  | More CI, unstable proposal  |
@@ -142,14 +148,14 @@ features; rather design discussion and PRs are welcome for many of the below
 features to figure out how best to implement them and at least move them to Tier
 3 above.
 
-* Target: ARM 32-bit
 * Target: [AArch64 FreeBSD](https://github.com/bytecodealliance/wasmtime/issues/5499)
 * Target: [NetBSD/OpenBSD](https://github.com/bytecodealliance/wasmtime/issues/6962)
-* Target: [i686 (32-bit Intel targets)](https://github.com/bytecodealliance/wasmtime/issues/1980)
-* Target: MIPS
-* Target: SPARC
-* Target: PowerPC
-* Target: RISC-V 32-bit
+* Cranelift Target: [i686 (32-bit Intel targets)](https://github.com/bytecodealliance/wasmtime/issues/1980)
+* Cranelift Target: ARM 32-bit
+* Cranelift Target: MIPS
+* Cranelift Target: SPARC
+* Cranelift Target: PowerPC
+* Cranelift Target: RISC-V 32-bit
 * WebAssembly Proposals: see [documentation here](./stability-wasm-proposals.md)
 * [WASI proposal: `proxy-wasm`](https://github.com/proxy-wasm/spec)
 * [WASI proposal: `wasi-blob-store`](https://github.com/WebAssembly/wasi-blob-store)


### PR DESCRIPTION
This commit notably adds release binaries for:

* `i686-unknown-linux-gnu` - named `i686-linux`
* `i686-pc-windows-msvc` - named `i686-windows`
* `armv7-unknown-linux-gnueabihf` - named `armv7-linux`

These artifacts all use Pulley for their execution of WebAssembly and have been added to the tiers listing under tier 3.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
