### PR TITLE
Wasmtime: generalize `async_stack_zeroing` knob to cover initialization

### DIFF
--- a/crates/c-api/include/wasmtime/async.h
+++ b/crates/c-api/include/wasmtime/async.h
@@ -332,7 +332,7 @@ typedef struct {
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackCreator.html#tymethod.new_stack
  */
 typedef wasmtime_error_t *(*wasmtime_new_stack_memory_callback_t)(
-    void *env, size_t size, wasmtime_stack_memory_t *stack_ret);
+    void *env, size_t size, bool zeroed, wasmtime_stack_memory_t *stack_ret);
 
 /**
  * A representation of custom stack creator.

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -131,10 +131,6 @@ wasmtime_option_group! {
         /// pooling allocator. (default: 100)
         pub pooling_max_unused_warm_slots: Option<u32>,
 
-        /// Configures whether or not stacks used for async futures are reset to
-        /// zero after usage. (default: false)
-        pub pooling_async_stack_zeroing: Option<bool>,
-
         /// How much memory, in bytes, to keep resident for async stacks allocated
         /// with the pooling allocator. (default: 0)
         pub pooling_async_stack_keep_resident: Option<usize>,
@@ -276,6 +272,9 @@ wasmtime_option_group! {
         /// difference between the two is how much stack the host has to execute
         /// on.
         pub async_stack_size: Option<usize>,
+        /// Configures whether or not stacks used for async futures are zeroed
+        /// before (re)use as a defense-in-depth mechanism. (default: false)
+        pub async_stack_zeroing: Option<bool>,
         /// Allow unknown exports when running commands.
         pub unknown_exports_allow: Option<bool>,
         /// Allow the main module to import unknown functions, using an
@@ -760,11 +759,6 @@ impl CommonOptions {
                         cfg.max_unused_warm_slots(max);
                     }
                     match_feature! {
-                        ["async" : self.opts.pooling_async_stack_zeroing]
-                        enable => cfg.async_stack_zeroing(enable),
-                        _ => err,
-                    }
-                    match_feature! {
                         ["async" : self.opts.pooling_async_stack_keep_resident]
                         size => cfg.async_stack_keep_resident(size),
                         _ => err,
@@ -829,6 +823,11 @@ impl CommonOptions {
         match_feature! {
             ["async" : self.wasm.async_stack_size]
             size => config.async_stack_size(size),
+            _ => err,
+        }
+        match_feature! {
+            ["async" : self.wasm.async_stack_zeroing]
+            enable => config.async_stack_zeroing(enable),
             _ => err,
         }
 

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -47,8 +47,8 @@ pub type Result<T, E = imp::Error> = core::result::Result<T, E>;
 
 impl FiberStack {
     /// Creates a new fiber stack of the given size.
-    pub fn new(size: usize) -> Result<Self> {
-        Ok(Self(imp::FiberStack::new(size)?))
+    pub fn new(size: usize, zeroed: bool) -> Result<Self> {
+        Ok(Self(imp::FiberStack::new(size, zeroed)?))
     }
 
     /// Creates a new fiber stack of the given size.
@@ -108,7 +108,7 @@ pub unsafe trait RuntimeFiberStackCreator: Send + Sync {
     ///
     /// This is useful to plugin previously allocated memory instead of mmap'ing a new stack for
     /// every instance.
-    fn new_stack(&self, size: usize) -> Result<Box<dyn RuntimeFiberStack>, Error>;
+    fn new_stack(&self, size: usize, zeroed: bool) -> Result<Box<dyn RuntimeFiberStack>, Error>;
 }
 
 /// A fiber stack backed by custom memory.

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -276,11 +276,11 @@ mod tests {
 
     #[test]
     fn small_stacks() {
-        Fiber::<(), (), ()>::new(FiberStack::new(0).unwrap(), |_, _| {})
+        Fiber::<(), (), ()>::new(FiberStack::new(0, false).unwrap(), |_, _| {})
             .unwrap()
             .resume(())
             .unwrap();
-        Fiber::<(), (), ()>::new(FiberStack::new(1).unwrap(), |_, _| {})
+        Fiber::<(), (), ()>::new(FiberStack::new(1, false).unwrap(), |_, _| {})
             .unwrap()
             .resume(())
             .unwrap();
@@ -290,10 +290,11 @@ mod tests {
     fn smoke() {
         let hit = Rc::new(Cell::new(false));
         let hit2 = hit.clone();
-        let fiber = Fiber::<(), (), ()>::new(FiberStack::new(1024 * 1024).unwrap(), move |_, _| {
-            hit2.set(true);
-        })
-        .unwrap();
+        let fiber =
+            Fiber::<(), (), ()>::new(FiberStack::new(1024 * 1024, false).unwrap(), move |_, _| {
+                hit2.set(true);
+            })
+            .unwrap();
         assert!(!hit.get());
         fiber.resume(()).unwrap();
         assert!(hit.get());
@@ -303,12 +304,13 @@ mod tests {
     fn suspend_and_resume() {
         let hit = Rc::new(Cell::new(false));
         let hit2 = hit.clone();
-        let fiber = Fiber::<(), (), ()>::new(FiberStack::new(1024 * 1024).unwrap(), move |_, s| {
-            s.suspend(());
-            hit2.set(true);
-            s.suspend(());
-        })
-        .unwrap();
+        let fiber =
+            Fiber::<(), (), ()>::new(FiberStack::new(1024 * 1024, false).unwrap(), move |_, s| {
+                s.suspend(());
+                hit2.set(true);
+                s.suspend(());
+            })
+            .unwrap();
         assert!(!hit.get());
         assert!(fiber.resume(()).is_err());
         assert!(!hit.get());
@@ -345,15 +347,17 @@ mod tests {
         }
 
         fn run_test() {
-            let fiber =
-                Fiber::<(), (), ()>::new(FiberStack::new(1024 * 1024).unwrap(), move |(), s| {
+            let fiber = Fiber::<(), (), ()>::new(
+                FiberStack::new(1024 * 1024, false).unwrap(),
+                move |(), s| {
                     assert_contains_host();
                     s.suspend(());
                     assert_contains_host();
                     s.suspend(());
                     assert_contains_host();
-                })
-                .unwrap();
+                },
+            )
+            .unwrap();
             assert!(fiber.resume(()).is_err());
             assert!(fiber.resume(()).is_err());
             assert!(fiber.resume(()).is_ok());
@@ -369,12 +373,14 @@ mod tests {
 
         let a = Rc::new(Cell::new(false));
         let b = SetOnDrop(a.clone());
-        let fiber =
-            Fiber::<(), (), ()>::new(FiberStack::new(1024 * 1024).unwrap(), move |(), _s| {
+        let fiber = Fiber::<(), (), ()>::new(
+            FiberStack::new(1024 * 1024, false).unwrap(),
+            move |(), _s| {
                 let _ = &b;
                 panic!();
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         assert!(panic::catch_unwind(AssertUnwindSafe(|| fiber.resume(()))).is_err());
         assert!(a.get());
 
@@ -389,11 +395,14 @@ mod tests {
 
     #[test]
     fn suspend_and_resume_values() {
-        let fiber = Fiber::new(FiberStack::new(1024 * 1024).unwrap(), move |first, s| {
-            assert_eq!(first, 2.0);
-            assert_eq!(s.suspend(4), 3.0);
-            "hello".to_string()
-        })
+        let fiber = Fiber::new(
+            FiberStack::new(1024 * 1024, false).unwrap(),
+            move |first, s| {
+                assert_eq!(first, 2.0);
+                assert_eq!(s.suspend(4), 3.0);
+                "hello".to_string()
+            },
+        )
         .unwrap();
         assert_eq!(fiber.resume(2.0), Err(4));
         assert_eq!(fiber.resume(3.0), Ok("hello".to_string()));

--- a/crates/fiber/src/nostd.rs
+++ b/crates/fiber/src/nostd.rs
@@ -62,10 +62,14 @@ fn align_ptr(ptr: *mut u8, len: usize, align: usize) -> (*mut u8, usize) {
 }
 
 impl FiberStack {
-    pub fn new(size: usize) -> Result<Self> {
+    pub fn new(size: usize, zeroed: bool) -> Result<Self> {
         // Round up the size to at least one page.
         let size = core::cmp::max(4096, size);
-        let mut storage = vec![0; size];
+        let mut storage = Vec::new();
+        storage.reserve_exact(size);
+        if zeroed {
+            storage.resize(size, 0);
+        }
         let (base, len) = align_ptr(storage.as_mut_ptr(), size, STACK_ALIGN);
         Ok(FiberStack {
             storage,

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -60,7 +60,11 @@ enum FiberStackStorage {
 }
 
 impl FiberStack {
-    pub fn new(size: usize) -> io::Result<Self> {
+    pub fn new(size: usize, zeroed: bool) -> io::Result<Self> {
+        // The anonymous `mmap`s we use for `FiberStackStorage` are alawys
+        // zeroed.
+        let _ = zeroed;
+
         // See comments in `mod asan` below for why asan has a different stack
         // allocation strategy.
         if cfg!(asan) {

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -14,7 +14,10 @@ pub type Error = io::Error;
 pub struct FiberStack(usize);
 
 impl FiberStack {
-    pub fn new(size: usize) -> io::Result<Self> {
+    pub fn new(size: usize, zeroed: bool) -> io::Result<Self> {
+        // We don't support fiber stack zeroing on windows.
+        let _ = zeroed;
+
         Ok(Self(size))
     }
 

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -275,7 +275,8 @@ impl Config {
             ))
             .allocation_strategy(self.wasmtime.strategy.to_wasmtime())
             .generate_address_map(self.wasmtime.generate_address_map)
-            .signals_based_traps(self.wasmtime.signals_based_traps);
+            .signals_based_traps(self.wasmtime.signals_based_traps)
+            .async_stack_zeroing(self.wasmtime.async_stack_zeroing);
 
         if !self.module_config.config.simd_enabled {
             cfg.wasm_relaxed_simd(false);
@@ -508,6 +509,7 @@ pub struct WasmtimeConfig {
     memory_init_cow: bool,
     memory_guaranteed_dense_image_size: u64,
     use_precompiled_cwasm: bool,
+    async_stack_zeroing: bool,
     /// Configuration for the instance allocation strategy to use.
     pub strategy: InstanceAllocationStrategy,
     codegen: CodegenSettings,

--- a/crates/fuzzing/src/generators/pooling_config.rs
+++ b/crates/fuzzing/src/generators/pooling_config.rs
@@ -30,7 +30,6 @@ pub struct PoolingAllocationConfig {
     pub decommit_batch_size: usize,
     pub max_unused_warm_slots: u32,
 
-    pub async_stack_zeroing: bool,
     pub async_stack_keep_resident: usize,
 
     pub memory_protection_keys: MpkEnabled,
@@ -65,7 +64,6 @@ impl PoolingAllocationConfig {
         cfg.decommit_batch_size(self.decommit_batch_size);
         cfg.max_unused_warm_slots(self.max_unused_warm_slots);
 
-        cfg.async_stack_zeroing(self.async_stack_zeroing);
         cfg.async_stack_keep_resident(self.async_stack_keep_resident);
 
         cfg.memory_protection_keys(self.memory_protection_keys);
@@ -112,7 +110,6 @@ impl<'a> Arbitrary<'a> for PoolingAllocationConfig {
             decommit_batch_size: u.int_in_range(1..=1000)?,
             max_unused_warm_slots: u.int_in_range(0..=total_memories + 10)?,
 
-            async_stack_zeroing: u.arbitrary()?,
             async_stack_keep_resident: u.int_in_range(0..=1 << 20)?,
 
             memory_protection_keys: *u.choose(&[MpkEnabled::Auto, MpkEnabled::Disable])?,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -259,7 +259,7 @@ impl Config {
             #[cfg(feature = "async")]
             async_stack_size: 2 << 20,
             #[cfg(feature = "async")]
-            async_stack_zeroing: true,
+            async_stack_zeroing: false,
             #[cfg(feature = "async")]
             stack_creator: None,
             async_support: false,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -155,6 +155,8 @@ pub struct Config {
     #[cfg(feature = "async")]
     pub(crate) async_stack_size: usize,
     #[cfg(feature = "async")]
+    pub(crate) async_stack_zeroing: bool,
+    #[cfg(feature = "async")]
     pub(crate) stack_creator: Option<Arc<dyn RuntimeFiberStackCreator>>,
     pub(crate) async_support: bool,
     pub(crate) module_version: ModuleVersionStrategy,
@@ -256,6 +258,8 @@ impl Config {
             disabled_features: WasmFeatures::empty(),
             #[cfg(feature = "async")]
             async_stack_size: 2 << 20,
+            #[cfg(feature = "async")]
+            async_stack_zeroing: true,
             #[cfg(feature = "async")]
             stack_creator: None,
             async_support: false,
@@ -725,6 +729,40 @@ impl Config {
     #[cfg(feature = "async")]
     pub fn async_stack_size(&mut self, size: usize) -> &mut Self {
         self.async_stack_size = size;
+        self
+    }
+
+    /// Configures whether or not stacks used for async futures are zeroed
+    /// before (re)use.
+    ///
+    /// When the [`async_support`](Config::async_support) method is enabled for
+    /// Wasmtime and the [`call_async`] variant of calling WebAssembly is used
+    /// then Wasmtime will create a separate runtime execution stack for each
+    /// future produced by [`call_async`]. By default upon allocation, depending
+    /// on the platform, these stacks might be filled with uninitialized
+    /// memory. This is safe and correct because, modulo bugs in Wasmtime,
+    /// compiled Wasm code will never read from a stack slot before it
+    /// initializes the stack slot.
+    ///
+    /// However, as a defense-in-depth mechanism, you may configure Wasmtime to
+    /// ensure that these stacks are zeroed before they are used. Notably, if
+    /// you are using the pooling allocator, stacks can be pooled and reused
+    /// across different Wasm guests; ensuring that stacks are zeroed can
+    /// prevent data leakage between Wasm guests even in the face of potential
+    /// read-of-stack-slot-before-initialization bugs in Wasmtime's compiler.
+    ///
+    /// Stack zeroing can be a costly operation in highly concurrent
+    /// environments due to modifications of the virtual address space requiring
+    /// process-wide synchronization. It can also be costly in `no-std`
+    /// environments that must manually zero memory, and cannot rely on an OS
+    /// and virtual memory to provide zeroed pages.
+    ///
+    /// This option defaults to `false`.
+    ///
+    /// [`call_async`]: crate::TypedFunc::call_async
+    #[cfg(feature = "async")]
+    pub fn async_stack_zeroing(&mut self, enable: bool) -> &mut Self {
+        self.async_stack_zeroing = enable;
         self
     }
 
@@ -2159,10 +2197,10 @@ impl Config {
         tunables: &Tunables,
     ) -> Result<Box<dyn InstanceAllocator + Send + Sync>> {
         #[cfg(feature = "async")]
-        let stack_size = self.async_stack_size;
+        let (stack_size, stack_zeroing) = (self.async_stack_size, self.async_stack_zeroing);
 
         #[cfg(not(feature = "async"))]
-        let stack_size = 0;
+        let (stack_size, stack_zeroing) = (0, false);
 
         let _ = tunables;
 
@@ -2172,6 +2210,7 @@ impl Config {
                 let mut allocator = Box::new(OnDemandInstanceAllocator::new(
                     self.mem_creator.clone(),
                     stack_size,
+                    stack_zeroing,
                 ));
                 #[cfg(feature = "async")]
                 if let Some(stack_creator) = &self.stack_creator {
@@ -2183,6 +2222,7 @@ impl Config {
             InstanceAllocationStrategy::Pooling(config) => {
                 let mut config = config.config;
                 config.stack_size = stack_size;
+                config.async_stack_zeroing = stack_zeroing;
                 Ok(Box::new(crate::runtime::vm::PoolingInstanceAllocator::new(
                     &config, tunables,
                 )?))
@@ -2949,31 +2989,6 @@ impl PoolingAllocationConfig {
     /// Defaults to `1`.
     pub fn decommit_batch_size(&mut self, batch_size: usize) -> &mut Self {
         self.config.decommit_batch_size = batch_size;
-        self
-    }
-
-    /// Configures whether or not stacks used for async futures are reset to
-    /// zero after usage.
-    ///
-    /// When the [`async_support`](Config::async_support) method is enabled for
-    /// Wasmtime and the [`call_async`] variant
-    /// of calling WebAssembly is used then Wasmtime will create a separate
-    /// runtime execution stack for each future produced by [`call_async`].
-    /// During the deallocation process Wasmtime won't by default reset the
-    /// contents of the stack back to zero.
-    ///
-    /// When this option is enabled it can be seen as a defense-in-depth
-    /// mechanism to reset a stack back to zero. This is not required for
-    /// correctness and can be a costly operation in highly concurrent
-    /// environments due to modifications of the virtual address space requiring
-    /// process-wide synchronization.
-    ///
-    /// This option defaults to `false`.
-    ///
-    /// [`call_async`]: crate::TypedFunc::call_async
-    #[cfg(feature = "async")]
-    pub fn async_stack_zeroing(&mut self, enable: bool) -> &mut Self {
-        self.config.async_stack_zeroing = enable;
         self
     }
 

--- a/crates/wasmtime/src/runtime/stack.rs
+++ b/crates/wasmtime/src/runtime/stack.rs
@@ -20,18 +20,21 @@ pub unsafe trait StackCreator: Send + Sync {
     ///
     /// The `size` parameter is the expected size of the stack without any guard pages.
     ///
+    /// The `zeroed` parameter is whether the stack's memory should be zeroed,
+    /// as a defense-in-depth measure.
+    ///
     /// Note there should be at least one guard page of protected memory at the bottom
     /// of the stack to catch potential stack overflow scenarios. Additionally, stacks should be
     /// page aligned and zero filled.
-    fn new_stack(&self, size: usize) -> Result<Box<dyn StackMemory>, Error>;
+    fn new_stack(&self, size: usize, zeroed: bool) -> Result<Box<dyn StackMemory>, Error>;
 }
 
 #[derive(Clone)]
 pub(crate) struct StackCreatorProxy(pub Arc<dyn StackCreator>);
 
 unsafe impl RuntimeFiberStackCreator for StackCreatorProxy {
-    fn new_stack(&self, size: usize) -> Result<Box<dyn RuntimeFiberStack>, Error> {
-        let stack = self.0.new_stack(size)?;
+    fn new_stack(&self, size: usize, zeroed: bool) -> Result<Box<dyn RuntimeFiberStack>, Error> {
+        let stack = self.0.new_stack(size, zeroed)?;
         Ok(Box::new(FiberStackProxy(stack)) as Box<dyn RuntimeFiberStack>)
     }
 }

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -39,7 +39,7 @@ fn create_handle(
         // as we don't want host objects to count towards instance limits.
         let module = Arc::new(module);
         let runtime_info = &ModuleRuntimeInfo::bare_maybe_imported_func(module, one_signature);
-        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0);
+        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0, false);
         let handle = allocator.allocate_module(InstanceAllocationRequest {
             imports,
             host_state,

--- a/tests/all/stack_creator.rs
+++ b/tests/all/stack_creator.rs
@@ -98,7 +98,10 @@ impl Drop for CustomStackCreator {
     }
 }
 unsafe impl StackCreator for CustomStackCreator {
-    fn new_stack(&self, size: usize) -> Result<Box<dyn StackMemory>> {
+    fn new_stack(&self, size: usize, zeroed: bool) -> Result<Box<dyn StackMemory>> {
+        if zeroed {
+            bail!("CustomStackCreator does not support stack zeroing");
+        }
         if size != self.size {
             bail!("must use the size we allocated for this stack memory creator");
         }


### PR DESCRIPTION
This commit moves the knob from the `PoolingInstanceAllocatorConfig` to the regular `Config` and now controls both whether stacks are zeroed before reuse and whether they are zeroed before the initial use. The latter doesn't matter usually, since anonymous mmaps are already zeroed so we don't have to do anything there, but for no-std environments it is the difference between manually zeroing the stack or simply using unininitialized memory.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
