### PR TITLE
Winch: Add splat instructions to x64 using AVX2

### DIFF
--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -502,6 +502,7 @@ impl WastTest {
             if !(std::is_x86_feature_detected!("avx") && std::is_x86_feature_detected!("avx2")) {
                 let unsupported = [
                     "misc_testsuite/winch/_simd_lane.wast",
+                    "misc_testsuite/winch/_simd_splat.wast",
                     "spec_testsuite/simd_align.wast",
                 ];
 

--- a/tests/disas/winch/x64/f32x4_splat/const_avx2.wat
+++ b/tests/disas/winch/x64/f32x4_splat/const_avx2.wat
@@ -1,0 +1,32 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (result v128)
+        (f32x4.splat (f32.const 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x3f
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movss   0x14(%rip), %xmm0
+;;       vpbroadcastd %xmm0, %xmm0
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   3f: ud2
+;;   41: addb    %al, (%rax)
+;;   43: addb    %al, (%rax)
+;;   45: addb    %al, (%rax)
+;;   47: addb    %al, (%rax)
+;;   49: addb    %al, (%rax)

--- a/tests/disas/winch/x64/f32x4_splat/params_avx2.wat
+++ b/tests/disas/winch/x64/f32x4_splat/params_avx2.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (param f32) (result v128)
+        (f32x4.splat (local.get 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x44
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movss   %xmm0, 0xc(%rsp)
+;;       movss   0xc(%rsp), %xmm0
+;;       vpbroadcastd %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   44: ud2

--- a/tests/disas/winch/x64/f64x2_splat/const_avx.wat
+++ b/tests/disas/winch/x64/f64x2_splat/const_avx.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+    (func (result v128)
+        (f64x2.splat (f64.const 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x3f
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movsd   0x14(%rip), %xmm0
+;;       vpshufd $0x44, %xmm0, %xmm0
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   3f: ud2
+;;   41: addb    %al, (%rax)
+;;   43: addb    %al, (%rax)
+;;   45: addb    %al, (%rax)
+;;   47: addb    %al, (%rax)
+;;   49: addb    %al, (%rax)
+;;   4b: addb    %al, (%rax)
+;;   4d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/f64x2_splat/param_avx.wat
+++ b/tests/disas/winch/x64/f64x2_splat/param_avx.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+    (func (param f64) (result v128)
+        (f64x2.splat (local.get 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x44
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movsd   %xmm0, 8(%rsp)
+;;       movsd   8(%rsp), %xmm0
+;;       vpshufd $0x44, %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   44: ud2

--- a/tests/disas/winch/x64/i16x8_splat/const_avx2.wat
+++ b/tests/disas/winch/x64/i16x8_splat/const_avx2.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (result v128)
+        (i16x8.splat (i32.const 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x3b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       vpbroadcastw 0xb(%rip), %xmm0
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   3b: ud2
+;;   3d: addb    %al, (%rax)
+;;   3f: addb    %al, (%rax)
+;;   41: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i16x8_splat/param_avx2.wat
+++ b/tests/disas/winch/x64/i16x8_splat/param_avx2.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (param i32) (result v128)
+        (i16x8.splat (local.get 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x44
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movd    %eax, %xmm0
+;;       vpbroadcastw %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   44: ud2

--- a/tests/disas/winch/x64/i32x4_splat/const_avx2.wat
+++ b/tests/disas/winch/x64/i32x4_splat/const_avx2.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (result v128)
+        (i32x4.splat (i32.const 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x3b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       vpbroadcastd 0xb(%rip), %xmm0
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   3b: ud2
+;;   3d: addb    %al, (%rax)
+;;   3f: addb    %al, (%rax)
+;;   41: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i32x4_splat/param_avx2.wat
+++ b/tests/disas/winch/x64/i32x4_splat/param_avx2.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (param i32) (result v128)
+        (i32x4.splat (local.get 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x44
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movd    %eax, %xmm0
+;;       vpbroadcastd %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   44: ud2

--- a/tests/disas/winch/x64/i64x2_splat/const_avx.wat
+++ b/tests/disas/winch/x64/i64x2_splat/const_avx.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+    (func (result v128)
+        (i64x2.splat (i64.const 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x3b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       vpshufd $0x44, 0xb(%rip), %xmm0
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   3b: ud2
+;;   3d: addb    %al, (%rax)
+;;   3f: addb    %al, (%rax)
+;;   41: addb    %al, (%rax)
+;;   43: addb    %al, (%rax)
+;;   45: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i64x2_splat/param_avx.wat
+++ b/tests/disas/winch/x64/i64x2_splat/param_avx.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+    (func (param i64) (result v128)
+        (i64x2.splat (local.get 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x47
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movq    %rdx, 8(%rsp)
+;;       movq    8(%rsp), %rax
+;;       movq    %rax, %xmm0
+;;       vpshufd $0x44, %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   47: ud2

--- a/tests/disas/winch/x64/i8x16_splat/const_avx2.wat
+++ b/tests/disas/winch/x64/i8x16_splat/const_avx2.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (result v128)
+        (i8x16.splat (i32.const 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x3b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       vpbroadcastb 0xb(%rip), %xmm0
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   3b: ud2
+;;   3d: addb    %al, (%rax)
+;;   3f: addb    %al, (%rax)
+;;   41: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i8x16_splat/param_avx2.wat
+++ b/tests/disas/winch/x64/i8x16_splat/param_avx2.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx2" ]
+
+(module
+    (func (param i32) (result v128)
+        (i8x16.splat (local.get 0))
+    )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x44
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movd    %eax, %xmm0
+;;       vpbroadcastb %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   44: ud2

--- a/tests/misc_testsuite/winch/_simd_splat.wast
+++ b/tests/misc_testsuite/winch/_simd_splat.wast
@@ -1,0 +1,432 @@
+;;! simd = true
+
+;; Tests for the *_splat instructions
+
+(module
+  (func (export "i8x16.splat") (param i32) (result v128) (i8x16.splat (local.get 0)))
+  (func (export "i16x8.splat") (param i32) (result v128) (i16x8.splat (local.get 0)))
+  (func (export "i32x4.splat") (param i32) (result v128) (i32x4.splat (local.get 0)))
+  (func (export "f32x4.splat") (param f32) (result v128) (f32x4.splat (local.get 0)))
+  (func (export "i64x2.splat") (param i64) (result v128) (i64x2.splat (local.get 0)))
+  (func (export "f64x2.splat") (param f64) (result v128) (f64x2.splat (local.get 0)))
+)
+
+(assert_return (invoke "i8x16.splat" (i32.const 0)) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+(assert_return (invoke "i8x16.splat" (i32.const 5)) (v128.const i8x16 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5))
+(assert_return (invoke "i8x16.splat" (i32.const -5)) (v128.const i8x16 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5 -5))
+(assert_return (invoke "i8x16.splat" (i32.const 257)) (v128.const i8x16 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1))
+(assert_return (invoke "i8x16.splat" (i32.const 0xff)) (v128.const i8x16 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1))
+(assert_return (invoke "i8x16.splat" (i32.const -128)) (v128.const i8x16 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128))
+(assert_return (invoke "i8x16.splat" (i32.const 127)) (v128.const i8x16 127 127 127 127 127 127 127 127 127 127 127 127 127 127 127 127))
+(assert_return (invoke "i8x16.splat" (i32.const -129)) (v128.const i8x16 127 127 127 127 127 127 127 127 127 127 127 127 127 127 127 127))
+(assert_return (invoke "i8x16.splat" (i32.const 128)) (v128.const i8x16 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128))
+(assert_return (invoke "i8x16.splat" (i32.const 0xff7f)) (v128.const i8x16 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f))
+(assert_return (invoke "i8x16.splat" (i32.const 0x80)) (v128.const i8x16 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80 0x80))
+(assert_return (invoke "i8x16.splat" (i32.const 0xAB)) (v128.const i32x4 0xABABABAB 0xABABABAB 0xABABABAB 0xABABABAB))
+
+(assert_return (invoke "i16x8.splat" (i32.const 0)) (v128.const i16x8 0 0 0 0 0 0 0 0))
+(assert_return (invoke "i16x8.splat" (i32.const 5)) (v128.const i16x8 5 5 5 5 5 5 5 5))
+(assert_return (invoke "i16x8.splat" (i32.const -5)) (v128.const i16x8 -5 -5 -5 -5 -5 -5 -5 -5))
+(assert_return (invoke "i16x8.splat" (i32.const 65537)) (v128.const i16x8 1 1 1 1 1 1 1 1))
+(assert_return (invoke "i16x8.splat" (i32.const 0xffff)) (v128.const i16x8 -1 -1 -1 -1 -1 -1 -1 -1))
+(assert_return (invoke "i16x8.splat" (i32.const -32768)) (v128.const i16x8 -32768 -32768 -32768 -32768 -32768 -32768 -32768 -32768))
+(assert_return (invoke "i16x8.splat" (i32.const 32767)) (v128.const i16x8 32767 32767 32767 32767 32767 32767 32767 32767))
+(assert_return (invoke "i16x8.splat" (i32.const -32769)) (v128.const i16x8 32767 32767 32767 32767 32767 32767 32767 32767))
+(assert_return (invoke "i16x8.splat" (i32.const 32768)) (v128.const i16x8 -32768 -32768 -32768 -32768 -32768 -32768 -32768 -32768))
+(assert_return (invoke "i16x8.splat" (i32.const 0xffff7fff)) (v128.const i16x8 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff))
+(assert_return (invoke "i16x8.splat" (i32.const 0x8000)) (v128.const i16x8 0x8000 0x8000 0x8000 0x8000 0x8000 0x8000 0x8000 0x8000))
+(assert_return (invoke "i16x8.splat" (i32.const 0xABCD)) (v128.const i32x4 0xABCDABCD 0xABCDABCD 0xABCDABCD 0xABCDABCD))
+(assert_return (invoke "i16x8.splat" (i32.const 012345)) (v128.const i16x8 012_345 012_345 012_345 012_345 012_345 012_345 012_345 012_345))
+(assert_return (invoke "i16x8.splat" (i32.const 0x01234)) (v128.const i16x8 0x0_1234 0x0_1234 0x0_1234 0x0_1234 0x0_1234 0x0_1234 0x0_1234 0x0_1234))
+
+(assert_return (invoke "i32x4.splat" (i32.const 0)) (v128.const i32x4 0 0 0 0))
+(assert_return (invoke "i32x4.splat" (i32.const 5)) (v128.const i32x4 5 5 5 5))
+(assert_return (invoke "i32x4.splat" (i32.const -5)) (v128.const i32x4 -5 -5 -5 -5))
+(assert_return (invoke "i32x4.splat" (i32.const 0xffffffff)) (v128.const i32x4 -1 -1 -1 -1))
+(assert_return (invoke "i32x4.splat" (i32.const 4294967295)) (v128.const i32x4 -1 -1 -1 -1))
+(assert_return (invoke "i32x4.splat" (i32.const -2147483648)) (v128.const i32x4 0x80000000 0x80000000 0x80000000 0x80000000))
+(assert_return (invoke "i32x4.splat" (i32.const 2147483647)) (v128.const i32x4 0x7fffffff 0x7fffffff 0x7fffffff 0x7fffffff))
+(assert_return (invoke "i32x4.splat" (i32.const 2147483648)) (v128.const i32x4 0x80000000 0x80000000 0x80000000 0x80000000))
+(assert_return (invoke "i32x4.splat" (i32.const 01234567890)) (v128.const i32x4 012_3456_7890 012_3456_7890 012_3456_7890 012_3456_7890))
+(assert_return (invoke "i32x4.splat" (i32.const 0x012345678)) (v128.const i32x4 0x0_1234_5678 0x0_1234_5678 0x0_1234_5678 0x0_1234_5678))
+
+(assert_return (invoke "f32x4.splat" (f32.const 0.0)) (v128.const f32x4 0.0 0.0 0.0 0.0))
+(assert_return (invoke "f32x4.splat" (f32.const 1.1)) (v128.const f32x4 1.1 1.1 1.1 1.1))
+(assert_return (invoke "f32x4.splat" (f32.const -1.1)) (v128.const f32x4 -1.1 -1.1 -1.1 -1.1))
+(assert_return (invoke "f32x4.splat" (f32.const 1e38)) (v128.const f32x4 1e38 1e38 1e38 1e38))
+(assert_return (invoke "f32x4.splat" (f32.const -1e38)) (v128.const f32x4 -1e38 -1e38 -1e38 -1e38))
+(assert_return (invoke "f32x4.splat" (f32.const 0x1.fffffep127)) (v128.const f32x4 0x1.fffffep127 0x1.fffffep127 0x1.fffffep127 0x1.fffffep127))
+(assert_return (invoke "f32x4.splat" (f32.const -0x1.fffffep127)) (v128.const f32x4 -0x1.fffffep127 -0x1.fffffep127 -0x1.fffffep127 -0x1.fffffep127))
+(assert_return (invoke "f32x4.splat" (f32.const 0x1p127)) (v128.const f32x4 0x1p127 0x1p127 0x1p127 0x1p127))
+(assert_return (invoke "f32x4.splat" (f32.const -0x1p127)) (v128.const f32x4 -0x1p127 -0x1p127 -0x1p127 -0x1p127))
+(assert_return (invoke "f32x4.splat" (f32.const inf)) (v128.const f32x4 inf inf inf inf))
+(assert_return (invoke "f32x4.splat" (f32.const -inf)) (v128.const f32x4 -inf -inf -inf -inf))
+(assert_return (invoke "f32x4.splat" (f32.const nan)) (v128.const f32x4 nan nan nan nan))
+(assert_return (invoke "f32x4.splat" (f32.const nan:0x1)) (v128.const f32x4 nan:0x1 nan:0x1 nan:0x1 nan:0x1))
+(assert_return (invoke "f32x4.splat" (f32.const nan:0x7f_ffff)) (v128.const f32x4 nan:0x7f_ffff nan:0x7f_ffff nan:0x7f_ffff nan:0x7f_ffff))
+(assert_return (invoke "f32x4.splat" (f32.const 0123456789)) (v128.const f32x4 0123456789 0123456789 0123456789 0123456789))
+(assert_return (invoke "f32x4.splat" (f32.const 0123456789.)) (v128.const f32x4 0123456789. 0123456789. 0123456789. 0123456789.))
+(assert_return (invoke "f32x4.splat" (f32.const 0x0123456789ABCDEF)) (v128.const f32x4 0x0123456789ABCDEF 0x0123456789ABCDEF 0x0123456789ABCDEF 0x0123456789ABCDEF))
+(assert_return (invoke "f32x4.splat" (f32.const 0x0123456789ABCDEF.)) (v128.const f32x4 0x0123456789ABCDEF. 0x0123456789ABCDEF. 0x0123456789ABCDEF. 0x0123456789ABCDEF.))
+(assert_return (invoke "f32x4.splat" (f32.const 0123456789e019)) (v128.const f32x4 0123456789e019 0123456789e019 0123456789e019 0123456789e019))
+(assert_return (invoke "f32x4.splat" (f32.const 0123456789.e+019)) (v128.const f32x4 0123456789.e+019 0123456789.e+019 0123456789.e+019 0123456789.e+019))
+(assert_return (invoke "f32x4.splat" (f32.const 0x0123456789ABCDEFp019)) (v128.const f32x4 0x0123456789ABCDEFp019 0x0123456789ABCDEFp019 0x0123456789ABCDEFp019 0x0123456789ABCDEFp019))
+(assert_return (invoke "f32x4.splat" (f32.const 0x0123456789ABCDEF.p-019)) (v128.const f32x4 0x0123456789ABCDEF.p-019 0x0123456789ABCDEF.p-019 0x0123456789ABCDEF.p-019 0x0123456789ABCDEF.p-019))
+
+(assert_return (invoke "i64x2.splat" (i64.const 0)) (v128.const i64x2 0 0))
+(assert_return (invoke "i64x2.splat" (i64.const -0)) (v128.const i64x2 0 0))
+(assert_return (invoke "i64x2.splat" (i64.const 1)) (v128.const i64x2 1 1))
+(assert_return (invoke "i64x2.splat" (i64.const -1)) (v128.const i64x2 -1 -1))
+(assert_return (invoke "i64x2.splat" (i64.const -9223372036854775808)) (v128.const i64x2 -9223372036854775808 -9223372036854775808))
+(assert_return (invoke "i64x2.splat" (i64.const -9223372036854775808)) (v128.const i64x2 9223372036854775808 9223372036854775808))
+(assert_return (invoke "i64x2.splat" (i64.const 9223372036854775807)) (v128.const i64x2 9223372036854775807 9223372036854775807))
+(assert_return (invoke "i64x2.splat" (i64.const 18446744073709551615)) (v128.const i64x2 -1 -1))
+(assert_return (invoke "i64x2.splat" (i64.const 0x7fffffffffffffff)) (v128.const i64x2 0x7fffffffffffffff 0x7fffffffffffffff))
+(assert_return (invoke "i64x2.splat" (i64.const 0xffffffffffffffff)) (v128.const i64x2 -1 -1))
+(assert_return (invoke "i64x2.splat" (i64.const -0x8000000000000000)) (v128.const i64x2 -0x8000000000000000 -0x8000000000000000))
+(assert_return (invoke "i64x2.splat" (i64.const -0x8000000000000000)) (v128.const i64x2 0x8000000000000000 0x8000000000000000))
+(assert_return (invoke "i64x2.splat" (i64.const 01234567890123456789)) (v128.const i64x2 01_234_567_890_123_456_789 01_234_567_890_123_456_789))
+(assert_return (invoke "i64x2.splat" (i64.const 0x01234567890ABcdef)) (v128.const i64x2 0x0_1234_5678_90AB_cdef 0x0_1234_5678_90AB_cdef))
+
+(assert_return (invoke "f64x2.splat" (f64.const 0.0)) (v128.const f64x2 0.0 0.0))
+(assert_return (invoke "f64x2.splat" (f64.const -0.0)) (v128.const f64x2 -0.0 -0.0))
+(assert_return (invoke "f64x2.splat" (f64.const 1.1)) (v128.const f64x2 1.1 1.1))
+(assert_return (invoke "f64x2.splat" (f64.const -1.1)) (v128.const f64x2 -1.1 -1.1))
+(assert_return (invoke "f64x2.splat" (f64.const 0x0.0000000000001p-1022)) (v128.const f64x2 0x0.0000000000001p-1022 0x0.0000000000001p-1022))
+(assert_return (invoke "f64x2.splat" (f64.const -0x0.0000000000001p-1022)) (v128.const f64x2 -0x0.0000000000001p-1022 -0x0.0000000000001p-1022))
+(assert_return (invoke "f64x2.splat" (f64.const 0x1p-1022)) (v128.const f64x2 0x1p-1022 0x1p-1022))
+(assert_return (invoke "f64x2.splat" (f64.const -0x1p-1022)) (v128.const f64x2 -0x1p-1022 -0x1p-1022))
+(assert_return (invoke "f64x2.splat" (f64.const 0x1p-1)) (v128.const f64x2 0x1p-1 0x1p-1))
+(assert_return (invoke "f64x2.splat" (f64.const -0x1p-1)) (v128.const f64x2 -0x1p-1 -0x1p-1))
+(assert_return (invoke "f64x2.splat" (f64.const 0x1p+0)) (v128.const f64x2 0x1p+0 0x1p+0))
+(assert_return (invoke "f64x2.splat" (f64.const -0x1p+0)) (v128.const f64x2 -0x1p+0 -0x1p+0))
+(assert_return (invoke "f64x2.splat" (f64.const 0x1.921fb54442d18p+2)) (v128.const f64x2 0x1.921fb54442d18p+2 0x1.921fb54442d18p+2))
+(assert_return (invoke "f64x2.splat" (f64.const -0x1.921fb54442d18p+2)) (v128.const f64x2 -0x1.921fb54442d18p+2 -0x1.921fb54442d18p+2))
+(assert_return (invoke "f64x2.splat" (f64.const 0x1.fffffffffffffp+1023)) (v128.const f64x2 0x1.fffffffffffffp+1023 0x1.fffffffffffffp+1023))
+(assert_return (invoke "f64x2.splat" (f64.const -0x1.fffffffffffffp+1023)) (v128.const f64x2 -0x1.fffffffffffffp+1023 -0x1.fffffffffffffp+1023))
+(assert_return (invoke "f64x2.splat" (f64.const inf)) (v128.const f64x2 inf inf))
+(assert_return (invoke "f64x2.splat" (f64.const -inf)) (v128.const f64x2 -inf -inf))
+(assert_return (invoke "f64x2.splat" (f64.const nan)) (v128.const f64x2 nan nan))
+(assert_return (invoke "f64x2.splat" (f64.const -nan)) (v128.const f64x2 -nan -nan))
+(assert_return (invoke "f64x2.splat" (f64.const nan:0x4000000000000)) (v128.const f64x2 nan:0x4000000000000 nan:0x4000000000000))
+(assert_return (invoke "f64x2.splat" (f64.const -nan:0x4000000000000)) (v128.const f64x2 -nan:0x4000000000000 -nan:0x4000000000000))
+(assert_return (invoke "f64x2.splat" (f64.const 0123456789)) (v128.const f64x2 0123456789 0123456789))
+(assert_return (invoke "f64x2.splat" (f64.const 0123456789.)) (v128.const f64x2 0123456789. 0123456789.))
+(assert_return (invoke "f64x2.splat" (f64.const 0x0123456789ABCDEFabcdef)) (v128.const f64x2 0x0123456789ABCDEFabcdef 0x0123456789ABCDEFabcdef))
+(assert_return (invoke "f64x2.splat" (f64.const 0x0123456789ABCDEFabcdef.)) (v128.const f64x2 0x0123456789ABCDEFabcdef. 0x0123456789ABCDEFabcdef.))
+(assert_return (invoke "f64x2.splat" (f64.const 0123456789e019)) (v128.const f64x2 0123456789e019 0123456789e019))
+(assert_return (invoke "f64x2.splat" (f64.const 0123456789e+019)) (v128.const f64x2 0123456789e+019 0123456789e+019))
+(assert_return (invoke "f64x2.splat" (f64.const 0x0123456789ABCDEFabcdef.p019)) (v128.const f64x2 0x0123456789ABCDEFabcdef.p019 0x0123456789ABCDEFabcdef.p019))
+(assert_return (invoke "f64x2.splat" (f64.const 0x0123456789ABCDEFabcdef.p-019)) (v128.const f64x2 0x0123456789ABCDEFabcdef.p-019 0x0123456789ABCDEFabcdef.p-019))
+
+;; Unknown operator
+
+(assert_malformed (module quote "(func (result v128) (v128.splat (i32.const 0)))") "unknown operator")
+
+
+;; Type mismatched
+
+(assert_invalid (module (func (result v128) i8x16.splat (i64.const 0))) "type mismatch")
+(assert_invalid (module (func (result v128) i8x16.splat (f32.const 0.0))) "type mismatch")
+(assert_invalid (module (func (result v128) i8x16.splat (f64.const 0.0))) "type mismatch")
+(assert_invalid (module (func (result v128) i16x8.splat (i64.const 1))) "type mismatch")
+(assert_invalid (module (func (result v128) i16x8.splat (f32.const 1.0))) "type mismatch")
+(assert_invalid (module (func (result v128) i16x8.splat (f64.const 1.0))) "type mismatch")
+(assert_invalid (module (func (result v128) i32x4.splat (i64.const 2))) "type mismatch")
+(assert_invalid (module (func (result v128) i32x4.splat (f32.const 2.0))) "type mismatch")
+(assert_invalid (module (func (result v128) i32x4.splat (f64.const 2.0))) "type mismatch")
+(assert_invalid (module (func (result v128) f32x4.splat (i32.const 4))) "type mismatch")
+(assert_invalid (module (func (result v128) f32x4.splat (i64.const 4))) "type mismatch")
+(assert_invalid (module (func (result v128) f32x4.splat (f64.const 4.0))) "type mismatch")
+(assert_invalid (module (func (result v128) i64x2.splat (i32.const 0))) "type mismatch")
+(assert_invalid (module (func (result v128) i64x2.splat (f64.const 0.0))) "type mismatch")
+(assert_invalid (module (func (result v128) f64x2.splat (i32.const 0))) "type mismatch")
+(assert_invalid (module (func (result v128) f64x2.splat (f32.const 0.0))) "type mismatch")
+
+
+;; V128 splat operators as the argument of other SIMD instructions
+
+;; v128.store and v128.load
+(module (memory 1)
+  (func (export "as-v128_store-operand-1") (param i32) (result v128)
+    (v128.store (i32.const 0) (i8x16.splat (local.get 0)))
+    (v128.load (i32.const 0)))
+  (func (export "as-v128_store-operand-2") (param i32) (result v128)
+    (v128.store (i32.const 0) (i16x8.splat (local.get 0)))
+    (v128.load (i32.const 0)))
+  (func (export "as-v128_store-operand-3") (param i32) (result v128)
+    (v128.store (i32.const 0) (i32x4.splat (local.get 0)))
+    (v128.load (i32.const 0)))
+  (func (export "as-v128_store-operand-4") (param i64) (result v128)
+    (v128.store (i32.const 0) (i64x2.splat (local.get 0)))
+    (v128.load (i32.const 0)))
+  (func (export "as-v128_store-operand-5") (param f64) (result v128)
+    (v128.store (i32.const 0) (f64x2.splat (local.get 0)))
+    (v128.load (i32.const 0)))
+)
+
+(assert_return (invoke "as-v128_store-operand-1" (i32.const 1)) (v128.const i8x16 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1))
+(assert_return (invoke "as-v128_store-operand-2" (i32.const 256)) (v128.const i16x8 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100))
+(assert_return (invoke "as-v128_store-operand-3" (i32.const 0xffffffff)) (v128.const i32x4 -1 -1 -1 -1))
+(assert_return (invoke "as-v128_store-operand-4" (i64.const 1)) (v128.const i64x2 1 1))
+(assert_return (invoke "as-v128_store-operand-5" (f64.const -0x1p+0)) (v128.const f64x2 -0x1p+0 -0x1p+0))
+
+;; (module
+;;   ;; Accessing lane
+;;   (func (export "as-i8x16_extract_lane_s-operand-first") (param i32) (result i32)
+;;     (i8x16.extract_lane_s 0 (i8x16.splat (local.get 0))))
+;;   (func (export "as-i8x16_extract_lane_s-operand-last") (param i32) (result i32)
+;;     (i8x16.extract_lane_s 15 (i8x16.splat (local.get 0))))
+;;   (func (export "as-i16x8_extract_lane_s-operand-first") (param i32) (result i32)
+;;     (i16x8.extract_lane_s 0 (i16x8.splat (local.get 0))))
+;;   (func (export "as-i16x8_extract_lane_s-operand-last") (param i32) (result i32)
+;;     (i16x8.extract_lane_s 7 (i16x8.splat (local.get 0))))
+;;   (func (export "as-i32x4_extract_lane_s-operand-first") (param i32) (result i32)
+;;     (i32x4.extract_lane 0 (i32x4.splat (local.get 0))))
+;;   (func (export "as-i32x4_extract_lane_s-operand-last") (param i32) (result i32)
+;;     (i32x4.extract_lane 3 (i32x4.splat (local.get 0))))
+;;   (func (export "as-f32x4_extract_lane_s-operand-first") (param f32) (result f32)
+;;     (f32x4.extract_lane 0 (f32x4.splat (local.get 0))))
+;;   (func (export "as-f32x4_extract_lane_s-operand-last") (param f32) (result f32)
+;;     (f32x4.extract_lane 3 (f32x4.splat (local.get 0))))
+;;   (func (export "as-v8x16_swizzle-operands") (param i32) (param i32) (result v128)
+;;     (i8x16.swizzle (i8x16.splat (local.get 0)) (i8x16.splat (local.get 1))))
+;;   (func (export "as-i64x2_extract_lane-operand-first") (param i64) (result i64)
+;;     (i64x2.extract_lane 0 (i64x2.splat (local.get 0))))
+;;   (func (export "as-i64x2_extract_lane-operand-last") (param i64) (result i64)
+;;     (i64x2.extract_lane 1 (i64x2.splat (local.get 0))))
+;;   (func (export "as-f64x2_extract_lane-operand-first") (param f64) (result f64)
+;;     (f64x2.extract_lane 0 (f64x2.splat (local.get 0))))
+;;   (func (export "as-f64x2_extract_lane-operand-last") (param f64) (result f64)
+;;     (f64x2.extract_lane 1 (f64x2.splat (local.get 0))))
+;; 
+;;   ;; Integer arithmetic
+;;   (func (export "as-i8x16_add_sub-operands") (param i32 i32 i32) (result v128)
+;;     (i8x16.add (i8x16.splat (local.get 0))
+;;       (i8x16.sub (i8x16.splat (local.get 1)) (i8x16.splat (local.get 2)))))
+;;   (func (export "as-i16x8_add_sub_mul-operands") (param i32 i32 i32 i32) (result v128)
+;;     (i16x8.add (i16x8.splat (local.get 0))
+;;       (i16x8.sub (i16x8.splat (local.get 1))
+;;         (i16x8.mul (i16x8.splat (local.get 2)) (i16x8.splat (local.get 3))))))
+;;   (func (export "as-i32x4_add_sub_mul-operands") (param i32 i32 i32 i32) (result v128)
+;;     (i32x4.add (i32x4.splat (local.get 0))
+;;       (i32x4.sub (i32x4.splat (local.get 1))
+;;         (i32x4.mul (i32x4.splat (local.get 2)) (i32x4.splat (local.get 3))))))
+;; 
+;;   (func (export "as-i64x2_add_sub_mul-operands") (param i64 i64 i64 i64) (result v128)
+;;     (i64x2.add (i64x2.splat (local.get 0))
+;;       (i64x2.sub (i64x2.splat (local.get 1))
+;;         (i64x2.mul (i64x2.splat (local.get 2)) (i64x2.splat (local.get 3))))))
+;;   (func (export "as-f64x2_add_sub_mul-operands") (param f64 f64 f64 f64) (result v128)
+;;     (f64x2.add (f64x2.splat (local.get 0))
+;;       (f64x2.sub (f64x2.splat (local.get 1))
+;;         (f64x2.mul (f64x2.splat (local.get 2)) (f64x2.splat (local.get 3))))))
+;; 
+;;   ;; Saturating integer arithmetic
+;;   (func (export "as-i8x16_add_sat_s-operands") (param i32 i32) (result v128)
+;;     (i8x16.add_sat_s (i8x16.splat (local.get 0)) (i8x16.splat (local.get 1))))
+;;   (func (export "as-i16x8_add_sat_s-operands") (param i32 i32) (result v128)
+;;     (i16x8.add_sat_s (i16x8.splat (local.get 0)) (i16x8.splat (local.get 1))))
+;;   (func (export "as-i8x16_sub_sat_u-operands") (param i32 i32) (result v128)
+;;     (i8x16.sub_sat_u (i8x16.splat (local.get 0)) (i8x16.splat (local.get 1))))
+;;   (func (export "as-i16x8_sub_sat_u-operands") (param i32 i32) (result v128)
+;;     (i16x8.sub_sat_u (i16x8.splat (local.get 0)) (i16x8.splat (local.get 1))))
+;; 
+;;   ;; Bit shifts
+;;   (func (export "as-i8x16_shr_s-operand") (param i32 i32) (result v128)
+;;     (i8x16.shr_s (i8x16.splat (local.get 0)) (local.get 1)))
+;;   (func (export "as-i16x8_shr_s-operand") (param i32 i32) (result v128)
+;;     (i16x8.shr_s (i16x8.splat (local.get 0)) (local.get 1)))
+;;   (func (export "as-i32x4_shr_s-operand") (param i32 i32) (result v128)
+;;     (i32x4.shr_s (i32x4.splat (local.get 0)) (local.get 1)))
+;; 
+;;   ;; Bitwise operantions
+;;   (func (export "as-v128_and-operands") (param i32 i32) (result v128)
+;;     (v128.and (i8x16.splat (local.get 0)) (i8x16.splat (local.get 1))))
+;;   (func (export "as-v128_or-operands") (param i32 i32) (result v128)
+;;     (v128.or (i16x8.splat (local.get 0)) (i16x8.splat (local.get 1))))
+;;   (func (export "as-v128_xor-operands") (param i32 i32) (result v128)
+;;     (v128.xor (i32x4.splat (local.get 0)) (i32x4.splat (local.get 1))))
+;; 
+;;   ;; Boolean horizontal reductions
+;;   (func (export "as-i8x16_all_true-operand") (param i32) (result i32)
+;;     (i8x16.all_true (i8x16.splat (local.get 0))))
+;;   (func (export "as-i16x8_all_true-operand") (param i32) (result i32)
+;;     (i16x8.all_true (i16x8.splat (local.get 0))))
+;;   (func (export "as-i32x4_all_true-operand1") (param i32) (result i32)
+;;     (i32x4.all_true (i32x4.splat (local.get 0))))
+;;   (func (export "as-i32x4_all_true-operand2") (param i64) (result i32)
+;;     (i32x4.all_true (i64x2.splat (local.get 0))))
+;; 
+;;   ;; Comparisons
+;;   (func (export "as-i8x16_eq-operands") (param i32 i32) (result v128)
+;;     (i8x16.eq (i8x16.splat (local.get 0)) (i8x16.splat (local.get 1))))
+;;   (func (export "as-i16x8_eq-operands") (param i32 i32) (result v128)
+;;     (i16x8.eq (i16x8.splat (local.get 0)) (i16x8.splat (local.get 1))))
+;;   (func (export "as-i32x4_eq-operands1") (param i32 i32) (result v128)
+;;     (i32x4.eq (i32x4.splat (local.get 0)) (i32x4.splat (local.get 1))))
+;;   (func (export "as-i32x4_eq-operands2") (param i64 i64) (result v128)
+;;     (i32x4.eq (i64x2.splat (local.get 0)) (i64x2.splat (local.get 1))))
+;;   (func (export "as-f32x4_eq-operands") (param f32 f32) (result v128)
+;;     (f32x4.eq (f32x4.splat (local.get 0)) (f32x4.splat (local.get 1))))
+;;   (func (export "as-f64x2_eq-operands") (param f64 f64) (result v128)
+;;     (f64x2.eq (f64x2.splat (local.get 0)) (f64x2.splat (local.get 1))))
+;; 
+;;   ;; Floating-point sign bit operations
+;;   (func (export "as-f32x4_abs-operand") (param f32) (result v128)
+;;     (f32x4.abs (f32x4.splat (local.get 0))))
+;; 
+;;   ;; Floating-point min
+;;   (func (export "as-f32x4_min-operands") (param f32 f32) (result v128)
+;;     (f32x4.min (f32x4.splat (local.get 0)) (f32x4.splat (local.get 1))))
+;; 
+;;   ;; Floating-point arithmetic
+;;   (func (export "as-f32x4_div-operands") (param f32 f32) (result v128)
+;;     (f32x4.div (f32x4.splat (local.get 0)) (f32x4.splat (local.get 1))))
+;; 
+;;   ;; Conversions
+;;   (func (export "as-f32x4_convert_s_i32x4-operand") (param i32) (result v128)
+;;     (f32x4.convert_i32x4_s (i32x4.splat (local.get 0))))
+;;   (func (export "as-i32x4_trunc_s_f32x4_sat-operand") (param f32) (result v128)
+;;     (i32x4.trunc_sat_f32x4_s (f32x4.splat (local.get 0))))
+;; )
+;; 
+;; (assert_return (invoke "as-i8x16_extract_lane_s-operand-first" (i32.const 42)) (i32.const 42))
+;; (assert_return (invoke "as-i8x16_extract_lane_s-operand-last" (i32.const -42)) (i32.const -42))
+;; (assert_return (invoke "as-i16x8_extract_lane_s-operand-first" (i32.const 0xffff7fff)) (i32.const 32767))
+;; (assert_return (invoke "as-i16x8_extract_lane_s-operand-last" (i32.const 0x8000)) (i32.const -32768))
+;; (assert_return (invoke "as-i32x4_extract_lane_s-operand-first" (i32.const 0x7fffffff)) (i32.const 2147483647))
+;; (assert_return (invoke "as-i32x4_extract_lane_s-operand-last" (i32.const 0x80000000)) (i32.const -2147483648))
+;; (assert_return (invoke "as-f32x4_extract_lane_s-operand-first" (f32.const 1.5)) (f32.const 1.5))
+;; (assert_return (invoke "as-f32x4_extract_lane_s-operand-last" (f32.const -0.25)) (f32.const -0.25))
+;; (assert_return (invoke "as-v8x16_swizzle-operands" (i32.const 1) (i32.const -1)) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+;; (assert_return (invoke "as-i64x2_extract_lane-operand-last" (i64.const -42)) (i64.const -42))
+;; (assert_return (invoke "as-i64x2_extract_lane-operand-first" (i64.const 42)) (i64.const 42))
+;; (assert_return (invoke "as-f64x2_extract_lane-operand-first" (f64.const 1.5)) (f64.const 1.5))
+;; (assert_return (invoke "as-f64x2_extract_lane-operand-last" (f64.const -0x1p+0)) (f64.const -0x1p+0))
+;; 
+;; (assert_return (invoke "as-i8x16_add_sub-operands" (i32.const 3) (i32.const 2) (i32.const 1)) (v128.const i8x16 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4))
+;; (assert_return (invoke "as-i16x8_add_sub_mul-operands" (i32.const 257) (i32.const 128) (i32.const 16) (i32.const 16)) (v128.const i16x8 129 129 129 129 129 129 129 129))
+;; (assert_return (invoke "as-i32x4_add_sub_mul-operands" (i32.const 65535) (i32.const 65537) (i32.const 256) (i32.const 256)) (v128.const i32x4 0x10000 0x10000 0x10000 0x10000))
+;; (assert_return (invoke "as-i64x2_add_sub_mul-operands" (i64.const 0x7fffffff) (i64.const 0x1_0000_0001) (i64.const 65536) (i64.const 65536)) (v128.const i64x2 0x8000_0000 0x8000_0000))
+;; (assert_return (invoke "as-f64x2_add_sub_mul-operands" (f64.const 0x1p-1) (f64.const 0.75) (f64.const 0x1p-1) (f64.const 0.5)) (v128.const f64x2 0x1p+0 0x1p+0))
+;; 
+;; (assert_return (invoke "as-i8x16_add_sat_s-operands" (i32.const 0x7f) (i32.const 1)) (v128.const i8x16 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f 0x7f))
+;; (assert_return (invoke "as-i16x8_add_sat_s-operands" (i32.const 0x7fff) (i32.const 1)) (v128.const i16x8 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff 0x7fff))
+;; (assert_return (invoke "as-i8x16_sub_sat_u-operands" (i32.const 0x7f) (i32.const 0xff)) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+;; (assert_return (invoke "as-i16x8_sub_sat_u-operands" (i32.const 0x7fff) (i32.const 0xffff)) (v128.const i16x8 0 0 0 0 0 0 0 0))
+;; 
+;; (assert_return (invoke "as-i8x16_shr_s-operand" (i32.const 0xf0) (i32.const 3)) (v128.const i8x16 -2 -2 -2 -2 -2 -2 -2 -2 -2 -2 -2 -2 -2 -2 -2 -2))
+;; (assert_return (invoke "as-i16x8_shr_s-operand" (i32.const 0x100) (i32.const 4)) (v128.const i16x8 16 16 16 16 16 16 16 16))
+;; (assert_return (invoke "as-i32x4_shr_s-operand" (i32.const -1) (i32.const 16)) (v128.const i32x4 -1 -1 -1 -1))
+;; 
+;; (assert_return (invoke "as-v128_and-operands" (i32.const 0x11) (i32.const 0xff)) (v128.const i8x16 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17 17))
+;; (assert_return (invoke "as-v128_or-operands" (i32.const 0) (i32.const 0xffff)) (v128.const i16x8 0xffff 0xffff 0xffff 0xffff 0xffff 0xffff 0xffff 0xffff))
+;; (assert_return (invoke "as-v128_xor-operands" (i32.const 0xf0f0f0f0) (i32.const 0xffffffff)) (v128.const i32x4 0xf0f0f0f 0xf0f0f0f 0xf0f0f0f 0xf0f0f0f))
+;; 
+;; (assert_return (invoke "as-i8x16_all_true-operand" (i32.const 0)) (i32.const 0))
+;; (assert_return (invoke "as-i16x8_all_true-operand" (i32.const 0xffff)) (i32.const 1))
+;; (assert_return (invoke "as-i32x4_all_true-operand1" (i32.const 0xf0f0f0f0)) (i32.const 1))
+;; (assert_return (invoke "as-i32x4_all_true-operand2" (i64.const -1)) (i32.const 1))
+;; 
+;; (assert_return (invoke "as-i8x16_eq-operands" (i32.const 1) (i32.const 2)) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+;; (assert_return (invoke "as-i16x8_eq-operands" (i32.const -1) (i32.const 65535)) (v128.const i16x8 0xffff 0xffff 0xffff 0xffff 0xffff 0xffff 0xffff 0xffff))
+;; (assert_return (invoke "as-i32x4_eq-operands1" (i32.const -1) (i32.const 0xffffffff)) (v128.const i32x4 0xffffffff 0xffffffff 0xffffffff 0xffffffff))
+;; (assert_return (invoke "as-f32x4_eq-operands" (f32.const +0.0) (f32.const -0.0)) (v128.const i32x4 0xffffffff 0xffffffff 0xffffffff 0xffffffff))
+;; (assert_return (invoke "as-i32x4_eq-operands2" (i64.const 1) (i64.const 2)) (v128.const i64x2 0xffffffff00000000 0xffffffff00000000))
+;; (assert_return (invoke "as-f64x2_eq-operands" (f64.const +0.0) (f64.const -0.0)) (v128.const i64x2 -1 -1))
+;; 
+;; (assert_return (invoke "as-f32x4_abs-operand" (f32.const -1.125)) (v128.const f32x4 1.125 1.125 1.125 1.125))
+;; (assert_return (invoke "as-f32x4_min-operands" (f32.const 0.25) (f32.const 1e-38)) (v128.const f32x4 1e-38 1e-38 1e-38 1e-38))
+;; (assert_return (invoke "as-f32x4_div-operands" (f32.const 1.0) (f32.const 8.0)) (v128.const f32x4 0.125 0.125 0.125 0.125))
+;; 
+;; (assert_return (invoke "as-f32x4_convert_s_i32x4-operand" (i32.const 12345)) (v128.const f32x4 12345.0 12345.0 12345.0 12345.0))
+;; (assert_return (invoke "as-i32x4_trunc_s_f32x4_sat-operand" (f32.const 1.1)) (v128.const i32x4 1 1 1 1))
+
+
+;; As the argument of control constructs and WASM instructions
+
+(module
+  (global $g (mut v128) (v128.const f32x4 0.0 0.0 0.0 0.0))
+  (func (export "as-br-value1") (param i32) (result v128)
+    (block (result v128) (br 0 (i8x16.splat (local.get 0)))))
+  (func (export "as-return-value1") (param i32) (result v128)
+    (return (i16x8.splat (local.get 0))))
+  (func (export "as-local_set-value1") (param i32) (result v128) (local v128)
+    (local.set 1 (i32x4.splat (local.get 0)))
+    (return (local.get 1)))
+  (func (export "as-global_set-value1") (param f32) (result v128)
+    (global.set $g (f32x4.splat (local.get 0)))
+    (return (global.get $g)))
+  (func (export "as-br-value2") (param i64) (result v128)
+    (block (result v128) (br 0 (i64x2.splat (local.get 0)))))
+  (func (export "as-return-value2") (param i64) (result v128)
+    (return (i64x2.splat (local.get 0))))
+  (func (export "as-local_set-value2") (param i64) (result v128) (local v128)
+    (local.set 1 (i64x2.splat (local.get 0)))
+    (return (local.get 1)))
+  (func (export "as-global_set-value2") (param f64) (result v128)
+    (global.set $g (f64x2.splat (local.get 0)))
+    (return (global.get $g)))
+)
+
+(assert_return (invoke "as-br-value1" (i32.const 0xAB)) (v128.const i8x16 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB 0xAB))
+(assert_return (invoke "as-return-value1" (i32.const 0xABCD)) (v128.const i16x8 0xABCD 0xABCD 0xABCD 0xABCD 0xABCD 0xABCD 0xABCD 0xABCD))
+(assert_return (invoke "as-local_set-value1" (i32.const 0x10000)) (v128.const i32x4 0x10000 0x10000 0x10000 0x10000))
+(assert_return (invoke "as-global_set-value1" (f32.const 1.0)) (v128.const f32x4 1.0 1.0 1.0 1.0))
+(assert_return (invoke "as-br-value2" (i64.const 0xABCD)) (v128.const i64x2 0xABCD 0xABCD))
+(assert_return (invoke "as-return-value2" (i64.const 0xABCD)) (v128.const i64x2 0xABCD 0xABCD))
+(assert_return (invoke "as-local_set-value2" (i64.const 0x10000)) (v128.const i64x2 0x10000 0x10000))
+(assert_return (invoke "as-global_set-value2" (f64.const 1.0)) (v128.const f64x2 1.0 1.0))
+
+
+;; Test operation with empty argument
+
+(assert_invalid
+  (module
+    (func $i8x16.splat-arg-empty (result v128)
+      (i8x16.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i16x8.splat-arg-empty (result v128)
+      (i16x8.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i32x4.splat-arg-empty (result v128)
+      (i32x4.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f32x4.splat-arg-empty (result v128)
+      (f32x4.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $i64x2.splat-arg-empty (result v128)
+      (i64x2.splat)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f64x2.splat-arg-empty (result v128)
+      (f64x2.splat)
+    )
+  )
+  "type mismatch"
+)

--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -23,6 +23,9 @@ pub(crate) enum CodeGenError {
     /// Unimplemented due to requiring AVX.
     #[error("Instruction not implemented for CPUs without AVX support")]
     UnimplementedForNoAvx,
+    /// Unimplemented due to requiring AVX2.
+    #[error("Instruction not implemented for CPUs without AVX2 support")]
+    UnimplementedForNoAvx2,
     /// Unsupported eager initialization of tables.
     #[error("Unsupported eager initialization of tables")]
     UnsupportedTableEagerInit,

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -894,15 +894,7 @@ impl Masm for MacroAssembler {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
 
-    fn splat_int(
-        &mut self,
-        _context: &mut CodeGenContext<Emission>,
-        _size: SplatKind,
-    ) -> Result<()> {
-        bail!(CodeGenError::unimplemented_masm_instruction())
-    }
-
-    fn splat(&mut self, _dst: WritableReg, _src: RegImm, _size: SplatKind) -> Result<()> {
+    fn splat(&mut self, _context: &mut CodeGenContext<Emission>, _size: SplatKind) -> Result<()> {
         bail!(CodeGenError::unimplemented_masm_instruction())
     }
 

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -14,7 +14,7 @@ use crate::{
     masm::{
         CalleeKind, DivKind, ExtendKind, FloatCmpKind, Imm as I, IntCmpKind, LoadKind,
         MacroAssembler as Masm, MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp,
-        RoundingMode, SPOffset, ShiftKind, StackSlot, TrapCode, TruncKind,
+        RoundingMode, SPOffset, ShiftKind, SplatKind, StackSlot, TrapCode, TruncKind,
     },
     stack::TypedReg,
 };
@@ -892,6 +892,18 @@ impl Masm for MacroAssembler {
     ) -> Result<()> {
         let _ = (context, kind);
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+    }
+
+    fn splat_int(
+        &mut self,
+        _context: &mut CodeGenContext<Emission>,
+        _size: SplatKind,
+    ) -> Result<()> {
+        bail!(CodeGenError::unimplemented_masm_instruction())
+    }
+
+    fn splat(&mut self, _dst: WritableReg, _src: RegImm, _size: SplatKind) -> Result<()> {
+        bail!(CodeGenError::unimplemented_masm_instruction())
     }
 
     fn shuffle(&mut self, _dst: WritableReg, _lhs: Reg, _rhs: Reg, _lanes: [u8; 16]) -> Result<()> {

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -4,7 +4,7 @@ use crate::{
     isa::{reg::Reg, CallingConvention},
     masm::{
         DivKind, ExtendKind, IntCmpKind, MulWideKind, OperandSize, RemKind, RoundingMode,
-        ShiftKind, SplatKind, VectorExtendKind,
+        ShiftKind, VectorExtendKind,
     },
 };
 use cranelift_codegen::{
@@ -164,18 +164,6 @@ impl From<OperandSize> for Option<ExtMode> {
             S8 => Some(ExtMode::BQ),
             S16 => Some(ExtMode::WQ),
             S32 => Some(ExtMode::LQ),
-        }
-    }
-}
-
-impl SplatKind {
-    /// Get the operand size for `vpbroadcast`.
-    pub(super) fn vpbroadcast_operand_size(&self) -> OperandSize {
-        match self {
-            SplatKind::S8 => OperandSize::S8,
-            SplatKind::S16 => OperandSize::S16,
-            SplatKind::S32 => OperandSize::S32,
-            SplatKind::S64 => OperandSize::S64,
         }
     }
 }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1343,18 +1343,11 @@ impl Masm for MacroAssembler {
             }
 
             match src {
-                RegImm::Reg(src) => {
-                    self.asm
-                        .xmm_vpbroadcast_rr(src, dst, size.vpbroadcast_operand_size())
-                }
+                RegImm::Reg(src) => self.asm.xmm_vpbroadcast_rr(src, dst, size.lane_size()),
                 RegImm::Imm(imm) => {
                     let src = self.asm.add_constant(&imm.to_bytes());
-                    self.asm.xmm_vpbroadcast_mr(
-                        &src,
-                        dst,
-                        size.vpbroadcast_operand_size(),
-                        MemFlags::trusted(),
-                    );
+                    self.asm
+                        .xmm_vpbroadcast_mr(&src, dst, size.lane_size(), MemFlags::trusted());
                 }
             }
         }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -271,20 +271,32 @@ pub(crate) enum VectorExtendKind {
     V128Extend32x2U,
 }
 
+/// Kinds of splat loads supported by WebAssembly.
+pub(crate) enum SplatLoadKind {
+    /// 8 bits.
+    S8,
+    /// 16 bits.
+    S16,
+    /// 32 bits.
+    S32,
+    /// 64 bits.
+    S64,
+}
+
 /// Kinds of splat supported by WebAssembly.
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
 pub(crate) enum SplatKind {
-    // 8 bit integer.
+    /// 8 bit integer.
     I8x16,
-    // 16 bit integer.
+    /// 16 bit integer.
     I16x8,
-    // 32 bit integer.
+    /// 32 bit integer.
     I32x4,
-    // 64 bit integer.
+    /// 64 bit integer.
     I64x2,
-    // 32 bit float.
+    /// 32 bit float.
     F32x4,
-    // 64 bit float.
+    /// 64 bit float.
     F64x2,
 }
 
@@ -305,7 +317,7 @@ pub(crate) enum LoadKind {
     /// Load the entire bytes of the operand size without any modifications.
     Operand(OperandSize),
     /// Duplicate value into vector lanes.
-    Splat(SplatKind),
+    Splat(SplatLoadKind),
     /// Scalar (non-vector) extend.
     ScalarExtend(ExtendKind),
     /// Vector extend.
@@ -349,12 +361,12 @@ impl LoadKind {
         }
     }
 
-    fn operand_size_for_splat(kind: &SplatKind) -> OperandSize {
+    fn operand_size_for_splat(kind: &SplatLoadKind) -> OperandSize {
         match kind {
-            SplatKind::I8x16 => OperandSize::S8,
-            SplatKind::I16x8 => OperandSize::S16,
-            SplatKind::I32x4 | SplatKind::F32x4 => OperandSize::S32,
-            SplatKind::I64x2 | SplatKind::F64x2 => OperandSize::S64,
+            SplatLoadKind::S8 => OperandSize::S8,
+            SplatLoadKind::S16 => OperandSize::S16,
+            SplatLoadKind::S32 => OperandSize::S32,
+            SplatLoadKind::S64 => OperandSize::S64,
         }
     }
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -284,6 +284,18 @@ pub(crate) enum SplatKind {
     S64,
 }
 
+impl SplatKind {
+    /// The lane size to use for different kinds of splats.
+    pub(crate) fn lane_size(&self) -> OperandSize {
+        match self {
+            SplatKind::S8 => OperandSize::S8,
+            SplatKind::S16 => OperandSize::S16,
+            SplatKind::S32 => OperandSize::S32,
+            SplatKind::S64 => OperandSize::S64,
+        }
+    }
+}
+
 /// Kinds of behavior supported by Wasm loads.
 pub(crate) enum LoadKind {
     /// Load the entire bytes of the operand size without any modifications.

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -274,24 +274,28 @@ pub(crate) enum VectorExtendKind {
 /// Kinds of splat supported by WebAssembly.
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
 pub(crate) enum SplatKind {
-    // 8 bit.
-    S8,
-    // 16 bit.
-    S16,
-    // 32 bit.
-    S32,
-    // 64 bit.
-    S64,
+    // 8 bit integer.
+    I8x16,
+    // 16 bit integer.
+    I16x8,
+    // 32 bit integer.
+    I32x4,
+    // 64 bit integer.
+    I64x2,
+    // 32 bit float.
+    F32x4,
+    // 64 bit float.
+    F64x2,
 }
 
 impl SplatKind {
     /// The lane size to use for different kinds of splats.
     pub(crate) fn lane_size(&self) -> OperandSize {
         match self {
-            SplatKind::S8 => OperandSize::S8,
-            SplatKind::S16 => OperandSize::S16,
-            SplatKind::S32 => OperandSize::S32,
-            SplatKind::S64 => OperandSize::S64,
+            SplatKind::I8x16 => OperandSize::S8,
+            SplatKind::I16x8 => OperandSize::S16,
+            SplatKind::I32x4 | SplatKind::F32x4 => OperandSize::S32,
+            SplatKind::I64x2 | SplatKind::F64x2 => OperandSize::S64,
         }
     }
 }
@@ -347,10 +351,10 @@ impl LoadKind {
 
     fn operand_size_for_splat(kind: &SplatKind) -> OperandSize {
         match kind {
-            SplatKind::S8 => OperandSize::S8,
-            SplatKind::S16 => OperandSize::S16,
-            SplatKind::S32 => OperandSize::S32,
-            SplatKind::S64 => OperandSize::S64,
+            SplatKind::I8x16 => OperandSize::S8,
+            SplatKind::I16x8 => OperandSize::S16,
+            SplatKind::I32x4 | SplatKind::F32x4 => OperandSize::S32,
+            SplatKind::I64x2 | SplatKind::F64x2 => OperandSize::S64,
         }
     }
 }
@@ -1281,13 +1285,9 @@ pub(crate) trait MacroAssembler {
     fn mul_wide(&mut self, context: &mut CodeGenContext<Emission>, kind: MulWideKind)
         -> Result<()>;
 
-    /// Takes the int in a `src` operand and replicates it across lanes of
+    /// Takes the value in a src operand and replicates it across lanes of
     /// `size` in a destination result.
-    fn splat_int(&mut self, context: &mut CodeGenContext<Emission>, size: SplatKind) -> Result<()>;
-
-    /// Takes the `src` operand and replicates it across lanes of `size` in
-    /// `dst`.
-    fn splat(&mut self, dst: WritableReg, src: RegImm, size: SplatKind) -> Result<()>;
+    fn splat(&mut self, context: &mut CodeGenContext<Emission>, size: SplatKind) -> Result<()>;
 
     /// Performs a shuffle between two 128-bit vectors into a 128-bit result
     /// using lanes as a mask to select which indexes to copy.

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -509,6 +509,9 @@ impl Imm {
     }
 
     /// Get a little endian representation of the immediate.
+    ///
+    /// This method heap allocates and is intended to be used when adding
+    /// values to the constant pool.
     pub fn to_bytes(&self) -> Vec<u8> {
         match self {
             Imm::I32(n) => n.to_le_bytes().to_vec(),

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -271,6 +271,12 @@ macro_rules! def_unsupported {
     (emit V128Load16Splat $($rest:tt)*) => {};
     (emit V128Load32Splat $($rest:tt)*) => {};
     (emit V128Load64Splat $($rest:tt)*) => {};
+    (emit I8x16Splat $($rest:tt)*) => {};
+    (emit I16x8Splat $($rest:tt)*) => {};
+    (emit I32x4Splat $($rest:tt)*) => {};
+    (emit I64x2Splat $($rest:tt)*) => {};
+    (emit F32x4Splat $($rest:tt)*) => {};
+    (emit F64x2Splat $($rest:tt)*) => {};
     (emit I32AtomicStore8 $($rest:tt)*) => {};
     (emit I32AtomicStore16 $($rest:tt)*) => {};
     (emit I32AtomicStore $($rest:tt)*) => {};
@@ -2470,6 +2476,38 @@ where
             LoadKind::Splat(SplatKind::S64),
             MemOpKind::Normal,
         )
+    }
+
+    fn visit_i8x16_splat(&mut self) -> Self::Output {
+        self.masm.splat_int(&mut self.context, SplatKind::S8)
+    }
+
+    fn visit_i16x8_splat(&mut self) -> Self::Output {
+        self.masm.splat_int(&mut self.context, SplatKind::S16)
+    }
+
+    fn visit_i32x4_splat(&mut self) -> Self::Output {
+        self.masm.splat_int(&mut self.context, SplatKind::S32)
+    }
+
+    fn visit_i64x2_splat(&mut self) -> Self::Output {
+        self.masm.splat_int(&mut self.context, SplatKind::S64)
+    }
+
+    fn visit_f32x4_splat(&mut self) -> Self::Output {
+        self.context
+            .unop(self.masm, OperandSize::S32, &mut |masm, reg, _size| {
+                masm.splat(writable!(reg), RegImm::reg(reg), SplatKind::S32)?;
+                Ok(TypedReg::v128(reg))
+            })
+    }
+
+    fn visit_f64x2_splat(&mut self) -> Self::Output {
+        self.context
+            .unop(self.masm, OperandSize::S64, &mut |masm, reg, _size| {
+                masm.splat(writable!(reg), RegImm::reg(reg), SplatKind::S64)?;
+                Ok(TypedReg::v128(reg))
+            })
     }
 
     fn visit_i8x16_shuffle(&mut self, lanes: [u8; 16]) -> Self::Output {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -11,7 +11,7 @@ use crate::codegen::{
 use crate::masm::{
     DivKind, ExtendKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler, MemMoveDirection,
     MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp, RoundingMode, SPOffset, ShiftKind,
-    SplatKind, TruncKind, VectorExtendKind,
+    SplatKind, SplatLoadKind, TruncKind, VectorExtendKind,
 };
 
 use crate::reg::{writable, Reg};
@@ -2446,7 +2446,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::I8x16),
+            LoadKind::Splat(SplatLoadKind::S8),
             MemOpKind::Normal,
         )
     }
@@ -2455,7 +2455,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::I16x8),
+            LoadKind::Splat(SplatLoadKind::S16),
             MemOpKind::Normal,
         )
     }
@@ -2464,7 +2464,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::I32x4),
+            LoadKind::Splat(SplatLoadKind::S32),
             MemOpKind::Normal,
         )
     }
@@ -2473,7 +2473,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::I64x2),
+            LoadKind::Splat(SplatLoadKind::S64),
             MemOpKind::Normal,
         )
     }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -2446,7 +2446,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::S8),
+            LoadKind::Splat(SplatKind::I8x16),
             MemOpKind::Normal,
         )
     }
@@ -2455,7 +2455,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::S16),
+            LoadKind::Splat(SplatKind::I16x8),
             MemOpKind::Normal,
         )
     }
@@ -2464,7 +2464,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::S32),
+            LoadKind::Splat(SplatKind::I32x4),
             MemOpKind::Normal,
         )
     }
@@ -2473,41 +2473,33 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::Splat(SplatKind::S64),
+            LoadKind::Splat(SplatKind::I64x2),
             MemOpKind::Normal,
         )
     }
 
     fn visit_i8x16_splat(&mut self) -> Self::Output {
-        self.masm.splat_int(&mut self.context, SplatKind::S8)
+        self.masm.splat(&mut self.context, SplatKind::I8x16)
     }
 
     fn visit_i16x8_splat(&mut self) -> Self::Output {
-        self.masm.splat_int(&mut self.context, SplatKind::S16)
+        self.masm.splat(&mut self.context, SplatKind::I16x8)
     }
 
     fn visit_i32x4_splat(&mut self) -> Self::Output {
-        self.masm.splat_int(&mut self.context, SplatKind::S32)
+        self.masm.splat(&mut self.context, SplatKind::I32x4)
     }
 
     fn visit_i64x2_splat(&mut self) -> Self::Output {
-        self.masm.splat_int(&mut self.context, SplatKind::S64)
+        self.masm.splat(&mut self.context, SplatKind::I64x2)
     }
 
     fn visit_f32x4_splat(&mut self) -> Self::Output {
-        self.context
-            .unop(self.masm, OperandSize::S32, &mut |masm, reg, _size| {
-                masm.splat(writable!(reg), RegImm::reg(reg), SplatKind::S32)?;
-                Ok(TypedReg::v128(reg))
-            })
+        self.masm.splat(&mut self.context, SplatKind::F32x4)
     }
 
     fn visit_f64x2_splat(&mut self) -> Self::Output {
-        self.context
-            .unop(self.masm, OperandSize::S64, &mut |masm, reg, _size| {
-                masm.splat(writable!(reg), RegImm::reg(reg), SplatKind::S64)?;
-                Ok(TypedReg::v128(reg))
-            })
+        self.masm.splat(&mut self.context, SplatKind::F64x2)
     }
 
     fn visit_i8x16_shuffle(&mut self, lanes: [u8; 16]) -> Self::Output {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Part of https://github.com/bytecodealliance/wasmtime/issues/8093. Implements the following instructions on x64 with AVX2 support:
- `i8x16.splat`
- `i16x8.splat`
- `i32x4.splat`
- `i64x2.splat`
- `f32x4.splat`
- `f64x2.splat`