### PR TITLE
Winch: implement rmw xchg for x64

### DIFF
--- a/tests/disas/winch/x64/atomic/rmw/i32_atomic_rmw16_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i32_atomic_rmw16_xchgu.wat
@@ -3,8 +3,8 @@
 
 (module
   (memory 1 1 shared)
-  (func (export "_start") (result i64)
-        (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42))))
+  (func (export "_start") (result i32)
+        (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 42))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
@@ -17,17 +17,17 @@
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
+;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
 ;;       jne     0x61
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
-;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
+;;       xchgw   %ax, (%rdx)
+;;       movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/winch/x64/atomic/rmw/i32_atomic_rmw8_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i32_atomic_rmw8_xchgu.wat
@@ -3,8 +3,8 @@
 
 (module
   (memory 1 1 shared)
-  (func (export "_start") (result i64)
-        (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42))))
+  (func (export "_start") (result i32)
+        (i32.atomic.rmw8.xchg_u (i32.const 0) (i32.const 42))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
@@ -12,24 +12,19 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x4b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
+;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x61
-;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
-;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
+;;       xchgb   %al, (%rdx)
+;;       movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
-;;   61: ud2
+;;   4b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/i32_atomic_rmw_xchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i32_atomic_rmw_xchg.wat
@@ -3,8 +3,8 @@
 
 (module
   (memory 1 1 shared)
-  (func (export "_start") (result i64)
-        (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42))))
+  (func (export "_start") (result i32)
+        (i32.atomic.rmw.xchg (i32.const 0) (i32.const 42))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
@@ -12,24 +12,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x59
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
+;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x61
-;;   44: movl    $0, %ecx
+;;       jne     0x5b
+;;   42: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
-;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
+;;       xchgl   %eax, (%rdx)
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
-;;   61: ud2
+;;   59: ud2
+;;   5b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw16_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw16_xchgu.wat
@@ -4,7 +4,7 @@
 (module
   (memory 1 1 shared)
   (func (export "_start") (result i64)
-        (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42))))
+        (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 42))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
@@ -12,24 +12,24 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x62
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x61
-;;   44: movl    $0, %ecx
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
+;;       jne     0x64
+;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
-;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
+;;       xchgw   %ax, (%rdx)
+;;       movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
-;;   61: ud2
+;;   62: ud2
+;;   64: ud2

--- a/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_addu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_addu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x5d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,15 +21,14 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x61
+;;       jne     0x5f
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   5d: ud2
 ;;   5f: ud2
-;;   61: ud2

--- a/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_xchgu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5d
+;;       ja      0x5b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,15 +21,14 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x5f
+;;       jne     0x5d
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       xchgl   %eax, (%rdx)
-;;       movl    %eax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   5b: ud2
 ;;   5d: ud2
-;;   5f: ud2

--- a/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_xchgu.wat
@@ -4,7 +4,7 @@
 (module
   (memory 1 1 shared)
   (func (export "_start") (result i64)
-        (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42))))
+        (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 42))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x5d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,15 +21,15 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x61
+;;       jne     0x5f
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
-;;       lock xaddl %eax, (%rdx)
+;;       xchgl   %eax, (%rdx)
 ;;       movl    %eax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   5d: ud2
 ;;   5f: ud2
-;;   61: ud2

--- a/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw8_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw8_xchgu.wat
@@ -4,7 +4,7 @@
 (module
   (memory 1 1 shared)
   (func (export "_start") (result i64)
-        (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42))))
+        (i64.atomic.rmw8.xchg_u (i32.const 0) (i64.const 42))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
@@ -12,24 +12,19 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x4e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x61
-;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
-;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
+;;       xchgb   %al, (%rdx)
+;;       movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
-;;   61: ud2
+;;   4e: ud2

--- a/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw_xchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw_xchg.wat
@@ -4,7 +4,7 @@
 (module
   (memory 1 1 shared)
   (func (export "_start") (result i64)
-        (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42))))
+        (i64.atomic.rmw.xchg (i32.const 0) (i64.const 42))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
@@ -12,24 +12,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x5e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    $0x2a, %rax
 ;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x61
-;;   44: movl    $0, %ecx
+;;       andq    $7, %rcx
+;;       cmpq    $0, %rcx
+;;       jne     0x60
+;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
-;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
+;;       xchgq   %rax, (%rdx)
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
-;;   61: ud2
+;;   5e: ud2
+;;   60: ud2

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1147,6 +1147,31 @@ impl Assembler {
         });
     }
 
+    pub fn xchg(
+        &mut self,
+        addr: Address,
+        operand: Reg,
+        dst: WritableReg,
+        size: OperandSize,
+        flags: MemFlags,
+    ) {
+        assert!(addr.is_offset());
+        let mem = Self::to_synthetic_amode(
+            &addr,
+            &mut self.pool,
+            &mut self.constants,
+            &mut self.buffer,
+            flags,
+        );
+
+        self.emit(Inst::Xchg {
+            size: size.into(),
+            operand: operand.into(),
+            mem,
+            dst_old: dst.map(Into::into),
+        });
+    }
+
     pub fn cmp_ir(&mut self, src1: Reg, imm: i32, size: OperandSize) {
         let imm = RegMemImm::imm(imm as u32);
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1410,6 +1410,9 @@ impl Masm for MacroAssembler {
                 self.asm
                     .lock_xadd(addr, operand.to_reg(), operand, size, flags);
             }
+            RmwOp::Xchg => {
+                self.asm.xchg(addr, operand.to_reg(), operand, size, flags);
+            }
         }
 
         if let Some(extend) = extend {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -56,6 +56,7 @@ pub(crate) enum MulWideKind {
 pub(crate) enum RmwOp {
     Add,
     Sub,
+    Xchg,
 }
 
 /// The direction to perform the memory move.

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -299,6 +299,13 @@ macro_rules! def_unsupported {
     (emit I64AtomicRmw16SubU $($rest:tt)*) => {};
     (emit I64AtomicRmw32SubU $($rest:tt)*) => {};
     (emit I64AtomicRmwSub $($rest:tt)*) => {};
+    (emit I32AtomicRmw8XchgU $($rest:tt)*) => {};
+    (emit I32AtomicRmw16XchgU $($rest:tt)*) => {};
+    (emit I32AtomicRmwXchg $($rest:tt)*) => {};
+    (emit I64AtomicRmw8XchgU $($rest:tt)*) => {};
+    (emit I64AtomicRmw16XchgU $($rest:tt)*) => {};
+    (emit I64AtomicRmw32XchgU $($rest:tt)*) => {};
+    (emit I64AtomicRmwXchg $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2350,14 +2357,6 @@ where
         self.emit_atomic_rmw(&arg, RmwOp::Add, OperandSize::S64, None)
     }
 
-    fn visit_i32_atomic_rmw_sub(&mut self, arg: MemArg) -> Self::Output {
-        self.emit_atomic_rmw(&arg, RmwOp::Sub, OperandSize::S32, None)
-    }
-
-    fn visit_i64_atomic_rmw_sub(&mut self, arg: MemArg) -> Self::Output {
-        self.emit_atomic_rmw(&arg, RmwOp::Sub, OperandSize::S64, None)
-    }
-
     fn visit_i32_atomic_rmw8_sub_u(&mut self, arg: MemArg) -> Self::Output {
         self.emit_atomic_rmw(
             &arg,
@@ -2374,6 +2373,10 @@ where
             OperandSize::S16,
             Some(ExtendKind::I32Extend16U),
         )
+    }
+
+    fn visit_i32_atomic_rmw_sub(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(&arg, RmwOp::Sub, OperandSize::S32, None)
     }
 
     fn visit_i64_atomic_rmw8_sub_u(&mut self, arg: MemArg) -> Self::Output {
@@ -2401,6 +2404,63 @@ where
             OperandSize::S32,
             Some(ExtendKind::I64Extend32U),
         )
+    }
+
+    fn visit_i64_atomic_rmw_sub(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(&arg, RmwOp::Sub, OperandSize::S64, None)
+    }
+
+    fn visit_i32_atomic_rmw8_xchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(
+            &arg,
+            RmwOp::Xchg,
+            OperandSize::S8,
+            Some(ExtendKind::I32Extend8U),
+        )
+    }
+
+    fn visit_i32_atomic_rmw16_xchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(
+            &arg,
+            RmwOp::Xchg,
+            OperandSize::S16,
+            Some(ExtendKind::I32Extend16U),
+        )
+    }
+
+    fn visit_i32_atomic_rmw_xchg(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(&arg, RmwOp::Xchg, OperandSize::S32, None)
+    }
+
+    fn visit_i64_atomic_rmw8_xchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(
+            &arg,
+            RmwOp::Xchg,
+            OperandSize::S8,
+            Some(ExtendKind::I64Extend8U),
+        )
+    }
+
+    fn visit_i64_atomic_rmw16_xchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(
+            &arg,
+            RmwOp::Xchg,
+            OperandSize::S16,
+            Some(ExtendKind::I64Extend16U),
+        )
+    }
+
+    fn visit_i64_atomic_rmw32_xchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(
+            &arg,
+            RmwOp::Xchg,
+            OperandSize::S32,
+            Some(ExtendKind::I64Extend32U),
+        )
+    }
+
+    fn visit_i64_atomic_rmw_xchg(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_rmw(&arg, RmwOp::Xchg, OperandSize::S64, None)
     }
 
     wasmparser::for_each_visit_operator!(def_unsupported);


### PR DESCRIPTION
implement `xchg` instructions for `x64`:
- `i32.atomic.rmw8.xchg_u`
- `i32.atomic.rmw16.xchg_u`
- `i32.atomic.rmw.xchg`
- `i64.atomic.rmw8.xchg_u`
- `i64.atomic.rmw16.xchg_u`
- `i64.atomic.rmw32.xchg_u`
- `i64.atomic.rmw.xchg`

#9734
