### PR TITLE
Disable parallel compilation during fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -246,7 +246,8 @@ impl Config {
         log::debug!("creating wasmtime config with {:#?}", self.wasmtime);
 
         let mut cfg = wasmtime::Config::new();
-        cfg.wasm_bulk_memory(true)
+        cfg.parallel_compilation(false)
+            .wasm_bulk_memory(true)
             .wasm_reference_types(self.module_config.config.reference_types_enabled)
             .wasm_multi_value(self.module_config.config.multi_value_enabled)
             .wasm_multi_memory(self.module_config.config.max_memories > 1)

--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -27,9 +27,5 @@ pub fn init_fuzzing() {
 
     INIT.call_once(|| {
         let _ = env_logger::try_init();
-
-        let _ = rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build_global();
-    })
+    });
 }


### PR DESCRIPTION
The intention has always been to disable parallel compilation during fuzzing and this was previously achieved with a single-thread pool for Rayon. This still spawns a rayon thread though and can offload work to it, so this instead explicitly uses `wasmtime::Config` to disable parallel compilation. This should ensure that `rayon` doesn't get used at runtime, as desired, and additionally avoids spawning threads or offloading work onto a thread.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
