### PR TITLE
Winch: avoid emitting 32->64 extend on rmw ops on x64

### DIFF
--- a/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_subu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/i64_atomic_rmw32_subu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x61
+;;       ja      0x5f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,16 +21,15 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x63
+;;       jne     0x61
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
 ;;       negl    %eax
 ;;       lock xaddl %eax, (%rdx)
-;;       movl    %eax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   5f: ud2
 ;;   61: ud2
-;;   63: ud2

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1338,8 +1338,14 @@ impl Masm for MacroAssembler {
         }
 
         if let Some(extend) = extend {
-            self.asm.movzx_rr(operand.to_reg(), operand, extend);
+            // We don't need to zero-extend from 32 to 64bits.
+            if !(extend.src_operand_size() == OperandSize::S32
+                && extend.dst_operand_size() == OperandSize::S64)
+            {
+                self.asm.movzx_rr(operand.to_reg(), operand, extend);
+            }
         }
+
         Ok(())
     }
 }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1339,9 +1339,7 @@ impl Masm for MacroAssembler {
 
         if let Some(extend) = extend {
             // We don't need to zero-extend from 32 to 64bits.
-            if !(extend.src_operand_size() == OperandSize::S32
-                && extend.dst_operand_size() == OperandSize::S64)
-            {
+            if !(extend.from_bits() == 32 && extend.to_bits() == 64) {
                 self.asm.movzx_rr(operand.to_reg(), operand, extend);
             }
         }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -252,35 +252,6 @@ impl ExtendKind {
             Self::I32Extend8S | Self::I32Extend8U | Self::I32Extend16U | Self::I32Extend16S => 32,
         }
     }
-
-    pub(crate) fn src_operand_size(&self) -> OperandSize {
-        match self {
-            ExtendKind::I32Extend8S
-            | ExtendKind::I32Extend8U
-            | ExtendKind::I64Extend8S
-            | ExtendKind::I64Extend8U => OperandSize::S8,
-            ExtendKind::I32Extend16S
-            | ExtendKind::I32Extend16U
-            | ExtendKind::I64Extend16U
-            | ExtendKind::I64Extend16S => OperandSize::S16,
-            ExtendKind::I64Extend32U | ExtendKind::I64Extend32S => OperandSize::S32,
-        }
-    }
-
-    pub(crate) fn dst_operand_size(&self) -> OperandSize {
-        match self {
-            ExtendKind::I32Extend8S
-            | ExtendKind::I32Extend8U
-            | ExtendKind::I32Extend16S
-            | ExtendKind::I32Extend16U
-            | ExtendKind::I64Extend8S => OperandSize::S32,
-            ExtendKind::I64Extend8U
-            | ExtendKind::I64Extend16S
-            | ExtendKind::I64Extend16U
-            | ExtendKind::I64Extend32S
-            | ExtendKind::I64Extend32U => OperandSize::S64,
-        }
-    }
 }
 
 /// Kinds of vector extends in WebAssembly. Each MacroAssembler implementation
@@ -349,7 +320,17 @@ impl LoadKind {
     }
 
     fn operand_size_for_scalar(extend_kind: &ExtendKind) -> OperandSize {
-        extend_kind.src_operand_size()
+        match extend_kind {
+            ExtendKind::I32Extend8S
+            | ExtendKind::I32Extend8U
+            | ExtendKind::I64Extend8S
+            | ExtendKind::I64Extend8U => OperandSize::S8,
+            ExtendKind::I32Extend16S
+            | ExtendKind::I32Extend16U
+            | ExtendKind::I64Extend16U
+            | ExtendKind::I64Extend16S => OperandSize::S16,
+            ExtendKind::I64Extend32U | ExtendKind::I64Extend32S => OperandSize::S32,
+        }
     }
 
     fn operand_size_for_splat(kind: &SplatKind) -> OperandSize {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -252,6 +252,35 @@ impl ExtendKind {
             Self::I32Extend8S | Self::I32Extend8U | Self::I32Extend16U | Self::I32Extend16S => 32,
         }
     }
+
+    pub(crate) fn src_operand_size(&self) -> OperandSize {
+        match self {
+            ExtendKind::I32Extend8S
+            | ExtendKind::I32Extend8U
+            | ExtendKind::I64Extend8S
+            | ExtendKind::I64Extend8U => OperandSize::S8,
+            ExtendKind::I32Extend16S
+            | ExtendKind::I32Extend16U
+            | ExtendKind::I64Extend16U
+            | ExtendKind::I64Extend16S => OperandSize::S16,
+            ExtendKind::I64Extend32U | ExtendKind::I64Extend32S => OperandSize::S32,
+        }
+    }
+
+    pub(crate) fn dst_operand_size(&self) -> OperandSize {
+        match self {
+            ExtendKind::I32Extend8S
+            | ExtendKind::I32Extend8U
+            | ExtendKind::I32Extend16S
+            | ExtendKind::I32Extend16U
+            | ExtendKind::I64Extend8S => OperandSize::S32,
+            ExtendKind::I64Extend8U
+            | ExtendKind::I64Extend16S
+            | ExtendKind::I64Extend16U
+            | ExtendKind::I64Extend32S
+            | ExtendKind::I64Extend32U => OperandSize::S64,
+        }
+    }
 }
 
 /// Kinds of vector extends in WebAssembly. Each MacroAssembler implementation
@@ -320,17 +349,7 @@ impl LoadKind {
     }
 
     fn operand_size_for_scalar(extend_kind: &ExtendKind) -> OperandSize {
-        match extend_kind {
-            ExtendKind::I32Extend8S
-            | ExtendKind::I32Extend8U
-            | ExtendKind::I64Extend8S
-            | ExtendKind::I64Extend8U => OperandSize::S8,
-            ExtendKind::I32Extend16S
-            | ExtendKind::I32Extend16U
-            | ExtendKind::I64Extend16U
-            | ExtendKind::I64Extend16S => OperandSize::S16,
-            ExtendKind::I64Extend32U | ExtendKind::I64Extend32S => OperandSize::S32,
-        }
+        extend_kind.src_operand_size()
     }
 
     fn operand_size_for_splat(kind: &SplatKind) -> OperandSize {


### PR DESCRIPTION
I got confused by [this comment](https://github.com/bytecodealliance/wasmtime/pull/9990#discussion_r1916804597), and read the code too fast, but we actually emit an unnecessary `mov` when extending from 32 to 64bits on x64 in winch.
