### PR TITLE
Optimize MIRI execution time in CI

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -281,6 +281,14 @@ impl Config {
             ret.cranelift_opt_level(OptLevel::Speed);
         }
 
+        // When running under MIRI try to optimize for compile time of wasm code
+        // itself as much as possible. Disable optimizations by default and use
+        // the fastest regalloc available to us.
+        if cfg!(miri) {
+            ret.cranelift_opt_level(OptLevel::None);
+            ret.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
+        }
+
         ret.wasm_backtrace_details(WasmBacktraceDetails::Environment);
 
         ret

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -279,14 +279,14 @@ impl Config {
         {
             ret.cranelift_debug_verifier(false);
             ret.cranelift_opt_level(OptLevel::Speed);
-        }
 
-        // When running under MIRI try to optimize for compile time of wasm code
-        // itself as much as possible. Disable optimizations by default and use
-        // the fastest regalloc available to us.
-        if cfg!(miri) {
-            ret.cranelift_opt_level(OptLevel::None);
-            ret.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
+            // When running under MIRI try to optimize for compile time of wasm
+            // code itself as much as possible. Disable optimizations by
+            // default and use the fastest regalloc available to us.
+            if cfg!(miri) {
+                ret.cranelift_opt_level(OptLevel::None);
+                ret.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
+            }
         }
 
         ret.wasm_backtrace_details(WasmBacktraceDetails::Environment);

--- a/tests/all/component_model/instance.rs
+++ b/tests/all/component_model/instance.rs
@@ -3,6 +3,7 @@ use wasmtime::component::*;
 use wasmtime::{Module, Store};
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn instance_exports() -> Result<()> {
     let engine = super::engine();
     let component = r#"
@@ -124,6 +125,7 @@ fn export_new_get_old() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn export_missing_get_max() -> Result<()> {
     let engine = super::engine();
     let component = r#"

--- a/tests/all/component_model/linker.rs
+++ b/tests/all/component_model/linker.rs
@@ -106,6 +106,7 @@ fn missing_import_selects_max() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn linker_substituting_types_issue_8003() -> Result<()> {
     let engine = Engine::default();
     let linker = Linker::<()>::new(&engine);

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -473,6 +473,7 @@ fn dtor_runs() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn dtor_delayed() -> Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
 

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -83,6 +83,7 @@ fn drop_func() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn drop_delayed() -> Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
 

--- a/tests/all/instance.rs
+++ b/tests/all/instance.rs
@@ -1,6 +1,7 @@
 use wasmtime::*;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn wrong_import_numbers() -> Result<()> {
     let mut store = Store::<()>::default();
     let module = Module::new(store.engine(), r#"(module (import "" "" (func)))"#)?;

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use wasmtime::*;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn link_undefined() -> Result<()> {
     let mut store = Store::<()>::default();
     let linker = Linker::new(store.engine());
@@ -269,6 +270,7 @@ fn no_leak_with_imports() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn get_host_function() -> Result<()> {
     let engine = Engine::default();
     let module = Module::new(&engine, r#"(module (import "mod" "f1" (func)))"#)?;
@@ -331,6 +333,7 @@ fn alias_one() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn instance_pre() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -300,6 +300,7 @@ fn tail_call_defaults() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn cross_engine_module_exports() -> Result<()> {
     let a_engine = Engine::default();
     let b_engine = Engine::default();


### PR DESCRIPTION
* Disable Cranelift optimizations and use single_pass register allocation by default.

* Ignore a number of tests that are compiling wasm which we generally don't want to do under MIRI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
