### PR TITLE
Winch: x64 atomic CAS

### DIFF
--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
@@ -1,0 +1,44 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1 1 shared)
+  (func (export "_start") (result i32)
+        (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 42) (i32.const 1337))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x18, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x82
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0x539, %eax
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x84
+;;   49: movl    $0, %edx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       lock cmpxchgw %cx, (%rbx)
+;;       movzwl  %ax, %eax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   82: ud2
+;;   84: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw8_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw8_cmpxchgu.wat
@@ -1,0 +1,39 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1 1 shared)
+  (func (export "_start") (result i32)
+        (i32.atomic.rmw8.cmpxchg_u (i32.const 0) (i32.const 42) (i32.const 1337))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x18, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x6e
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0x539, %eax
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       lock cmpxchgb %cl, (%rbx)
+;;       movzbl  %al, %eax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   6e: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg.wat
@@ -1,0 +1,43 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1 1 shared)
+  (func (export "_start") (result i32)
+        (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 42) (i32.const 1337))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x18, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x7c
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0x539, %eax
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x7e
+;;   47: movl    $0, %edx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       lock cmpxchgl %ecx, (%rbx)
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   7c: ud2
+;;   7e: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1 1 shared)
+  (func (export "_start") (result i64)
+        (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 42) (i64.const 1337))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x6f
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x539, %rax
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x71
+;;   4d: movl    $0, %edx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       pushq   %rcx
+;;       pushq   %rax
+;;       popq    %rcx
+;;       popq    %rax
+;;       lock cmpxchgw %cx, (%rbx)
+;;       movzwq  %ax, %rax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   6f: ud2
+;;   71: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu.wat
@@ -1,0 +1,39 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1 1 shared)
+  (func (export "_start") (result i64)
+        (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 42) (i64.const 1337))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x68
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x539, %rax
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x6a
+;;   4b: movl    $0, %edx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       pushq   %rcx
+;;       pushq   %rax
+;;       popq    %rcx
+;;       popq    %rax
+;;       lock cmpxchgl %ecx, (%rbx)
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   68: ud2
+;;   6a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw8_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw8_cmpxchgu.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1 1 shared)
+  (func (export "_start") (result i64)
+        (i64.atomic.rmw8.cmpxchg_u (i32.const 0) (i64.const 42) (i64.const 1337))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x5b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x539, %rax
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       pushq   %rcx
+;;       pushq   %rax
+;;       popq    %rcx
+;;       popq    %rax
+;;       lock cmpxchgb %cl, (%rbx)
+;;       movzbq  %al, %rax
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   5b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
@@ -1,0 +1,39 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1 1 shared)
+  (func (export "_start") (result i64)
+        (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 42) (i64.const 1337))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x6b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    $0x539, %rax
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andq    $7, %rdx
+;;       cmpq    $0, %rdx
+;;       jne     0x6d
+;;   4d: movl    $0, %edx
+;;       movq    0x58(%r14), %r11
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       pushq   %rcx
+;;       pushq   %rax
+;;       popq    %rcx
+;;       popq    %rax
+;;       lock cmpxchgq %rcx, (%rbx)
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   6b: ud2
+;;   6d: ud2

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -928,6 +928,17 @@ impl Masm for MacroAssembler {
     ) -> Result<()> {
         bail!(CodeGenError::unimplemented_masm_instruction())
     }
+
+    fn atomic_cas(
+        &mut self,
+        _context: &mut CodeGenContext<Emission>,
+        _addr: Self::Address,
+        _size: OperandSize,
+        _flags: MemFlags,
+        _extend: Option<Extend<Zero>>,
+    ) -> Result<()> {
+        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+    }
 }
 
 impl MacroAssembler {

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1196,6 +1196,32 @@ impl Assembler {
             dst_old: dst.map(Into::into),
         });
     }
+    pub fn cmpxchg(
+        &mut self,
+        addr: Address,
+        expected: Reg,
+        replacement: Reg,
+        dst: WritableReg,
+        size: OperandSize,
+        flags: MemFlags,
+    ) {
+        assert!(addr.is_offset());
+        let mem = Self::to_synthetic_amode(
+            &addr,
+            &mut self.pool,
+            &mut self.constants,
+            &mut self.buffer,
+            flags,
+        );
+
+        self.emit(Inst::LockCmpxchg {
+            ty: Type::int_with_byte_size(size.bytes() as _).unwrap(),
+            replacement: replacement.into(),
+            expected: expected.into(),
+            mem,
+            dst_old: dst.map(Into::into),
+        })
+    }
 
     pub fn cmp_ir(&mut self, src1: Reg, imm: i32, size: OperandSize) {
         let imm = RegMemImm::imm(imm as u32);

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1427,4 +1427,20 @@ pub(crate) trait MacroAssembler {
         lane: u8,
         kind: ExtractLaneKind,
     ) -> Result<()>;
+
+    /// Perform an atomic CAS (compare-and-swap) operation with the value at `addr`, and `expected`
+    /// and `replacement` (at the top of the context's stack).
+    ///
+    /// This method takes the `CodeGenContext` as an arguments to accommodate architectures that
+    /// expect parameters in specific registers. The context stack contains the `replacement`,
+    /// and `expected` values in that order. The implementer is expected to push the value at
+    /// `addr` before the update to the context's stack before returning.
+    fn atomic_cas(
+        &mut self,
+        context: &mut CodeGenContext<Emission>,
+        addr: Self::Address,
+        size: OperandSize,
+        flags: MemFlags,
+        extend: Option<Extend<Zero>>,
+    ) -> Result<()>;
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -336,6 +336,13 @@ macro_rules! def_unsupported {
     (emit I64AtomicRmw16XorU $($rest:tt)*) => {};
     (emit I64AtomicRmw32XorU $($rest:tt)*) => {};
     (emit I64AtomicRmwXor $($rest:tt)*) => {};
+    (emit I32AtomicRmw8CmpxchgU $($rest:tt)*) => {};
+    (emit I32AtomicRmw16CmpxchgU $($rest:tt)*) => {};
+    (emit I32AtomicRmwCmpxchg $($rest:tt)*) => {};
+    (emit I64AtomicRmw8CmpxchgU $($rest:tt)*) => {};
+    (emit I64AtomicRmw16CmpxchgU $($rest:tt)*) => {};
+    (emit I64AtomicRmw32CmpxchgU $($rest:tt)*) => {};
+    (emit I64AtomicRmwCmpxchg $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -2654,6 +2661,34 @@ where
 
     fn visit_i64_atomic_rmw_xor(&mut self, arg: MemArg) -> Self::Output {
         self.emit_atomic_rmw(&arg, RmwOp::Xor, OperandSize::S64, None)
+    }
+
+    fn visit_i32_atomic_rmw8_cmpxchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_cmpxchg(&arg, OperandSize::S8, Some(Extend::I32Extend8))
+    }
+
+    fn visit_i32_atomic_rmw16_cmpxchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_cmpxchg(&arg, OperandSize::S16, Some(Extend::I32Extend16))
+    }
+
+    fn visit_i32_atomic_rmw_cmpxchg(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_cmpxchg(&arg, OperandSize::S32, None)
+    }
+
+    fn visit_i64_atomic_rmw8_cmpxchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_cmpxchg(&arg, OperandSize::S8, Some(Extend::I64Extend8))
+    }
+
+    fn visit_i64_atomic_rmw16_cmpxchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_cmpxchg(&arg, OperandSize::S16, Some(Extend::I64Extend16))
+    }
+
+    fn visit_i64_atomic_rmw32_cmpxchg_u(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_cmpxchg(&arg, OperandSize::S32, Some(Extend::I64Extend32))
+    }
+
+    fn visit_i64_atomic_rmw_cmpxchg(&mut self, arg: MemArg) -> Self::Output {
+        self.emit_atomic_cmpxchg(&arg, OperandSize::S64, None)
     }
 
     wasmparser::for_each_visit_operator!(def_unsupported);


### PR DESCRIPTION
This PR implements atomic CAS operations for winch x64 backend:
- `i32.atomic.rmw8.cmpxchg_u`
- `i32.atomic.rmw16.cmpxchg_u`
- `i32.atomic.rmw.cmpxchg`
- `i64.atomic.rmw8.cmpxchg_u`
- `i64.atomic.rmw16.cmpxchg_u`
- `i64.atomic.rmw32.cmpxchg_u`
- `i64.atomic.rmw.cmpxchg`

#9734
