### PR TITLE
 Provenance preparation for Pulley 

### DIFF
--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -516,7 +516,7 @@ impl Component {
             .info
             .resource_drop_wasm_to_array_trampoline
             .as_ref()
-            .map(|i| self.func(i).cast());
+            .map(|i| self.func(i).cast().into());
         VMFuncRef {
             wasm_call,
             ..*dtor.func_ref()

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -470,10 +470,11 @@ impl Func {
             crate::Func::call_unchecked_raw(
                 store,
                 export.func_ref,
-                core::ptr::slice_from_raw_parts_mut(
+                NonNull::new(core::ptr::slice_from_raw_parts_mut(
                     space.as_mut_ptr().cast(),
                     mem::size_of_val(space) / mem::size_of::<ValRaw>(),
-                ),
+                ))
+                .unwrap(),
             )?;
 
             // Note that `.assume_init_ref()` here is unsafe but we're relying
@@ -622,7 +623,8 @@ impl Func {
                 crate::Func::call_unchecked_raw(
                     &mut store,
                     func.func_ref,
-                    core::ptr::slice_from_raw_parts(&post_return_arg, 1).cast_mut(),
+                    NonNull::new(core::ptr::slice_from_raw_parts(&post_return_arg, 1).cast_mut())
+                        .unwrap(),
                 )?;
             }
 

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -138,7 +138,7 @@ impl Options {
         // is an optional configuration in canonical ABI options.
         unsafe {
             let memory = self.memory.unwrap().as_ref();
-            core::slice::from_raw_parts(memory.base, memory.current_length())
+            core::slice::from_raw_parts(memory.base.as_ptr(), memory.current_length())
         }
     }
 
@@ -149,7 +149,7 @@ impl Options {
         // See comments in `memory` about the unsafety
         unsafe {
             let memory = self.memory.unwrap().as_ref();
-            core::slice::from_raw_parts_mut(memory.base, memory.current_length())
+            core::slice::from_raw_parts_mut(memory.base.as_ptr(), memory.current_length())
         }
     }
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -12,7 +12,7 @@ use crate::store::{StoreOpaque, Stored};
 use crate::{AsContextMut, Engine, Module, StoreContextMut};
 use alloc::sync::Arc;
 use core::marker;
-use core::ptr::{self, NonNull};
+use core::ptr::NonNull;
 use wasmtime_environ::{component::*, EngineOrModuleTypeIndex};
 use wasmtime_environ::{EntityIndex, EntityType, Global, PrimaryMap, WasmValType};
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -376,7 +376,7 @@ impl InstanceData {
             CoreDef::InstanceFlags(idx) => {
                 crate::runtime::vm::Export::Global(crate::runtime::vm::ExportGlobal {
                     definition: self.state.instance_flags(*idx).as_raw(),
-                    vmctx: ptr::null_mut(),
+                    vmctx: None,
                     global: Global {
                         wasm_ty: WasmValType::I32,
                         mutability: true,

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -1034,7 +1034,7 @@ impl ResourceAny {
         // destructors have al been previously type-checked and are guaranteed
         // to take one i32 argument and return no results, so the parameters
         // here should be configured correctly.
-        unsafe { crate::Func::call_unchecked_raw(store, dtor, &mut args) }
+        unsafe { crate::Func::call_unchecked_raw(store, dtor, NonNull::from(&mut args)) }
     }
 
     fn lower_to_index<U>(&self, cx: &mut LowerContext<'_, U>, ty: InterfaceType) -> Result<u32> {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::runtime::vm::{
     ExportFunction, InterpreterRef, SendSyncPtr, StoreBox, VMArrayCallHostFuncContext, VMContext,
-    VMFuncRef, VMFunctionImport, VMOpaqueContext,
+    VMFuncRef, VMFunctionImport, VMOpaqueContext, VmPtr,
 };
 use crate::runtime::Uninhabited;
 use crate::store::{AutoAssertNoGc, StoreData, StoreOpaque, Stored};
@@ -1060,13 +1060,14 @@ impl Func {
         let mut store = store.as_context_mut();
         let data = &store.0.store_data()[self.0];
         let func_ref = data.export().func_ref;
+        let params_and_returns = NonNull::new(params_and_returns).unwrap_or(NonNull::from(&mut []));
         Self::call_unchecked_raw(&mut store, func_ref, params_and_returns)
     }
 
     pub(crate) unsafe fn call_unchecked_raw<T>(
         store: &mut StoreContextMut<'_, T>,
         func_ref: NonNull<VMFuncRef>,
-        params_and_returns: *mut [ValRaw],
+        params_and_returns: NonNull<[ValRaw]>,
     ) -> Result<()> {
         invoke_wasm_and_catch_traps(store, |caller, vm| {
             func_ref.as_ref().array_call(
@@ -1320,7 +1321,7 @@ impl Func {
             };
             VMFunctionImport {
                 wasm_call: if let Some(wasm_call) = f.as_ref().wasm_call {
-                    wasm_call
+                    wasm_call.into()
                 } else {
                     // Assert that this is a array-call function, since those
                     // are the only ones that could be missing a `wasm_call`
@@ -1331,7 +1332,7 @@ impl Func {
                     module.wasm_to_array_trampoline(sig).expect(
                         "if the wasm is importing a function of a given type, it must have the \
                          type's trampoline",
-                    )
+                    ).into()
                 },
                 array_call: f.as_ref().array_call,
                 vmctx: f.as_ref().vmctx,
@@ -1594,7 +1595,7 @@ impl Func {
 /// can pass to the called wasm function, if desired.
 pub(crate) fn invoke_wasm_and_catch_traps<T>(
     store: &mut StoreContextMut<'_, T>,
-    closure: impl FnMut(*mut VMContext, Option<InterpreterRef<'_>>) -> bool,
+    closure: impl FnMut(NonNull<VMContext>, Option<InterpreterRef<'_>>) -> bool,
 ) -> Result<()> {
     unsafe {
         let exit = enter_wasm(store);
@@ -2026,7 +2027,7 @@ pub struct Caller<'a, T> {
 }
 
 impl<T> Caller<'_, T> {
-    unsafe fn with<F, R>(caller: *mut VMContext, f: F) -> R
+    unsafe fn with<F, R>(caller: NonNull<VMContext>, f: F) -> R
     where
         // The closure must be valid for any `Caller` it is given; it doesn't
         // get to choose the `Caller`'s lifetime.
@@ -2034,7 +2035,6 @@ impl<T> Caller<'_, T> {
         // And the return value must not borrow from the caller/store.
         R: 'static,
     {
-        debug_assert!(!caller.is_null());
         crate::runtime::vm::InstanceAndStore::from_vmctx(caller, |pair| {
             let (instance, mut store) = pair.unpack_context_mut::<T>();
 
@@ -2294,9 +2294,9 @@ impl HostContext {
     }
 
     unsafe extern "C" fn array_call_trampoline<T, F, P, R>(
-        callee_vmctx: *mut VMOpaqueContext,
-        caller_vmctx: *mut VMOpaqueContext,
-        args: *mut ValRaw,
+        callee_vmctx: VmPtr<VMOpaqueContext>,
+        caller_vmctx: VmPtr<VMOpaqueContext>,
+        args: VmPtr<ValRaw>,
         args_len: usize,
     ) -> bool
     where
@@ -2311,10 +2311,12 @@ impl HostContext {
         // should be part of this closure, and the long-jmp-ing
         // happens after the closure in handling the result.
         let run = move |mut caller: Caller<'_, T>| {
-            let args =
-                core::slice::from_raw_parts_mut(args.cast::<MaybeUninit<ValRaw>>(), args_len);
+            let mut args = NonNull::slice_from_raw_parts(
+                args.as_non_null().cast::<MaybeUninit<ValRaw>>(),
+                args_len,
+            );
             let vmctx = VMArrayCallHostFuncContext::from_opaque(callee_vmctx);
-            let state = (*vmctx).host_state();
+            let state = vmctx.as_ref().host_state();
 
             // Double-check ourselves in debug mode, but we control
             // the `Any` here so an unsafe downcast should also
@@ -2333,7 +2335,7 @@ impl HostContext {
                 } else {
                     unsafe { AutoAssertNoGc::disabled(caller.store.0) }
                 };
-                let params = P::load(&mut store, args);
+                let params = P::load(&mut store, args.as_mut());
                 let _ = &mut store;
                 drop(store);
 
@@ -2352,7 +2354,7 @@ impl HostContext {
                 } else {
                     unsafe { AutoAssertNoGc::disabled(caller.store.0) }
                 };
-                let ret = ret.store(&mut store, args)?;
+                let ret = ret.store(&mut store, args.as_mut())?;
                 Ok(ret)
             }
         };
@@ -2534,7 +2536,7 @@ impl HostFunc {
 
     pub(crate) fn func_ref(&self) -> &VMFuncRef {
         match &self.ctx {
-            HostContext::Array(ctx) => unsafe { (*ctx.get()).func_ref() },
+            HostContext::Array(ctx) => unsafe { ctx.get().as_ref().func_ref() },
         }
     }
 

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -217,6 +217,7 @@ where
             let storage: *mut Storage<_, _> = storage;
             let storage = storage.cast::<ValRaw>();
             let storage = core::ptr::slice_from_raw_parts_mut(storage, storage_len);
+            let storage = NonNull::new(storage).unwrap();
             func_ref
                 .as_ref()
                 .array_call(vm, VMOpaqueContext::from_vmcontext(caller), storage)

--- a/crates/wasmtime/src/runtime/store/func_refs.rs
+++ b/crates/wasmtime/src/runtime/store/func_refs.rs
@@ -77,7 +77,9 @@ impl FuncRefs {
                 // that is the only kind that can have holes.
                 let _ = VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx);
 
-                func_ref.wasm_call = modules.wasm_to_array_trampoline(func_ref.type_index);
+                func_ref.wasm_call = modules
+                    .wasm_to_array_trampoline(func_ref.type_index)
+                    .map(|f| f.into());
                 func_ref.wasm_call.is_none()
             }
         });

--- a/crates/wasmtime/src/runtime/store/func_refs.rs
+++ b/crates/wasmtime/src/runtime/store/func_refs.rs
@@ -57,7 +57,7 @@ impl FuncRefs {
         debug_assert!(func_ref.wasm_call.is_none());
         // Debug assert that the vmctx is a `VMArrayCallHostFuncContext` as
         // that is the only kind that can have holes.
-        let _ = unsafe { VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx) };
+        let _ = unsafe { VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx.as_non_null()) };
 
         let func_ref = self.bump.alloc(func_ref);
         let unpatched = SendSyncPtr::from(func_ref);
@@ -75,7 +75,7 @@ impl FuncRefs {
 
                 // Debug assert that the vmctx is a `VMArrayCallHostFuncContext` as
                 // that is the only kind that can have holes.
-                let _ = VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx);
+                let _ = VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx.as_non_null());
 
                 func_ref.wasm_call = modules
                     .wasm_to_array_trampoline(func_ref.type_index)

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -1,7 +1,7 @@
 //! Support for a calling of an imported function.
 
 use crate::prelude::*;
-use crate::runtime::vm::{StoreBox, VMArrayCallHostFuncContext, VMContext, VMOpaqueContext, VmPtr};
+use crate::runtime::vm::{StoreBox, VMArrayCallHostFuncContext, VMContext, VMOpaqueContext};
 use crate::type_registry::RegisteredType;
 use crate::{FuncType, ValRaw};
 use core::ptr::NonNull;
@@ -22,9 +22,9 @@ struct TrampolineState<F> {
 ///
 /// Also shepherds panics and traps across Wasm.
 unsafe extern "C" fn array_call_shim<F>(
-    vmctx: VmPtr<VMOpaqueContext>,
-    caller_vmctx: VmPtr<VMOpaqueContext>,
-    values_vec: VmPtr<ValRaw>,
+    vmctx: NonNull<VMOpaqueContext>,
+    caller_vmctx: NonNull<VMOpaqueContext>,
+    values_vec: NonNull<ValRaw>,
     values_vec_len: usize,
 ) -> bool
 where
@@ -40,8 +40,7 @@ where
         let state = vmctx.as_ref().host_state();
         debug_assert!(state.is::<TrampolineState<F>>());
         let state = &*(state as *const _ as *const TrampolineState<F>);
-        let mut values_vec =
-            NonNull::slice_from_raw_parts(values_vec.as_non_null(), values_vec_len);
+        let mut values_vec = NonNull::slice_from_raw_parts(values_vec, values_vec_len);
         (state.func)(VMContext::from_opaque(caller_vmctx), values_vec.as_mut())
     })
 }

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -1,7 +1,7 @@
 use crate::runtime::vm::{StoreBox, VMGlobalDefinition};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{GlobalType, Mutability, Result, RootedGcRefImpl, Val};
-use core::ptr;
+use core::ptr::{self, NonNull};
 
 #[repr(C)]
 pub struct VMHostGlobalContext {
@@ -28,7 +28,7 @@ pub fn generate_global_export(
 
     let mut store = AutoAssertNoGc::new(store);
     let definition = unsafe {
-        let global = &mut (*ctx.get()).global;
+        let global = &mut ctx.get().as_mut().global;
         match val {
             Val::I32(x) => *global.as_i32_mut() = x,
             Val::I64(x) => *global.as_i64_mut() = x,
@@ -63,8 +63,8 @@ pub fn generate_global_export(
 
     store.host_globals().push(ctx);
     Ok(crate::runtime::vm::ExportGlobal {
-        definition,
-        vmctx: ptr::null_mut(),
+        definition: NonNull::from(definition),
+        vmctx: None,
         global,
     })
 }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -29,6 +29,7 @@ mod imports;
 mod instance;
 mod memory;
 mod mmap_vec;
+mod provenance;
 mod send_sync_ptr;
 mod send_sync_unsafe_cell;
 mod store_box;
@@ -77,6 +78,7 @@ pub use crate::runtime::vm::memory::{
 };
 pub use crate::runtime::vm::mmap_vec::MmapVec;
 pub use crate::runtime::vm::mpk::MpkEnabled;
+pub use crate::runtime::vm::provenance::*;
 pub use crate::runtime::vm::store_box::*;
 #[cfg(feature = "std")]
 pub use crate::runtime::vm::sys::mmap::open_file_for_mmap;

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -110,14 +110,14 @@ pub struct ComponentInstance {
 // Needs benchmarking one way or another though to figure out what the best
 // balance is here.
 pub type VMLoweringCallee = extern "C" fn(
-    vmctx: VmPtr<VMOpaqueContext>,
-    data: VmPtr<u8>,
+    vmctx: NonNull<VMOpaqueContext>,
+    data: NonNull<u8>,
     ty: u32,
-    flags: VmPtr<VMGlobalDefinition>,
-    opt_memory: VmPtr<VMMemoryDefinition>,
-    opt_realloc: VmPtr<VMFuncRef>,
+    flags: NonNull<VMGlobalDefinition>,
+    opt_memory: *mut VMMemoryDefinition,
+    opt_realloc: *mut VMFuncRef,
     string_encoding: u8,
-    args_and_results: VmPtr<mem::MaybeUninit<ValRaw>>,
+    args_and_results: NonNull<mem::MaybeUninit<ValRaw>>,
     nargs_and_results: usize,
 ) -> bool;
 
@@ -792,9 +792,8 @@ impl VMComponentContext {
     /// Helper function to cast between context types using a debug assertion to
     /// protect against some mistakes.
     #[inline]
-    pub unsafe fn from_opaque(opaque: VmPtr<VMOpaqueContext>) -> NonNull<VMComponentContext> {
+    pub unsafe fn from_opaque(opaque: NonNull<VMOpaqueContext>) -> NonNull<VMComponentContext> {
         // See comments in `VMContext::from_opaque` for this debug assert
-        let opaque = opaque.as_non_null();
         debug_assert_eq!(opaque.as_ref().magic, VMCOMPONENT_MAGIC);
         opaque.cast()
     }

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -5,6 +5,7 @@ use crate::runtime::vm::component::{ComponentInstance, VMComponentContext};
 use crate::runtime::vm::HostResultHasUnwindSentinel;
 use core::cell::Cell;
 use core::convert::Infallible;
+use core::ptr::NonNull;
 use core::slice;
 use wasmtime_environ::component::TypeResourceTableIndex;
 
@@ -19,7 +20,7 @@ macro_rules! signature {
     (@ty u32) => (u32);
     (@ty u64) => (u64);
     (@ty bool) => (bool);
-    (@ty vmctx) => (*mut VMComponentContext);
+    (@ty vmctx) => (NonNull<VMComponentContext>);
 }
 
 /// Defines a `VMComponentBuiltins` structure which contains any builtins such
@@ -59,6 +60,7 @@ wasmtime_environ::foreach_builtin_component_function!(define_builtins);
 #[allow(improper_ctypes_definitions)]
 mod trampolines {
     use super::VMComponentContext;
+    use core::ptr::NonNull;
 
     macro_rules! shims {
         (
@@ -486,18 +488,26 @@ fn inflate_latin1_bytes(dst: &mut [u16], latin1_bytes_so_far: usize) -> &mut [u1
     return rest;
 }
 
-unsafe fn resource_new32(vmctx: *mut VMComponentContext, resource: u32, rep: u32) -> Result<u32> {
+unsafe fn resource_new32(
+    vmctx: NonNull<VMComponentContext>,
+    resource: u32,
+    rep: u32,
+) -> Result<u32> {
     let resource = TypeResourceTableIndex::from_u32(resource);
     ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_new32(resource, rep))
 }
 
-unsafe fn resource_rep32(vmctx: *mut VMComponentContext, resource: u32, idx: u32) -> Result<u32> {
+unsafe fn resource_rep32(
+    vmctx: NonNull<VMComponentContext>,
+    resource: u32,
+    idx: u32,
+) -> Result<u32> {
     let resource = TypeResourceTableIndex::from_u32(resource);
     ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_rep32(resource, idx))
 }
 
 unsafe fn resource_drop(
-    vmctx: *mut VMComponentContext,
+    vmctx: NonNull<VMComponentContext>,
     resource: u32,
     idx: u32,
 ) -> Result<ResourceDropRet> {
@@ -521,7 +531,7 @@ unsafe impl HostResultHasUnwindSentinel for ResourceDropRet {
 }
 
 unsafe fn resource_transfer_own(
-    vmctx: *mut VMComponentContext,
+    vmctx: NonNull<VMComponentContext>,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -534,7 +544,7 @@ unsafe fn resource_transfer_own(
 }
 
 unsafe fn resource_transfer_borrow(
-    vmctx: *mut VMComponentContext,
+    vmctx: NonNull<VMComponentContext>,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -546,15 +556,15 @@ unsafe fn resource_transfer_borrow(
     })
 }
 
-unsafe fn resource_enter_call(vmctx: *mut VMComponentContext) {
+unsafe fn resource_enter_call(vmctx: NonNull<VMComponentContext>) {
     ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_enter_call())
 }
 
-unsafe fn resource_exit_call(vmctx: *mut VMComponentContext) -> Result<()> {
+unsafe fn resource_exit_call(vmctx: NonNull<VMComponentContext>) -> Result<()> {
     ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_exit_call())
 }
 
-unsafe fn trap(_vmctx: *mut VMComponentContext, code: u8) -> Result<Infallible> {
+unsafe fn trap(_vmctx: NonNull<VMComponentContext>, code: u8) -> Result<Infallible> {
     Err(wasmtime_environ::Trap::from_u8(code).unwrap().into())
 }
 

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -569,7 +569,7 @@ unsafe fn trap(_vmctx: NonNull<VMComponentContext>, code: u8) -> Result<Infallib
 }
 
 unsafe fn future_transfer(
-    vmctx: *mut VMComponentContext,
+    vmctx: NonNull<VMComponentContext>,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -579,7 +579,7 @@ unsafe fn future_transfer(
 }
 
 unsafe fn stream_transfer(
-    vmctx: *mut VMComponentContext,
+    vmctx: NonNull<VMComponentContext>,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -589,7 +589,7 @@ unsafe fn stream_transfer(
 }
 
 unsafe fn error_context_transfer(
-    vmctx: *mut VMComponentContext,
+    vmctx: NonNull<VMComponentContext>,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -33,11 +33,7 @@ impl<'a> ConstEvalContext<'a> {
 
     fn global_get(&mut self, store: &mut AutoAssertNoGc<'_>, index: GlobalIndex) -> Result<ValRaw> {
         unsafe {
-            let global = self
-                .instance
-                .defined_or_imported_global_ptr(index)
-                .as_ref()
-                .unwrap();
+            let global = self.instance.defined_or_imported_global_ptr(index).as_ref();
             global.to_val_raw(store, self.instance.env_module().globals[index].wasm_ty)
         }
     }

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -2,10 +2,11 @@
 
 use crate::runtime::vm::instance::Instance;
 use crate::runtime::vm::vmcontext::VMContext;
+use core::ptr::NonNull;
 use wasmtime_environ::{EntityRef, MemoryIndex};
 use wasmtime_versioned_export_macros::versioned_export;
 
-static mut VMCTX_AND_MEMORY: (*mut VMContext, usize) = (std::ptr::null_mut(), 0);
+static mut VMCTX_AND_MEMORY: (NonNull<VMContext>, usize) = (NonNull::dangling(), 0);
 
 // These implementatations are referenced from C code in "helpers.c". The symbols defined
 // there (prefixed by "wasmtime_") are the real 'public' interface used in the debug info.
@@ -14,7 +15,7 @@ static mut VMCTX_AND_MEMORY: (*mut VMContext, usize) = (std::ptr::null_mut(), 0)
 pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
     let ptr = std::ptr::read(p);
     assert!(
-        !VMCTX_AND_MEMORY.0.is_null(),
+        VMCTX_AND_MEMORY.0 != NonNull::dangling(),
         "must call `__vmctx->set()` before resolving Wasm pointers"
     );
     Instance::from_vmctx(VMCTX_AND_MEMORY.0, |handle| {
@@ -24,14 +25,14 @@ pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
         );
         let index = MemoryIndex::new(VMCTX_AND_MEMORY.1);
         let mem = handle.get_memory(index);
-        mem.base.add(ptr as usize)
+        mem.base.as_ptr().add(ptr as usize)
     })
 }
 
 #[versioned_export]
 pub unsafe extern "C" fn set_vmctx_memory(vmctx_ptr: *mut VMContext) {
     // TODO multi-memory
-    VMCTX_AND_MEMORY = (vmctx_ptr, 0);
+    VMCTX_AND_MEMORY = (NonNull::new(vmctx_ptr).unwrap(), 0);
 }
 
 /// A bit of a hack around various linkage things. The goal here is to force the

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -45,9 +45,9 @@ impl From<ExportFunction> for Export {
 #[derive(Debug, Clone)]
 pub struct ExportTable {
     /// The address of the table descriptor.
-    pub definition: *mut VMTableDefinition,
+    pub definition: NonNull<VMTableDefinition>,
     /// Pointer to the containing `VMContext`.
-    pub vmctx: *mut VMContext,
+    pub vmctx: NonNull<VMContext>,
     /// The table declaration, used for compatibility checking.
     pub table: Table,
 }
@@ -66,9 +66,9 @@ impl From<ExportTable> for Export {
 #[derive(Debug, Clone)]
 pub struct ExportMemory {
     /// The address of the memory descriptor.
-    pub definition: *mut VMMemoryDefinition,
+    pub definition: NonNull<VMMemoryDefinition>,
     /// Pointer to the containing `VMContext`.
-    pub vmctx: *mut VMContext,
+    pub vmctx: NonNull<VMContext>,
     /// The memory declaration, used for compatibility checking.
     pub memory: Memory,
     /// The index at which the memory is defined within the `vmctx`.
@@ -89,10 +89,10 @@ impl From<ExportMemory> for Export {
 #[derive(Debug, Clone)]
 pub struct ExportGlobal {
     /// The address of the global storage.
-    pub definition: *mut VMGlobalDefinition,
+    pub definition: NonNull<VMGlobalDefinition>,
     /// Pointer to the containing `VMContext`. May be null for host-created
     /// globals.
-    pub vmctx: *mut VMContext,
+    pub vmctx: Option<NonNull<VMContext>>,
     /// The global declaration, used for compatibility checking.
     pub global: Global,
 }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -667,9 +667,9 @@ unsafe impl GcHeap for DrcHeap {
         })
     }
 
-    unsafe fn vmctx_gc_heap_data(&self) -> *mut u8 {
-        let ptr = &*self.activations_table as *const VMGcRefActivationsTable;
-        ptr.cast_mut().cast::<u8>()
+    unsafe fn vmctx_gc_heap_data(&self) -> NonNull<u8> {
+        let ptr: NonNull<VMGcRefActivationsTable> = NonNull::from(&*self.activations_table);
+        ptr.cast()
     }
 
     #[cfg(feature = "pooling-allocator")]

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     GcHeapOutOfMemory,
 };
+use core::ptr::NonNull;
 use core::{
     alloc::Layout,
     any::Any,
@@ -309,8 +310,8 @@ unsafe impl GcHeap for NullHeap {
         Box::new(NullCollection {})
     }
 
-    unsafe fn vmctx_gc_heap_data(&self) -> *mut u8 {
-        self.next.get().cast()
+    unsafe fn vmctx_gc_heap_data(&self) -> NonNull<u8> {
+        NonNull::new(self.next.get()).unwrap().cast()
     }
 
     #[cfg(feature = "pooling-allocator")]

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -5,6 +5,7 @@ use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GcHeapObject, SendSyncPtr, TypedGcRef, VMArrayRef,
     VMExternRef, VMGcHeader, VMGcObjectDataMut, VMGcRef, VMStructRef,
 };
+use core::ptr::NonNull;
 use core::{
     alloc::Layout, any::Any, cell::UnsafeCell, marker, mem, num::NonZeroUsize, ops::Range, ptr,
 };
@@ -353,7 +354,7 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     ///
     /// The returned pointer, if any, must remain valid as long as `self` is not
     /// dropped.
-    unsafe fn vmctx_gc_heap_data(&self) -> *mut u8;
+    unsafe fn vmctx_gc_heap_data(&self) -> NonNull<u8>;
 
     ////////////////////////////////////////////////////////////////////////////
     // Recycling GC Heap Methods

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -735,7 +735,7 @@ fn initialize_memories(
             unsafe {
                 let src = self.context.instance.wasm_data(init.data.clone());
                 let offset = usize::try_from(init.offset).unwrap();
-                let dst = memory.base.add(offset);
+                let dst = memory.base.as_ptr().add(offset);
 
                 assert!(offset + src.len() <= memory.current_length());
 
@@ -812,10 +812,7 @@ fn initialize_globals(
         // This write is safe because we know we have the correct module for
         // this instance and its vmctx due to the assert above.
         unsafe {
-            ptr::write(
-                to,
-                VMGlobalDefinition::from_val_raw(&mut store, wasm_ty, raw)?,
-            )
+            to.write(VMGlobalDefinition::from_val_raw(&mut store, wasm_ty, raw)?);
         };
     }
     Ok(())

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::runtime::vm::vmcontext::VMArrayCallNative;
-use crate::runtime::vm::{tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext};
+use crate::runtime::vm::{tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext, VmPtr};
 use crate::{Engine, ValRaw};
 use core::ptr::NonNull;
 use pulley_interpreter::interp::{DoneReason, RegType, TrapKind, Val, Vm, XRegVal};
@@ -85,15 +85,15 @@ impl InterpreterRef<'_> {
     pub unsafe fn call(
         mut self,
         mut bytecode: NonNull<u8>,
-        callee: *mut VMOpaqueContext,
-        caller: *mut VMOpaqueContext,
-        args_and_results: *mut [ValRaw],
+        callee: NonNull<VMOpaqueContext>,
+        caller: NonNull<VMOpaqueContext>,
+        args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         // Initialize argument registers with the ABI arguments.
         let args = [
-            XRegVal::new_ptr(callee).into(),
-            XRegVal::new_ptr(caller).into(),
-            XRegVal::new_ptr(args_and_results.cast::<u8>()).into(),
+            XRegVal::new_ptr(callee.as_ptr()).into(),
+            XRegVal::new_ptr(caller.as_ptr()).into(),
+            XRegVal::new_ptr(args_and_results.cast::<u8>().as_ptr()).into(),
             XRegVal::new_u64(args_and_results.len() as u64).into(),
         ];
 
@@ -321,6 +321,7 @@ impl InterpreterRef<'_> {
             (@get vmctx $reg:ident) => (self.0[$reg].get_ptr());
             (@get pointer $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr $reg:ident) => (self.0[$reg].get_ptr());
+            (@get vmptr $reg:ident) => (VmPtr::from(NonNull::new(self.0[$reg].get_ptr()).unwrap()));
             (@get ptr_u8 $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr_u16 $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr_size $reg:ident) => (self.0[$reg].get_ptr());
@@ -352,7 +353,7 @@ impl InterpreterRef<'_> {
         //
 
         if id == const { HostCall::ArrayCall.index() } {
-            call!(@host VMArrayCallNative(ptr, ptr, ptr, size) -> bool);
+            call!(@host VMArrayCallNative(vmptr, vmptr, vmptr, size) -> bool);
         }
 
         macro_rules! core {
@@ -378,7 +379,7 @@ impl InterpreterRef<'_> {
             use wasmtime_environ::component::ComponentBuiltinFunctionIndex;
 
             if id == const { HostCall::ComponentLowerImport.index() } {
-                call!(@host VMLoweringCallee(ptr, ptr, u32, ptr, ptr, ptr, u8, ptr, size) -> bool);
+                call!(@host VMLoweringCallee(vmptr, vmptr, u32, vmptr, vmptr, vmptr, u8, vmptr, size) -> bool);
             }
 
             macro_rules! component {

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::runtime::vm::vmcontext::VMArrayCallNative;
-use crate::runtime::vm::{tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext, VmPtr};
+use crate::runtime::vm::{tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext};
 use crate::{Engine, ValRaw};
 use core::ptr::NonNull;
 use pulley_interpreter::interp::{DoneReason, RegType, TrapKind, Val, Vm, XRegVal};
@@ -321,7 +321,7 @@ impl InterpreterRef<'_> {
             (@get vmctx $reg:ident) => (self.0[$reg].get_ptr());
             (@get pointer $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr $reg:ident) => (self.0[$reg].get_ptr());
-            (@get vmptr $reg:ident) => (VmPtr::from(NonNull::new(self.0[$reg].get_ptr()).unwrap()));
+            (@get nonnull $reg:ident) => (NonNull::new(self.0[$reg].get_ptr()).unwrap());
             (@get ptr_u8 $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr_u16 $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr_size $reg:ident) => (self.0[$reg].get_ptr());
@@ -353,7 +353,7 @@ impl InterpreterRef<'_> {
         //
 
         if id == const { HostCall::ArrayCall.index() } {
-            call!(@host VMArrayCallNative(vmptr, vmptr, vmptr, size) -> bool);
+            call!(@host VMArrayCallNative(nonnull, nonnull, nonnull, size) -> bool);
         }
 
         macro_rules! core {
@@ -379,7 +379,7 @@ impl InterpreterRef<'_> {
             use wasmtime_environ::component::ComponentBuiltinFunctionIndex;
 
             if id == const { HostCall::ComponentLowerImport.index() } {
-                call!(@host VMLoweringCallee(vmptr, vmptr, u32, vmptr, vmptr, vmptr, u8, vmptr, size) -> bool);
+                call!(@host VMLoweringCallee(nonnull, nonnull, u32, nonnull, ptr, ptr, u8, nonnull, size) -> bool);
             }
 
             macro_rules! component {

--- a/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
@@ -40,9 +40,9 @@ impl InterpreterRef<'_> {
     pub unsafe fn call(
         self,
         _bytecode: NonNull<u8>,
-        _callee: *mut VMOpaqueContext,
-        _caller: *mut VMOpaqueContext,
-        _args_and_results: *mut [ValRaw],
+        _callee: NonNull<VMOpaqueContext>,
+        _caller: NonNull<VMOpaqueContext>,
+        _args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         match self.empty {}
     }

--- a/crates/wasmtime/src/runtime/vm/memory/shared_memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/shared_memory.rs
@@ -5,6 +5,7 @@ use crate::runtime::vm::vmcontext::VMMemoryDefinition;
 use crate::runtime::vm::{Memory, VMStore, WaitResult};
 use std::cell::RefCell;
 use std::ops::Range;
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -63,8 +64,8 @@ impl SharedMemory {
     }
 
     /// Return a pointer to the shared memory's [VMMemoryDefinition].
-    pub fn vmmemory_ptr(&self) -> *const VMMemoryDefinition {
-        &self.0.def.0
+    pub fn vmmemory_ptr(&self) -> NonNull<VMMemoryDefinition> {
+        NonNull::from(&self.0.def.0)
     }
 
     /// Same as `RuntimeLinearMemory::grow`, except with `&self`.

--- a/crates/wasmtime/src/runtime/vm/memory/shared_memory_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/shared_memory_disabled.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use crate::runtime::vm::memory::LocalMemory;
 use crate::runtime::vm::{VMMemoryDefinition, VMStore, WaitResult};
 use core::ops::Range;
+use core::ptr::NonNull;
 use core::time::Duration;
 use wasmtime_environ::{Trap, Tunables};
 
@@ -23,7 +24,7 @@ impl SharedMemory {
         match self {}
     }
 
-    pub fn vmmemory_ptr(&self) -> *const VMMemoryDefinition {
+    pub fn vmmemory_ptr(&self) -> NonNull<VMMemoryDefinition> {
         match *self {}
     }
 

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -6,6 +6,7 @@ use crate::prelude::*;
 use crate::runtime::vm::sys::{mmap, vm::MemoryImageSource};
 use alloc::sync::Arc;
 use core::ops::Range;
+use core::ptr::NonNull;
 #[cfg(feature = "std")]
 use std::fs::File;
 
@@ -261,6 +262,12 @@ impl<T> Mmap<T> {
         self.sys.as_send_sync_ptr().as_ptr()
     }
 
+    /// Return the allocated memory as a mutable pointer to u8.
+    #[inline]
+    pub fn as_non_null(&self) -> NonNull<u8> {
+        self.sys.as_send_sync_ptr().as_non_null()
+    }
+
     /// Return the length of the allocated memory.
     ///
     /// This is the byte length of this entire mapping which includes both
@@ -383,8 +390,14 @@ impl MmapOffset {
     /// Returns the raw pointer in memory represented by this offset.
     #[inline]
     pub fn as_mut_ptr(&self) -> *mut u8 {
+        self.as_non_null().as_ptr()
+    }
+
+    /// Returns the raw pointer in memory represented by this offset.
+    #[inline]
+    pub fn as_non_null(&self) -> NonNull<u8> {
         // SAFETY: constructor checks that offset is within this allocation.
-        unsafe { self.mmap().as_mut_ptr().byte_add(self.offset.byte_count()) }
+        unsafe { self.mmap().as_non_null().byte_add(self.offset.byte_count()) }
     }
 
     /// Maps an image into the mmap with read/write permissions.

--- a/crates/wasmtime/src/runtime/vm/provenance.rs
+++ b/crates/wasmtime/src/runtime/vm/provenance.rs
@@ -51,8 +51,8 @@ use wasmtime_environ::VMSharedTypeIndex;
 /// outside of Rust.
 ///
 /// This is intended to be the fundamental data type used to share
-/// pointers-to-things with Cranelift-compiled code for example. An example of
-/// this is that the `VMMemoryDefinition` type, which compiled code reads to
+/// pointers-to-things with compiled wasm compiled code for example. An example
+/// of this is that the `VMMemoryDefinition` type, which compiled code reads to
 /// learn about linear memory, uses a `VmPtr<u8>` to represent the base pointer
 /// of linear memory.
 ///
@@ -83,11 +83,6 @@ use wasmtime_environ::VMSharedTypeIndex;
 /// In general usage of this type should be minimized to only where absolutely
 /// necessary when sharing data structures with compiled code. Prefer to use
 /// `NonNull` or `SendSyncPtr` where possible.
-///
-/// > **Note**: at this time this type was just introduced to Wasmtime. This
-/// > doesn't actually do anything with provenance just yet as the original
-/// > pointer used to create a `VmPtr<T>` is preserved even at-rest. That will
-/// > change in the near future as more refactorings are completed.
 #[repr(transparent)]
 pub struct VmPtr<T>(SendSyncPtr<T>);
 
@@ -147,13 +142,13 @@ impl<T> From<SendSyncPtr<T>> for VmPtr<T> {
 }
 
 /// A custom "marker trait" used to tag types that are safe to share with
-/// compiled code.
+/// compiled wasm code.
 ///
 /// The intention of this trait is to be used as a bound in a few core locations
 /// in Wasmtime, such as `Instance::vmctx_plus_offset_mut`, and otherwise not
 /// present very often. The purpose of this trait is to ensure that all types
 /// stored to be shared with compiled code have a known layout and are
-/// guaranteed to be "safe" to share with Cranelift.
+/// guaranteed to be "safe" to share with compiled wasm code.
 ///
 /// This is an `unsafe` trait as it's generally not safe to share anything with
 /// compiled code and it is used to invite extra scrutiny to manual `impl`s of

--- a/crates/wasmtime/src/runtime/vm/provenance.rs
+++ b/crates/wasmtime/src/runtime/vm/provenance.rs
@@ -43,8 +43,6 @@
 
 use crate::vm::SendSyncPtr;
 use core::fmt;
-use core::marker;
-use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, AtomicUsize};
 use wasmtime_environ::VMSharedTypeIndex;

--- a/crates/wasmtime/src/runtime/vm/provenance.rs
+++ b/crates/wasmtime/src/runtime/vm/provenance.rs
@@ -1,0 +1,217 @@
+//! Helpers related to pointer provenance for Wasmtime and its runtime.
+//!
+//! This module encapsulates the efforts and lengths that Wasmtime goes to in
+//! order to properly respect pointer provenance in Rust with respect to unsafe
+//! code. Wasmtime has a nontrivial amount of `unsafe` code and when/where
+//! pointers are valid is something we need to be particularly careful about.
+//! All safe Rust does not need to worry about this module and only the unsafe
+//! runtime bits need to worry about it.
+//!
+//! In general Wasmtime does not work with Rust's strict pointer provenance
+//! rules. The primary reason for this is that Cranelift does not have the
+//! concept of a pointer type meaning that backends cannot know what values are
+//! pointers and what aren't. This isn't a huge issue for ISAs like x64 but for
+//! an ISA like Pulley Bytecode it means that the Pulley interpreter cannot
+//! respect strict provenance.
+//!
+//! > **Aside**: an example of how Pulley can't respect pointer provenance is
+//! > consider a wasm load. The wasm load will add a wasm address to the base
+//! > address of the host. In this situation what actually needs to happen is
+//! > that the base address of the host is a pointer which is byte-offset'd by
+//! > the wasm address. Cranelift IR has no knowledge of which value is
+//! > the wasm address and which is the host address. This means that Cranelift
+//! > can freely commute the operands of the addition. This means that when
+//! > executing Pulley doesn't know which values are addresses and which aren't.
+//!
+//! This isn't the end of the world for Wasmtime, however, it just means that
+//! when we run in MIRI we are restricted to "permissive provenance" or "exposed
+//! provenance". The tl;dr; of exposed provenance is that at certain points we
+//! declare a pointer as "this is now exposed". That converts a pointer to the
+//! `usize` address and then semantically (just for rustc/llvm mostly) indicates
+//! that the provenance of the pointer is added to a global list of provenances.
+//! Later on Wasmtime will execute an operation to convert a `usize` back into a
+//! pointer which will pick "the most appropriate provenance" from said global
+//! list of provenances.
+//!
+//! In practice we expect that at runtime all of these provenance-related ops
+//! are noops and compile away to nothing. The only practical effect that's
+//! expected is that some optimizations may be hindered in LLVM occasionally or
+//! something like that which is by-and-large what we want to happen. Note that
+//! another practical consequence of not working with "strict provenance" means
+//! that Wasmtime is incompatible with platforms such as CHERI where exposed
+//! provenance is not available.
+
+use crate::vm::SendSyncPtr;
+use core::fmt;
+use core::marker;
+use core::num::NonZeroUsize;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicU64, AtomicUsize};
+use wasmtime_environ::VMSharedTypeIndex;
+
+/// A pointer that is used by compiled code, or in other words is accessed
+/// outside of Rust.
+///
+/// This is intended to be the fundamental data type used to share
+/// pointers-to-things with Cranelift-compiled code for example. An example of
+/// this is that the `VMMemoryDefinition` type, which compiled code reads to
+/// learn about linear memory, uses a `VmPtr<u8>` to represent the base pointer
+/// of linear memory.
+///
+/// This type is pointer-sized and typed-like-a-pointer. This is additionally
+/// like a `NonNull<T>` in that it's never a null pointer (and
+/// `Option<VmPtr<T>>` is pointer-sized). This pointer auto-infers
+/// `Send` and `Sync` based on `T`. Note the lack of `T: ?Sized` bounds in this
+/// type additionally, meaning that it only works with sized types. That's
+/// intentional as compiled code should not be interacting with dynamically
+/// sized types in Rust.
+///
+/// This type serves two major purposes with respect to provenance and safety:
+///
+/// * Primarily this type is the only pointer type that implements `VmSafe`, the
+///   marker trait below. That forces all pointers shared with compiled code to
+///   use this type.
+///
+/// * This type represents a pointer with "exposed provenance". Once a value of
+///   this type is created the original pointer's provenance will be marked as
+///   exposed. This operation may hinder optimizations around the use of said
+///   pointer in that case.
+///
+/// This type is expected to be used not only when sending pointers to compiled
+/// code (e.g. `VMContext`) but additionally for any data at rest which shares
+/// pointers with compiled code (for example the base of linear memory or
+/// pointers stored within `VMContext` itself).
+///
+/// In general usage of this type should be minimized to only where absolutely
+/// necessary when sharing data structures with compiled code. Prefer to use
+/// `NonNull` or `SendSyncPtr` where possible.
+///
+/// > **Note**: at this time this type was just introduced to Wasmtime. This
+/// > doesn't actually do anything with provenance just yet as the original
+/// > pointer used to create a `VmPtr<T>` is preserved even at-rest. That will
+/// > change in the near future as more refactorings are completed.
+#[repr(transparent)]
+pub struct VmPtr<T>(SendSyncPtr<T>);
+
+impl<T> VmPtr<T> {
+    /// View this pointer as a [`SendSyncPtr<T>`].
+    ///
+    /// This operation will convert the storage at-rest to a native pointer on
+    /// the host. This is effectively an integer-to-pointer operation which will
+    /// assume that the original pointer's provenance was previously exposed.
+    /// In typical operation this means that Wasmtime will initialize data
+    /// structures by creating an instance of `VmPtr`, exposing provenance.
+    /// Later on this type will be handed back to Wasmtime or read from its
+    /// location at-rest in which case provenance will be "re-acquired".
+    pub fn as_send_sync(&self) -> SendSyncPtr<T> {
+        self.0
+    }
+
+    /// Similar to `as_send_sync`, but returns a `NonNull<T>`.
+    pub fn as_non_null(&self) -> NonNull<T> {
+        self.0.as_non_null()
+    }
+
+    /// Similar to `as_send_sync`, but returns a `*mut T`.
+    pub fn as_ptr(&self) -> *mut T {
+        self.0.as_ptr()
+    }
+}
+
+// `VmPtr<T>`, like raw pointers, is trivially `Clone`/`Copy`.
+impl<T> Clone for VmPtr<T> {
+    fn clone(&self) -> VmPtr<T> {
+        *self
+    }
+}
+
+impl<T> Copy for VmPtr<T> {}
+
+// Forward debugging to `SendSyncPtr<T>` which renders the address.
+impl<T> fmt::Debug for VmPtr<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_send_sync().fmt(f)
+    }
+}
+
+// Constructor from `NonNull<T>`
+impl<T> From<NonNull<T>> for VmPtr<T> {
+    fn from(ptr: NonNull<T>) -> VmPtr<T> {
+        VmPtr::from(SendSyncPtr::from(ptr))
+    }
+}
+
+// Constructor from `SendSyncPtr<T>`
+impl<T> From<SendSyncPtr<T>> for VmPtr<T> {
+    fn from(ptr: SendSyncPtr<T>) -> VmPtr<T> {
+        VmPtr(ptr)
+    }
+}
+
+/// A custom "marker trait" used to tag types that are safe to share with
+/// compiled code.
+///
+/// The intention of this trait is to be used as a bound in a few core locations
+/// in Wasmtime, such as `Instance::vmctx_plus_offset_mut`, and otherwise not
+/// present very often. The purpose of this trait is to ensure that all types
+/// stored to be shared with compiled code have a known layout and are
+/// guaranteed to be "safe" to share with Cranelift.
+///
+/// This is an `unsafe` trait as it's generally not safe to share anything with
+/// compiled code and it is used to invite extra scrutiny to manual `impl`s of
+/// this trait. Types which implement this marker trait must satisfy at least
+/// the following requirements.
+///
+/// * The ABI of `Self` must be well-known and defined. This means that the type
+///   can interoperate with compiled code. For example `u8` is well defined as
+///   is a `#[repr(C)]` structure. Types lacking `#[repr(C)]` or other types
+///   like Rust tuples do not satisfy this requirement.
+///
+/// * For types which contain pointers the pointer's provenance is guaranteed to
+///   have been exposed when the type is constructed. This is satisfied where
+///   the only pointer that implements this trait is `VmPtr<T>` above which is
+///   explicitly used to indicate exposed provenance. Notably `*mut T` and
+///   `NonNull<T>` do not implement this trait, and intentionally so.
+///
+/// * For composite structures (e.g. `struct`s in Rust) all member fields must
+///   satisfy the above criteria. All fields must have defined layouts and
+///   pointers must be `VmPtr<T>`.
+///
+/// * Newtype or wrapper types around primitives that are used by value must be
+///   `#[repr(transparent)]` to ensure they aren't considered aggregates by the
+///   compile to match the ABI of the primitive type.
+///
+/// In this module a number of impls are provided for the primitives of Rust,
+/// for example integers. Additionally some basic pointer-related impls are
+/// provided for `VmPtr<T>` above. More impls can be found in `vmcontext.rs`
+/// where there are manual impls for all `VM*` data structures which are shared
+/// with compiled code.
+pub unsafe trait VmSafe {}
+
+// Implementations for primitive types. Note that atomics are included here as
+// some atomic values are shared with compiled code. Rust's atomics are
+// guaranteed to have the same memory representation as their primitive.
+unsafe impl VmSafe for u8 {}
+unsafe impl VmSafe for u16 {}
+unsafe impl VmSafe for u32 {}
+unsafe impl VmSafe for u64 {}
+unsafe impl VmSafe for u128 {}
+unsafe impl VmSafe for usize {}
+unsafe impl VmSafe for i8 {}
+unsafe impl VmSafe for i16 {}
+unsafe impl VmSafe for i32 {}
+unsafe impl VmSafe for i64 {}
+unsafe impl VmSafe for i128 {}
+unsafe impl VmSafe for isize {}
+unsafe impl VmSafe for AtomicUsize {}
+unsafe impl VmSafe for AtomicU64 {}
+
+// This is a small `u32` wrapper defined in `wasmtime-environ`, so impl the
+// vm-safe-ness here.
+unsafe impl VmSafe for VMSharedTypeIndex {}
+
+// Core implementations for `VmPtr`. Notably `VMPtr<T>` requires that `T` also
+// implements `VmSafe`. Additionally an `Option` wrapper is allowed as that's
+// just a nullable pointer.
+unsafe impl<T: VmSafe> VmSafe for VmPtr<T> {}
+unsafe impl<T: VmSafe> VmSafe for Option<VmPtr<T>> {}

--- a/crates/wasmtime/src/runtime/vm/store_box.rs
+++ b/crates/wasmtime/src/runtime/vm/store_box.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+use crate::runtime::vm::SendSyncPtr;
+use core::ptr::NonNull;
 
 /// A `Box<T>` lookalike for memory that's stored in a `Store<T>`
 ///
@@ -8,30 +10,28 @@ use crate::prelude::*;
 /// around without invalidating pointers to the contents within the box. The
 /// standard `Box<T>` type does not implement this for example and moving that
 /// will invalidate derived pointers.
-pub struct StoreBox<T: ?Sized>(*mut T);
-
-unsafe impl<T: Send + ?Sized> Send for StoreBox<T> {}
-unsafe impl<T: Sync + ?Sized> Sync for StoreBox<T> {}
+pub struct StoreBox<T: ?Sized>(SendSyncPtr<T>);
 
 impl<T> StoreBox<T> {
     /// Allocates space on the heap to store `val` and returns a pointer to it
     /// living on the heap.
     pub fn new(val: T) -> StoreBox<T> {
-        StoreBox(Box::into_raw(Box::new(val)))
+        let ptr = Box::into_raw(Box::new(val));
+        StoreBox(SendSyncPtr::from(NonNull::new(ptr).unwrap()))
     }
 }
 
 impl<T: ?Sized> StoreBox<T> {
     /// Returns the underlying pointer to `T` which is owned by the store.
-    pub fn get(&self) -> *mut T {
-        self.0
+    pub fn get(&self) -> NonNull<T> {
+        self.0.as_non_null()
     }
 }
 
 impl<T: ?Sized> Drop for StoreBox<T> {
     fn drop(&mut self) {
         unsafe {
-            drop(Box::from_raw(self.0));
+            drop(Box::from_raw(self.0.as_ptr()));
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::runtime::vm::VMContext;
 use core::mem;
+use core::ptr::NonNull;
 
 pub use crate::runtime::vm::sys::capi::{self, wasmtime_longjmp};
 

--- a/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
@@ -9,15 +9,15 @@ pub type SignalHandler = Box<dyn Fn() + Send + Sync>;
 
 pub unsafe fn wasmtime_setjmp(
     jmp_buf: *mut *const u8,
-    callback: extern "C" fn(*mut u8, *mut VMContext) -> bool,
+    callback: extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,
     payload: *mut u8,
-    callee: *mut VMContext,
+    callee: NonNull<VMContext>,
 ) -> bool {
     let callback = mem::transmute::<
-        extern "C" fn(*mut u8, *mut VMContext) -> bool,
+        extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,
         extern "C" fn(*mut u8, *mut u8) -> bool,
     >(callback);
-    capi::wasmtime_setjmp(jmp_buf, callback, payload, callee.cast())
+    capi::wasmtime_setjmp(jmp_buf, callback, payload, callee.as_ptr().cast())
 }
 
 #[cfg(has_native_signals)]

--- a/crates/wasmtime/src/runtime/vm/sys/miri/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/traphandlers.rs
@@ -14,9 +14,9 @@ use crate::runtime::vm::VMContext;
 
 pub fn wasmtime_setjmp(
     _jmp_buf: *mut *const u8,
-    callback: extern "C" fn(*mut u8, *mut VMContext) -> bool,
+    callback: extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,
     payload: *mut u8,
-    callee: *mut VMContext,
+    callee: NonNull<VMContext>,
 ) -> bool {
     callback(payload, callee)
 }

--- a/crates/wasmtime/src/runtime/vm/sys/miri/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/traphandlers.rs
@@ -11,6 +11,7 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::VMContext;
+use core::ptr::NonNull;
 
 pub fn wasmtime_setjmp(
     _jmp_buf: *mut *const u8,

--- a/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
@@ -1,4 +1,5 @@
 use crate::vm::VMContext;
+use core::ptr::NonNull;
 
 #[link(name = "wasmtime-helpers")]
 unsafe extern "C" {
@@ -6,9 +7,9 @@ unsafe extern "C" {
     #[allow(improper_ctypes)]
     pub fn wasmtime_setjmp(
         jmp_buf: *mut *const u8,
-        callback: extern "C" fn(*mut u8, *mut VMContext) -> bool,
+        callback: extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,
         payload: *mut u8,
-        callee: *mut VMContext,
+        callee: NonNull<VMContext>,
     ) -> bool;
 
     #[wasmtime_versioned_export_macros::versioned_link]

--- a/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
@@ -3,6 +3,7 @@ use crate::runtime::vm::traphandlers::{tls, TrapRegisters, TrapTest};
 use crate::runtime::vm::VMContext;
 use std::ffi::c_void;
 use std::io;
+use std::ptr::NonNull;
 use windows_sys::Win32::Foundation::*;
 use windows_sys::Win32::System::Diagnostics::Debug::*;
 use windows_sys::Win32::System::Kernel::*;
@@ -13,9 +14,9 @@ unsafe extern "C" {
     #[allow(improper_ctypes)]
     pub fn wasmtime_setjmp(
         jmp_buf: *mut *const u8,
-        callback: extern "C" fn(*mut u8, *mut VMContext) -> bool,
+        callback: extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,
         payload: *mut u8,
-        callee: *mut VMContext,
+        callee: NonNull<VMContext>,
     ) -> bool;
 
     #[wasmtime_versioned_export_macros::versioned_link]

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -740,25 +740,29 @@ impl Table {
         match self {
             Table::Static(StaticTable::Func(StaticFuncTable { data, size, .. })) => {
                 VMTableDefinition {
-                    base: data.as_ptr().cast(),
+                    base: data.cast().into(),
                     current_elements: *size,
                 }
             }
             Table::Static(StaticTable::GcRef(StaticGcRefTable { data, size })) => {
                 VMTableDefinition {
-                    base: data.as_ptr().cast(),
+                    base: data.cast().into(),
                     current_elements: *size,
                 }
             }
             Table::Dynamic(DynamicTable::Func(DynamicFuncTable { elements, .. })) => {
                 VMTableDefinition {
-                    base: elements.as_mut_ptr().cast(),
+                    base: NonNull::<[FuncTableElem]>::from(&mut elements[..])
+                        .cast()
+                        .into(),
                     current_elements: elements.len(),
                 }
             }
             Table::Dynamic(DynamicTable::GcRef(DynamicGcRefTable { elements, .. })) => {
                 VMTableDefinition {
-                    base: elements.as_mut_ptr().cast(),
+                    base: NonNull::<[Option<VMGcRef>]>::from(&mut elements[..])
+                        .cast()
+                        .into(),
                     current_elements: elements.len(),
                 }
             }

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -116,7 +116,7 @@ impl Backtrace {
             // trampoline did not get a chance to save the last Wasm PC and FP,
             // and we need to use the plumbed-through values instead.
             Some((pc, fp)) => {
-                assert!(core::ptr::eq(limits, state.limits));
+                assert!(core::ptr::eq(limits, state.limits.as_ptr()));
                 (pc, fp)
             }
             // Either there is no Wasm currently on the stack, or we exited Wasm
@@ -136,7 +136,7 @@ impl Backtrace {
         .chain(
             state
                 .iter()
-                .filter(|state| core::ptr::eq(limits, state.limits))
+                .filter(|state| core::ptr::eq(limits, state.limits.as_ptr()))
                 .map(|state| {
                     (
                         state.old_last_wasm_exit_pc(),

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -5,7 +5,7 @@ mod vm_host_func_context;
 
 pub use self::vm_host_func_context::VMArrayCallHostFuncContext;
 use crate::prelude::*;
-use crate::runtime::vm::{GcStore, InterpreterRef, VMGcRef};
+use crate::runtime::vm::{GcStore, InterpreterRef, VMGcRef, VmPtr, VmSafe};
 use crate::store::StoreOpaque;
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
@@ -42,8 +42,12 @@ use wasmtime_environ::{
 ///
 /// * `true` if this call succeeded.
 /// * `false` if this call failed and a trap was recorded in TLS.
-pub type VMArrayCallNative =
-    unsafe extern "C" fn(*mut VMOpaqueContext, *mut VMOpaqueContext, *mut ValRaw, usize) -> bool;
+pub type VMArrayCallNative = unsafe extern "C" fn(
+    VmPtr<VMOpaqueContext>,
+    VmPtr<VMOpaqueContext>,
+    VmPtr<ValRaw>,
+    usize,
+) -> bool;
 
 /// An opaque function pointer which might be `VMArrayCallNative` or it might be
 /// pulley bytecode. Requires external knowledge to determine what kind of
@@ -67,11 +71,11 @@ pub struct VMWasmCallFunction(VMFunctionBody);
 #[repr(C)]
 pub struct VMFunctionImport {
     /// Function pointer to use when calling this imported function from Wasm.
-    pub wasm_call: NonNull<VMWasmCallFunction>,
+    pub wasm_call: VmPtr<VMWasmCallFunction>,
 
     /// Function pointer to use when calling this imported function with the
     /// "array" calling convention that `Func::new` et al use.
-    pub array_call: NonNull<VMArrayCallFunction>,
+    pub array_call: VmPtr<VMArrayCallFunction>,
 
     /// The VM state associated with this function.
     ///
@@ -79,13 +83,11 @@ pub struct VMFunctionImport {
     /// VMContext`, but for lifted/lowered component model functions this will
     /// be a `VMComponentContext`, and for a host function it will be a
     /// `VMHostFuncContext`, etc.
-    pub vmctx: *mut VMOpaqueContext,
+    pub vmctx: VmPtr<VMOpaqueContext>,
 }
 
-// Declare that this type is send/sync, it's the responsibility of users of
-// `VMFunctionImport` to uphold this guarantee.
-unsafe impl Send for VMFunctionImport {}
-unsafe impl Sync for VMFunctionImport {}
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMFunctionImport {}
 
 #[cfg(test)]
 mod test_vmfunction_import {
@@ -124,6 +126,9 @@ mod test_vmfunction_import {
 #[repr(C)]
 pub struct VMFunctionBody(u8);
 
+// SAFETY: this structure is never read and is safe to pass to jit code.
+unsafe impl VmSafe for VMFunctionBody {}
+
 #[cfg(test)]
 mod test_vmfunction_body {
     use super::VMFunctionBody;
@@ -141,16 +146,14 @@ mod test_vmfunction_body {
 #[repr(C)]
 pub struct VMTableImport {
     /// A pointer to the imported table description.
-    pub from: *mut VMTableDefinition,
+    pub from: VmPtr<VMTableDefinition>,
 
     /// A pointer to the `VMContext` that owns the table description.
-    pub vmctx: *mut VMContext,
+    pub vmctx: VmPtr<VMContext>,
 }
 
-// Declare that this type is send/sync, it's the responsibility of users of
-// `VMTableImport` to uphold this guarantee.
-unsafe impl Send for VMTableImport {}
-unsafe impl Sync for VMTableImport {}
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMTableImport {}
 
 #[cfg(test)]
 mod test_vmtable_import {
@@ -184,19 +187,17 @@ mod test_vmtable_import {
 #[repr(C)]
 pub struct VMMemoryImport {
     /// A pointer to the imported memory description.
-    pub from: *mut VMMemoryDefinition,
+    pub from: VmPtr<VMMemoryDefinition>,
 
     /// A pointer to the `VMContext` that owns the memory description.
-    pub vmctx: *mut VMContext,
+    pub vmctx: VmPtr<VMContext>,
 
     /// The index of the memory in the containing `vmctx`.
     pub index: DefinedMemoryIndex,
 }
 
-// Declare that this type is send/sync, it's the responsibility of users of
-// `VMMemoryImport` to uphold this guarantee.
-unsafe impl Send for VMMemoryImport {}
-unsafe impl Sync for VMMemoryImport {}
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMMemoryImport {}
 
 #[cfg(test)]
 mod test_vmmemory_import {
@@ -234,13 +235,11 @@ mod test_vmmemory_import {
 #[repr(C)]
 pub struct VMGlobalImport {
     /// A pointer to the imported global variable description.
-    pub from: *mut VMGlobalDefinition,
+    pub from: VmPtr<VMGlobalDefinition>,
 }
 
-// Declare that this type is send/sync, it's the responsibility of users of
-// `VMGlobalImport` to uphold this guarantee.
-unsafe impl Send for VMGlobalImport {}
-unsafe impl Sync for VMGlobalImport {}
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMGlobalImport {}
 
 #[cfg(test)]
 mod test_vmglobal_import {
@@ -271,7 +270,7 @@ mod test_vmglobal_import {
 #[repr(C)]
 pub struct VMMemoryDefinition {
     /// The start address.
-    pub base: *mut u8,
+    pub base: VmPtr<u8>,
 
     /// The current logical size of this linear memory in bytes.
     ///
@@ -280,6 +279,10 @@ pub struct VMMemoryDefinition {
     /// [`VMMemoryDefinition::current_length()`].
     pub current_length: AtomicUsize,
 }
+
+// SAFETY: the above definition has `repr(C)` and each field individually
+// implements `VmSafe`, which satisfies the requirements of this trait.
+unsafe impl VmSafe for VMMemoryDefinition {}
 
 impl VMMemoryDefinition {
     /// Return the current length (in bytes) of the [`VMMemoryDefinition`] by
@@ -343,11 +346,14 @@ mod test_vmmemory_definition {
 #[repr(C)]
 pub struct VMTableDefinition {
     /// Pointer to the table data.
-    pub base: *mut u8,
+    pub base: VmPtr<u8>,
 
     /// The current number of elements in the table.
     pub current_elements: usize,
 }
+
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMTableDefinition {}
 
 #[cfg(test)]
 mod test_vmtable_definition {
@@ -385,6 +391,9 @@ pub struct VMGlobalDefinition {
     storage: [u8; 16],
     // If more elements are added here, remember to add offset_of tests below!
 }
+
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMGlobalDefinition {}
 
 #[cfg(test)]
 mod test_vmglobal_definition {
@@ -669,7 +678,7 @@ mod test_vmshared_type_index {
 pub struct VMFuncRef {
     /// Function pointer for this funcref if being called via the "array"
     /// calling convention that `Func::new` et al use.
-    pub array_call: NonNull<VMArrayCallFunction>,
+    pub array_call: VmPtr<VMArrayCallFunction>,
 
     /// Function pointer for this funcref if being called via the calling
     /// convention we use when compiling Wasm.
@@ -689,7 +698,7 @@ pub struct VMFuncRef {
     /// it means that the Wasm cannot actually call this function. But it does
     /// mean that this field needs to be an `Option` even though it is non-null
     /// the vast vast vast majority of the time.
-    pub wasm_call: Option<NonNull<VMWasmCallFunction>>,
+    pub wasm_call: Option<VmPtr<VMWasmCallFunction>>,
 
     /// Function signature's type id.
     pub type_index: VMSharedTypeIndex,
@@ -700,12 +709,12 @@ pub struct VMFuncRef {
     /// function being referenced: for core Wasm functions, this is a `*mut
     /// VMContext`, for host functions it is a `*mut VMHostFuncContext`, and for
     /// component functions it is a `*mut VMComponentContext`.
-    pub vmctx: *mut VMOpaqueContext,
+    pub vmctx: VmPtr<VMOpaqueContext>,
     // If more elements are added here, remember to add offset_of tests below!
 }
 
-unsafe impl Send for VMFuncRef {}
-unsafe impl Sync for VMFuncRef {}
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMFuncRef {}
 
 impl VMFuncRef {
     /// Invokes the `array_call` field of this `VMFuncRef` with the supplied
@@ -736,8 +745,8 @@ impl VMFuncRef {
     pub unsafe fn array_call(
         &self,
         pulley: Option<InterpreterRef<'_>>,
-        caller: *mut VMOpaqueContext,
-        args_and_results: *mut [ValRaw],
+        caller: NonNull<VMOpaqueContext>,
+        args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         match pulley {
             Some(vm) => self.array_call_interpreted(vm, caller, args_and_results),
@@ -748,35 +757,42 @@ impl VMFuncRef {
     unsafe fn array_call_interpreted(
         &self,
         vm: InterpreterRef<'_>,
-        caller: *mut VMOpaqueContext,
-        args_and_results: *mut [ValRaw],
+        caller: NonNull<VMOpaqueContext>,
+        args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         // If `caller` is actually a `VMArrayCallHostFuncContext` then skip the
         // interpreter, even though it's available, as `array_call` will be
         // native code.
-        if (*self.vmctx).magic == wasmtime_environ::VM_ARRAY_CALL_HOST_FUNC_MAGIC {
+        if self.vmctx.as_non_null().as_ref().magic
+            == wasmtime_environ::VM_ARRAY_CALL_HOST_FUNC_MAGIC
+        {
             return self.array_call_native(caller, args_and_results);
         }
-        vm.call(self.array_call.cast(), self.vmctx, caller, args_and_results)
+        vm.call(
+            self.array_call.as_non_null().cast(),
+            self.vmctx.as_non_null(),
+            caller,
+            args_and_results,
+        )
     }
 
     unsafe fn array_call_native(
         &self,
-        caller: *mut VMOpaqueContext,
-        args_and_results: *mut [ValRaw],
+        caller: NonNull<VMOpaqueContext>,
+        args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         union GetNativePointer {
             native: VMArrayCallNative,
             ptr: NonNull<VMArrayCallFunction>,
         }
         let native = GetNativePointer {
-            ptr: self.array_call,
+            ptr: self.array_call.as_non_null(),
         }
         .native;
         native(
-            self.vmctx,
-            caller,
-            args_and_results.cast(),
+            self.vmctx.into(),
+            caller.into(),
+            args_and_results.cast().into(),
             args_and_results.len(),
         )
     }
@@ -849,8 +865,11 @@ macro_rules! define_builtin_array {
     (@ty u8) => (u8);
     (@ty bool) => (bool);
     (@ty pointer) => (*mut u8);
-    (@ty vmctx) => (*mut VMContext);
+    (@ty vmctx) => (VmPtr<VMContext>);
 }
+
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMBuiltinFunctionsArray {}
 
 wasmtime_environ::foreach_builtin_function!(define_builtin_array);
 
@@ -939,6 +958,9 @@ pub struct VMRuntimeLimits {
 unsafe impl Send for VMRuntimeLimits {}
 unsafe impl Sync for VMRuntimeLimits {}
 
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMRuntimeLimits {}
+
 impl Default for VMRuntimeLimits {
     fn default() -> VMRuntimeLimits {
         VMRuntimeLimits {
@@ -1014,7 +1036,7 @@ impl VMContext {
     /// Helper function to cast between context types using a debug assertion to
     /// protect against some mistakes.
     #[inline]
-    pub unsafe fn from_opaque(opaque: *mut VMOpaqueContext) -> *mut VMContext {
+    pub unsafe fn from_opaque(opaque: VmPtr<VMOpaqueContext>) -> NonNull<VMContext> {
         // Note that in general the offset of the "magic" field is stored in
         // `VMOffsets::vmctx_magic`. Given though that this is a sanity check
         // about converting this pointer to another type we ideally don't want
@@ -1030,7 +1052,8 @@ impl VMContext {
         // bugs, meaning we don't actually read the magic and act differently
         // at runtime depending what it is, so this is a debug assertion as
         // opposed to a regular assertion.
-        debug_assert_eq!((*opaque).magic, VMCONTEXT_MAGIC);
+        let opaque = opaque.as_non_null();
+        debug_assert_eq!(opaque.as_ref().magic, VMCONTEXT_MAGIC);
         opaque.cast()
     }
 }
@@ -1350,15 +1373,15 @@ pub struct VMOpaqueContext {
 impl VMOpaqueContext {
     /// Helper function to clearly indicate that casts are desired.
     #[inline]
-    pub fn from_vmcontext(ptr: *mut VMContext) -> *mut VMOpaqueContext {
+    pub fn from_vmcontext(ptr: NonNull<VMContext>) -> NonNull<VMOpaqueContext> {
         ptr.cast()
     }
 
     /// Helper function to clearly indicate that casts are desired.
     #[inline]
     pub fn from_vm_array_call_host_func_context(
-        ptr: *mut VMArrayCallHostFuncContext,
-    ) -> *mut VMOpaqueContext {
+        ptr: NonNull<VMArrayCallHostFuncContext>,
+    ) -> NonNull<VMOpaqueContext> {
         ptr.cast()
     }
 }

--- a/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
@@ -4,7 +4,7 @@
 
 use super::{VMArrayCallNative, VMOpaqueContext};
 use crate::prelude::*;
-use crate::runtime::vm::{StoreBox, VMFuncRef};
+use crate::runtime::vm::{StoreBox, VMFuncRef, VmPtr};
 use core::any::Any;
 use core::ptr::{self, NonNull};
 use wasmtime_environ::{VMSharedTypeIndex, VM_ARRAY_CALL_HOST_FUNC_MAGIC};
@@ -38,16 +38,16 @@ impl VMArrayCallHostFuncContext {
         let ctx = StoreBox::new(VMArrayCallHostFuncContext {
             magic: wasmtime_environ::VM_ARRAY_CALL_HOST_FUNC_MAGIC,
             func_ref: VMFuncRef {
-                array_call: NonNull::new(host_func as *mut u8).unwrap().cast(),
+                array_call: NonNull::new(host_func as *mut u8).unwrap().cast().into(),
                 type_index,
                 wasm_call: None,
-                vmctx: ptr::null_mut(),
+                vmctx: NonNull::dangling().into(),
             },
             host_state,
         });
         let vmctx = VMOpaqueContext::from_vm_array_call_host_func_context(ctx.get());
         unsafe {
-            (*ctx.get()).func_ref.vmctx = vmctx;
+            ctx.get().as_mut().func_ref.vmctx = vmctx.into();
         }
         ctx
     }
@@ -67,9 +67,12 @@ impl VMArrayCallHostFuncContext {
     /// Helper function to cast between context types using a debug assertion to
     /// protect against some mistakes.
     #[inline]
-    pub unsafe fn from_opaque(opaque: *mut VMOpaqueContext) -> *mut VMArrayCallHostFuncContext {
+    pub unsafe fn from_opaque(
+        opaque: VmPtr<VMOpaqueContext>,
+    ) -> NonNull<VMArrayCallHostFuncContext> {
+        let opaque = opaque.as_non_null();
         // See comments in `VMContext::from_opaque` for this debug assert
-        debug_assert_eq!((*opaque).magic, VM_ARRAY_CALL_HOST_FUNC_MAGIC);
+        debug_assert_eq!(opaque.as_ref().magic, VM_ARRAY_CALL_HOST_FUNC_MAGIC);
         opaque.cast()
     }
 }

--- a/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
@@ -6,7 +6,7 @@ use super::{VMArrayCallNative, VMOpaqueContext};
 use crate::prelude::*;
 use crate::runtime::vm::{StoreBox, VMFuncRef, VmPtr};
 use core::any::Any;
-use core::ptr::{self, NonNull};
+use core::ptr::NonNull;
 use wasmtime_environ::{VMSharedTypeIndex, VM_ARRAY_CALL_HOST_FUNC_MAGIC};
 
 /// The `VM*Context` for array-call host functions.

--- a/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext/vm_host_func_context.rs
@@ -4,7 +4,7 @@
 
 use super::{VMArrayCallNative, VMOpaqueContext};
 use crate::prelude::*;
-use crate::runtime::vm::{StoreBox, VMFuncRef, VmPtr};
+use crate::runtime::vm::{StoreBox, VMFuncRef};
 use core::any::Any;
 use core::ptr::NonNull;
 use wasmtime_environ::{VMSharedTypeIndex, VM_ARRAY_CALL_HOST_FUNC_MAGIC};
@@ -68,9 +68,8 @@ impl VMArrayCallHostFuncContext {
     /// protect against some mistakes.
     #[inline]
     pub unsafe fn from_opaque(
-        opaque: VmPtr<VMOpaqueContext>,
+        opaque: NonNull<VMOpaqueContext>,
     ) -> NonNull<VMArrayCallHostFuncContext> {
-        let opaque = opaque.as_non_null();
         // See comments in `VMContext::from_opaque` for this debug assert
         debug_assert_eq!(opaque.as_ref().magic, VM_ARRAY_CALL_HOST_FUNC_MAGIC);
         opaque.cast()


### PR DESCRIPTION
This commit is an internal refactoring of Wasmtime's runtime to prepare
to execute Pulley in MIRI. Currently today this is not possible because
Pulley does not properly respect either strict or permissive provenance
models. The goal of this refactoring is to enable fixing this in a
future commit that doesn't touch everything in the codebase. Instead
everything is touched here in this commit.

The basic problem with Pulley is that it is incompatible with the strict
provenance model of Rust which means that we'll be using "exposed
provenance" APIs to satisfy Rust's soundness requirements. In this model
we must explicitly call `ptr.expose_provenance()` on any pointers
which are exposed to compiled code. Arguably we should also be already
doing this for natively-compiled code but I am not certain about how
strictly this is required.

Currently in Wasmtime today we call `ptr.expose_provenance()` nowhere.
It also turns out, though, that we share quite a few pointers in quite a
few places with compiled code. This creates a bit of a problem! The
solution settled on in this commit looks like:

* A new marker trait, `VmSafe`, is introduced. This trait is used to
  represent "safe to share with compiled code" types and enumerates some
  properties such as defined ABIs, primitives wrappers match primitive
  ABIs, and notably "does not contain a pointer".

* A new type, `VmPtr<T>`, is added to represent pointers shared with
  compiled code. Internally for now this is just `SendSyncPtr<T>` but in
  the future it will be `usize`. By using `SendSyncPtr<T>` it shouldn't
  actually really change anything today other than requiring a lot of
  refactoring to get the types to line up.

* The core `vmctx_plus_offset*` methods are updated to require
  `T: VmSafe`. Previously they allowed any `T` which is relatively
  dangerous to store any possible Rust type in Cranelift-accessible
  areas.

These three fundamental changes were introduced in this commit. All
further changes were refactoring necessary to get everything working
after these changes. For example many types in `vmcontext.rs`, such as
`VMFuncRef`, have changed to using `VmPtr<T>` instead of `NonNull<T>` or
`*mut T`. This is a pretty expansive change which resulted in touching a
lot of places.

One premise of `VmPtr<T>` is that it's non-null. This was an
additional refactoring that updated a lot of places where previously
`*mut T` was used and now either `VmPtr<T>` or `NonNull<T>` is used.

In the end the intention is that `VmPtr<T>` is used whenever pointers
are store in memory that can be accessed from Cranelift. When operating
inside of the runtime `NonNull<T>` or `SendSyncPtr<T>` is preferred
instead.

As a final note, no provenance changes have actually happened yet. For
example this doesn't fix Pulley in MIRI. What it does enable, though, is
that the future commit to fix Pulley in MIRI will be much smaller with
this having already landed.